### PR TITLE
Fix logic on some tile placement and Colony cards

### DIFF
--- a/src/cards/Capital.ts
+++ b/src/cards/Capital.ts
@@ -19,7 +19,7 @@ export class Capital implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 2 &&
         game.board.getOceansOnBoard() >= 4 - player.getRequirementsBonus(game) &&
-        game.board.getAvailableSpacesForCity(player).length >= 0;
+        game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public getVictoryPoints(_player: Player, game: Game) {
       const usedSpace = game.board.getSpaceByTileCard(this.name);

--- a/src/cards/CommercialDistrict.ts
+++ b/src/cards/CommercialDistrict.ts
@@ -16,8 +16,9 @@ export class CommercialDistrict implements IProjectCard {
     public name: CardName = CardName.COMMERCIAL_DISTRICT;
     public cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1;
+    public canPlay(player: Player, game: Game): boolean {
+      return player.getProduction(Resources.ENERGY) >= 1 &&
+      game.board.getAvailableSpacesOnLand(player).length > 0;
     }
     public getVictoryPoints(_player: Player, game: Game) {
       const usedSpace = game.board.getSpaceByTileCard(this.name);

--- a/src/cards/CorporateStronghold.ts
+++ b/src/cards/CorporateStronghold.ts
@@ -16,7 +16,8 @@ export class CorporateStronghold implements IProjectCard {
     public name: CardName = CardName.CORPORATE_STRONGHOLD;
     public hasRequirements = false;
     public canPlay(player: Player, game: Game): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1 && game.board.getAvailableSpacesForCity(player).length >= 0;
+      return player.getProduction(Resources.ENERGY) >= 1 &&
+      game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
       return new SelectSpace(

--- a/src/cards/CupolaCity.ts
+++ b/src/cards/CupolaCity.ts
@@ -16,7 +16,8 @@ export class CupolaCity implements IProjectCard {
     public name: CardName = CardName.CUPOLA_CITY;
     public canPlay(player: Player, game: Game): boolean {
       return game.getOxygenLevel() <= 9 + player.getRequirementsBonus(game) &&
-        player.getProduction(Resources.ENERGY) >= 1;
+        player.getProduction(Resources.ENERGY) >= 1 &&
+        game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
       return new SelectSpace(

--- a/src/cards/DomedCrater.ts
+++ b/src/cards/DomedCrater.ts
@@ -17,7 +17,7 @@ export class DomedCrater implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 1 &&
         game.getOxygenLevel() <= 7 + player.getRequirementsBonus(game) &&
-        game.board.getAvailableSpacesForCity(player).length >= 0;
+        game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
       return new SelectSpace(

--- a/src/cards/ImmigrantCity.ts
+++ b/src/cards/ImmigrantCity.ts
@@ -17,7 +17,7 @@ export class ImmigrantCity implements IProjectCard {
     public name: CardName = CardName.IMMIGRANT_CITY;
     public hasRequirements = false;
     public canPlay(player: Player,game: Game): boolean {
-        return player.getProduction(Resources.ENERGY) >= 1 && player.getProduction(Resources.MEGACREDITS) >= -3 && game.board.getAvailableSpacesForCity(player).length >= 0;
+        return player.getProduction(Resources.ENERGY) >= 1 && player.getProduction(Resources.MEGACREDITS) >= -3 && game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public onTilePlaced(player: Player, space: ISpace) {
         if (space.tile !== undefined && space.tile.tileType === TileType.CITY) {

--- a/src/cards/NoctisCity.ts
+++ b/src/cards/NoctisCity.ts
@@ -17,8 +17,13 @@ export class NoctisCity implements IProjectCard {
     public name: CardName = CardName.NOCTIS_CITY;
     public cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.ENERGY) >= 1;
+    public canPlay(player: Player, game: Game): boolean {
+        if (game.boardName === BoardName.ORIGINAL) {
+            return player.getProduction(Resources.ENERGY) >= 1;
+        } else {
+            return player.getProduction(Resources.ENERGY) >= 1 &&
+            game.board.getAvailableSpacesForCity(player).length > 0;;
+        }
     }
     public play(player: Player, game: Game) {
         const noctisSpace = game.getSpace(SpaceName.NOCTIS_CITY);

--- a/src/cards/OpenCity.ts
+++ b/src/cards/OpenCity.ts
@@ -15,7 +15,7 @@ export class OpenCity implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.OPEN_CITY;
     public canPlay(player: Player, game: Game): boolean {
-        return game.getOxygenLevel() >= 12 - player.getRequirementsBonus(game) && player.getProduction(Resources.ENERGY) >= 1 && game.board.getAvailableSpacesForCity(player).length >= 0;
+        return game.getOxygenLevel() >= 12 - player.getRequirementsBonus(game) && player.getProduction(Resources.ENERGY) >= 1 && game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for city tile", game.board.getAvailableSpacesForCity(player), (space: ISpace) => {

--- a/src/cards/RestrictedArea.ts
+++ b/src/cards/RestrictedArea.ts
@@ -17,6 +17,10 @@ export class RestrictedArea implements IActionCard, IProjectCard {
     public cardType: CardType = CardType.ACTIVE;
     public name: CardName = CardName.RESTRICTED_AREA;
 
+    public canPlay(player: Player, game: Game): boolean {
+        return game.board.getAvailableSpacesOnLand(player).length > 0;
+      }
+
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for tile", game.board.getAvailableSpacesOnLand(player), (foundSpace: ISpace) => {
             game.addTile(player, foundSpace.spaceType, foundSpace, { tileType: TileType.RESTRICTED_AREA });

--- a/src/cards/UndergroundCity.ts
+++ b/src/cards/UndergroundCity.ts
@@ -16,7 +16,7 @@ export class UndergroundCity implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;
     public canPlay(player: Player, game: Game): boolean {
-        return player.getProduction(Resources.ENERGY) >= 2 && game.board.getAvailableSpacesForCity(player).length >= 0;
+        return player.getProduction(Resources.ENERGY) >= 2 && game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for city tile", game.board.getAvailableSpacesForCity(player), (foundSpace: ISpace) => {

--- a/src/cards/colonies/MinorityRefuge.ts
+++ b/src/cards/colonies/MinorityRefuge.ts
@@ -13,6 +13,10 @@ export class MinorityRefuge implements IProjectCard {
     public name: CardName = CardName.MINORITY_REFUGE;
     public cardType: CardType = CardType.AUTOMATED;
 
+    public canPlay(player: Player): boolean {
+      return player.getProduction(Resources.MEGACREDITS) >= -3;
+    }
+
     public play(player: Player, game: Game) {
       game.addColonyInterrupt(player, false, "Select colony for Minority Refuge");
       player.setProduction(Resources.MEGACREDITS, -2); 

--- a/src/cards/colonies/RefugeeCamps.ts
+++ b/src/cards/colonies/RefugeeCamps.ts
@@ -16,7 +16,7 @@ export class RefugeeCamps implements IProjectCard, IResourceCard {
     public resourceCount: number = 0;
 
     public canAct(player: Player): boolean {
-        return player.getProduction(Resources.MEGACREDITS) > -4;
+        return player.getProduction(Resources.MEGACREDITS) >= -4;
     } 
 
     public action(player: Player) {

--- a/tests/cards/CommercialDistrict.spec.ts
+++ b/tests/cards/CommercialDistrict.spec.ts
@@ -12,7 +12,8 @@ describe("CommercialDistrict", function () {
     it("Can't play", function () {
         const card = new CommercialDistrict();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
+        const game = new Game("foobar", [player,player], player);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
     it("Should play", function () {
         const card = new CommercialDistrict();

--- a/tests/cards/NoctisCity.spec.ts
+++ b/tests/cards/NoctisCity.spec.ts
@@ -12,7 +12,8 @@ describe("NoctisCity", function () {
     it("Should throw", function () {
         const card = new NoctisCity();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
+        const game = new Game("foobar", [player,player], player);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
     it("Should play", function () {
         const card = new NoctisCity();


### PR DESCRIPTION
**Context:**
1. City cards should not be selectable for play if there are no more valid city spots remaining. It currently logs an error message: `Error processing input from player No available spaces`
2. Cards like Restricted Area should not be selectable for play if there are no more valid tile placement spots remaining
3. Refugee Camps should still be usable at -4 MC production
4. Minority Refuge should not be playable at less than -3 MC production

<img width="746" alt="Screenshot 2020-05-25 at 6 08 33 PM" src="https://user-images.githubusercontent.com/2408094/82810384-ef110180-9ec0-11ea-8f71-04b8ab084cea.png">
