### PR TITLE
Better AndOptions with only one save button!

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -391,11 +391,9 @@ export class Player {
           mappedCards.push(this.getCard(pi.cards, cardName));
         }
         if (input[0].length < pi.minCardsToSelect) {
-          console.warn('selected cards', input[0]);
           throw new Error('Not enough cards selected');
         }
         if (input[0].length > pi.maxCardsToSelect) {
-          console.warn('selected cards', input[0]);
           throw new Error('Too many cards selected');
         }
         if (mappedCards.length !== input[0].length) {
@@ -1675,7 +1673,6 @@ export class Player {
           waitingFor.onend();
         }
       } catch (err) {
-        console.warn('Error running input', err);
         this.waitingFor = waitingFor;
         throw err;
       }

--- a/src/components/AndOptions.ts
+++ b/src/components/AndOptions.ts
@@ -4,28 +4,34 @@ import { PlayerInputFactory } from "./PlayerInputFactory";
 import { PlayerInputModel } from "../models/PlayerInputModel";
 
 export const AndOptions = Vue.component("and-options", {
-    props: ["player", "players", "playerinput", "onsave", "showtitle"],
+    props: ["player", "players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
+            childComponents: [],
             responded: {} as {[x: string]: Array<string>}
         };
     },
     methods: {
-        saveData: function (inputChildren: Array<VNode>) {
-            for (var i = 0; i < inputChildren.length; i++) {
-                const componentInstance = inputChildren[i].componentInstance;
+        saveData: function () {
+            for (var i = 0; i < this.$data.childComponents.length; i++) {
+                const componentInstance = this.$data.childComponents[i].componentInstance;
                 if (componentInstance !== undefined) {
-                    if ((componentInstance as any).selectCards instanceof Function) {
-                        (componentInstance as any).selectCards();
+                    if ((componentInstance as any).saveData instanceof Function) {
+                        (componentInstance as any).saveData();
                     }
                 }
             }
+            const res: Array<Array<string>> = [];
+            for (let i = 0; i < this.playerinput.options.length; i++) {
+                res.push(this.responded["" + i]);
+            }
+            this.onsave(res);
         }
     },
     render: function(createElement) {
         const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
         const children: Array<VNode> = [];
-        const inputChildren: Array<VNode> = [];
+        this.$data.childComponents = [];
         if (this.showtitle) {
             children.push(createElement("div", playerInput.title));
         }
@@ -35,19 +41,14 @@ export const AndOptions = Vue.component("and-options", {
                 if (this.responded[idx] === undefined) {
                     children.push(new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
                         this.responded[idx] = out[0];
-                        if (Object.keys(this.responded).length === options.length) {
-                            let res: Array<Array<string>> = [];
-                            for (let i = 0; i < options.length; i++) {
-                                res.push(this.responded["" + i]);
-                            }
-                            this.onsave(res);
-                        }
                     }, false, true));
-                    inputChildren.push(children[children.length - 1]);
+                    this.$data.childComponents.push(children[children.length - 1]);
                 }
             });
         }
-        children.push(createElement("div", [createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.saveData(inputChildren); } } }, "Save")]));
+        if (this.showsave) {
+            children.push(createElement("div", [createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.saveData(); } } }, "Save")]));
+        }
         return createElement("div", children);
     }
 });

--- a/src/components/AndOptions.ts
+++ b/src/components/AndOptions.ts
@@ -10,9 +10,22 @@ export const AndOptions = Vue.component("and-options", {
             responded: {} as {[x: string]: Array<string>}
         };
     },
+    methods: {
+        saveData: function (inputChildren: Array<VNode>) {
+            for (var i = 0; i < inputChildren.length; i++) {
+                const componentInstance = inputChildren[i].componentInstance;
+                if (componentInstance !== undefined) {
+                    if ((componentInstance as any).selectCards instanceof Function) {
+                        (componentInstance as any).selectCards();
+                    }
+                }
+            }
+        }
+    },
     render: function(createElement) {
         const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
         const children: Array<VNode> = [];
+        const inputChildren: Array<VNode> = [];
         if (this.showtitle) {
             children.push(createElement("div", playerInput.title));
         }
@@ -29,10 +42,12 @@ export const AndOptions = Vue.component("and-options", {
                             }
                             this.onsave(res);
                         }
-                    }, true));
+                    }, false, true));
+                    inputChildren.push(children[children.length - 1]);
                 }
             });
         }
+        children.push(createElement("div", [createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.saveData(inputChildren); } } }, "Save")]));
         return createElement("div", children);
     }
 });

--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -39,21 +39,40 @@ export const Board = Vue.component("board", {
     template: `
     <div class="board_cont">
         <div class="board" id="main_board">
-            <bonus v-for="space in getSpacesWithBonus()" :space="space" :key="getKey('bonus', space)"></bonus>
             <tile v-for="space in getSpacesWithTile()" :space="space" :key="getKey('tile', space)"></tile>
+            <bonus v-for="space in getSpacesWithBonus()" :space="space" :key="getKey('bonus', space)"></bonus>
             <svg height="470" width="450">
                 <defs>
                     <symbol id="hexagon">
                         <polygon points="24,48.5 45.3,36.5 45.3,13.5 24,2 3.5,13.5 3.5,36.5" fill="#fff" fill-opacity="0.01" stroke-width="3" stroke-opacity="0.4" />
-                        <polygon style="visibility: var(--board_space_visibility, hidden)" transform="scale(0.9, 0.9) translate(3, 3)" points="24,48.5 45.3,36.5 45.3,13.5 24,2 3.5,13.5 3.5,36.5" fill="none" stroke="#4f4" stroke-width="4" stroke-opacity="0.4">
+                        <polygon 
+                            style="visibility: var(--board_space_visibility, hidden)" 
+                            transform="scale(0.9, 0.9) translate(3, 3)" 
+                            points="24,48.5 45.3,36.5 45.3,13.5 24,2 3.5,13.5 3.5,36.5" 
+                            fill="none" 
+                            stroke="#4f4" 
+                            stroke-width="4" 
+                            stroke-opacity="0.4">
+
                             <animate
                                 attributeType="XML"
                                 attributeName="stroke"
                                 values="#e95c2e;#f9c4b3;#e95c2e;#e95c2e"
                                 dur="1.2s"
                                 repeatCount="indefinite"/>
+
+                        </polygon>
+                        <polygon 
+                            style="visibility: var(--board_space_selected, hidden)" 
+                            transform="scale(0.9, 0.9) translate(3, 3)" 
+                            points="24,48.5 45.3,36.5 45.3,13.5 24,2 3.5,13.5 3.5,36.5" 
+                            fill="none" 
+                            stroke="#3c3" 
+                            stroke-width="4" 
+                            stroke-opacity="0.7">
                         </polygon>
                     </symbol>
+
                 </defs>
                 <g transform="translate(1, 1)" id="main_grid">
                     <use v-for="space in getMainSpaces()"
@@ -65,7 +84,6 @@ export const Board = Vue.component("board", {
                         xlink:href="#hexagon" />
                 </g>
             </svg>
-
             <svg id="board_legend" height="470" width="450" class="board_legend">
 
                 <g id="ganymede_colony">

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -5,7 +5,7 @@ import { PlayerInputFactory } from "./PlayerInputFactory";
 let unique: number = 0;
 
 export const OrOptions = Vue.component("or-options", {
-    props: ["player", "players", "playerinput", "onsave", "showtitle"],
+    props: ["player", "players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             selectedOption: 0
@@ -37,7 +37,7 @@ export const OrOptions = Vue.component("or-options", {
                 const copy = out[0].slice();
                 copy.unshift(String(idx));
                 this.onsave([copy]);
-            }, false)]));
+            }, this.showsave, false)]));
             optionElements.push(subchildren[subchildren.length - 1]);
             children.push(createElement("div", subchildren));
         });

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -8,39 +8,62 @@ export const OrOptions = Vue.component("or-options", {
     props: ["player", "players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
+            childComponents: [],
             selectedOption: 0
         };
     },
+    methods: {
+        saveData: function () {
+            const componentInstance = this.$data.childComponents[this.$data.selectedOption].componentInstance;
+            if (componentInstance !== undefined) {
+                if ((componentInstance as any).saveData instanceof Function) {
+                    (componentInstance as any).saveData();
+                    return;
+                }
+            }
+            throw new Error("Unexpected unable to save data");
+        }
+    },
     render: function (createElement) {
         unique++;
+        this.$data.childComponents = [];
         const children: Array<VNode> = [];
         if (this.showtitle) {
             children.push(createElement('label', [createElement("div", this.playerinput.title)]))
         }
         const optionElements: Array<VNode> = [];
         this.playerinput.options.forEach((option: any, idx: number) => {
+            const domProps: any = {
+                className: "nes-radio",
+                name: "selectOption" + unique,
+                type: "radio",
+                value: String(idx)
+            };
             const subchildren: Array<VNode> = [];
+            if (this.$data.selectedOption === idx) {
+                domProps.checked = true;
+            }
             subchildren.push(createElement("label", [
-                createElement("input", { domProps: { className: "nes-radio", name: "selectOption" + unique, type: "radio", value: String(idx) }, on: { change: (event: any) => {
+                createElement("input", { style: { display: this.$data.selectedOption === idx ? "block": "none" }, domProps, on: { change: (event: any) => {
                     this.selectedOption = Number(event.target.value);
                     optionElements.forEach((optionElement, optionIdx) => {
-                        if (optionIdx === this.selectedOption) {
-                            (optionElement.elm as HTMLElement).style.display = "block";
-                        } else {
-                            (optionElement.elm as HTMLElement).style.display = "none";
-                        }
+                        (optionElement.elm as HTMLElement).style.display = (optionIdx === this.selectedOption ? "block" : "none");
                     });
                 }}}),
                 createElement("span", option.title)
             ]));
-            subchildren.push(createElement("div", { style: { display: "none", marginLeft: "30px" } }, [new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
+            this.$data.childComponents.push(new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
                 const copy = out[0].slice();
                 copy.unshift(String(idx));
                 this.onsave([copy]);
-            }, this.showsave, false)]));
+            }, false, false));
+            subchildren.push(createElement("div", { style: { display: "none", marginLeft: "30px" } }, [this.$data.childComponents[this.$data.childComponents.length - 1]]));
             optionElements.push(subchildren[subchildren.length - 1]);
             children.push(createElement("div", subchildren));
         });
+        if (this.showsave) {
+            children.push(createElement("div", [createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.saveData(); } } }, "Save")]));
+        }
         return createElement("div", children);
     }
 });

--- a/src/components/PlayerInputFactory.ts
+++ b/src/components/PlayerInputFactory.ts
@@ -29,10 +29,10 @@ export class PlayerInputFactory {
                 throw "Unsupported input type";
         }
     }
-    public getPlayerInput(createElement: typeof Vue.prototype.$createElement, players: Array<PlayerModel>, player: PlayerModel, playerinput: PlayerInputModel, onsave: (out: Array<Array<string>>) => void, showtitle: boolean): VNode {
+    public getPlayerInput(createElement: typeof Vue.prototype.$createElement, players: Array<PlayerModel>, player: PlayerModel, playerinput: PlayerInputModel, onsave: (out: Array<Array<string>>) => void, showsave: boolean, showtitle: boolean): VNode {
         return createElement(this.getComponentName(playerinput.inputType), {
             attrs: {
-                player, players, playerinput, showtitle, onsave
+                player, players, playerinput, showsave, showtitle, onsave
             }
         });
     }

--- a/src/components/SelectAmount.ts
+++ b/src/components/SelectAmount.ts
@@ -2,7 +2,7 @@
 import Vue from "vue";
 
 export const SelectAmount = Vue.component("select-amount", {
-    props: ["playerinput", "onsave", "showtitle"],
+    props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             amount: 0
@@ -17,7 +17,7 @@ export const SelectAmount = Vue.component("select-amount", {
         <div>
             <div v-if="showtitle === true">{{playerinput.title}}</div>
             <input type="number" class="nes-input" value="0" min="0" :max="playerinput.max" v-model="amount" />
-            <button class="nes-btn" v-on:click="saveAmount">Save</button> 
+            <button v-if="showsave === true" class="nes-btn" v-on:click="saveAmount">Save</button> 
         </div>
     `
 });

--- a/src/components/SelectAmount.ts
+++ b/src/components/SelectAmount.ts
@@ -9,16 +9,14 @@ export const SelectAmount = Vue.component("select-amount", {
         };
     },
     methods: {
-        saveAmount: function () {
+        saveData: function () {
             this.onsave([[parseInt(this.$data.amount)]]);
         }
     },
-    template: `
-        <div>
-            <div v-if="showtitle === true">{{playerinput.title}}</div>
-            <input type="number" class="nes-input" value="0" min="0" :max="playerinput.max" v-model="amount" />
-            <button v-if="showsave === true" class="nes-btn" v-on:click="saveAmount">Save</button> 
-        </div>
-    `
+    template: `<div>
+  <div v-if="showtitle === true">{{playerinput.title}}</div>
+  <input type="number" class="nes-input" value="0" min="0" :max="playerinput.max" v-model="amount" />
+  <button v-if="showsave === true" class="nes-btn" v-on:click="saveData">Save</button> 
+</div>`
 });
 

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -8,7 +8,7 @@ interface SelectCardModel {
 import { Card } from "./Card";
 
 export const SelectCard = Vue.component("select-card", {
-    props: ["playerinput", "onsave", "showtitle"],
+    props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             cards: []
@@ -30,7 +30,7 @@ export const SelectCard = Vue.component("select-card", {
                 <input v-else class="nes-checkbox" type="checkbox" v-model="cards" :value="card" :disabled="cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
                 <card :card="card"></card>
             </label>
-            <div class="nofloat">
+            <div v-if="showsave === true" class="nofloat">
                 <button class="nes-btn" v-on:click="selectCards">Save</button>
             </div>
         </div>

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -18,22 +18,20 @@ export const SelectCard = Vue.component("select-card", {
         "card": Card
     },
     methods: {
-        selectCards: function () {
+        saveData: function () {
             this.onsave([Array.isArray(this.$data.cards) ? this.$data.cards : [this.$data.cards]]);
         }
     },
-    template: `
-        <div>
-            <div v-if="showtitle === true" class="nofloat">{{playerinput.title}}</div>
-            <label v-for="card in playerinput.cards" :key="card" class="cardbox">
-                <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" class="nes-radio" type="radio" v-model="cards" :value="card" />
-                <input v-else class="nes-checkbox" type="checkbox" v-model="cards" :value="card" :disabled="cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
-                <card :card="card"></card>
-            </label>
-            <div v-if="showsave === true" class="nofloat">
-                <button class="nes-btn" v-on:click="selectCards">Save</button>
-            </div>
-        </div>
-    `
+    template: `<div>
+  <div v-if="showtitle === true" class="nofloat">{{playerinput.title}}</div>
+  <label v-for="card in playerinput.cards" :key="card" class="cardbox">
+    <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" class="nes-radio" type="radio" v-model="cards" :value="card" />
+    <input v-else class="nes-checkbox" type="checkbox" v-model="cards" :value="card" :disabled="cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
+    <card :card="card"></card>
+  </label>
+  <div v-if="showsave === true" class="nofloat">
+    <button class="nes-btn" v-on:click="saveData">Save</button>
+  </div>
+</div>`
 });
 

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -14,7 +14,7 @@ interface SelectHowToPayModel {
 }
 
 export const SelectHowToPay = Vue.component("select-how-to-pay", {
-    props: ["player", "playerinput", "onsave", "showtitle"],
+    props: ["player", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             heat: 0,
@@ -76,42 +76,35 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
     template: `
     <div class="payments_cont"> 
         <section class="nes-container with-title" v-trim-whitespace>
-
             <h3 class="payments_title">"How to pay?"</h3>
-
             <div class="payments_type" v-if="playerinput.canUseSteel">
                 <i class="resource_icon resource_icon--steel payments_type_icon" title="Pay by Steel"></i>
                 <button class="nes-btn" v-on:click="reduceValue('steel', 1)" :class="getCssClassFor('<', 'steel')"><</button>
                 <input class="nes-input payments_input" v-model.number="steel" />
                 <button class="nes-btn" v-on:click="addValue('steel', 1)" :class="getCssClassFor('>', 'steel')">></button>
             </div>
-
             <div class="payments_type" v-if="playerinput.canUseTitanium">
                 <i class="resource_icon resource_icon--titanium payments_type_icon" title="Pay by Titanium"></i>
                 <button class="nes-btn" v-on:click="reduceValue('titanium', 1)" :class="getCssClassFor('<', 'titanium')"><</button>
                 <input class="nes-input payments_input" v-model.number="titanium" />
                 <button class="nes-btn" v-on:click="addValue('titanium', 1)" :class="getCssClassFor('>', 'titanium')">></button>
             </div>
-
             <div class="payments_type" v-if="playerinput.canUseHeat">
                 <i class="resource_icon resource_icon--heat payments_type_icon" title="Pay by Heat"></i>
                 <button class="nes-btn" v-on:click="reduceValue('heat', 1)" :class="getCssClassFor('<', 'heat')"><</button>
                 <input class="nes-input payments_input" v-model.number="heat" />
                 <button class="nes-btn" v-on:click="addValue('heat', 1)" :class="getCssClassFor('>', 'heat')">></button>
             </div>
-
             <div class="payments_type">
                 <i class="resource_icon resource_icon--megacredits payments_type_icon" title="Pay by Megacredits"></i>
                 <button class="nes-btn" v-on:click="reduceValue('megaCredits', 1)" :class="getCssClassFor('<', 'megaCredits')"><</button>
                 <input class="nes-input payments_input" v-model.number="megaCredits" />
                 <button class="nes-btn" v-on:click="addValue('megaCredits', 1)" :class="getCssClassFor('>', 'megaCredits')">></button>
             </div>
-
             <div v-if="hasWarning()" class="nes-container is-rounded">
                 <span class="nes-text is-warning">{{ warning }}</span>
             </div>
-
-            <div class="payments_save">
+            <div v-if="showsave === true" class="payments_save">
                 <button class="nes-btn" v-on:click="pay">Save</button>
             </div>
         </section>

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -34,7 +34,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         hasWarning: function () {
             return this.$data.warning !== undefined;
         },
-        pay: function () {
+        saveData: function () {
             const htp: HowToPay = {
                 heat: this.$data.heat,
                 megaCredits: this.$data.megaCredits,
@@ -73,42 +73,40 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
             this.onsave([[JSON.stringify(htp)]]);
         }
     },
-    template: `
-    <div class="payments_cont"> 
-        <section class="nes-container with-title" v-trim-whitespace>
-            <h3 class="payments_title">"How to pay?"</h3>
-            <div class="payments_type" v-if="playerinput.canUseSteel">
-                <i class="resource_icon resource_icon--steel payments_type_icon" title="Pay by Steel"></i>
-                <button class="nes-btn" v-on:click="reduceValue('steel', 1)" :class="getCssClassFor('<', 'steel')"><</button>
-                <input class="nes-input payments_input" v-model.number="steel" />
-                <button class="nes-btn" v-on:click="addValue('steel', 1)" :class="getCssClassFor('>', 'steel')">></button>
-            </div>
-            <div class="payments_type" v-if="playerinput.canUseTitanium">
-                <i class="resource_icon resource_icon--titanium payments_type_icon" title="Pay by Titanium"></i>
-                <button class="nes-btn" v-on:click="reduceValue('titanium', 1)" :class="getCssClassFor('<', 'titanium')"><</button>
-                <input class="nes-input payments_input" v-model.number="titanium" />
-                <button class="nes-btn" v-on:click="addValue('titanium', 1)" :class="getCssClassFor('>', 'titanium')">></button>
-            </div>
-            <div class="payments_type" v-if="playerinput.canUseHeat">
-                <i class="resource_icon resource_icon--heat payments_type_icon" title="Pay by Heat"></i>
-                <button class="nes-btn" v-on:click="reduceValue('heat', 1)" :class="getCssClassFor('<', 'heat')"><</button>
-                <input class="nes-input payments_input" v-model.number="heat" />
-                <button class="nes-btn" v-on:click="addValue('heat', 1)" :class="getCssClassFor('>', 'heat')">></button>
-            </div>
-            <div class="payments_type">
-                <i class="resource_icon resource_icon--megacredits payments_type_icon" title="Pay by Megacredits"></i>
-                <button class="nes-btn" v-on:click="reduceValue('megaCredits', 1)" :class="getCssClassFor('<', 'megaCredits')"><</button>
-                <input class="nes-input payments_input" v-model.number="megaCredits" />
-                <button class="nes-btn" v-on:click="addValue('megaCredits', 1)" :class="getCssClassFor('>', 'megaCredits')">></button>
-            </div>
-            <div v-if="hasWarning()" class="nes-container is-rounded">
-                <span class="nes-text is-warning">{{ warning }}</span>
-            </div>
-            <div v-if="showsave === true" class="payments_save">
-                <button class="nes-btn" v-on:click="pay">Save</button>
-            </div>
-        </section>
+    template: `<div class="payments_cont"> 
+  <section class="nes-container with-title" v-trim-whitespace>
+    <h3 class="payments_title">"How to pay?"</h3>
+    <div class="payments_type" v-if="playerinput.canUseSteel">
+      <i class="resource_icon resource_icon--steel payments_type_icon" title="Pay by Steel"></i>
+      <button class="nes-btn" v-on:click="reduceValue('steel', 1)" :class="getCssClassFor('<', 'steel')"><</button>
+      <input class="nes-input payments_input" v-model.number="steel" />
+      <button class="nes-btn" v-on:click="addValue('steel', 1)" :class="getCssClassFor('>', 'steel')">></button>
     </div>
-`
+    <div class="payments_type" v-if="playerinput.canUseTitanium">
+      <i class="resource_icon resource_icon--titanium payments_type_icon" title="Pay by Titanium"></i>
+      <button class="nes-btn" v-on:click="reduceValue('titanium', 1)" :class="getCssClassFor('<', 'titanium')">&lt;</button>
+      <input class="nes-input payments_input" v-model.number="titanium" />
+      <button class="nes-btn" v-on:click="addValue('titanium', 1)" :class="getCssClassFor('>', 'titanium')">></button>
+    </div>
+    <div class="payments_type" v-if="playerinput.canUseHeat">
+      <i class="resource_icon resource_icon--heat payments_type_icon" title="Pay by Heat"></i>
+      <button class="nes-btn" v-on:click="reduceValue('heat', 1)" :class="getCssClassFor('<', 'heat')"><</button>
+      <input class="nes-input payments_input" v-model.number="heat" />
+      <button class="nes-btn" v-on:click="addValue('heat', 1)" :class="getCssClassFor('>', 'heat')">></button>
+    </div>
+    <div class="payments_type">
+      <i class="resource_icon resource_icon--megacredits payments_type_icon" title="Pay by Megacredits"></i>
+      <button class="nes-btn" v-on:click="reduceValue('megaCredits', 1)" :class="getCssClassFor('<', 'megaCredits')"><</button>
+      <input class="nes-input payments_input" v-model.number="megaCredits" />
+      <button class="nes-btn" v-on:click="addValue('megaCredits', 1)" :class="getCssClassFor('>', 'megaCredits')">&gt;</button>
+    </div>
+    <div v-if="hasWarning()" class="nes-container is-rounded">
+      <span class="nes-text is-warning">{{ warning }}</span>
+    </div>
+    <div v-if="showsave === true" class="payments_save">
+      <button class="nes-btn" v-on:click="saveData">Save</button>
+    </div>
+  </section>
+</div>`
 });
 

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -18,7 +18,7 @@ import { Tags } from "../cards/Tags";
 import { PaymentWidgetMixin } from "./PaymentWidgetMixin";
 
 export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card", {
-    props: ["player", "playerinput", "onsave", "showtitle"],
+    props: ["player", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             card: this.playerinput.cards[0],
@@ -214,7 +214,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             <span class="nes-text is-warning">{{ warning }}</span>
         </div>
 
-        <div class="payments_save">
+        <div v-if="showsave === true" class="payments_save">
             <button class="nes-btn" v-on:click="save">Save</button>
         </div>
     </section>

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -97,7 +97,6 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             }
             return false;			
         },
-
         cardChanged: function () {
             this.$data.megaCredits = this.getCardCost();
             
@@ -110,7 +109,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         hasWarning: function () {
             return this.$data.warning !== undefined;
         },
-        save: function () {
+        saveData: function () {
             const htp: HowToPay = {
                 heat: this.$data.heat,
                 megaCredits: this.$data.megaCredits,
@@ -153,72 +152,57 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             ]]);
         }
     },
-    template: `
-<div class="payments_cont">
-
-    <div v-if="showtitle === true">{{playerinput.title}}</div>
-
-    <label v-for="availableCard in playerinput.cards" :key="availableCard" class="payments_cards">
-        <input class="nes-radio" type="radio" v-model="card" v-on:change="cardChanged()" :value="availableCard" />
-        <card class="cardbox" :card="availableCard"></card>
-    </label>
-  
-    <section class="nes-container with-title" v-trim-whitespace>
-
-        <h3 class="payments_title">How to pay?</h3>
-
-        <div class="payments_type" v-if="canUseSteel()">
-            <i class="resource_icon resource_icon--steel payments_type_icon" title="Pay by Steel"></i>
-            <button class="nes-btn" v-on:click="reduceValue('steel', 1)" :class="getCssClassFor('<', 'steel')"><</button>
-            <input class="nes-input payments_input" v-model.number="steel" />
-            <button class="nes-btn" v-on:click="addValue('steel', 1)" :class="getCssClassFor('>', 'steel')">></button>
-        </div>
-
-        <div class="payments_type" v-if="canUseTitanium()">
-            <i class="resource_icon resource_icon--titanium payments_type_icon" title="Pay by Titanium"></i>
-            <button class="nes-btn" v-on:click="reduceValue('titanium', 1)" :class="getCssClassFor('<', 'titanium')"><</button>
-            <input class="nes-input payments_input" v-model.number="titanium" />
-            <button class="nes-btn" v-on:click="addValue('titanium', 1)" :class="getCssClassFor('>', 'titanium')">></button>
-        </div>
-
-        <div class="payments_type" v-if="canUseHeat()">
-            <i class="resource_icon resource_icon--heat payments_type_icon" title="Pay by Heat"></i>
-            <button class="nes-btn" v-on:click="reduceValue('heat', 1)" :class="getCssClassFor('<', 'heat')"><</button>
-            <input class="nes-input payments_input" v-model.number="heat" />
-            <button class="nes-btn" v-on:click="addValue('heat', 1)" :class="getCssClassFor('>', 'heat')">></button>
-        </div>
-
-
-        <div class="payments_type" v-if="canUseMicrobes()">
-            <i class="resource_icon resource_icon--microbe payments_type_icon" title="Pay by Microbes"></i>
-            <button class="nes-btn" v-on:click="reduceValue('microbes', 1)" :class="getCssClassFor('<', 'microbes')"><</button>
-            <input class="nes-input payments_input" v-model.number="microbes" />
-            <button class="nes-btn" v-on:click="addValue('microbes', 1)" :class="getCssClassFor('>', 'microbes')">></button>
-        </div>
-
-        <div class="payments_type" v-if="canUseFloaters()">
-            <i class="resource_icon resource_icon--floater payments_type_icon" title="Pay by Floaters"></i>
-            <button class="nes-btn" v-on:click="reduceValue('floaters', 1)" :class="getCssClassFor('<', 'floaters')"><</button>
-            <input class="nes-input payments_input" v-model.number="floaters" />
-            <button class="nes-btn" v-on:click="addValue('floaters', 1)" :class="getCssClassFor('>', 'floaters')">></button>
-        </div>
-
-        <div class="payments_type">
-            <i class="resource_icon resource_icon--megacredits payments_type_icon" title="Pay by Megacredits"></i>
-            <button class="nes-btn" v-on:click="reduceValue('megaCredits', 1)" :class="getCssClassFor('<', 'megaCredits')"><</button>
-            <input class="nes-input payments_input" v-model.number="megaCredits" />
-            <button class="nes-btn" v-on:click="addValue('megaCredits', 1)" :class="getCssClassFor('>', 'megaCredits')">></button>
-        </div>
-
-        <div v-if="hasWarning()" class="nes-container is-rounded">
-            <span class="nes-text is-warning">{{ warning }}</span>
-        </div>
-
-        <div v-if="showsave === true" class="payments_save">
-            <button class="nes-btn" v-on:click="save">Save</button>
-        </div>
-    </section>
-</div>
-`
+    template: `<div class="payments_cont">
+  <div v-if="showtitle === true">{{playerinput.title}}</div>
+  <label v-for="availableCard in playerinput.cards" :key="availableCard" class="payments_cards">
+    <input class="nes-radio" type="radio" v-model="card" v-on:change="cardChanged()" :value="availableCard" />
+    <card class="cardbox" :card="availableCard"></card>
+  </label>
+  <section class="nes-container with-title" v-trim-whitespace>
+    <h3 class="payments_title">How to pay?</h3>
+    <div class="payments_type" v-if="canUseSteel()">
+      <i class="resource_icon resource_icon--steel payments_type_icon" title="Pay by Steel"></i>
+      <button class="nes-btn" v-on:click="reduceValue('steel', 1)" :class="getCssClassFor('<', 'steel')"><</button>
+      <input class="nes-input payments_input" v-model.number="steel" />
+      <button class="nes-btn" v-on:click="addValue('steel', 1)" :class="getCssClassFor('>', 'steel')">></button>
+    </div>
+    <div class="payments_type" v-if="canUseTitanium()">
+      <i class="resource_icon resource_icon--titanium payments_type_icon" title="Pay by Titanium"></i>
+      <button class="nes-btn" v-on:click="reduceValue('titanium', 1)" :class="getCssClassFor('<', 'titanium')">&lt;</button>
+      <input class="nes-input payments_input" v-model.number="titanium" />
+      <button class="nes-btn" v-on:click="addValue('titanium', 1)" :class="getCssClassFor('>', 'titanium')">></button>
+    </div>
+    <div class="payments_type" v-if="canUseHeat()">
+      <i class="resource_icon resource_icon--heat payments_type_icon" title="Pay by Heat"></i>
+      <button class="nes-btn" v-on:click="reduceValue('heat', 1)" :class="getCssClassFor('<', 'heat')"><</button>
+      <input class="nes-input payments_input" v-model.number="heat" />
+      <button class="nes-btn" v-on:click="addValue('heat', 1)" :class="getCssClassFor('>', 'heat')">></button>
+    </div>
+    <div class="payments_type" v-if="canUseMicrobes()">
+      <i class="resource_icon resource_icon--microbe payments_type_icon" title="Pay by Microbes"></i>
+      <button class="nes-btn" v-on:click="reduceValue('microbes', 1)" :class="getCssClassFor('<', 'microbes')"><</button>
+      <input class="nes-input payments_input" v-model.number="microbes" />
+      <button class="nes-btn" v-on:click="addValue('microbes', 1)" :class="getCssClassFor('>', 'microbes')">></button>
+    </div>
+    <div class="payments_type" v-if="canUseFloaters()">
+      <i class="resource_icon resource_icon--floater payments_type_icon" title="Pay by Floaters"></i>
+      <button class="nes-btn" v-on:click="reduceValue('floaters', 1)" :class="getCssClassFor('<', 'floaters')"><</button>
+      <input class="nes-input payments_input" v-model.number="floaters" />
+      <button class="nes-btn" v-on:click="addValue('floaters', 1)" :class="getCssClassFor('>', 'floaters')">></button>
+    </div>
+    <div class="payments_type">
+      <i class="resource_icon resource_icon--megacredits payments_type_icon" title="Pay by Megacredits"></i>
+      <button class="nes-btn" v-on:click="reduceValue('megaCredits', 1)" :class="getCssClassFor('<', 'megaCredits')"><</button>
+      <input class="nes-input payments_input" v-model.number="megaCredits" />
+      <button class="nes-btn" v-on:click="addValue('megaCredits', 1)" :class="getCssClassFor('>', 'megaCredits')">&gt;</button>
+    </div>
+    <div v-if="hasWarning()" class="nes-container is-rounded">
+      <span class="nes-text is-warning">{{ warning }}</span>
+    </div>
+    <div v-if="showsave === true" class="payments_save">
+      <button class="nes-btn" v-on:click="saveData">Save</button>
+    </div>
+  </section>
+</div>`
 });
 

--- a/src/components/SelectOption.ts
+++ b/src/components/SelectOption.ts
@@ -1,21 +1,19 @@
 
-import Vue, { VNode } from "vue";
+import Vue from "vue";
 
 export const SelectOption = Vue.component("select-option", {
     props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {};
     },
-    render: function (createElement) {
-        const children: Array<VNode> = [];
-        if (this.showtitle) {
-            children.push(createElement("div", this.playerinput.title));
+    methods: {
+        saveData: function () {
+            this.onsave([["1"]]);
         }
-        if (this.showsave) {
-            children.push(createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.onsave([["1"]]); } } }, "Select"));
-        }
-        return createElement("div", children);
-    }
+    },
+    template: `<div>
+  <div v-if="showtitle === true">{{playerinput.title}}</div>
+  <button v-if="showsave === true" class="nes-btn" v-on:click="saveData">Select</button>
+</div>`
 });
-
 

--- a/src/components/SelectOption.ts
+++ b/src/components/SelectOption.ts
@@ -2,7 +2,7 @@
 import Vue, { VNode } from "vue";
 
 export const SelectOption = Vue.component("select-option", {
-    props: ["playerinput", "onsave", "showtitle"],
+    props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {};
     },
@@ -11,7 +11,9 @@ export const SelectOption = Vue.component("select-option", {
         if (this.showtitle) {
             children.push(createElement("div", this.playerinput.title));
         }
-        children.push(createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.onsave([["1"]]); } } }, "Select"));
+        if (this.showsave) {
+            children.push(createElement("button", { domProps: { className: "nes-btn" }, on: { click: () => { this.onsave([["1"]]); } } }, "Select"));
+        }
         return createElement("div", children);
     }
 });

--- a/src/components/SelectPlayer.ts
+++ b/src/components/SelectPlayer.ts
@@ -3,7 +3,7 @@ import Vue from "vue";
 import { SelectPlayerRow } from "./SelectPlayerRow";
 
 export const SelectPlayer = Vue.component("select-player", {
-    props: ["players", "playerinput", "onsave", "showtitle"],
+    props: ["players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
             selectedPlayer: undefined
@@ -24,7 +24,7 @@ export const SelectPlayer = Vue.component("select-player", {
                 <input class="nes-radio" type="radio" v-model="selectedPlayer" :value="player" />
                 <select-player-row :player="players.find((otherPlayer) => otherPlayer.id === player)"></select-player-row>
             </label>
-            <button class="nes-btn" v-on:click="selectPlayers">Save</button>
+            <button v-if="showsave === true" class="nes-btn" v-on:click="selectPlayers">Save</button>
         </div>
     `
 });

--- a/src/components/SelectPlayer.ts
+++ b/src/components/SelectPlayer.ts
@@ -13,19 +13,17 @@ export const SelectPlayer = Vue.component("select-player", {
         "select-player-row": SelectPlayerRow
     },
     methods: {
-        selectPlayers: function () {
+        saveData: function () {
             this.onsave([[this.$data.selectedPlayer]]);
         }
     },
-    template: `
-        <div>
-            <div v-if="showtitle === true">{{playerinput.title}}</div>
-            <label v-for="player in playerinput.players" :key="player" style="display:block;font-size:12px">
-                <input class="nes-radio" type="radio" v-model="selectedPlayer" :value="player" />
-                <select-player-row :player="players.find((otherPlayer) => otherPlayer.id === player)"></select-player-row>
-            </label>
-            <button v-if="showsave === true" class="nes-btn" v-on:click="selectPlayers">Save</button>
-        </div>
-    `
+    template: `<div>
+  <div v-if="showtitle === true">{{playerinput.title}}</div>
+  <label v-for="player in playerinput.players" :key="player" style="display:block;font-size:12px">
+    <input class="nes-radio" type="radio" v-model="selectedPlayer" :value="player" />
+    <select-player-row :player="players.find((otherPlayer) => otherPlayer.id === player)"></select-player-row>
+  </label>
+  <button v-if="showsave === true" class="nes-btn" v-on:click="saveData">Save</button>
+</div>`
 });
 

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -2,9 +2,8 @@
 import Vue, { VNode } from "vue";
 import { PlayerInputModel } from "../models/PlayerInputModel";
 
-
 export const SelectSpace = Vue.component("select-space", {
-    props: ["playerinput", "onsave", "showtitle"],
+    props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {};
     },
@@ -44,6 +43,7 @@ export const SelectSpace = Vue.component("select-space", {
                             (elTiles[j] as HTMLElement).onclick = null;
                         }
                         el_id = elTile.getAttribute("data_space_id");
+                        // TODO - Store this property for when showsave === false
                         this.onsave([[el_id]]);
                     }
                 }

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -31,7 +31,7 @@ export const SelectSpace = Vue.component("select-space", {
         const clearAllAvailableSpaces = function() {
             const elTiles = document.getElementsByClassName("board_space");
             for (let i = 0; i < elTiles.length; i++) {
-                elTiles[0].classList.remove("board_space--available");
+                elTiles[i].classList.remove("board_space--available");
             }
         };
 
@@ -59,6 +59,8 @@ export const SelectSpace = Vue.component("select-space", {
                         this.$data.spaceId = elTile.getAttribute("data_space_id");
                         if (this.showsave) {
                             this.saveData();
+                        } else {
+                            elTile.classList.add("board_space--selected")
                         }
                     }
                 }

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -5,7 +5,19 @@ import { PlayerInputModel } from "../models/PlayerInputModel";
 export const SelectSpace = Vue.component("select-space", {
     props: ["playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
-        return {};
+        return {
+            spaceId: undefined,
+            warning: undefined
+        };
+    },
+    methods: {
+        saveData: function () {
+            if (this.$data.spaceId === undefined) {
+                this.$data.warning = "Must select a space";
+                return;
+            }
+            this.onsave([[this.$data.spaceId]]);
+        }
     },
     render: function (createElement) {
         const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
@@ -13,7 +25,9 @@ export const SelectSpace = Vue.component("select-space", {
         if (this.showtitle) {
             children.push(createElement("div", playerInput.title));
         }
-
+        if (this.$data.warning) {
+            children.push(createElement("div", { domProps: { className: "nes-container is-rounded" } }, [createElement("span", { domProps: { className: "nes-text is-warning" } }, this.$data.warning)]));
+        }
         const clearAllAvailableSpaces = function() {
             const elTiles = document.getElementsByClassName("board_space");
             for (let i = 0; i < elTiles.length; i++) {
@@ -42,9 +56,10 @@ export const SelectSpace = Vue.component("select-space", {
                         for (let j = 0; j < elTiles.length; j++) {
                             (elTiles[j] as HTMLElement).onclick = null;
                         }
-                        el_id = elTile.getAttribute("data_space_id");
-                        // TODO - Store this property for when showsave === false
-                        this.onsave([[el_id]]);
+                        this.$data.spaceId = elTile.getAttribute("data_space_id");
+                        if (this.showsave) {
+                            this.saveData();
+                        }
                     }
                 }
             } } }, "Select Space"));

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -32,6 +32,7 @@ export const SelectSpace = Vue.component("select-space", {
             const elTiles = document.getElementsByClassName("board_space");
             for (let i = 0; i < elTiles.length; i++) {
                 elTiles[i].classList.remove("board_space--available");
+                elTiles[i].classList.remove("board_space--selected");
             }
         };
 
@@ -57,11 +58,8 @@ export const SelectSpace = Vue.component("select-space", {
                             (elTiles[j] as HTMLElement).onclick = null;
                         }
                         this.$data.spaceId = elTile.getAttribute("data_space_id");
-                        if (this.showsave) {
-                            this.saveData();
-                        } else {
-                            elTile.classList.add("board_space--selected")
-                        }
+                        elTile.classList.add("board_space--selected")
+                        this.saveData();
                     }
                 }
             } } }, "Select Space"));

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -107,7 +107,7 @@ export const WaitingFor = Vue.component("waiting-for", {
                 }
             }
             xhr.send(JSON.stringify(out));  
-        }, true);
+        }, true, true);
     }
 });
 

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -125,3 +125,7 @@
 .board_space--available {
 	--board_space_visibility: visible;
 }
+
+.board_space--selected {
+	--board_space_selected: visible;
+}


### PR DESCRIPTION
I have been keeping this work on my computer and haven't had as much time to work on it. The overall pattern is in place of hiding the save button for children of `AndOptions`. The only work left is calling the save method of each child when the save button of the `AndOptions` is clicked. For `SelectSpace` we will have to store the selected space on the data model so that the parent `AndOptions` can call the save method for the situation where `SelectSpace` is a child of `AndOptions`. This makes the initial selection of corporation and project cards much simpler as it only involves one click.