### PR TITLE
Update Diversifier milestone to support wildcards

### DIFF
--- a/src/milestones/Diversifier.ts
+++ b/src/milestones/Diversifier.ts
@@ -1,25 +1,31 @@
 import { IMilestone } from "./IMilestone";
 import { Player } from "../Player";
-import { Game } from "../Game";
 import { CardType } from "../cards/CardType";
+import { Tags } from "../cards/Tags";
 
 export class Diversifier implements IMilestone {
     public name: string = "Diversifier";
     public description: string = "Requires that you have 8 different tags in play"
-    public canClaim(player: Player, _game: Game): boolean {
-        let allTags = new Set();
+    public canClaim(player: Player): boolean {
+        const allTags: Tags[] = [];
+        let wildcardCount: number = 0;
+        const uniqueTags: Set<Tags> = new Set<Tags>();
         if (player.corporationCard !== undefined && player.corporationCard.tags.length > 0) {
-          player.corporationCard.tags.forEach(tag => {
-            allTags.add(tag);
-          });
+          player.corporationCard.tags.forEach((tag) => allTags.push(tag));
         }
         player.playedCards.filter((card) => card.cardType !== CardType.EVENT)
-          .forEach(card => {
-            card.tags.forEach(tag => {
-              allTags.add(tag);
-            });  
+          .forEach((card) => {
+            card.tags.forEach((tag) => {
+              allTags.push(tag);
+            });
+          });
+        for (const tags of allTags) {
+          if (tags === Tags.WILDCARD) {
+            wildcardCount++;
+          } else {
+            uniqueTags.add(tags);
           }
-        );        
-        return allTags.size >= 8;
+        }
+        return uniqueTags.size + wildcardCount >= 8;
     }   
 }

--- a/tests/milestones/Diversifier.spec.ts
+++ b/tests/milestones/Diversifier.spec.ts
@@ -1,0 +1,18 @@
+
+import { expect } from "chai";
+import { Diversifier } from "../../src/milestones/Diversifier";
+import { Color } from "../../src/Color";
+import { Player } from "../../src/Player";
+import { ResearchNetwork } from "../../src/cards/prelude/ResearchNetwork";
+
+describe("Diversifier", function () {
+    it("Counts wildcard tags as unique tags", function () {
+        const milestone = new Diversifier();
+        const player = new Player("test", Color.BLUE, false);
+        expect(milestone.canClaim(player)).to.eq(false);
+        for (let i = 0; i < 8; i++) {
+          player.playedCards.push(new ResearchNetwork());
+        }
+        expect(milestone.canClaim(player)).to.eq(true);
+    });
+});

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -22,7 +22,8 @@
         "tests/cards/venusNext/*.spec.ts",
         "tests/cards/colonies/*.spec.ts",
         "tests/cards/turmoil/*.spec.ts",        
-        "tests/cards/promo/*.spec.ts",       
+        "tests/cards/promo/*.spec.ts",
+        "tests/milestones/*.spec.ts", 
         "tests/*.spec.ts",
         "tests/TestingUtils.ts"
     ],
@@ -394,6 +395,7 @@
         "tests/cards/promo/MonsInsurance.spec.ts",
         "tests/cards/promo/Recyclon.spec.ts",
         "tests/cards/promo/Splice.spec.ts",
+        "tests/milestones/Diversifier.spec.ts",
         "tests/Board.spec.ts",
         "tests/Game.spec.ts",
         "tests/OriginalBoard.spec.ts",


### PR DESCRIPTION
This is the first part of issue #528 . This counts all wild card tags as a unique count.