### PR TITLE
removing text, requirements, description, and actionText from prelude cards

### DIFF
--- a/src/cards/prelude/AcquiredSpaceAgency.ts
+++ b/src/cards/prelude/AcquiredSpaceAgency.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class AcquiredSpaceAgency extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Acquired Space Agency";
-    public text: string = "Gain 6 titanium. Reveal cards until you reveal two cards with Space Tags. Take them into your hand, discard the rest.";
-    public requirements: undefined;
-    public description: string = "The Western Alliance Space Agency has a lot of leverage, at your disposal";
     public play(player: Player, game: Game) {
         for (let foundCard of game.drawCardsByTag(Tags.SPACE,2)) {
             player.cardsInHand.push(foundCard);

--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class AlliedBanks extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: string = "Allied Banks";
-    public text: string = "Raise MC production 4 steps. Gains 3 MC.";
-    public requirements: undefined;
-    public description: string = "We are benefited by human bank savings";
     public play(player: Player, _game: Game) {
         player.megaCreditProduction += 4;
 	    player.megaCredits += 3; 

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -9,9 +9,6 @@ import { SelectSpace } from "../../inputs/SelectSpace";
 export class AquiferTurbines extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: string = "Aquifer Turbines";
-    public text: string = "Place an ocean tile and and increase energy production 2 steps. Pay 3 MC.";
-    public requirements: undefined;
-    public description: string = "The high pressure of an underground aquifer can be used for energy production when the water is released";
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for ocean", game.getAvailableSpacesForOcean(player), (space: ISpace) => {
             game.addOceanTile(player, space.id);

--- a/src/cards/prelude/Biofuels.ts
+++ b/src/cards/prelude/Biofuels.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Biofuels extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.MICROBES];
     public name: string = "Biofuels";
-    public text: string = "Increase your energy and plant production 1 step. Gain 2 plants.";
-    public requirements: undefined;
-    public description: string = "Organic production of fuels and fertilizers";
     public play(player: Player, _game: Game) {     
             player.energyProduction++;
 			player.plantProduction++;

--- a/src/cards/prelude/Biolab.ts
+++ b/src/cards/prelude/Biolab.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Biolab extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Biolab";
-    public text: string = "Increase your plant production 1 step. Draw 3 cards.";
-    public requirements: undefined;
-    public description: string = "Bioengineering is of the utmost importance on Mars, and you just got a headstart";
     public play(player: Player, game: Game) {
         player.plantProduction++;
 		for (let i = 0; i < 3; i++) {

--- a/src/cards/prelude/BiosphereSupport.ts
+++ b/src/cards/prelude/BiosphereSupport.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class BiosphereSupport extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT];
     public name: string = "Biosphere Support";
-    public text: string = "Decrease MC production 1 step and increase plant production 2 steps.";
-    public requirements: undefined;
-    public description: string = "The greening of the red planet has begun";
     public canPlay(player: Player): boolean {
         return player.megaCreditProduction >= -4;
     }    

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -8,9 +8,6 @@ export class BusinessEmpire extends PreludeCard implements IProjectCard {
 
     public tags: Array<Tags> = [Tags.EARTH];
     public name: string = "Business Empire";
-    public text: string = "Increase MC production 6 steps. Pay 6 MC.";
-    public requirements: undefined;
-    public description: string = "Numerous asset on Earth to support your Mars efforts";
     public play(player: Player, _game: Game) {     
 			player.megaCredits -= 6;
 			player.megaCreditProduction += 6;

--- a/src/cards/prelude/CheungShingMARS.ts
+++ b/src/cards/prelude/CheungShingMARS.ts
@@ -9,9 +9,6 @@ export class CheungShingMARS implements CorporationCard {
     public name: string = "Cheung Shing MARS";
     public tags: Array<Tags> = [Tags.STEEL];
     public startingMegaCredits: number = 44;
-    public text: string = "You start with 3 MC production and 44 MC. Effect: When you play a building tag, you pay 2 MC less for it.";
-    public requirements: undefined;
-    public description: string = "An Asian company that has become a leader in industry and construction on Mars, Cheung Shing Mars is a force to be reckoned with";
 
     public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
         if (card.tags.indexOf(Tags.STEEL) !== -1) {

--- a/src/cards/prelude/DomeFarming.ts
+++ b/src/cards/prelude/DomeFarming.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class DomeFarming extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT, Tags.STEEL];
     public name: string = "Dome Farming";
-    public text: string = "Increase MC production 2 steps and plant production 1 step.";
-    public requirements: undefined;
-    public description: string = "Growing flowers of different types, but mainly potatoes...";
     public play(player: Player, _game: Game) {     
 			player.plantProduction++;
 			player.megaCreditProduction += 2;

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Donation extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Donation";
-    public text: string = "Gain 21 MC.";
-    public requirements: undefined;
-    public description: string = "From a rich benefactor with absolutely no hidden agenda";
     public play(player: Player, _game: Game) {     
 			player.megaCredits += 21;
             return undefined;

--- a/src/cards/prelude/EarlySettlement.ts
+++ b/src/cards/prelude/EarlySettlement.ts
@@ -9,9 +9,6 @@ import { ISpace } from "../../ISpace";
 export class EarlySettlement extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL, Tags.CITY];
     public name: string = "Early Settlement";
-    public text: string = "Place a city tile. Increase your plant production 1 step.";
-    public requirements: undefined;
-    public description: string = "The first Martians wrote their story of civilisation shortly after the terraforming anouncement";
     public play(player: Player, game: Game) {  
         player.plantProduction++;  	
         return new SelectSpace("Select space for city tile", game.getAvailableSpacesOnLand(player), (space: ISpace) => {

--- a/src/cards/prelude/EccentricSponsor.ts
+++ b/src/cards/prelude/EccentricSponsor.ts
@@ -7,10 +7,7 @@ import { IProjectCard } from "../IProjectCard";
 export class EccentricSponsor extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Eccentric Sponsor";
-    public text: string = "Next card you play this turn will have a 25 MC reduction. Playing this card does not count as an action";
-    public requirements: undefined;
     public postPlay: boolean = true;
-    public description: string = "He will support you, but he wants something big with his name on it";
 
     public getCardDiscount(player: Player, game: Game) {
         const lastCardPlayed = player.lastCardPlayedThisGeneration(game);

--- a/src/cards/prelude/EcologyExperts.ts
+++ b/src/cards/prelude/EcologyExperts.ts
@@ -7,10 +7,7 @@ import { IProjectCard } from "../IProjectCard";
 export class EcologyExperts extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT, Tags.MICROBES];
     public name: string = "Ecology Experts";
-    public text: string = "Ignore global requirements for the next card you play this turn. Playing this card does not count as an action. Increase your plant production 1 step.";
-    public requirements: undefined;
     public postPlay: boolean = true;
-    public description: string = "I had no idea that you could actually do that";
     public getRequirementBonus(player: Player, _game: Game): number {
         const lastCardPlayed = player.getLastCardPlayedThisTurn();
         if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {

--- a/src/cards/prelude/ExperimentalForest.ts
+++ b/src/cards/prelude/ExperimentalForest.ts
@@ -9,9 +9,6 @@ import { ISpace } from "../../ISpace";
 export class ExperimentalForest extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT];
     public name: string = "Experimental Forest";
-    public text: string = "Place 1 Greenery Tile. Reveal cards until you reveal two cards with plant tags on them. Take them into your hand and discard the rest.";
-    public requirements: undefined;
-    public description: string = "Nothing puts new ecology balance like having a biological testing ground";
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for greenery tile", game.getAvailableSpacesForGreenery(player), (space: ISpace) => {
 	        for (let foundCard of game.drawCardsByTag(Tags.PLANT,2)) {

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class GalileanMining extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN];
     public name: string = "Galilean Mining";
-    public text: string = "Increase your titanium production 2 steps. Pay 5 MC.";
-    public requirements: undefined;
-    public description: string = "The big moons of Jupiter are great for mining";
     public play(player: Player, _game: Game) {     
             player.titaniumProduction +=2;	
             player.megaCredits -=5;		

--- a/src/cards/prelude/GreatAquifer.ts
+++ b/src/cards/prelude/GreatAquifer.ts
@@ -9,9 +9,6 @@ import { SelectSpace } from "../../inputs/SelectSpace";
 export class GreatAquifer extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Great Aquifer";
-    public text: string = "Place 2 ocean tiles.";
-    public requirements: undefined;
-    public description: string = "We found a big one !";
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for first ocean tile", game.getAvailableSpacesForOcean(player), (space: ISpace) => {
             game.addOceanTile(player, space.id);

--- a/src/cards/prelude/HousePrinting.ts
+++ b/src/cards/prelude/HousePrinting.ts
@@ -11,9 +11,6 @@ export class HousePrinting implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "House Printing";
     public cardType: CardType = CardType.AUTOMATED;
-    public text: string = "Increase your steel production 1 step. Gain 1 victory point.";
-    public requirements: undefined;
-    public description: string = "Large scale 3D printing - on Mars";
     public canPlay(): boolean {
         return true;
     }

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class HugeAsteroid extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Huge Asteroid";
-    public text: string = "Increase Temperature 3 steps. Pay 5 MC.";
-    public requirements: undefined;
-    public description: string = "Deep impact on Mars before too many move here";
     public play(player: Player, game: Game) {
       player.megaCredits -=5;	
 		  return game.increaseTemperature(player, 3);

--- a/src/cards/prelude/IoResearchOutpost.ts
+++ b/src/cards/prelude/IoResearchOutpost.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class IoResearchOutpost extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN];
     public name: string = "Io Research Outpost";
-    public text: string = "Increase your titanium production 1 step. Draw 1 card.";
-    public requirements: undefined;
-    public description: string = "Exploring the most volcanic place of the solar system";
     public play(player: Player, game: Game) {     
         player.titaniumProduction++;
         player.cardsInHand.push(game.dealer.dealCard());

--- a/src/cards/prelude/LavaTubeSettlement.ts
+++ b/src/cards/prelude/LavaTubeSettlement.ts
@@ -14,9 +14,6 @@ export class LavaTubeSettlement implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL, Tags.CITY];
     public name: string = "Lava Tube Settlement";
     public cardType: CardType = CardType.AUTOMATED;
-    public text: string = "Decrease your energy production 1 step and increase your MC production 2 steps. Place a City Tile on a VOLCANIC AREA regardless of adjacent cities.";
-    public requirements: undefined;
-    public description: string = "Giant lava tubes can provide protection for early settlement on Mars";
 
     private getAvailableSpaces(player: Player, game: Game): Array<ISpace> {
         return game.getSpaces(SpaceType.LAND)

--- a/src/cards/prelude/Loan.ts
+++ b/src/cards/prelude/Loan.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Loan extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Loan";
-    public text: string = "Gain 30 MC. Decrease your MC production 2 steps.";
-    public requirements: undefined;
-    public description: string = "If your outgo exceeds your income, your upkeep will be your downfall";
     public canPlay(player: Player): boolean {
         return player.megaCreditProduction >= -3;
     }    

--- a/src/cards/prelude/MartianIndustries.ts
+++ b/src/cards/prelude/MartianIndustries.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class MartianIndustries extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Martian Industries";
-    public text: string = "Increase energy and stell production 1 step. Gain 6 MC.";
-    public requirements: undefined;
-    public description: string = "Allowing a steely growth of the Martian society";
     public play(player: Player, _game: Game) {
         player.energyProduction++ ;
 	    player.steelProduction++ ;

--- a/src/cards/prelude/MartianSurvey.ts
+++ b/src/cards/prelude/MartianSurvey.ts
@@ -11,9 +11,6 @@ export class MartianSurvey implements IProjectCard {
     public tags: Array<Tags> = [Tags.SCIENCE];
     public name: string = "Martian Survey";
     public cardType: CardType = CardType.EVENT;
-    public text: string = "Oxygen must be 4% or lower. Draw two cards.";
-    public requirements: string = "4% or less Oxygen";
-    public description: string = "A thorough investigation of the geology of Mars";
     public canPlay(player: Player, game: Game): boolean {
 		return game.getOxygenLevel() <= 4 + player.getRequirementsBonus(game);
     }

--- a/src/cards/prelude/MetalRichAsteroid.ts
+++ b/src/cards/prelude/MetalRichAsteroid.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class MetalRichAsteroid extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Metal-Rich Asteroid";
-    public text: string = "Increase temperature 1 step. Gain 4 titanium and 4 steel.";
-    public requirements: undefined;
-    public description: string = "Metal delivery. Without brakes";
     public play(player: Player, game: Game) {
 		player.titanium += 4;
 		player.steel += 4;

--- a/src/cards/prelude/MetalsCompany.ts
+++ b/src/cards/prelude/MetalsCompany.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class MetalsCompany extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Metals Company";
-    public text: string = "Increase your MC, steel and titanium production 1 step.";
-    public requirements: undefined;
-    public description: string = "Your accreditation to this company connects you to the whole metal market";
     public play(player: Player, _game: Game) {     
         player.megaCreditProduction++;
         player.titaniumProduction++;

--- a/src/cards/prelude/MiningOperations.ts
+++ b/src/cards/prelude/MiningOperations.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class MiningOperations extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Mining Operations";
-    public text: string = "Increase your steel production 2 steps. Gain 4 steel.";
-    public requirements: undefined;
-    public description: string = "Your castle is made of metal";
     public play(player: Player, _game: Game) {     
         player.steelProduction += 2;
         player.steel += 4;

--- a/src/cards/prelude/Mohole.ts
+++ b/src/cards/prelude/Mohole.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Mohole extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Mohole";
-    public text: string = "Increase your heat production 3 steps. Gain 3 heat.";
-    public requirements: undefined;
-    public description: string = "Getting down to the heat of the mantle";
     public play(player: Player, _game: Game) {     
         player.heatProduction +=3;
         player.heat += 3;

--- a/src/cards/prelude/MoholeExcavation.ts
+++ b/src/cards/prelude/MoholeExcavation.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class MoholeExcavation extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Mohole Excavation";
-    public text: string = "Increase your steel production 1 step and your heat production 2 steps. Gain 2 heat.";
-    public requirements: undefined;
-    public description: string = "Making use of all the minerals you're digging up";
     public play(player: Player, _game: Game) {     
         player.steelProduction++;
         player.heatProduction += 2;

--- a/src/cards/prelude/NitrogenDelivery.ts
+++ b/src/cards/prelude/NitrogenDelivery.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class NitrogenDelivery extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Nitrogen Shipment";
-    public text: string = "Increase your TR and plant production 1 step. Gain 5 MC.";
-    public requirements: undefined;
-    public description: string = "Deliver it to get the air pressure up";
     public play(player: Player, _game: Game) {     
         player.megaCredits += 5;
         player.terraformRating++;

--- a/src/cards/prelude/OrbitalConstructionYard.ts
+++ b/src/cards/prelude/OrbitalConstructionYard.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class OrbitalConstructionYard extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: string = "Orbital Construction Yard";
-    public text: string = "Increase your titanium production 1 step. Gain 4 titanium.";
-    public requirements: undefined;
-    public description: string = "Materials arrive to Earth orbit from all around the solar system, to be assembled into interplanerary vessels";
     public play(player: Player, _game: Game) {
         player.titaniumProduction++;
         player.titanium +=4;	

--- a/src/cards/prelude/PointLuna.ts
+++ b/src/cards/prelude/PointLuna.ts
@@ -9,9 +9,6 @@ export class PointLuna implements CorporationCard {
     public name: string = "Point Luna";
     public tags: Array<Tags> = [Tags.SPACE, Tags.EARTH];
     public startingMegaCredits: number = 38;
-    public text: string = "You start with 1 titanium production and 38 MC. Effect: When you play an Earth tag, including this, draw a card.";
-    public requirements: undefined;
-    public description: string = "The moon is a perfect springboard to the solar system, and the mining company Point Luna has the largest spaceport on Luna, making it a perfect partner for Earth inventors wanting to realize their space projects";
 
     public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
         if (card.tags.indexOf(Tags.EARTH) !== -1) {

--- a/src/cards/prelude/PolarIndustries.ts
+++ b/src/cards/prelude/PolarIndustries.ts
@@ -9,9 +9,6 @@ import { SelectSpace } from "../../inputs/SelectSpace";
 export class PolarIndustries extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Polar Industries";
-    public text: string = "Place an ocean tile and and increase heat production 2 steps";
-    public requirements: undefined;
-    public description: string = "The poles of Mars have an abundance of both water and carbon dioxide ready to be taken";
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for ocean", game.getAvailableSpacesForOcean(player), (space: ISpace) => {
             game.addOceanTile(player, space.id);

--- a/src/cards/prelude/PowerGeneration.ts
+++ b/src/cards/prelude/PowerGeneration.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class PowerGeneration extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: string = "Power Generation";
-    public text: string = "Increase your energy production 3 steps.";
-    public requirements: undefined;
-    public description: string = "A solid base for your energy needs";
     public play(player: Player, _game: Game) {     
         player.energyProduction += 3;
         return undefined;

--- a/src/cards/prelude/ResearchCoordination.ts
+++ b/src/cards/prelude/ResearchCoordination.ts
@@ -10,9 +10,6 @@ export class ResearchCoordination implements IProjectCard {
     public tags: Array<Tags> = [Tags.WILDCARD];
     public name: string = "Research Coordination";
     public cardType: CardType = CardType.AUTOMATED;
-    public text: string = "After being played, when you perform an action, the wildcard tag counts as any tag of your choice.";
-    public requirements: undefined;
-    public description: string = "By combining different competences, many projects may benefit in new ways";
     public canPlay(): boolean {
         return true;
     }

--- a/src/cards/prelude/ResearchNetwork.ts
+++ b/src/cards/prelude/ResearchNetwork.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class ResearchNetwork extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.WILDCARD];
     public name: string = "Research Network";
-    public text: string = "Increase your money production 1 step. Draw 3 cards.";
-    public requirements: undefined;
-    public description: string = "Having the right connections for every scientific problem";
     public play(player: Player, game: Game) {     
         player.megaCreditProduction++;
         for (let i = 0; i < 3; i++) {

--- a/src/cards/prelude/SFMemorial.ts
+++ b/src/cards/prelude/SFMemorial.ts
@@ -11,9 +11,6 @@ export class SFMemorial implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "SF Memorial";
     public cardType: CardType = CardType.AUTOMATED;
-    public text: string = "Draw 1 card. Gain 1 victory point.";
-    public requirements: undefined;
-    public description: string = "A tribute to those who inspired us to come";
     public canPlay(): boolean {
         return true;
     }

--- a/src/cards/prelude/SelfSufficientSettlement.ts
+++ b/src/cards/prelude/SelfSufficientSettlement.ts
@@ -9,9 +9,6 @@ import { ISpace } from "../../ISpace";
 export class SelfSufficientSettlement extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL, Tags.CITY];
     public name: string = "Self-Sufficient Settlement";
-    public text: string = "Place a city tile. Increase your MC production 2 steps.";
-    public requirements: undefined;
-    public description: string = "The investment was high, but it's paying off now";
     public play(player: Player, game: Game) {     
         return new SelectSpace("Select space for city tile", game.getAvailableSpacesOnLand(player), (space: ISpace) => {
             game.addCityTile(player, space.id);

--- a/src/cards/prelude/SmeltingPlant.ts
+++ b/src/cards/prelude/SmeltingPlant.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class SmeltingPlant extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: string = "Smelting Plant";
-    public text: string = "Raise oxygen 2 steps. Gain 5 steel.";
-    public requirements: undefined;
-    public description: string = "A prototype facility for electrolyzing regolith into oxygen and iron";
     public play(player: Player, game: Game) {     
         player.steel += 5;
         return game.increaseOxygenLevel(player, 2);

--- a/src/cards/prelude/SocietySupport.ts
+++ b/src/cards/prelude/SocietySupport.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class SocietySupport extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Society Support";
-    public text: string = "Decrease your MC production 1 step and increase plant, energy and heat production 1 step.";
-    public requirements: undefined;
-    public description: string = "Meeting the needs of society is good, because it's your society";
     public play(player: Player, _game: Game) {     
         player.megaCreditProduction--;
         player.plantProduction++;

--- a/src/cards/prelude/SpaceHotels.ts
+++ b/src/cards/prelude/SpaceHotels.ts
@@ -10,9 +10,6 @@ export class SpaceHotels implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE, Tags.EARTH];
     public name: string = "Space Hotels";
     public cardType: CardType = CardType.AUTOMATED;
-    public text: string = "Requires 2 Earth tags. Increase MC production 4 steps";
-    public requirements: string = "2 Earth";
-    public description: string = "Space tourism was one of the most important sources of income for the space industry";
     public canPlay(player: Player): boolean {
        return player.getTagCount(Tags.EARTH) >= 2; 
     }

--- a/src/cards/prelude/Supplier.ts
+++ b/src/cards/prelude/Supplier.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class Supplier extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: string = "Supplier";
-    public text: string = "Increase energy production 2 steps. Gain 4 steel.";
-    public requirements: undefined;
-    public description: string = "A subcontractor provides power and material for your project";
     public play(player: Player, _game: Game) {
         player.energyProduction +=2;
         player.steel +=4;

--- a/src/cards/prelude/SupplyDrop.ts
+++ b/src/cards/prelude/SupplyDrop.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class SupplyDrop extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: string = "Supply Drop";
-    public text: string = "Gain 3 titanium, 8 steel and 3 plants.";
-    public requirements: undefined;
-    public description: string = "Let you speed up the colonization";
     public play(player: Player, _game: Game) {
         player.titanium +=3;
         player.steel +=8;

--- a/src/cards/prelude/UNMIContractor.ts
+++ b/src/cards/prelude/UNMIContractor.ts
@@ -7,9 +7,6 @@ import { IProjectCard } from "../IProjectCard";
 export class UNMIContractor extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: string = "UNMI Contractor";
-    public text: string = "Raise your terraform rating 3 steps. Draw 1 card.";
-    public requirements: undefined;
-    public description: string = "Your early terraforming work for UNMI is taken into account by the ???? Committee";
     public play(player: Player, game: Game) {
         player.terraformRating += 3;
 	    player.cardsInHand.push(game.dealer.dealCard());

--- a/src/cards/prelude/ValleyTrust.ts
+++ b/src/cards/prelude/ValleyTrust.ts
@@ -10,9 +10,6 @@ export class ValleyTrust implements CorporationCard {
     public name: string = "Valley Trust";
     public tags: Array<Tags> = [Tags.EARTH];
     public startingMegaCredits: number = 37;
-    public text: string = "You start with 37 MC. As your first action, draw 3 Prelude cards, and play one of them. Discard the other two. Effect: When you play an Science tag, you pay 2MC less for it.";
-    public requirements: undefined;
-    public description: string = "A community of technological entrepreneurs join forces to invest in space exploration";
 
     public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
         if (card.tags.indexOf(Tags.SCIENCE) !== -1) {

--- a/src/cards/prelude/Vitor.ts
+++ b/src/cards/prelude/Vitor.ts
@@ -12,9 +12,6 @@ export class Vitor implements CorporationCard {
     public name: string = "Vitor";
     public tags: Array<Tags> = [Tags.EARTH];
     public startingMegaCredits: number = 45;
-    public text: string = "You start with 45 MC. As your first action, fund an award for free. Effect: When you play a card with a NON-NEGATIVE VP icon, including this, gain 3MC";
-    public requirements: undefined;
-    public description: string = "A corporation grown from crowd funding of new innovations. Always inclined to initiate projects to gain public support as well as innovation prizes";
 
     public initialAction(player: Player, game: Game) {        
         const freeAward = new OrOptions();

--- a/styles.css
+++ b/styles.css
@@ -400,14 +400,9 @@ border-right: 2px solid rgb(137,137,137);
                 content: "\25b2";
           }
 
-.project-icon:after {
-  margin-left: 10px;
+.project-icon:after, .preludeCard-icon:after {
+  margin-left: -235px;
   margin-top: 284px;
-}
-
-.preludeCard-icon:after {
-  margin-left: 10px;
-  margin-top: 214px;
 }
 
 .corporation-icon:after {


### PR DESCRIPTION
Used this but it needs some review as multi line text will not be handled:

for i in grep "public requirements" *.ts | cut -d ':' -f1
do
sed -i '/description: string/d' $i
sed -i '/public requirements:/d' $i
sed -i '/public actionText:/d' $i
sed -i '/public text: string =/d' $i
done