### PR TITLE
Clear corporation cards before adding custom list

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -162,6 +162,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
       // Setup custom corporation list
       if (gameOptions.customCorporationsList && gameOptions.corporations.length >= players.length * 2) {
+        corporationCards = [];
         gameOptions.corporations.forEach((cardName) => {
             const cardFactory = ALL_CORPORATION_CARDS.find((cf) => cf.cardName === cardName);
             if (cardFactory !== undefined) {


### PR DESCRIPTION
When I put in the card factory I stopped clearing the corporations list prior to using the custom list.