### PR TITLE
Run build during build for linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
       with:
         node-version: '10.x'
     - run: npm install
+    - run: npm run build
     - run: npm test
     - run: npm run cover
       


### PR DESCRIPTION
I am attempting to add `eslint` rules to the project to enforce some sort of standards within the repository. These checks are not running and wont block a build. This adds the `npm run build` command to the github actions to ensure that with any change we can still run a build.