### PR TITLE
Pay for card before playing it

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1022,31 +1022,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
     public playCard(game: Game, selectedCard: IProjectCard, howToPay?: HowToPay): undefined { 
 
-        //Activate some colonies
-        if (game.coloniesExtension && selectedCard.resourceType !== undefined) {
-          game.colonies.filter(colony => colony.resourceType !== undefined && colony.resourceType === selectedCard.resourceType).forEach(colony => {
-            colony.isActive = true;
-          });
-        }
-
-        // Play the card
-        const action = selectedCard.play(this, game);
-        if (action !== undefined) {
-            game.interrupts.push({
-                player: this,
-                playerInput: action
-            });
-        }
-
-        const projectCardIndex = this.cardsInHand.findIndex((card) => card.name === selectedCard.name);
-        const preludeCardIndex = this.preludeCardsInHand.findIndex((card) => card.name === selectedCard.name);
-        if (projectCardIndex !== -1) {
-          this.cardsInHand.splice(projectCardIndex, 1);
-        } else if (preludeCardIndex !== -1) {
-          this.preludeCardsInHand.splice(preludeCardIndex, 1);
-        }
-        this.addPlayedCard(game, selectedCard);
-
+        // Pay for card
         if (howToPay !== undefined) {
             this.steel -= howToPay.steel;
             this.titanium -= howToPay.titanium;
@@ -1059,36 +1035,59 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
                 if (playedCard.name === CardName.DIRIGIBLES) {
                     this.removeResourceFrom(playedCard, howToPay.floaters);
-                } 
+                }
             }
-          }
+        }
 
-          for (const playedCard of this.playedCards) {
+        //Activate some colonies
+        if (game.coloniesExtension && selectedCard.resourceType !== undefined) {
+            game.colonies.filter(colony => colony.resourceType !== undefined && colony.resourceType === selectedCard.resourceType).forEach(colony => {
+                colony.isActive = true;
+            });
+        }
+
+        // Play the card
+        const action = selectedCard.play(this, game);
+        if (action !== undefined) {
+            game.interrupts.push({
+                player: this,
+                playerInput: action
+            });
+        }
+
+        // Remove card from hand
+        const projectCardIndex = this.cardsInHand.findIndex((card) => card.name === selectedCard.name);
+        const preludeCardIndex = this.preludeCardsInHand.findIndex((card) => card.name === selectedCard.name);
+        if (projectCardIndex !== -1) {
+          this.cardsInHand.splice(projectCardIndex, 1);
+        } else if (preludeCardIndex !== -1) {
+          this.preludeCardsInHand.splice(preludeCardIndex, 1);
+        }
+        this.addPlayedCard(game, selectedCard);
+
+        for (const playedCard of this.playedCards) {
             if (playedCard.onCardPlayed !== undefined) {
-              const actionFromPlayedCard: OrOptions | void =
-                            playedCard.onCardPlayed(this, game, selectedCard);
-              if (actionFromPlayedCard !== undefined) {
-                game.interrupts.push({
-                    player: this,
-                    playerInput: actionFromPlayedCard
-                });
-              }
+                const actionFromPlayedCard: OrOptions | void = playedCard.onCardPlayed(this, game, selectedCard);
+                if (actionFromPlayedCard !== undefined) {
+                    game.interrupts.push({
+                        player: this,
+                        playerInput: actionFromPlayedCard
+                    });
+                }
             }
-          }
+        }
 
-          for (let somePlayer of game.getPlayers()) {
-            if (somePlayer.corporationCard !== undefined &&
-                somePlayer.corporationCard.onCardPlayed !== undefined
-            ) {
-              const actionFromPlayedCard: OrOptions | void = somePlayer.corporationCard.onCardPlayed(this, game, selectedCard);
-              if (actionFromPlayedCard !== undefined) {
-                game.interrupts.push({
-                    player: this,
-                    playerInput: actionFromPlayedCard
-                });
-              }
+        for (let somePlayer of game.getPlayers()) {
+            if (somePlayer.corporationCard !== undefined && somePlayer.corporationCard.onCardPlayed !== undefined) {
+                const actionFromPlayedCard: OrOptions | void = somePlayer.corporationCard.onCardPlayed(this, game, selectedCard);
+                if (actionFromPlayedCard !== undefined) {
+                    game.interrupts.push({
+                        player: this,
+                        playerInput: actionFromPlayedCard
+                    });
+                }
             }
-          }
+        }
 
         if (selectedCard.name === CardName.ECOLOGY_EXPERTS || selectedCard.name === CardName.ECCENTRIC_SPONSOR) {
             if (this.getPlayableCards(game).length > 0) {


### PR DESCRIPTION
When I first wrote this game I paid for the card after playing it. I did this in case an error was thrown while playing the card. If an error were thrown while playing the card then I would have had to handle reverting the payment for the card. I don't think this is an actual issue. As the saying goes, you have to PAY to PLAY. This change moves the payment of the card before playing the card. It should fix the issue reported in #625 as well as others that haven't been reported.