### PR TITLE
Fix for greenery placement when player tiles are all blocked

### DIFF
--- a/src/Board.ts
+++ b/src/Board.ts
@@ -102,15 +102,6 @@ export abstract class Board {
         );
     } 
 
-    public playerHasSpace(player: Player): boolean {
-        return this.spaces.find(
-            (space) => space.tile !== undefined &&
-                    space.player === player &&
-                    space.spaceType !== SpaceType.COLONY &&
-                    space.tile.tileType !== TileType.OCEAN
-        ) !== undefined;
-    }
-
     public getAvailableSpacesForMarker(player: Player): Array<ISpace> {
         let spaces =  this.getAvailableSpacesOnLand(player)
         .filter(
@@ -123,16 +114,12 @@ export abstract class Board {
     }  
 
     public getAvailableSpacesForGreenery(player: Player): Array<ISpace> {
-        // Greenery must be placed by a space you own if you own a space
-        if (this.playerHasSpace(player)) {
-        return this.getAvailableSpacesOnLand(player)
-            .filter(
-                (space) => this.getAdjacentSpaces(space).find(
-                    (adj) => adj.tile !== undefined &&
-                                adj.tile.tileType !== TileType.OCEAN &&
-                                adj.player === player
-                ) !== undefined
-            );
+        const spacesForGreenery = this.getAvailableSpacesOnLand(player)
+            .filter((space) => this.getAdjacentSpaces(space).find((adj) => adj.tile !== undefined && adj.player === player && (adj.tile.tileType === TileType.GREENERY || adj.tile.tileType === TileType.SPECIAL || adj.tile.tileType === TileType.CITY)) !== undefined);
+
+        // Spaces next to tiles you own
+        if (spacesForGreenery.length > 0) {
+            return spacesForGreenery;
         }
         // Place anywhere if no space owned
         return this.getAvailableSpacesOnLand(player);
@@ -170,7 +157,7 @@ export abstract class Board {
                 return space;
             }
         }
-    }    
+    }
 
     protected canPlaceTile(space: ISpace): boolean {
         return space !== undefined && space.tile === undefined && space instanceof Land;

--- a/tests/Board.spec.ts
+++ b/tests/Board.spec.ts
@@ -1,0 +1,39 @@
+
+import { expect } from "chai";
+import { Color } from "../src/Color";
+import { OriginalBoard } from "../src/OriginalBoard";
+import { Player } from "../src/Player";
+import { TileType } from "../src/TileType";
+
+describe("Board", function () {
+    it("Can have greenery placed on any available land when player has no tile placed", function () {
+        const board = new OriginalBoard();
+        const player = new Player("test", Color.BLUE, false);
+        const availableSpaces = board.getAvailableSpacesForGreenery(player);
+        expect(availableSpaces.length).to.eq(board.getAvailableSpacesOnLand(player).length);
+    });
+    it("Can have greenery placed on any available land when player has a tile placed that is land locked", function () {
+        const board = new OriginalBoard();
+        const player1 = new Player("test", Color.BLUE, false);
+        const player2 = new Player("foo", Color.RED, false);
+        board.spaces[2].player = player1;
+        board.spaces[2].tile = { tileType: TileType.GREENERY };
+        board.spaces[7].player = player2;
+        board.spaces[7].tile = { tileType: TileType.GREENERY };
+        board.spaces[8].player = player2;
+        board.spaces[8].tile = { tileType: TileType.GREENERY };
+        const availableSpaces = board.getAvailableSpacesForGreenery(player1);
+        expect(availableSpaces.length).to.eq(board.getAvailableSpacesOnLand(player1).length);
+    });
+    it("Can only place greenery adjacent to a tile a player owns", function () {
+        const board = new OriginalBoard();
+        const player1 = new Player("test", Color.BLUE, false);
+        const player2 = new Player("foo", Color.RED, false);
+        board.spaces[2].player = player1;
+        board.spaces[2].tile = { tileType: TileType.GREENERY };
+        board.spaces[7].player = player2;
+        board.spaces[7].tile = { tileType: TileType.GREENERY };
+        const availableSpaces = board.getAvailableSpacesForGreenery(player1);
+        expect(availableSpaces.length).to.eq(1);
+    });
+});

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -357,6 +357,7 @@
         "tests/cards/promo/MonsInsurance.spec.ts",
         "tests/cards/promo/Recyclon.spec.ts",
         "tests/cards/promo/Splice.spec.ts",
+        "tests/Board.spec.ts",
         "tests/Game.spec.ts",
         "tests/OriginalBoard.spec.ts",
         "tests/Player.spec.ts"


### PR DESCRIPTION
Updates greenery placement logic for the situation where every adjacent tile is blocked or an ocean.