### PR TITLE
Added promo card Hi-Tech Lab (#539)

### DIFF
--- a/src/CardName.ts
+++ b/src/CardName.ts
@@ -394,5 +394,6 @@ export enum CardName {
     REGO_PLASTICS = "Rego Plastics",
     INTERPLANETARY_TRADE = "Interplanetary Trade",
     ORBITAL_CLEANUP = "Orbital Cleanup",
-    PROJECT_INSPECTION = "Project Inspection"
+    PROJECT_INSPECTION = "Project Inspection",
+    HI_TECH_LAB = "Hi-Tech Lab"
 }

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -402,6 +402,7 @@ import { RegoPlastics } from "./cards/promo/RegoPlastics";
 import { InterplanetaryTrade } from "./cards/promo/InterplanetaryTrade";
 import { OrbitalCleanup } from "./cards/promo/OrbitalCleanup";
 import { ProjectInspection } from "./cards/promo/ProjectInspection";
+import { HiTechLab } from "./cards/promo/HiTechLab";
 
 import { ILoadable } from "./ILoadable";
 import { CardName } from "./CardName";
@@ -835,7 +836,8 @@ export const ALL_PROJECT_CARDS: Array<ICardFactory<IProjectCard>> = [
     { cardName: CardName.REGO_PLASTICS, factory: RegoPlastics },
     { cardName: CardName.INTERPLANETARY_TRADE, factory: InterplanetaryTrade },
     { cardName: CardName.ORBITAL_CLEANUP, factory: OrbitalCleanup },
-    { cardName: CardName.PROJECT_INSPECTION, factory: ProjectInspection }
+    { cardName: CardName.PROJECT_INSPECTION, factory: ProjectInspection },
+    { cardName: CardName.HI_TECH_LAB, factory: HiTechLab }
 ];
 
 // Function to return a card object by its name

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -6803,5 +6803,20 @@ export const HTML_DATA: Map<string, string> =
             (Decrease your MC production 2 steps.)
         </div>
     </div>
+`],
+[CardName.HI_TECH_LAB, `
+    <div class="title background-color-active">Hi-Tech Lab</div>
+    <div class="price ">17</div>
+    <div class="tag tag1 tag-building"></div>
+    <div class="tag tag2 tag-science"></div>
+    <div class="promo-icon project-icon"></div>
+    <div class="card-number">X04</div>
+    <div class="content">
+        <div class="points points-big">1</div>
+        X <div class="energy resource "></div> <div class="red-arrow"></div> X <div class="card resource "></div>*
+        <div class="description">
+            (Action: Spend any amount of energy to draw the same number of cards. TAKE 1 INTO HAND AND DISCARD THE REST.)
+        </div>
+    </div>
 `]
 ]);

--- a/src/cards/promo/HiTechLab.ts
+++ b/src/cards/promo/HiTechLab.ts
@@ -1,0 +1,42 @@
+import { IProjectCard } from "../IProjectCard";
+import { CardName } from "../../CardName";
+import { CardType } from "../CardType";
+import { Tags } from "../Tags";
+import { Player } from "../../Player";
+import { Resources } from "../../Resources";
+import { Game } from "../../Game";
+import { SelectAmount } from "../../inputs/SelectAmount";
+import { SelectFromCards } from "../../interrupts/SelectFromCards";
+
+export class HiTechLab implements IProjectCard {
+
+    public name: CardName = CardName.HI_TECH_LAB;
+    public cost: number = 17;
+    public tags: Array<Tags> = [Tags.SCIENCE, Tags.STEEL];
+    public cardType: CardType = CardType.ACTIVE;
+
+    public play() {
+        return undefined;
+    }
+
+    public canAct(player: Player): boolean {
+        return player.getResource(Resources.ENERGY) > 0;
+    }
+
+    public action(player: Player, game: Game) {
+        return new SelectAmount("Select amount of energy to spend", (amount: number) => {
+            player.setResource(Resources.ENERGY, -amount);
+            let cardsDrawn: Array<IProjectCard> = [];
+            for (let counter = 0; counter < amount; counter++) {
+                cardsDrawn.push(game.dealer.dealCard());
+            };
+            game.addInterrupt(new SelectFromCards(player, game, "Select card to take into hand", cardsDrawn));
+            return undefined;
+        }, player.getResource(Resources.ENERGY));
+    }
+
+    public getVictoryPoints() {
+        return 1;
+    }
+
+}

--- a/src/interrupts/SelectFromCards.ts
+++ b/src/interrupts/SelectFromCards.ts
@@ -1,0 +1,24 @@
+import { PlayerInput } from '../PlayerInput';
+import { Player } from '../Player';
+import { PlayerInterrupt } from './PlayerInterrupt';
+import { SelectCard } from '../inputs/SelectCard';
+import { Game } from '../Game';
+import { IProjectCard } from '../cards/IProjectCard';
+
+export class SelectFromCards implements PlayerInterrupt {
+    
+    public playerInput: PlayerInput;
+    constructor(
+        public player: Player,
+        public game: Game,
+        public title: string,
+        public cards: Array<IProjectCard>
+    ) {
+        this.playerInput = new SelectCard(this.title, this.cards, (foundCards: Array<IProjectCard>) => {
+            player.cardsInHand.push(foundCards[0]);
+            this.cards.filter((c) => c !== foundCards[0]).forEach((c) => game.dealer.discard(c));
+                return undefined;
+            }
+        );
+    };
+}

--- a/tests/cards/promo/HiTechLab.spec.ts
+++ b/tests/cards/promo/HiTechLab.spec.ts
@@ -30,4 +30,12 @@ describe("HiTechLab", function () {
         amount.cb(3);
         expect(player.getResource(Resources.ENERGY)).to.eq(2);
     });
+    it("Should give victory points", function () {
+        const card = new HiTechLab();
+        const player = new Player("test", Color.BLUE, false);
+        const play = card.play();
+        expect(play).to.eq(undefined);
+        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+    });
 });

--- a/tests/cards/promo/HiTechLab.spec.ts
+++ b/tests/cards/promo/HiTechLab.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { HiTechLab } from "../../../src/cards/promo/HiTechLab";
+import { Color } from "../../../src/Color";
+import { Player } from "../../../src/Player";
+import { Game } from "../../../src/Game";
+import { Resources } from "../../../src/Resources";
+import { SelectAmount } from "../../../src/inputs/SelectAmount";
+
+describe("HiTechLab", function () {
+    it("Should play", function () {
+        const card = new HiTechLab();
+        expect(card.play()).to.eq(undefined);
+    });
+    it("Can't act if not energy resources available", function () {
+        const card = new HiTechLab();
+        const player = new Player("test", Color.BLUE, false);
+        expect(card.play()).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(false);
+    });
+    it("Should act", function () {
+        const card = new HiTechLab();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player, player], player);
+        player.setResource(Resources.ENERGY, 5);
+        expect(card.play()).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        const amount = card.action(player, game) as SelectAmount;
+        expect(amount).not.to.eq(undefined);
+        expect(amount instanceof SelectAmount).to.eq(true);
+        amount.cb(3);
+        expect(player.getResource(Resources.ENERGY)).to.eq(2);
+    });
+});

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -404,6 +404,7 @@
         "tests/cards/promo/InterplanetaryTrade.spec.ts",
         "tests/cards/promo/OrbitalCleanup.spec.ts",
         "tests/cards/promo/ProjectInspection.spec.ts",
+        "tests/cards/promo/HiTechLab.spec.ts",
         "tests/milestones/Diversifier.spec.ts",
         "tests/Board.spec.ts",
         "tests/Game.spec.ts",


### PR DESCRIPTION
Please double check if using a (new) interrupt in the card is the best/correct way of implementing the two step card selection. 

I am also not sure if this shouldn't be tested better. The test implemented only respects the first step (energy spending) not the second one (card selection). I looked around in the code but couldn't find anything better, _Titan Floating Launch-Pad_ is doing it the same way.