### PR TITLE
Better OrOptions for use within AndOptions for #148

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -243,9 +243,10 @@ export class Player {
       } else if (pi instanceof OrOptions) {
         const waiting: OrOptions = pi;
         const optionIndex = parseInt(input[0][0]);
-        const remainingInput = input.slice();
-        remainingInput.splice(0, 1);
-        return this.runInput(remainingInput, waiting.options[optionIndex]);
+        const remainingInput = input[0].slice();
+        // Remove option index to process option
+        remainingInput.shift();
+        return this.runInput([remainingInput], waiting.options[optionIndex]);
       } else if (pi instanceof SelectHowToPayForCard) {
         if (input.length !== 1 || input[0].length !== 2) {
           throw new Error('Incorrect options provided');

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -34,7 +34,9 @@ export const OrOptions = Vue.component("or-options", {
                 createElement("span", option.title)
             ]));
             subchildren.push(createElement("div", { style: { display: "none", marginLeft: "30px" } }, [new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
-                this.onsave([[String(idx)]].concat(out));
+                const copy = out[0].slice();
+                copy.unshift(String(idx));
+                this.onsave([copy]);
             }, false)]));
             optionElements.push(subchildren[subchildren.length - 1]);
             children.push(createElement("div", subchildren));


### PR DESCRIPTION
When `OrOptions` was an option within `AndOptions` we would lose some of the selected items. This change to `OrOptions` should ensure data is not lost when using `OrOptions` inside an `AndOptions`.