### PR TITLE
Fixed erroneous MC production change (#402)

### DIFF
--- a/src/cards/ImmigrantCity.ts
+++ b/src/cards/ImmigrantCity.ts
@@ -29,8 +29,6 @@ export class ImmigrantCity implements IProjectCard {
             game.addCityTile(player, space.id);
             player.setProduction(Resources.ENERGY,-1);
             player.setProduction(Resources.MEGACREDITS, -2);
-            // Resolve onTilePlaced
-            player.setProduction(Resources.MEGACREDITS);
             return undefined;
         });
     }

--- a/tests/cards/ImmigrantCity.spec.ts
+++ b/tests/cards/ImmigrantCity.spec.ts
@@ -22,9 +22,9 @@ describe("ImmigrantCity", function () {
         const action = card.play(player, game);
         action.cb(action.availableSpaces[0]);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
-        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
+        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-2);
         player.playedCards.push(card);
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
-        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(0);
+        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
     });
 });

--- a/tests/cards/prelude/Vitor.spec.ts
+++ b/tests/cards/prelude/Vitor.spec.ts
@@ -34,6 +34,7 @@ describe("Vitor", function () {
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player], player);
         const card = new Vitor();
+        player.corporationCard = card;
         card.onCardPlayed(player, game, ants);
         expect(player.megaCredits).to.eq(3);
         card.onCardPlayed(player, game, lava);


### PR DESCRIPTION
Fixed erroneous MC production change for Immigrant City. The card effect (+1 MC production) was apparently awarded in the `play()` method and then triggered again in the `onTilePlaced()` method resulting in a MC production change of _0_ instead of _-1_.