### PR TITLE
Issue #254

### DIFF
--- a/src/cards/DomedCrater.ts
+++ b/src/cards/DomedCrater.ts
@@ -15,7 +15,7 @@ export class DomedCrater implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 1 &&
-        game.getOxygenLevel() <= 7 - player.getRequirementsBonus(game) &&
+        game.getOxygenLevel() <= 7 + player.getRequirementsBonus(game) &&
         game.board.getAvailableSpacesForCity(player).length >= 0;
     }
     public play(player: Player, game: Game) {

--- a/src/cards/EcologicalZone.ts
+++ b/src/cards/EcologicalZone.ts
@@ -38,15 +38,13 @@ export class EcologicalZone implements IProjectCard {
     return this.hasGreeneryTile(player, game);
   }
   public onCardPlayed(player: Player, _game: Game, card: IProjectCard): void {
-    if (card.tags.indexOf(Tags.ANIMAL) !== -1 ||
-          card.tags.indexOf(Tags.PLANT) !== -1) {
-      player.addResourceTo(this);
-    }
+      player.addResourceTo(this, card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT).length);
   }
   public getVictoryPoints(player: Player): number {
     return Math.floor(player.getResourcesOnCard(this) / 2);
   }
   public play(player: Player, game: Game) {
+    player.addResourceTo(this, 2);
     return new SelectSpace(
         'Select space next to greenery for special tile',
         this.getAvailableSpaces(player, game),

--- a/src/cards/EcologicalZone.ts
+++ b/src/cards/EcologicalZone.ts
@@ -44,7 +44,6 @@ export class EcologicalZone implements IProjectCard {
     return Math.floor(player.getResourcesOnCard(this) / 2);
   }
   public play(player: Player, game: Game) {
-    player.addResourceTo(this, 2);
     return new SelectSpace(
         'Select space next to greenery for special tile',
         this.getAvailableSpaces(player, game),

--- a/src/cards/ViralEnhancers.ts
+++ b/src/cards/ViralEnhancers.ts
@@ -14,19 +14,20 @@ export class ViralEnhancers implements IProjectCard {
     public cardType: CardType = CardType.ACTIVE;
 
     public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
-        if (card.tags.find((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES) !== undefined && card.resourceType !== undefined) {
+        let resourceCount = card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES).length;
+        if (resourceCount > 0 && card.resourceType !== undefined) {
             return new OrOptions(
-                new SelectOption("Add resource to card " + card.name, () => {
-                    player.addResourceTo(card);
+                new SelectOption("Add " + resourceCount + " resource(s) to card " + card.name, () => {
+                    player.addResourceTo(card, resourceCount);
                     return undefined;
                 }),
-                new SelectOption("Gain 1 plant", () => {
-                    player.plants++;
+                new SelectOption("Gain " + resourceCount + " plant(s)", () => {
+                    player.plants += resourceCount;
                     return undefined;
                 })
             );
         }
-        player.plants++;
+        player.plants += resourceCount;
         return undefined;
     }
     public play() {

--- a/tests/cards/EcologicalZone.spec.ts
+++ b/tests/cards/EcologicalZone.spec.ts
@@ -28,13 +28,12 @@ describe("EcologicalZone", function () {
         const adjacentSpace = action.availableSpaces[0];
         action.cb(adjacentSpace);
         expect(adjacentSpace.tile && adjacentSpace.tile.tileType).to.eq(TileType.SPECIAL); 
-        card.onCardPlayed(player, game, card);
-        expect(player.getResourcesOnCard(card)).to.eq(1);
-        card.onCardPlayed(player, game, card);
         expect(player.getResourcesOnCard(card)).to.eq(2);
-        expect(card.getVictoryPoints(player)).to.eq(1);
+        card.onCardPlayed(player, game, card);
+        expect(player.getResourcesOnCard(card)).to.eq(4);
+        expect(card.getVictoryPoints(player)).to.eq(2);
         card.onCardPlayed(player, game, new Virus());
-        expect(player.getResourcesOnCard(card)).to.eq(2);
+        expect(player.getResourcesOnCard(card)).to.eq(4);
     });
 });
 

--- a/tests/cards/EcologicalZone.spec.ts
+++ b/tests/cards/EcologicalZone.spec.ts
@@ -28,12 +28,11 @@ describe("EcologicalZone", function () {
         const adjacentSpace = action.availableSpaces[0];
         action.cb(adjacentSpace);
         expect(adjacentSpace.tile && adjacentSpace.tile.tileType).to.eq(TileType.SPECIAL); 
-        expect(player.getResourcesOnCard(card)).to.eq(2);
         card.onCardPlayed(player, game, card);
-        expect(player.getResourcesOnCard(card)).to.eq(4);
-        expect(card.getVictoryPoints(player)).to.eq(2);
+        expect(player.getResourcesOnCard(card)).to.eq(2);
+        expect(card.getVictoryPoints(player)).to.eq(1);
         card.onCardPlayed(player, game, new Virus());
-        expect(player.getResourcesOnCard(card)).to.eq(4);
+        expect(player.getResourcesOnCard(card)).to.eq(2);
     });
 });
 


### PR DESCRIPTION
Fix a bug in Domed crater requirements
Fix Ecological zone
Quick and dirty fix for Viral Enhancers, if x tags are played, you either choose to add x resource to card or gain x plants.
The only card impacted by this is Ecological zone. All other cards either have only one tag or cannot hold resources.