### PR TITLE
EOS bug: any but only to your cards

### DIFF
--- a/src/cards/EOSChasmaNationalPark.ts
+++ b/src/cards/EOSChasmaNationalPark.ts
@@ -8,6 +8,8 @@ import {Game} from '../Game';
 import {SelectCard} from '../inputs/SelectCard';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { ResourceType } from '../ResourceType';
+
 
 export class EosChasmaNationalPark implements IProjectCard {
   public cost: number = 16;
@@ -22,31 +24,13 @@ export class EosChasmaNationalPark implements IProjectCard {
     );
   }
 
-  public play(player: Player, game: Game) {   
-    const availableCards = game.getPlayedCardsWithAnimals();
-    if (availableCards.length < 1) {
-      player.plants += 3;
-      player.setProduction(Resources.MEGACREDITS,2);
-      return undefined;
-    }
-
-    if (availableCards.length === 1) {
-      game.getCardPlayer(availableCards[0].name).addResourceTo(availableCards[0]);
-      player.plants += 3;
-      player.setProduction(Resources.MEGACREDITS,2);
-      return undefined;
-    }
-
-    return new SelectCard(
-        'Select card to add 1 animal',
-        availableCards,
-        (foundCards: Array<ICard>) => {
-          game.getCardPlayer(foundCards[0].name).addResourceTo(foundCards[0]);
+  public play(player: Player) {
+      return new SelectCard("Add 1 animal to a card", player.getResourceCards(ResourceType.ANIMAL), (foundCards: Array<ICard>) => {
+          player.addResourceTo(foundCards[0], 1);
           player.plants += 3;
           player.setProduction(Resources.MEGACREDITS,2);
           return undefined;
-        }
-    );
+      });
   }
 
   public getVictoryPoints() {


### PR DESCRIPTION
This was an error. You can add to any card, meaning any of your cards.
I'll have to check if there are other cards using `getPlayedCardsWithAnimals` that have the same problem