### PR TITLE
Show game log for all actions #96

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -711,6 +711,7 @@ export class Player {
                 this.actionsThisGeneration.add(foundCard.name);
                 this.actionsTakenThisRound++;
               }
+              game.log(this.name + " used " + foundCard.name + " action");
               this.takeAction(game);
             };
             if (action !== undefined) {
@@ -718,7 +719,6 @@ export class Player {
               return action;
             }
             whenDone();
-            game.log(this.name + " used " + foundCard.name + " action");
             return undefined;
           }
       );


### PR DESCRIPTION
Actions were not being displayed in the game log for actions which had subsequent actions such as  `AndOptions`. This is now resolved by always logging the action in the `whenDone` function.