### PR TITLE
Add science tag to IoResearchOutput #94

### DIFF
--- a/src/cards/prelude/IoResearchOutpost.ts
+++ b/src/cards/prelude/IoResearchOutpost.ts
@@ -5,7 +5,7 @@ import { PreludeCard } from "./PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 
 export class IoResearchOutpost extends PreludeCard implements IProjectCard {
-    public tags: Array<Tags> = [Tags.JOVIAN];
+    public tags: Array<Tags> = [Tags.JOVIAN, Tags.SCIENCE];
     public name: string = "Io Research Outpost";
     public play(player: Player, game: Game) {     
         player.titaniumProduction++;


### PR DESCRIPTION
The IoResearchOutpost card was missing a Tags.SCIENCE from it's metadata. It was being displayed fine but not included in game logic.