### PR TITLE
Improved for optional played cards and others player board

### DIFF
--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -22,12 +22,18 @@ export const OtherPlayer = Vue.component("other-player", {
         },
         isVisible: function () {
             return (this.$root as any).getVisibilityState("other_player_"+this.player.id);
+        },
+        toggleVisible: function() {
+            (this.$root as any).setVisibilityState("other_player_"+this.player.id,  !(this.isVisible()));
+        },
+        buttonTitle: function() {
+            return ( this.isVisible() ? "Hide Cards" : "Show Cards" )
         }
     },
     template: `
         <div> 
-            <div v-show="isVisible()" class="other_player_cont menu">
-                <button class="btn btn-lg btn-error other_player_close" v-on:click="hideMe()"><i class="icon icon-cross"></i></button> 
+            <div class="other_player_cont menu">
+                <button class="btn btn-lg btn-error other_player_close" v-on:click="toggleVisible()"> {{buttonTitle()}}  </button> 
                 <div class="player_home_block">
                     <span class="player_name" :class="'player_bg_color_' + player.color"> {{ player.name }} : {{player.cardsInHandNbr}} cards in hand </span>
                 </div>
@@ -51,7 +57,7 @@ export const OtherPlayer = Vue.component("other-player", {
                     <player-resources :player="player"></player-resources>
                 </div>
 
-                <div v-if="player.playedCards.length > 0 || player.corporationCard !== undefined" class="player_home_block">
+                <div v-show="isVisible()" v-if="player.playedCards.length > 0 || player.corporationCard !== undefined" class="player_home_block">
                     <span class="player_name" :class="'player_bg_color_' + player.color"> {{ player.name }} played cards </span>
                     <div>
                         <div v-if="player.corporationCard !== undefined" class="cardbox">

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -101,23 +101,23 @@ export const PlayerHome = Vue.component("player-home", {
                         <milestone :milestones_list="player.milestones" />
                         <award :awards_list="player.awards" />
                     </div>
+
+                    <div class="player_home_block player_home_block--log nofloat" v-if="player.players.length > 1 && player.gameLog.length > 0">
+                        <h2 :class="'player_color_'+ player.color" v-i18n>Last Actions</h2>
+                        <log-panel :messages="player.gameLog" :players="player.players"></log-panel>
+                    </div>
+
                 </div>
 
                 <div class="player_home_block player_home_block--turnorder nofloat" v-if="player.players.length>1">
                     <h2 :class="'player_color_'+ player.color">
                         <span v-i18n>Turn order</span>
-                        <span class="help_tip" v-i18n>(click on player name to see details)</span>
                     </h2>
                     <div class="player_item" v-for="(p, idx) in player.players" v-trim-whitespace>
                         <div class="player_name_cont" :class="getPlayerCssForTurnOrder(p, true)">
                             <span class="player_number">{{ idx+1 }}.</span><a v-on:click.prevent="showPlayerDetails(p)" class="player_name" :class="getPlayerCssForTurnOrder(p, false)" href="#">{{ p.name }}</a>
                         </div>
                         <div class="player_separator" v-if="idx !== player.players.length - 1">⟶</div>
-                    </div>
-                    <div v-if="player.players.length > 1" style="display:flex;flex-wrap:wrap;">
-                        <div v-for="otherPlayer in player.players" :key="otherPlayer.id">
-                            <other-player v-if="otherPlayer.id !== player.id" :player="otherPlayer"></other-player>
-                        </div>
                     </div>
                 </div>
 
@@ -151,11 +151,6 @@ export const PlayerHome = Vue.component("player-home", {
                     </div>
                 </div>
 
-                <div class="player_home_block player_home_block--log nofloat" v-if="player.players.length > 1 && player.gameLog.length > 0">
-                    <h2 :class="'player_color_'+ player.color" v-i18n>Last Actions</h2>
-                    <log-panel :messages="player.gameLog" :players="player.players"></log-panel>
-                </div>
-
                 <a name="cards" class="player_home_anchor"></a>
                 <div class="player_home_block player_home_block--hand" v-if="player.cardsInHand.length > 0">
                     <h2 :class="'player_color_'+ player.color" v-i18n>Cards In Hand</h2>
@@ -177,7 +172,15 @@ export const PlayerHome = Vue.component("player-home", {
                     <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" ></stacked-cards>
                     <stacked-cards :cards="getCardsByType(player.playedCards, [getEventCardType()])" ></stacked-cards>
                 </div>
+               
+                <div v-if="player.players.length > 1" >
+                    <div v-for="otherPlayer in player.players" :key="otherPlayer.id">
+                        <other-player v-if="otherPlayer.id !== player.id" :player="otherPlayer"></other-player>
+                    </div>
+                </div>
+       
             </div>
+
 
             <div class="player_home_block player_home_block--setup nofloat"  v-if="!player.corporationCard">
                 <h2 :class="'player_color_'+ player.color" v-i18n>Select initial cards:</h2>


### PR DESCRIPTION
I've tested this version which seems to be a good compromise.
The others players board are always shown, but you can hide/show played cards, which can speed up the middle-end game phase.
I've moved the log on to, right after the awards and milestones and above the turn order and above the player's board.

<img width="878" alt="Screenshot 2020-05-12 at 15 15 36" src="https://user-images.githubusercontent.com/29941924/81695921-8f980800-9463-11ea-88a9-41a795de3630.png">

<img width="737" alt="Screenshot 2020-05-12 at 15 15 46" src="https://user-images.githubusercontent.com/29941924/81695930-945cbc00-9463-11ea-8a14-700247826a73.png">
