### PR TITLE
lastCardPlayed rework

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -235,9 +235,6 @@ export class Player {
       return requirementsBonus;
     }
 
-    public addAnimalsToCard(card: ICard, count: number): void {
-      this.addResourceTo(card, count);
-    }
     private generateId(): string {
       return Math.floor(Math.random() * Math.pow(16, 12)).toString(16);
     }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -53,7 +53,7 @@ export class Player {
     public preludeCardsInHand: Array<IProjectCard> = [];    
     public playedCards: Array<IProjectCard> = [];
     public draftedCards: Array<IProjectCard> = [];
-    public generationPlayed: Map<string, number> = new Map<string, number>();
+    private generationPlayed: Map<string, number> = new Map<string, number>();
     public actionsTakenThisRound: number = 0;
     public terraformRating: number = 20;
     public terraformRatingAtGenerationStart: number = 20;
@@ -61,13 +61,13 @@ export class Player {
     public victoryPoints: number = 0;
     public victoryPointsBreakdown = new VictoryPointsBreakdown();
     private actionsThisGeneration: Set<string> = new Set<string>();
-    private lastCardPlayedThisTurn: IProjectCard | undefined;
+    public lastCardPlayed: IProjectCard | undefined;
     private waitingFor?: PlayerInput;
     private waitingForCb?: () => void;
     public cardCost: number = constants.CARD_COST;
     public oceanBonus: number = constants.OCEAN_BONUS;
     public fleetSize: number = 1;
-    public  tradesThisTurn: number = 0;
+    public tradesThisTurn: number = 0;
     public colonyTradeOffset: number = 0;
     public colonyTradeDiscount: number = 0;
 
@@ -160,9 +160,6 @@ export class Player {
       return;
     }
 
-    public getLastCardPlayedThisTurn(): IProjectCard | undefined {
-      return this.lastCardPlayedThisTurn;
-    }
     public getOtherPlayersWithPlantsToRemove(game: Game): Array<Player> {
       return game.getPlayers().filter((player) => player.id !== this.id && !player.hasProtectedHabitats() && player.plants > 0);
     }
@@ -237,17 +234,7 @@ export class Player {
       }
       return requirementsBonus;
     }
-    public lastCardPlayedThisGeneration(game: Game): undefined | IProjectCard {
-      const lastCardPlayed = this.playedCards[this.playedCards.length - 1];
-      if (lastCardPlayed !== undefined) {
-        const generationPlayed =
-                this.generationPlayed.get(lastCardPlayed.name);
-        if (generationPlayed === game.generation) {
-          return lastCardPlayed;
-        }
-      }
-      return undefined;
-    }
+
     public addAnimalsToCard(card: ICard, count: number): void {
       this.addResourceTo(card, count);
     }
@@ -777,7 +764,7 @@ export class Player {
     private addPlayedCard(game: Game, card: IProjectCard): void {
       this.playedCards.push(card);
       game.log(this.name + " played " + card.name);
-      this.lastCardPlayedThisTurn = card;
+      this.lastCardPlayed = card;
       this.generationPlayed.set(card.name, game.generation);
     }
 
@@ -1458,6 +1445,7 @@ export class Player {
       return new SelectOption('Pass', () => {
         game.playerHasPassed(this);
         game.log(this.name + " passed");
+        this.lastCardPlayed = undefined;
         return undefined;
       });
     }
@@ -1637,7 +1625,6 @@ export class Player {
 
       if (game.hasPassedThisActionPhase(this) || this.actionsTakenThisRound >= 2) {
         this.actionsTakenThisRound = 0;
-        this.lastCardPlayedThisTurn = undefined;
         game.playerIsFinishedTakingActions();
         return;
       }         

--- a/src/cards/IndenturedWorkers.ts
+++ b/src/cards/IndenturedWorkers.ts
@@ -11,9 +11,8 @@ export class IndenturedWorkers implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = "Indentured Workers";
 
-    public getCardDiscount(player: Player, game: Game) {
-        const lastCardPlayed = player.lastCardPlayedThisGeneration(game);
-        if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {
+    public getCardDiscount(player: Player, _game: Game) {
+        if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
             return 8;
         }
         return 0;

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -34,7 +34,7 @@ export class LocalHeatTrapping implements IProjectCard {
             options = new OrOptions(
                 new SelectOption("Gain 4 plants", gain4Plants),
                 new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
-                    player.addAnimalsToCard(foundCards[0], 2);
+                    player.addResourceTo(foundCards[0], 2);
                     return undefined;
                 }));
         };

--- a/src/cards/SpecialDesign.ts
+++ b/src/cards/SpecialDesign.ts
@@ -11,9 +11,8 @@ export class SpecialDesign implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
     public name: string = "Special Design";
 
-    public getRequirementBonus(player: Player, game: Game): number {
-        const lastCardPlayed = player.lastCardPlayedThisGeneration(game);
-        if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {
+    public getRequirementBonus(player: Player, _game: Game): number {
+        if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
             return 2;
         }
         return 0;

--- a/src/cards/colonies/Conscription.ts
+++ b/src/cards/colonies/Conscription.ts
@@ -16,9 +16,8 @@ export class Conscription implements IProjectCard {
         return player.getTagCount(Tags.EARTH) >= 2;
     }
 
-    public getCardDiscount(player: Player, game: Game) {
-        const lastCardPlayed = player.lastCardPlayedThisGeneration(game);
-        if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {
+    public getCardDiscount(player: Player, _game: Game) {
+        if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
             return 16;
         }
         return 0;

--- a/src/cards/prelude/EccentricSponsor.ts
+++ b/src/cards/prelude/EccentricSponsor.ts
@@ -9,9 +9,8 @@ export class EccentricSponsor extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: string = CardName.ECCENTRIC_SPONSOR;
 
-    public getCardDiscount(player: Player, game: Game) {
-        const lastCardPlayed = player.lastCardPlayedThisGeneration(game);
-        if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {
+    public getCardDiscount(player: Player, _game: Game) {
+        if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
             return 25;
         }
         return 0;

--- a/src/cards/prelude/EcologyExperts.ts
+++ b/src/cards/prelude/EcologyExperts.ts
@@ -9,8 +9,7 @@ export class EcologyExperts extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT, Tags.MICROBES];
     public name: string = CardName.ECOLOGY_EXPERTS;
     public getRequirementBonus(player: Player): number {
-        const lastCardPlayed = player.getLastCardPlayedThisTurn();
-        if (lastCardPlayed !== undefined && lastCardPlayed.name === this.name) {
+        if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
             // Magic number high enough to always ignore requirements.
             return 50;
         }

--- a/tests/cards/prelude/EccentricSponsor.spec.ts
+++ b/tests/cards/prelude/EccentricSponsor.spec.ts
@@ -11,8 +11,7 @@ describe("EccentricSponsor", function () {
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player], player);
         expect(card.getCardDiscount(player, game)).to.eq(0);
-        player.generationPlayed.set(card.name, 1);
-        player.playedCards.push(card);
+        player.lastCardPlayed = card;
         expect(card.getCardDiscount(player, game)).to.eq(25);
     });
     it("Should play", function () {

--- a/tests/cards/prelude/EcologyExperts.spec.ts
+++ b/tests/cards/prelude/EcologyExperts.spec.ts
@@ -10,7 +10,7 @@ describe("EcologyExperts", function () {
         const card = new EcologyExperts();
         const player = new Player("test", Color.BLUE, false);
         expect(card.getRequirementBonus(player)).to.eq(0);
-        (player as any).lastCardPlayedThisTurn = card;
+        player.lastCardPlayed = card;
         expect(card.getRequirementBonus(player)).to.eq(50);
     });
     it("Should play", function () {


### PR DESCRIPTION
Simplify `lastCardPlayed `logic and remove `lastCardPlayedThisGeneration` method
`lastCardPlayed `is now the last card played for current generation as there is no need to track played cards between turns.
Fix Eccentric Sponsor bug
Switch `generationPlayed` to private, not used anymore but could be used for statistics in the future
Remove `addAnimalsToCard `method