### PR TITLE
2 bug fixes

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1203,7 +1203,7 @@ export class Player {
 
       if (
         this.canAfford(constants.CITY_COST) &&
-            game.getAvailableSpacesForGreenery(this).length > 0) {
+            game.getAvailableSpacesForCity(this).length > 0) {
         standardProjects.options.push(
             this.addCity(game)
         );

--- a/src/cards/Shuttles.ts
+++ b/src/cards/Shuttles.ts
@@ -8,7 +8,7 @@ import { Game } from "../Game";
 export class Shuttles implements IProjectCard {
     public cost: number = 10;
     public nonNegativeVPIcon: boolean = true;
-    public tags: Array<Tags> = [Tags.SCIENCE];
+    public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.ACTIVE;
     public name: string = "Shuttles";
     public canPlay(player: Player, game: Game): boolean {


### PR DESCRIPTION
- Shuttles tag was science instead of space
- Bug with standard city project (this one was funny, I only had a tile on Phobos, so the game did not let me put a greenery / city on the board). I think getAvailableSpacesOnLand should not take Phobos and Ganymede into account...