### PR TITLE
Visualize used actions from blue cards (#400)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -336,7 +336,7 @@ function getPlayer(player: Player, game: Game): string {
     boardName: game.boardName,
     colonies: getColonies(game.colonies),
     tags: player.getAllTags(),
-    actionsThisGeneration: player.getActionsThisGeneration()
+    actionsThisGeneration: Array.from(player.getActionsThisGeneration())
   } as PlayerModel;
   return JSON.stringify(output);
 }
@@ -479,7 +479,7 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       boardName: game.boardName,
       colonies: getColonies(game.colonies),
       tags: player.getAllTags(),
-      actionsThisGeneration: player.getActionsThisGeneration()
+      actionsThisGeneration: Array.from(player.getActionsThisGeneration())
     } as PlayerModel;
   });
 }

--- a/server.ts
+++ b/server.ts
@@ -335,7 +335,8 @@ function getPlayer(player: Player, game: Game): string {
     venusScaleLevel: game.getVenusScaleLevel(),
     boardName: game.boardName,
     colonies: getColonies(game.colonies),
-    tags: player.getAllTags()
+    tags: player.getAllTags(),
+    actionsThisGeneration: player.getActionsThisGeneration()
   } as PlayerModel;
   return JSON.stringify(output);
 }
@@ -477,7 +478,8 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       venusScaleLevel: game.getVenusScaleLevel(),
       boardName: game.boardName,
       colonies: getColonies(game.colonies),
-      tags: player.getAllTags()
+      tags: player.getAllTags(),
+      actionsThisGeneration: player.getActionsThisGeneration()
     } as PlayerModel;
   });
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -64,7 +64,7 @@ export class Player {
     public resourcesOnCards: Map<string, number> = new Map<string, number>();
     public victoryPoints: number = 0;
     public victoryPointsBreakdown = new VictoryPointsBreakdown();
-    private actionsThisGeneration: Array<string> = [];
+    private actionsThisGeneration: Set<string> = new Set<string>();
     public lastCardPlayed: IProjectCard | undefined;
     private waitingFor?: PlayerInput;
     private waitingForCb?: () => void;
@@ -166,12 +166,12 @@ export class Player {
 
     };  
 
-    public getActionsThisGeneration(): Array<string> {
+    public getActionsThisGeneration(): Set<string> {
       return this.actionsThisGeneration;
     }
 
     public setActionsThisGeneration(cardName: string): void {
-      this.actionsThisGeneration.push(cardName);
+      this.actionsThisGeneration.add(cardName);
       return;
     }
 
@@ -578,7 +578,7 @@ export class Player {
       const result: Array<ICard> = [];
       if (
         this.corporationCard !== undefined &&
-            this.getActionsThisGeneration().indexOf(this.corporationCard.name) === -1 &&
+            !this.actionsThisGeneration.has(this.corporationCard.name) &&
             this.corporationCard.action !== undefined &&
             this.corporationCard.canAct !== undefined &&
             this.corporationCard.canAct(this, game)) {
@@ -588,7 +588,7 @@ export class Player {
         if (
           playedCard.action !== undefined &&
                 playedCard.canAct !== undefined &&
-                this.getActionsThisGeneration().indexOf(playedCard.name) === -1 &&
+                !this.actionsThisGeneration.has(playedCard.name) &&
                 playedCard.canAct(this, game)) {
           result.push(playedCard);
         }
@@ -597,7 +597,7 @@ export class Player {
     }
 
     public runProductionPhase(): void {
-      this.actionsThisGeneration.splice(0);
+      this.actionsThisGeneration.clear();
       this.tradesThisTurn = 0;
       this.megaCredits += this.megaCreditProduction + this.terraformRating;
       this.heat += this.energy;
@@ -990,7 +990,7 @@ export class Player {
                     playerInput: action
                 });
             }
-            this.actionsThisGeneration.push(foundCard.name);
+            this.actionsThisGeneration.add(foundCard.name);
             game.log(this.name + " used " + foundCard.name + " action");
             return undefined;
           }
@@ -1472,7 +1472,7 @@ export class Player {
         game.getGeneration() === 1 &&
             this.corporationCard !== undefined &&
             this.corporationCard.initialAction !== undefined &&
-            this.getActionsThisGeneration().indexOf("CORPORATION_INITIAL_ACTION") === -1 &&
+            !this.actionsThisGeneration.has("CORPORATION_INITIAL_ACTION") &&
             this.actionsTakenThisRound === 0
       ) {
         const input = this.corporationCard.initialAction(this, game);
@@ -1482,7 +1482,7 @@ export class Player {
             playerInput: input
           });
         }
-        this.actionsThisGeneration.push("CORPORATION_INITIAL_ACTION");
+        this.actionsThisGeneration.add("CORPORATION_INITIAL_ACTION");
         this.actionsTakenThisRound++;
         this.takeAction(game);
         return;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -64,7 +64,7 @@ export class Player {
     public resourcesOnCards: Map<string, number> = new Map<string, number>();
     public victoryPoints: number = 0;
     public victoryPointsBreakdown = new VictoryPointsBreakdown();
-    private actionsThisGeneration: Set<string> = new Set<string>();
+    private actionsThisGeneration: Array<string> = [];
     public lastCardPlayed: IProjectCard | undefined;
     private waitingFor?: PlayerInput;
     private waitingForCb?: () => void;
@@ -166,12 +166,12 @@ export class Player {
 
     };  
 
-    public getActionsThisGeneration(): Set<string> {
+    public getActionsThisGeneration(): Array<string> {
       return this.actionsThisGeneration;
     }
 
     public setActionsThisGeneration(cardName: string): void {
-      this.actionsThisGeneration.add(cardName);
+      this.actionsThisGeneration.push(cardName);
       return;
     }
 
@@ -578,7 +578,7 @@ export class Player {
       const result: Array<ICard> = [];
       if (
         this.corporationCard !== undefined &&
-            !this.actionsThisGeneration.has(this.corporationCard.name) &&
+            this.getActionsThisGeneration().indexOf(this.corporationCard.name) === -1 &&
             this.corporationCard.action !== undefined &&
             this.corporationCard.canAct !== undefined &&
             this.corporationCard.canAct(this, game)) {
@@ -588,7 +588,7 @@ export class Player {
         if (
           playedCard.action !== undefined &&
                 playedCard.canAct !== undefined &&
-                !this.actionsThisGeneration.has(playedCard.name) &&
+                this.getActionsThisGeneration().indexOf(playedCard.name) === -1 &&
                 playedCard.canAct(this, game)) {
           result.push(playedCard);
         }
@@ -597,7 +597,7 @@ export class Player {
     }
 
     public runProductionPhase(): void {
-      this.actionsThisGeneration.clear();
+      this.actionsThisGeneration.splice(0);
       this.tradesThisTurn = 0;
       this.megaCredits += this.megaCreditProduction + this.terraformRating;
       this.heat += this.energy;
@@ -990,7 +990,7 @@ export class Player {
                     playerInput: action
                 });
             }
-            this.actionsThisGeneration.add(foundCard.name);
+            this.actionsThisGeneration.push(foundCard.name);
             game.log(this.name + " used " + foundCard.name + " action");
             return undefined;
           }
@@ -1472,7 +1472,7 @@ export class Player {
         game.getGeneration() === 1 &&
             this.corporationCard !== undefined &&
             this.corporationCard.initialAction !== undefined &&
-            !this.actionsThisGeneration.has("CORPORATION_INITIAL_ACTION") &&
+            this.getActionsThisGeneration().indexOf("CORPORATION_INITIAL_ACTION") === -1 &&
             this.actionsTakenThisRound === 0
       ) {
         const input = this.corporationCard.initialAction(this, game);
@@ -1482,7 +1482,7 @@ export class Player {
             playerInput: input
           });
         }
-        this.actionsThisGeneration.add("CORPORATION_INITIAL_ACTION");
+        this.actionsThisGeneration.push("CORPORATION_INITIAL_ACTION");
         this.actionsTakenThisRound++;
         this.takeAction(game);
         return;

--- a/src/cards/venusNext/Viron.ts
+++ b/src/cards/venusNext/Viron.ts
@@ -17,7 +17,7 @@ export class Viron implements ICard, CorporationCard {
             if (
               playedCard.action !== undefined &&
                     playedCard.canAct !== undefined &&
-                    player.getActionsThisGeneration().has(playedCard.name) &&
+                    player.getActionsThisGeneration().indexOf(playedCard.name) !== -1 &&
                     playedCard.canAct(player, game)) {
               result.push(playedCard);
             }
@@ -26,7 +26,7 @@ export class Viron implements ICard, CorporationCard {
     }
 
     public canAct(player: Player, game: Game): boolean {
-        return this.getActionCards(player, game).length > 0 && !player.getActionsThisGeneration().has(this.name); 
+        return this.getActionCards(player, game).length > 0 && player.getActionsThisGeneration().indexOf(this.name) === -1;
     }
 
     public action(player: Player, game: Game) {

--- a/src/cards/venusNext/Viron.ts
+++ b/src/cards/venusNext/Viron.ts
@@ -17,7 +17,7 @@ export class Viron implements ICard, CorporationCard {
             if (
               playedCard.action !== undefined &&
                     playedCard.canAct !== undefined &&
-                    player.getActionsThisGeneration().indexOf(playedCard.name) !== -1 &&
+                    player.getActionsThisGeneration().has(playedCard.name) &&
                     playedCard.canAct(player, game)) {
               result.push(playedCard);
             }
@@ -26,7 +26,7 @@ export class Viron implements ICard, CorporationCard {
     }
 
     public canAct(player: Player, game: Game): boolean {
-        return this.getActionCards(player, game).length > 0 && player.getActionsThisGeneration().indexOf(this.name) === -1;
+        return this.getActionCards(player, game).length > 0 && !player.getActionsThisGeneration().has(this.name);
     }
 
     public action(player: Player, game: Game) {

--- a/src/components/Card.ts
+++ b/src/components/Card.ts
@@ -33,7 +33,7 @@ export function getProjectCardByName(cardName: string): IProjectCard | undefined
     || ALL_COLONIES_PROJECTS_CARDS.find((card) => card.name === cardName);
 }
 
-function getData(cardName: string, resources: string): string | undefined {
+function getData(cardName: string, resources: string, wasPlayed: boolean): string | undefined {
     let htmlData : string | undefined = '';
     htmlData = HTML_DATA.get(cardName);
     if (htmlData !== undefined && (resources === undefined || resources === '0')) {
@@ -48,17 +48,22 @@ function getData(cardName: string, resources: string): string | undefined {
               '<div class="card_resources_counter">RES:<span class="card_resources_counter--number">' + resources + '</span></div>');
         }
     }
+    if (htmlData !== undefined && wasPlayed) {
+      htmlData = '<div class="cards-action-was-used">'+htmlData+'</div>';
+    }
     return htmlData;
 }
 
 export const Card = Vue.component("card", {
     props: [
         "card",
-        "resources"
+        "resources",
+        "player"
     ],
     methods: {
         getData: function() {
-            return getData(this.card, this.resources);
+            const wasPlayed = (this.player !== undefined && this.player.actionsThisGeneration !== undefined && this.player.actionsThisGeneration.indexOf(this.card) !== -1) ? true : false;
+            return getData(this.card, this.resources, wasPlayed);
         },
         getCard: function () {
             return getProjectCardByName(this.card) || getCorporationCardByName(this.card);

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -50,7 +50,7 @@ export const OtherPlayer = Vue.component("other-player", {
                             <card :card="player.corporationCard" :resources="player.corporationCardResources"></card>
                         </div>
                         <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                            <card :card="card.name" :resources="card.resources"></card>
+                            <card :card="card.name" :resources="card.resources" :player="player"></card>
                         </div>
 
                         <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType])" ></stacked-cards>

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -1,4 +1,4 @@
-
+ 
 import Vue from "vue";
 
 import { Board } from "./Board";
@@ -148,7 +148,7 @@ export const PlayerHome = Vue.component("player-home", {
                         <card :card="player.corporationCard" :resources="player.corporationCardResources"></card>
                     </div>
                     <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                        <card :card="card.name" :resources="card.resources"></card>
+                        <card :card="card.name" :resources="card.resources" :player="player"></card>
                     </div>
 
                     <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType])" ></stacked-cards>

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -37,4 +37,5 @@ export interface PlayerModel {
     victoryPoints: number;
     victoryPointsBreakdown: VictoryPointsBreakdown;
     tags: Array<ITagCount>;
+    actionsThisGeneration: Array<string>;
 }

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -34,6 +34,10 @@
     z-index: 2;
   }
 
+.cards-action-was-used {
+    filter: grayscale(1);
+}
+
 .nofloat {
   clear: both;
   margin-bottom: 15px;


### PR DESCRIPTION
When using the action of a blue card the card is now grayed out so all players can easily see which action was already used and which is still available.

To realize this feature, the `Set<string> actionsThisGeneration` had to be turned into an `Array` as `Set`s are not reactive so the views could not react to changes when an action was used.