### PR TITLE
For payment, cache card/ability cost for accurate setting of remaining MC.

### DIFF
--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -3,7 +3,7 @@
 export const PaymentWidgetMixin = {
     "methods": {
         getMegaCreditsMax: function (): number {
-            return Math.min((this as any).player.megaCredits, (this as any).getCardCost());
+            return Math.min((this as any).player.megaCredits, (this as any).$data.cost);
         },
         getCssClassFor: function (action: string, target: string): string {
             let currentValue: number = (this as any)[target];
@@ -54,8 +54,7 @@ export const PaymentWidgetMixin = {
             this.setRemainingMCValue();
         },
         setRemainingMCValue: function (): void {
-            let costInMC: number = (this as any).getCardCost();
-            let remainingMC: number = costInMC -
+            let remainingMC: number = (this as any).$data.cost -
               (this as any)["titanium"] * this.getResourceRate("titanium") -
               (this as any)["steel"] * this.getResourceRate("steel") -
               (this as any)["microbes"] * this.getResourceRate("microbes") -

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -17,6 +17,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
     props: ["player", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
+            cost: 0,
             heat: 0,
             megaCredits: 0,
             steel: 0,
@@ -30,7 +31,8 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
     mounted: function () {
       let app = this;
       Vue.nextTick(function () {
-        app.$data.megaCredits = app.playerinput.amount;
+        app.$data.cost = app.playerinput.amount;
+        app.$data.megaCredits = (app as any).getMegaCreditsMax();
       });
     },
     methods: {
@@ -62,10 +64,10 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                 this.$data.warning = "You don't have enough steel";
                 return;
             }
-            if (this.playerinput.amount > 0 && 
-                htp.heat + 
-                htp.megaCredits + 
-                (htp.steel * this.player.steelValue) + 
+            if (this.playerinput.amount > 0 &&
+                htp.heat +
+                htp.megaCredits +
+                (htp.steel * this.player.steelValue) +
                 (htp.titanium * this.player.titaniumValue) +
                 (htp.microbes * 2) +
                 (htp.floaters * 3)
@@ -76,7 +78,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
             this.onsave([[JSON.stringify(htp)]]);
         }
     },
-    template: `<div class="payments_cont"> 
+    template: `<div class="payments_cont">
   <section v-trim-whitespace>
 
     <h3 class="payments_title">{{playerinput.title}}</h3>

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -22,6 +22,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
     data: function () {
         return {
             card: this.playerinput.cards[0],
+            cost: 0,
             heat: 0,
             megaCredits: 0,
             steel: 0,
@@ -38,7 +39,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
     mounted: function () {
         let app = this;
         Vue.nextTick(function () {
-            app.$data.megaCredits = app.getCardCost();
+            app.$data.cost = app.getCardCost();
+            app.$data.megaCredits = (app as any).getMegaCreditsMax();
         });
     },
     methods: {
@@ -101,7 +103,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             return false;
         },
         cardChanged: function () {
-            this.$data.megaCredits = this.getCardCost();
+            this.$data.cost = this.getCardCost();
+            this.$data.megaCredits = (this as any).getMegaCreditsMax();
 
             this.titanium = 0;
             this.steel = 0;


### PR DESCRIPTION
When choosing a card or ability, cache the cost for more accurate calculation of remaining MC. Without this, current code is using the card cost _even for payments on cards_ e.g. aquifer pumping.