### PR TITLE
Run build from forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   build:


### PR DESCRIPTION
Builds are not running from users on forks. I _think_ this is because the `pull_request` option is missing in the github action configuration file. 

https://github.community/t5/GitHub-Actions/Run-a-GitHub-action-on-pull-request-for-PR-opened-from-a-forked/td-p/15426

Hoping to get builds running from forks to help enforce what linting rules and unit tests exist.