### PR TITLE
Fix for subsequent on subsequent onend for #215

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1652,10 +1652,15 @@ export class Player {
       try {
         const subsequent = this.runInput(input, waitingFor);
         if (subsequent !== undefined) {
-          if (
-            subsequent.onend === undefined &&
-                    waitingFor.onend !== undefined) {
+          if (subsequent.onend === undefined && waitingFor.onend !== undefined) {
             subsequent.onend = waitingFor.onend;
+          } else if (subsequent.onend !== undefined && waitingFor.onend !== undefined) {
+            const lastOnEnd: () => void = waitingFor.onend;
+            const nextOnEnd: () => void = subsequent.onend;
+            subsequent.onend = function () {
+                nextOnEnd();
+                lastOnEnd();
+            };
           }
           this.setWaitingFor(subsequent);
         } else if (waitingFor.onend) {

--- a/src/inputs/SelectOption.ts
+++ b/src/inputs/SelectOption.ts
@@ -8,7 +8,7 @@ import { AndOptions } from './AndOptions';
 export class SelectOption implements PlayerInput {
     public inputType: PlayerInputTypes = PlayerInputTypes.SELECT_OPTION;
     public onend?: () => void;
-    constructor(public title: string, public cb: () => SelectSpace | SelectHowToPay | AndOptions | undefined) {
+    constructor(public title: string, public cb: () => SelectSpace | SelectHowToPay | AndOptions | SelectOption | undefined) {
     }
 }
 

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -8,6 +8,7 @@ import { Insulation } from "../src/cards/Insulation";
 import { IoMiningIndustries } from  "../src/cards/IoMiningIndustries";
 import { PowerSupplyConsortium } from "../src/cards/PowerSupplyConsortium";
 import { SaturnSystems } from "../src/cards/corporation/SaturnSystems";
+import { SelectOption } from "../src/inputs/SelectOption";
 import { Resources } from '../src/Resources';
 
 describe("Player", function () {
@@ -66,7 +67,6 @@ describe("Player", function () {
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         expect(player.getWaitingFor()).to.eq(undefined);
     });
-
     it("Runs SaturnSystems when other player plays card", function () {
         const player1 = new Player("p1", Color.BLUE, false);
         const player2 = new Player("p2", Color.RED, false);
@@ -77,5 +77,28 @@ describe("Player", function () {
         player1.corporationCard = corporationCard;
         player2.playCard(game, card, undefined);
         expect(player1.getProduction(Resources.MEGACREDITS)).to.eq(1);
+    });
+    it("Chains onend functions from player inputs", function (done) {
+        const player = new Player("p1", Color.BLUE, false);
+        const mockOption3 = new SelectOption("Mock select option 3", () => {
+            return undefined;
+        });
+        const mockOption2 = new SelectOption("Mock select option 2", () => {
+            return mockOption3;
+        });
+        mockOption2.onend = () => {};
+        const mockOption = new SelectOption("Mock select option", () => {
+            return mockOption2;
+        });
+        mockOption.onend = () => {
+            done();
+        };
+        player.setWaitingFor(mockOption);
+        player.process([["1"]]);
+        expect(player.getWaitingFor()).not.to.be.undefined;
+        player.process([["1"]]);
+        expect(player.getWaitingFor()).not.to.be.undefined;
+        player.process([["1"]]);
+        expect(player.getWaitingFor()).to.be.undefined;
     });
 });


### PR DESCRIPTION
If an action has an `onend` and the following action then also has an `onend` this change now chains the `onend` functions into a lambda function. I added `onend` as a quick work around when finishing up the original deck. This change should cover the last branch of processing an input. This missing logic was most likely causing other bugs but we only spotted the issue with `ValleyTrust`. Should be a nice improvement! I added a regression test which fails without the change.