### PR TITLE
Fix crashes if certain corps are selected without required expansions

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1334,12 +1334,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
       return this.getPlayers().filter((p) => p.getProduction(resource) >= minQuantity).length > 0 || this.soloMode ;
     }
 
-    public hasVenusCards() {
-      return this.dealer.deck.some((card) => card.tags.includes(Tags.VENUS));
+    public hasCardsWithTag(tag: Tags) {
+      return this.dealer.deck.some((card) => card.tags.includes(tag));
     }
 
-    public hasFloaterCards() {
-      return this.dealer.deck.some((card) => card.resourceType === ResourceType.FLOATER);
+    public hasCardsWithResource(resource: ResourceType) {
+      return this.dealer.deck.some((card) => card.resourceType === resource);
     }
 
     private setupSolo() {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1334,6 +1334,14 @@ export class Game implements ILoadable<SerializedGame, Game> {
       return this.getPlayers().filter((p) => p.getProduction(resource) >= minQuantity).length > 0 || this.soloMode ;
     }
 
+    public hasVenusCards() {
+      return this.dealer.deck.some((card) => card.tags.includes(Tags.VENUS));
+    }
+
+    public hasFloaterCards() {
+      return this.dealer.deck.some((card) => card.resourceType === ResourceType.FLOATER);
+    }
+
     private setupSolo() {
       this.players[0].setTerraformRating(14);
       this.players[0].terraformRatingAtGenerationStart = 14;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1334,12 +1334,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
       return this.getPlayers().filter((p) => p.getProduction(resource) >= minQuantity).length > 0 || this.soloMode ;
     }
 
-    public hasCardsWithTag(tag: Tags) {
-      return this.dealer.deck.some((card) => card.tags.includes(tag));
+    public hasCardsWithTag(tag: Tags, requiredQuantity: number = 1) {
+      return this.dealer.deck.filter((card) => card.tags.includes(tag)).length >= requiredQuantity;
     }
 
-    public hasCardsWithResource(resource: ResourceType) {
-      return this.dealer.deck.some((card) => card.resourceType === resource);
+    public hasCardsWithResource(resource: ResourceType, requiredQuantity: number = 1) {
+      return this.dealer.deck.filter((card) => card.resourceType === resource).length >= requiredQuantity;
     }
 
     private setupSolo() {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1991,10 +1991,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             player: this,
             playerInput: input
           });
-
-          this.actionsTakenThisRound++; // only increment if corp can take its corp first action
         }
         this.actionsThisGeneration.add("CORPORATION_INITIAL_ACTION");
+        this.actionsTakenThisRound++;
         this.takeAction(game);
         return;
       }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1991,9 +1991,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             player: this,
             playerInput: input
           });
+
+          this.actionsTakenThisRound++; // only increment if corp can take its corp first action
         }
         this.actionsThisGeneration.add("CORPORATION_INITIAL_ACTION");
-        this.actionsTakenThisRound++;
         this.takeAction(game);
         return;
       }

--- a/src/cards/colonies/Aridor.ts
+++ b/src/cards/colonies/Aridor.ts
@@ -17,7 +17,7 @@ export class Aridor implements CorporationCard {
     public allTags = new Set();
 
     public initialAction(_player: Player, game: Game) {
-        if (game.colonyDealer === undefined) return undefined;
+        if (game.colonyDealer === undefined || !game.coloniesExtension) return undefined;
         let addColony = new OrOptions();
         addColony.title = "Aridor first action - Select colony tile to add";
         game.colonyDealer.discardedColonies.forEach(colony => {

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -32,7 +32,7 @@ export class Poseidon implements CorporationCard {
         }
         else {
           console.warn("Colonies extension isn't selected.");
-          return;
+          return undefined;
         }
     }
 

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -31,7 +31,7 @@ export class Poseidon implements CorporationCard {
           return buildColony;
         }
         else {
-          console.warn("Colonie extension isn't selected.");
+          console.warn("Colonies extension isn't selected.");
           return;
         }
     }

--- a/src/cards/prelude/ValleyTrust.ts
+++ b/src/cards/prelude/ValleyTrust.ts
@@ -29,7 +29,7 @@ export class ValleyTrust implements CorporationCard {
         }
         else {
             console.warn("Prelude extension isn't selected.");
-            return;
+            return undefined;
         }
     }
 

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -16,7 +16,7 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
     public resourceCount: number = 0;
 
     public initialAction(player: Player, game: Game) {
-        if (game.hasCardsWithResource(ResourceType.FLOATER)) {
+        if (game.hasCardsWithResource(ResourceType.FLOATER, 2)) {
             for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
                 player.cardsInHand.push(foundCard);
             }

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -16,9 +16,14 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
     public resourceCount: number = 0;
 
     public initialAction(player: Player, game: Game) {
-        for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
-            player.cardsInHand.push(foundCard);
+        if (game.venusNextExtension || game.coloniesExtension) {
+            for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
+                player.cardsInHand.push(foundCard);
+            }
+
+            return;
         }
+        
         return undefined;
     }
 

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -16,7 +16,7 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
     public resourceCount: number = 0;
 
     public initialAction(player: Player, game: Game) {
-        if (game.hasFloaterCards()) {
+        if (game.hasCardsWithResource(ResourceType.FLOATER)) {
             for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
                 player.cardsInHand.push(foundCard);
             }

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -16,12 +16,10 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
     public resourceCount: number = 0;
 
     public initialAction(player: Player, game: Game) {
-        if (game.venusNextExtension || game.coloniesExtension) {
+        if (game.hasFloaterCards()) {
             for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
                 player.cardsInHand.push(foundCard);
             }
-
-            return;
         }
         
         return undefined;

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -11,9 +11,14 @@ export class MorningStarInc implements CorporationCard {
     public startingMegaCredits: number = 50;
 
     public initialAction(player: Player, game: Game) {
-        for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
-            player.cardsInHand.push(foundCard);
+        if (game.venusNextExtension || game.coloniesExtension) {
+            for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
+                player.cardsInHand.push(foundCard);
+            }
+
+            return;
         }
+        
         return undefined;
     }
 

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -11,7 +11,7 @@ export class MorningStarInc implements CorporationCard {
     public startingMegaCredits: number = 50;
 
     public initialAction(player: Player, game: Game) {
-        if (game.hasVenusCards()) {
+        if (game.hasCardsWithTag(Tags.VENUS)) {
             for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
                 player.cardsInHand.push(foundCard);
             }

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -11,12 +11,10 @@ export class MorningStarInc implements CorporationCard {
     public startingMegaCredits: number = 50;
 
     public initialAction(player: Player, game: Game) {
-        if (game.venusNextExtension || game.coloniesExtension) {
+        if (game.hasVenusCards()) {
             for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
                 player.cardsInHand.push(foundCard);
             }
-
-            return;
         }
         
         return undefined;

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -11,7 +11,7 @@ export class MorningStarInc implements CorporationCard {
     public startingMegaCredits: number = 50;
 
     public initialAction(player: Player, game: Game) {
-        if (game.hasCardsWithTag(Tags.VENUS)) {
+        if (game.hasCardsWithTag(Tags.VENUS, 3)) {
             for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
                 player.cardsInHand.push(foundCard);
             }


### PR DESCRIPTION
**Scope:**
- Handle edge cases causing game to crash by not triggering corp's first action if the required expansion is not selected
- Affected corps: Aridor, Celestic and MSI 
- Don't increment turn action counter if corp could not take its first action - player should still be able to do two actions on turn 1 in this case