### PR TITLE
Fix resource decrement

### DIFF
--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -2,8 +2,8 @@
 
 export const PaymentWidgetMixin = {
     "methods": {
-        getCardCost: function (): number {
-            return (this as any).player.megaCredits;
+        getMegaCreditsMax: function (): number {
+            return Math.min((this as any).player.megaCredits, (this as any).getCardCost());
         },
         getCssClassFor: function (action: string, target: string): string {
             let currentValue: number = (this as any)[target];
@@ -38,12 +38,11 @@ export const PaymentWidgetMixin = {
 
             let rate = this.getResourceRate(target)
             this.addValue("megaCredits", rate * realTo);
-
         },
         addValue: function (target: string, to: number): void {
             let currentValue: number = (this as any)[target];
             let maxValue: number = (this as any).player[target];
-            if (target === "megaCredits") maxValue = this.getCardCost();
+            if (target === "megaCredits") maxValue = this.getMegaCreditsMax();
             if (target === "microbes") maxValue = (this as any).playerinput.microbes;
             if (target === "floaters") maxValue = (this as any).playerinput.floaters;
             if (currentValue === maxValue) return;

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -13,7 +13,7 @@ export const PaymentWidgetMixin = {
             if (currentValue === disablingLimit) return "is-disabled";
             return "is-primary"
         },
-        getRersourceRate: function (resourceName: string): number {
+        getResourceRate: function (resourceName: string): number {
             let rate = 1; // one resource == one money
             if (resourceName === "titanium") {
                 rate = (this as any).player.titaniumValue;
@@ -36,7 +36,7 @@ export const PaymentWidgetMixin = {
 
             if (target === "megaCredits" || realTo === 0) return;
 
-            let rate = this.getRersourceRate(target)
+            let rate = this.getResourceRate(target)
             this.addValue("megaCredits", rate * realTo);
 
         },
@@ -47,13 +47,13 @@ export const PaymentWidgetMixin = {
             if (target === "microbes") maxValue = (this as any).playerinput.microbes;
             if (target === "floaters") maxValue = (this as any).playerinput.floaters;
             if (currentValue === maxValue) return;
-            
+
             const realTo = (currentValue + to <= maxValue) ? to : maxValue - currentValue;
             (this as any)[target] += realTo;
 
             if (target === "megaCredits" || realTo === 0) return;
 
-            let rate = this.getRersourceRate(target)
+            let rate = this.getResourceRate(target)
             this.reduceValue("megaCredits", rate * realTo);
         }
     }

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -36,8 +36,7 @@ export const PaymentWidgetMixin = {
 
             if (target === "megaCredits" || realTo === 0) return;
 
-            let rate = this.getResourceRate(target)
-            this.addValue("megaCredits", rate * realTo);
+            this.setRemainingMCValue();
         },
         addValue: function (target: string, to: number): void {
             let currentValue: number = (this as any)[target];
@@ -52,8 +51,16 @@ export const PaymentWidgetMixin = {
 
             if (target === "megaCredits" || realTo === 0) return;
 
-            let rate = this.getResourceRate(target)
-            this.reduceValue("megaCredits", rate * realTo);
+            this.setRemainingMCValue();
+        },
+        setRemainingMCValue: function (): void {
+            let costInMC: number = (this as any).getCardCost();
+            let remainingMC: number = costInMC -
+              (this as any)["titanium"] * this.getResourceRate("titanium") -
+              (this as any)["steel"] * this.getResourceRate("steel") -
+              (this as any)["microbes"] * this.getResourceRate("microbes") -
+              (this as any)["floaters"] * this.getResourceRate("floaters");
+            (this as any)["megaCredits"] = Math.max(0, remainingMC);
         }
     }
 }

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -77,7 +77,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 }
             }
             return false;
-		},	
+        },
         canUseMicrobes: function () {
             if (this.$data.card !== undefined && this.playerinput.microbes > 0) {
                 const card = getProjectCardByName(this.$data.card);
@@ -87,7 +87,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     }
                 }
             }
-            return false;			
+            return false;
         },
         canUseFloaters: function () {
             if (this.$data.card !== undefined && this.playerinput.floaters > 0) {
@@ -98,11 +98,11 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     }
                 }
             }
-            return false;			
+            return false;
         },
         cardChanged: function () {
             this.$data.megaCredits = this.getCardCost();
-            
+
             this.titanium = 0;
             this.steel = 0;
             this.heat = 0;


### PR DESCRIPTION
These changes allow the SelectHowToPay inputs to refund an appropriate amount of MegaCredits when reducing the amount of a resource allocated to payment. The canonical example:

* The player is paying for a 10 MC card with space tag, and the player has 4 titanium.
* The player allocates 3 titanium and sees 1 MC will be spent.
* The player increases titanium to 4 and sees 0 MC will be spent.
* The player decreases titanium to 3.

Without these changes, the MC will be set to 3, resulting in a situation where the player might accidentally overpay. With these changes, the MC will be set to 1, which is the minimum MC needed to fund the purchase with the 3 titanium.

Additionally, these changes prevent a player from paying more MC than a card costs. They can no longer allocate MC up to the amount they have; only enough to pay for the card. They can still overpay with resources.