### PR TITLE
Don't calculate an MC value larger than the player possesses.

### DIFF
--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -59,7 +59,7 @@ export const PaymentWidgetMixin = {
               (this as any)["steel"] * this.getResourceRate("steel") -
               (this as any)["microbes"] * this.getResourceRate("microbes") -
               (this as any)["floaters"] * this.getResourceRate("floaters");
-            (this as any)["megaCredits"] = Math.max(0, remainingMC);
+            (this as any)["megaCredits"] = Math.max(0, Math.min(this.getMegaCreditsMax(), remainingMC));
         }
     }
 }


### PR DESCRIPTION
One more fixup. This prevents the remaining MC calculation from suggesting an MC value greater than the player has.