### PR TITLE
Fix: Always allow Business Network scry action

### DIFF
--- a/src/cards/BusinessNetwork.ts
+++ b/src/cards/BusinessNetwork.ts
@@ -23,16 +23,18 @@ export class BusinessNetwork implements IActionCard, IProjectCard {
       player.setProduction(Resources.MEGACREDITS,-1);
       return undefined;
     }
-    public canAct(player: Player): boolean {
-      return player.canAfford(player.cardCost);
+    public canAct(): boolean {
+      return true;
     }
     public action(player: Player, game: Game) {
       const dealtCard = game.dealer.dealCard();
+      const canSelectCard = player.canAfford(player.cardCost);
+
       return new SelectCard(
-        "Select card to keep or none to discard",
+        canSelectCard ? "Select card to keep or none to discard" : "You cannot pay for this card" ,
         [dealtCard],
         (cards: Array<IProjectCard>) => {
-          if (cards.length === 0) {
+          if (cards.length === 0 || !canSelectCard) {
             game.dealer.discard(dealtCard);
             return undefined;
           }
@@ -55,7 +57,7 @@ export class BusinessNetwork implements IActionCard, IProjectCard {
           player.cardsInHand.push(dealtCard);
           player.megaCredits -= player.cardCost;
           return undefined;
-        }, 1, 0
+        }, canSelectCard ? 1 : 0 , 0
       );
     }
 }

--- a/src/cards/InventorsGuild.ts
+++ b/src/cards/InventorsGuild.ts
@@ -25,10 +25,10 @@ export class InventorsGuild implements IActionCard, IProjectCard {
         const dealtCard = game.dealer.dealCard();
         const canSelectCard = player.canAfford(player.cardCost);
         return new SelectCard(
-          canSelectCard ? "Select card to keep or none to discard" : "You cannot pay this card" ,
+          canSelectCard ? "Select card to keep or none to discard" : "You cannot pay for this card" ,
           [dealtCard],
           (cards: Array<IProjectCard>) => {
-            if (cards.length === 0) {
+            if (cards.length === 0 || !canSelectCard) {
               game.dealer.discard(dealtCard);
               return undefined;
             }

--- a/tests/cards/BusinessNetwork.spec.ts
+++ b/tests/cards/BusinessNetwork.spec.ts
@@ -25,10 +25,19 @@ describe("BusinessNetwork", function () {
     });
     it("Can act", function () {
         const card = new BusinessNetwork();
+        expect(card.canAct()).to.eq(true);
+    });
+    it("Cannot buy card if cannot pay", function () {
+        const card = new BusinessNetwork();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canAct(player)).to.eq(false);
-        player.megaCredits = 3;
-        expect(card.canAct(player)).to.eq(true);
+        const game = new Game("foobar", [player,player], player);
+        player.megaCredits = 2;
+        const action = card.action(player, game);
+        expect(action instanceof SelectCard).to.eq(true);
+        (action! as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+        expect(game.dealer.discarded.length).to.eq(1);
+        expect(player.cardsInHand.length).to.eq(0);
+        expect(player.megaCredits).to.eq(2);
     });
     it("Should action as not helion", function () {
         const card = new BusinessNetwork();

--- a/tests/cards/InventorsGuild.spec.ts
+++ b/tests/cards/InventorsGuild.spec.ts
@@ -30,4 +30,16 @@ describe("InventorsGuild", function () {
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });
+    it("Cannot buy card if cannot pay", function () {
+        const card = new InventorsGuild();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+        player.megaCredits = 2;
+        const action = card.action(player, game);
+        expect(action instanceof SelectCard).to.eq(true);
+        (action! as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
+        expect(game.dealer.discarded.length).to.eq(1);
+        expect(player.cardsInHand.length).to.eq(0);
+        expect(player.megaCredits).to.eq(2);
+    });
 });


### PR DESCRIPTION
Context:
- **Business Network** action currently cannot be used if player cannot afford to buy the card
- Player should always be allowed to take the action to look at the top card, but can only buy it if he can afford to pay (identical to **Inventor's Guild**)
- If the player cannot pay, the viewed card is simply discarded

<img width="502" alt="Screenshot 2020-05-27 at 6 48 11 PM" src="https://user-images.githubusercontent.com/2408094/83016540-b30ea580-a054-11ea-963f-588321799b88.png">
