### PR TITLE
Run OlympusConference for each science tag

### DIFF
--- a/tests/cards/OlympusConference.spec.ts
+++ b/tests/cards/OlympusConference.spec.ts
@@ -6,6 +6,7 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Bushes } from "../../src/cards/Bushes";
 import { OrOptions } from "../../src/inputs/OrOptions";
+import { Research } from "../../src/cards/Research";
 
 describe("OlympusConference", function () {
     it("Should play", function () {
@@ -20,13 +21,28 @@ describe("OlympusConference", function () {
         expect(card.onCardPlayed(player, game, new Bushes())).to.eq(undefined) 
         card.onCardPlayed(player, game, card);
         expect(card.resourceCount).to.eq(1);
-        const orOptions = card.onCardPlayed(player, game, card) as OrOptions;
-        expect(orOptions).not.to.eq(undefined);
-        expect(orOptions instanceof OrOptions).to.eq(true);
+        card.onCardPlayed(player, game, card);
+        expect(game.interrupts.length).to.eq(1);
+        const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
         orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(2);
         orOptions.options[1].cb();
         expect(card.resourceCount).to.eq(1);
         expect(player.cardsInHand.length).to.eq(1);
+        expect(game.interrupts.length).to.eq(1);
+    });
+    it("Plays twice for Research", function () {
+        const card = new OlympusConference();
+        const player = new Player("test", Color.BLUE, false);
+        player.playedCards.push(card);
+        const game = new Game("foobar", [player], player);
+        card.onCardPlayed(player, game, new Research());
+        expect(game.interrupts.length).to.eq(1);
+        expect(card.resourceCount).to.eq(1);
+        const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
+        game.interrupts.splice(0, 1);
+        orOptions.options[0].cb();
+        expect(card.resourceCount).to.eq(2);
+        expect(game.interrupts.length).to.eq(0);
     });
 });


### PR DESCRIPTION
Part one of the bug reported in #453 where multiple science tags were not considered. This half is for `OlympusConference`. I added a unit test for the case as well.