### PR TITLE
Disable Undo Turn action if there's no lastSave available

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1854,7 +1854,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       // Propose undo action only if you have done one action this turn
-      if (this.actionsTakenThisRound > 0) {
+      if (this.actionsTakenThisRound > 0 && game.lastSaveId !== 0) {
         action.options.push(this.undoTurnOption(game));
       }
 


### PR DESCRIPTION
Fix to not crash the game if first player tries to undo his first turn