### PR TITLE
Improvement: Log revealed cards and discarded cards

### DIFF
--- a/src/CardName.ts
+++ b/src/CardName.ts
@@ -296,7 +296,7 @@ export enum CardName {
     LOCAL_SHADING = "Local Shading",
     LUNA_METROPOLIS = "Luna Metropolis",
     LUXURY_FOODS = "Luxury Foods",
-    MAXWELL_BASE = "MAxwell Base",
+    MAXWELL_BASE = "Maxwell Base",
     MORNING_STAR_INC = "Morning Star Inc.",
     NEUTRALIZER_FACTORY = "Neutralizer Factory",
     ORBITAL_REFLECTORS = "Orbital Reflectors",

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -54,6 +54,7 @@ import { CardName } from "./CardName";
 import { Turmoil } from "./turmoil/Turmoil";
 import { PartyName } from "./turmoil/parties/PartyName";
 import { IParty } from "./turmoil/parties/IParty";
+import { ColonyName } from "./colonies/ColonyName"
 
 export interface GameOptions {
   draftVariant: boolean;
@@ -1345,6 +1346,58 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public hasCardsWithResource(resource: ResourceType, requiredQuantity: number = 1) {
       return this.dealer.deck.filter((card) => card.resourceType === resource).length >= requiredQuantity;
+    }
+    
+    public logCorpFirstAction(player: Player, colonyName?: ColonyName) {
+      if (player.corporationCard !== undefined) {
+        let message = "";
+
+        switch (player.corporationCard.name) {
+          case CardName.INVENTRIX:
+            message = "drew 3 cards"
+            break;
+
+          case CardName.THARSIS_REPUBLIC:
+            message = "placed a City tile"
+            break;
+
+          case CardName.CELESTIC:
+            const floaterCards = player.cardsInHand.filter((card) => card.resourceType === ResourceType.FLOATER).slice(-2)
+            message = "drew 2 floater cards: " + floaterCards.map((card) => card.name).join(", ")
+            break;
+
+          case CardName.MORNING_STAR_INC:
+            const venusCards = player.cardsInHand.filter((card) => card.tags.includes(Tags.VENUS)).slice(-3)
+            message = "drew 3 Venus cards: " + venusCards.map((card) => card.name).join(", ")
+            break;
+
+          case CardName.ARIDOR:
+            message = "added a new Colony tile: " + colonyName
+            break;
+
+          case CardName.PHILARES:
+            message = "placed a Greenery tile"
+            break;
+
+          case CardName.ARCADIAN_COMMUNITIES:
+            message = "placed a Community (player marker)"
+            break;
+
+          case CardName.SPLICE:
+            const drawnCard = player.cardsInHand.filter((card) => card.tags.includes(Tags.MICROBES)).slice(-1)[0]
+            message = "drew a Microbe card: " + drawnCard.name
+            break;
+        
+          default:
+            break;
+        }
+
+        this.log(
+          LogMessageType.DEFAULT,
+          "${0} " + message,
+          new LogMessageData(LogMessageDataType.PLAYER, player.id)
+        );
+      }
     }
 
     private setupSolo() {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1306,6 +1306,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
           result.push(projectCard);
         } else {
           this.dealer.discard(projectCard);
+          this.log(
+            LogMessageType.DEFAULT,
+           "${0} was discarded",
+           new LogMessageData(LogMessageDataType.CARD, projectCard.name)
+          );
         }
       }
       return result;
@@ -1321,6 +1326,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
           result.push(projectCard);
         } else {
           this.dealer.discard(projectCard);
+          this.log(
+            LogMessageType.DEFAULT,
+           "${0} was discarded",
+           new LogMessageData(LogMessageDataType.CARD, projectCard.name)
+          );
         }
       }
       return result;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -54,7 +54,6 @@ import { CardName } from "./CardName";
 import { Turmoil } from "./turmoil/Turmoil";
 import { PartyName } from "./turmoil/parties/PartyName";
 import { IParty } from "./turmoil/parties/IParty";
-import { ColonyName } from "./colonies/ColonyName"
 
 export interface GameOptions {
   draftVariant: boolean;
@@ -1354,76 +1353,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public hasCardsWithResource(resource: ResourceType, requiredQuantity: number = 1) {
       return this.dealer.deck.filter((card) => card.resourceType === resource).length >= requiredQuantity;
-    }
-    
-    public logCorpFirstAction(player: Player, colonyName?: ColonyName) {
-      if (player.corporationCard !== undefined) {
-        let message = "", drawnCards = undefined;
-        const corpName = player.corporationCard.name;
-
-        if (corpName === CardName.CELESTIC) {
-          drawnCards = this.getCardsInHandByResource(player, ResourceType.FLOATER).slice(-2);
-
-          this.log(
-            LogMessageType.DEFAULT,
-            "${0} drew ${1} and ${2}",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name)
-          );
-        } else if (corpName === CardName.MORNING_STAR_INC) {
-          drawnCards = this.getCardsInHandByTag(player, Tags.VENUS).slice(-3);
-
-          this.log(
-            LogMessageType.DEFAULT,
-            "${0} drew ${1}, ${2} and ${3}",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[2].name)
-          );
-        } else if (corpName === CardName.SPLICE) {
-          drawnCards = this.getCardsInHandByTag(player, Tags.MICROBES).slice(-1);
-
-          this.log(
-            LogMessageType.DEFAULT,
-            "${0} drew ${1}",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name)
-          );
-        } else {
-          switch (corpName) {
-            case CardName.INVENTRIX:
-              message = "drew 3 cards"
-              break;
-
-            case CardName.THARSIS_REPUBLIC:
-              message = "placed a City tile"
-              break;
-
-            case CardName.ARIDOR:
-              message = "added a new Colony tile: " + colonyName
-              break;
-
-            case CardName.PHILARES:
-              message = "placed a Greenery tile"
-              break;
-
-            case CardName.ARCADIAN_COMMUNITIES:
-              message = "placed a Community (player marker)"
-              break;
-
-            default:
-              break;
-          }
-  
-          this.log(
-            LogMessageType.DEFAULT,
-            "${0} " + message,
-            new LogMessageData(LogMessageDataType.PLAYER, player.id)
-          );
-        }
-      }
     }
 
     private setupSolo() {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1299,40 +1299,50 @@ export class Game implements ILoadable<SerializedGame, Game> {
     public drawCardsByTag(tag: Tags, total: number): Array<IProjectCard> {
       let cardsToDraw = 0;
       const result: Array<IProjectCard> = [];
+      const discardedCards: Array<IProjectCard> = [];
+
       while (cardsToDraw < total) {
         const projectCard = this.dealer.dealCard();
         if (projectCard.tags.includes(tag)) {
           cardsToDraw++;
           result.push(projectCard);
         } else {
+          discardedCards.push(projectCard);
           this.dealer.discard(projectCard);
-          this.log(
-            LogMessageType.DEFAULT,
-           "${0} was discarded",
-           new LogMessageData(LogMessageDataType.CARD, projectCard.name)
-          );
         }
       }
+
+      this.log(
+        LogMessageType.DEFAULT,
+        discardedCards.length + " card(s) were discarded",
+       ...discardedCards.map((card) => new LogMessageData(LogMessageDataType.CARD, card.name)),
+      );
+
       return result;
     }
 
     public drawCardsByResource(resource: ResourceType, total: number): Array<IProjectCard> {
       let cardsToDraw = 0;
       const result: Array<IProjectCard> = [];
+      const discardedCards: Array<IProjectCard> = [];
+
       while (cardsToDraw < total) {
         const projectCard = this.dealer.dealCard();
         if (projectCard.resourceType !== undefined && projectCard.resourceType === resource ) {
           cardsToDraw++;
           result.push(projectCard);
         } else {
+          discardedCards.push(projectCard);
           this.dealer.discard(projectCard);
-          this.log(
-            LogMessageType.DEFAULT,
-           "${0} was discarded",
-           new LogMessageData(LogMessageDataType.CARD, projectCard.name)
-          );
         }
       }
+
+      this.log(
+        LogMessageType.DEFAULT,
+        discardedCards.length + " card(s) were discarded",
+       ...discardedCards.map((card) => new LogMessageData(LogMessageDataType.CARD, card.name)),
+      );
+
       return result;
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1313,12 +1313,6 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             game.addSelectHowToPayInterrupt(this, constants.BUILD_COLONY_COST, false, false, "Select how to pay for Colony project");
             colony.onColonyPlaced(this, game);
             this.onStandardProject(StandardProjectType.BUILD_COLONY);
-            game.log(
-              LogMessageType.DEFAULT,
-              "${0} built a colony on ${1}",
-              new LogMessageData(LogMessageDataType.PLAYER, this.id),
-              new LogMessageData(LogMessageDataType.COLONY, colony.name)
-            );
             return undefined;
           }
         );

--- a/src/cards/SearchForLife.ts
+++ b/src/cards/SearchForLife.ts
@@ -8,6 +8,9 @@ import { Game } from "../Game";
 import { ResourceType } from "../ResourceType";
 import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { CardName } from '../CardName';
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
 
 export class SearchForLife implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 3;
@@ -37,6 +40,14 @@ export class SearchForLife implements IActionCard, IProjectCard, IResourceCard {
             if (topCard.tags.indexOf(Tags.MICROBES) !== -1) {
                 this.resourceCount++;
             }
+
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} revealed and discarded ${1}",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                new LogMessageData(LogMessageDataType.CARD, topCard.name)
+            );
+            
             game.dealer.discard(topCard);
             return undefined;
         };

--- a/src/cards/colonies/Aridor.ts
+++ b/src/cards/colonies/Aridor.ts
@@ -16,7 +16,7 @@ export class Aridor implements CorporationCard {
     public startingMegaCredits: number = 40;
     public allTags = new Set();
 
-    public initialAction(_player: Player, game: Game) {
+    public initialAction(player: Player, game: Game) {
         if (game.colonyDealer === undefined || !game.coloniesExtension) return undefined;
         let addColony = new OrOptions();
         addColony.title = "Aridor first action - Select colony tile to add";
@@ -26,6 +26,7 @@ export class Aridor implements CorporationCard {
             () => {
                 game.colonies.push(colony);
                 game.colonies.sort((a,b) => (a.name > b.name) ? 1 : -1);
+                game.logCorpFirstAction(player, colony.name);
                 this.checkActivation(colony, game);
                 return undefined;
             }

--- a/src/cards/colonies/Aridor.ts
+++ b/src/cards/colonies/Aridor.ts
@@ -9,6 +9,9 @@ import { Resources } from '../../Resources';
 import { CardType } from '../CardType';
 import { CardName } from '../../CardName';
 import { IColony } from '../../colonies/Colony';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Aridor implements CorporationCard {
     public name: CardName =  CardName.ARIDOR;
@@ -26,7 +29,14 @@ export class Aridor implements CorporationCard {
             () => {
                 game.colonies.push(colony);
                 game.colonies.sort((a,b) => (a.name > b.name) ? 1 : -1);
-                game.logCorpFirstAction(player, colony.name);
+                
+                game.log(
+                    LogMessageType.DEFAULT,
+                    "${0} added a new Colony tile: ${1}",
+                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                    new LogMessageData(LogMessageDataType.STRING, colony.name)
+                );
+
                 this.checkActivation(colony, game);
                 return undefined;
             }

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -5,6 +5,9 @@ import { Game } from '../../Game';
 import { SelectOption } from '../../inputs/SelectOption';
 import { OrOptions } from '../../inputs/OrOptions';
 import { CardName } from '../../CardName';
+import {LogMessageType} from "../../LogMessageType";
+import {LogMessageData} from "../../LogMessageData";
+import {LogMessageDataType} from "../../LogMessageDataType";
 
 export class Poseidon implements CorporationCard {
     public name: CardName =  CardName.POSEIDON;
@@ -23,6 +26,12 @@ export class Poseidon implements CorporationCard {
               colony.name + " - (" + colony.description + ")", 
               () => {
                   colony.onColonyPlaced(player, game);
+                  game.log(
+                    LogMessageType.DEFAULT,
+                    "${0} built a colony on ${1}",
+                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                    new LogMessageData(LogMessageDataType.COLONY, colony.name)
+                  );
                   return undefined;
               }
             );

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -5,9 +5,6 @@ import { Game } from '../../Game';
 import { SelectOption } from '../../inputs/SelectOption';
 import { OrOptions } from '../../inputs/OrOptions';
 import { CardName } from '../../CardName';
-import {LogMessageType} from "../../LogMessageType";
-import {LogMessageData} from "../../LogMessageData";
-import {LogMessageDataType} from "../../LogMessageDataType";
 
 export class Poseidon implements CorporationCard {
     public name: CardName =  CardName.POSEIDON;
@@ -26,12 +23,6 @@ export class Poseidon implements CorporationCard {
               colony.name + " - (" + colony.description + ")", 
               () => {
                   colony.onColonyPlaced(player, game);
-                  game.log(
-                    LogMessageType.DEFAULT,
-                    "${0} built a colony on ${1}",
-                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                    new LogMessageData(LogMessageDataType.COLONY, colony.name)
-                  );
                   return undefined;
               }
             );

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -4,6 +4,9 @@ import { Tags } from "../Tags";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Inventrix implements CorporationCard {
     public name: CardName = CardName.INVENTRIX;
@@ -15,7 +18,13 @@ export class Inventrix implements CorporationCard {
             game.dealer.dealCard(),
             game.dealer.dealCard()
         );
-        game.logCorpFirstAction(player);
+        
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} drew 3 cards",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id)
+        );
+        
         return undefined;
     }
     public getRequirementBonus(_player: Player, _game: Game): number {

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -3,7 +3,6 @@ import { CorporationCard } from "./CorporationCard";
 import { Tags } from "../Tags";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
-import { SelectOption } from "../../inputs/SelectOption";
 import { CardName } from '../../CardName';
 
 export class Inventrix implements CorporationCard {
@@ -11,15 +10,13 @@ export class Inventrix implements CorporationCard {
     public tags: Array<Tags> = [Tags.SCIENCE];
     public startingMegaCredits: number = 45;
     public initialAction(player: Player, game: Game) {
-        return new SelectOption("Draw 3 cards", () => {
-            player.cardsInHand.push(
-                game.dealer.dealCard(),
-                game.dealer.dealCard(),
-                game.dealer.dealCard()
-            );
-            game.logCorpFirstAction(player);
-            return undefined;
-        });
+        player.cardsInHand.push(
+            game.dealer.dealCard(),
+            game.dealer.dealCard(),
+            game.dealer.dealCard()
+        );
+        game.logCorpFirstAction(player);
+        return undefined;
     }
     public getRequirementBonus(_player: Player, _game: Game): number {
         return 2;

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -17,6 +17,7 @@ export class Inventrix implements CorporationCard {
                 game.dealer.dealCard(),
                 game.dealer.dealCard()
             );
+            game.logCorpFirstAction(player);
             return undefined;
         });
     }

--- a/src/cards/corporation/OriginalCorporation.ts
+++ b/src/cards/corporation/OriginalCorporation.ts
@@ -8,5 +8,6 @@ export enum OriginalCorporation {
     TERACTOR = "Teractor",
     THARSIS_REPUBLIC = "Tharsis Republic",
     THORGATE = "Thorgate",
-    UNITED_NATIONS_MARS_INITIATIVE = "United Nations Mars Initiative"
+    UNITED_NATIONS_MARS_INITIATIVE = "United Nations Mars Initiative",
+    INVENTRIX = "Inventrix"
 }

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -9,6 +9,9 @@ import { ISpace } from "../../ISpace";
 import { TileType } from "../../TileType";
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class TharsisRepublic implements CorporationCard {
     public name: CardName = CardName.THARSIS_REPUBLIC;
@@ -17,7 +20,13 @@ export class TharsisRepublic implements CorporationCard {
     public initialAction(player: Player, game: Game) {
         return new SelectSpace("Select space on mars for city tile", game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
             game.addCityTile(player, space.id);
-            game.logCorpFirstAction(player);
+            
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} placed a City tile",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id)
+            );
+            
             return undefined;
         });
     }

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -17,6 +17,7 @@ export class TharsisRepublic implements CorporationCard {
     public initialAction(player: Player, game: Game) {
         return new SelectSpace("Select space on mars for city tile", game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
             game.addCityTile(player, space.id);
+            game.logCorpFirstAction(player);
             return undefined;
         });
     }

--- a/src/cards/prelude/AcquiredSpaceAgency.ts
+++ b/src/cards/prelude/AcquiredSpaceAgency.ts
@@ -4,6 +4,9 @@ import { Game } from "../../Game";
 import { PreludeCard } from "./PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class AcquiredSpaceAgency extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
@@ -12,6 +15,17 @@ export class AcquiredSpaceAgency extends PreludeCard implements IProjectCard {
         for (let foundCard of game.drawCardsByTag(Tags.SPACE, 2)) {
             player.cardsInHand.push(foundCard);
         }
+
+        const drawnCards = game.getCardsInHandByTag(player, Tags.SPACE).slice(-2);
+
+        game.log(
+             LogMessageType.DEFAULT,
+            "${0} drew ${1} and ${2}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
+            new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name)
+        );
+
 	    player.titanium += 6;
         return undefined;
     };

--- a/src/cards/prelude/ExperimentalForest.ts
+++ b/src/cards/prelude/ExperimentalForest.ts
@@ -6,6 +6,9 @@ import { IProjectCard } from "../IProjectCard";
 import { SelectSpace } from "../../inputs/SelectSpace";
 import { ISpace } from "../../ISpace";
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class ExperimentalForest extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.PLANT];
@@ -15,6 +18,17 @@ export class ExperimentalForest extends PreludeCard implements IProjectCard {
 	        for (let foundCard of game.drawCardsByTag(Tags.PLANT, 2)) {
                 player.cardsInHand.push(foundCard);
             }
+
+            const drawnCards = game.getCardsInHandByTag(player, Tags.PLANT).slice(-2);
+
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} drew ${1} and ${2}",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name)
+            );
+
             return game.addGreenery(player, space.id);
         });
     }

--- a/src/cards/promo/ArcadianCommunities.ts
+++ b/src/cards/promo/ArcadianCommunities.ts
@@ -6,6 +6,9 @@ import { SelectSpace } from "../../inputs/SelectSpace";
 import { ISpace } from '../../ISpace';
 import { IActionCard } from '../ICard';
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class ArcadianCommunities implements IActionCard, CorporationCard {
     public name: CardName = CardName.ARCADIAN_COMMUNITIES;
@@ -18,7 +21,13 @@ export class ArcadianCommunities implements IActionCard, CorporationCard {
             game.board.getAvailableSpacesOnLand(player), 
             (foundSpace: ISpace) => {
                 foundSpace.player = player;
-                game.logCorpFirstAction(player);
+                
+                game.log(
+                    LogMessageType.DEFAULT,
+                    "${0} placed a Community (player marker)",
+                    new LogMessageData(LogMessageDataType.PLAYER, player.id)
+                );
+
                 return undefined;
             }
         );

--- a/src/cards/promo/ArcadianCommunities.ts
+++ b/src/cards/promo/ArcadianCommunities.ts
@@ -18,6 +18,7 @@ export class ArcadianCommunities implements IActionCard, CorporationCard {
             game.board.getAvailableSpacesOnLand(player), 
             (foundSpace: ISpace) => {
                 foundSpace.player = player;
+                game.logCorpFirstAction(player);
                 return undefined;
             }
         );

--- a/src/cards/promo/Philares.ts
+++ b/src/cards/promo/Philares.ts
@@ -20,6 +20,7 @@ export class Philares implements CorporationCard {
         return new SelectSpace("Select space for greenery tile", 
         game.board.getAvailableSpacesForGreenery(player), (space: ISpace) => {
             game.addGreenery(player, space.id);
+            game.logCorpFirstAction(player);
             return undefined;
         });
     }

--- a/src/cards/promo/Philares.ts
+++ b/src/cards/promo/Philares.ts
@@ -9,7 +9,9 @@ import { TileType } from '../../TileType';
 import { SelectAmount } from '../../inputs/SelectAmount';
 import { AndOptions } from '../../inputs/AndOptions';
 import { CardName } from '../../CardName';
-
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Philares implements CorporationCard {
     public name: CardName = CardName.PHILARES;
@@ -20,7 +22,13 @@ export class Philares implements CorporationCard {
         return new SelectSpace("Select space for greenery tile", 
         game.board.getAvailableSpacesForGreenery(player), (space: ISpace) => {
             game.addGreenery(player, space.id);
-            game.logCorpFirstAction(player);
+            
+            game.log(
+              LogMessageType.DEFAULT,
+              "${0} placed a Greenery tile",
+              new LogMessageData(LogMessageDataType.PLAYER, player.id)
+            );
+            
             return undefined;
         });
     }

--- a/src/cards/promo/Splice.ts
+++ b/src/cards/promo/Splice.ts
@@ -15,6 +15,7 @@ export class Splice implements CorporationCard {
 
     public initialAction(player: Player, game: Game) {
         player.cardsInHand.push(game.drawCardsByTag(Tags.MICROBES, 1)[0]);
+        game.logCorpFirstAction(player);
         return undefined;
     }
 

--- a/src/cards/promo/Splice.ts
+++ b/src/cards/promo/Splice.ts
@@ -7,6 +7,9 @@ import { SelectOption } from "../../inputs/SelectOption";
 import { OrOptions } from "../../inputs/OrOptions";
 import { ResourceType } from "../../ResourceType";
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Splice implements CorporationCard {
     public name: CardName = CardName.SPLICE;
@@ -15,7 +18,16 @@ export class Splice implements CorporationCard {
 
     public initialAction(player: Player, game: Game) {
         player.cardsInHand.push(game.drawCardsByTag(Tags.MICROBES, 1)[0]);
-        game.logCorpFirstAction(player);
+        
+        const drawnCards = game.getCardsInHandByTag(player, Tags.MICROBES).slice(-1);
+
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} drew ${1}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name)
+        );
+        
         return undefined;
     }
 

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -7,6 +7,9 @@ import { Game } from '../../Game';
 import { IActionCard, ICard, IResourceCard } from '../ICard';
 import { SelectCard } from '../../inputs/SelectCard';
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Celestic implements IActionCard, CorporationCard, IResourceCard {
     public name: CardName = CardName.CELESTIC;
@@ -20,8 +23,18 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
             for (let foundCard of game.drawCardsByResource(ResourceType.FLOATER, 2)) {
                 player.cardsInHand.push(foundCard);
             }
+
+            const drawnCards = game.getCardsInHandByResource(player, ResourceType.FLOATER).slice(-2);
+
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} drew ${1} and ${2}",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name)
+            );
         }
-        game.logCorpFirstAction(player);
+        
         return undefined;
     }
 

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -21,7 +21,7 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
                 player.cardsInHand.push(foundCard);
             }
         }
-        
+        game.logCorpFirstAction(player);
         return undefined;
     }
 

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -16,7 +16,7 @@ export class MorningStarInc implements CorporationCard {
                 player.cardsInHand.push(foundCard);
             }
         }
-        
+        game.logCorpFirstAction(player);
         return undefined;
     }
 

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -4,6 +4,9 @@ import { Player } from "../../Player";
 import { Tags } from "../Tags";
 import { Game } from '../../Game';
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class MorningStarInc implements CorporationCard {
     public name: CardName = CardName.MORNING_STAR_INC;
@@ -15,8 +18,19 @@ export class MorningStarInc implements CorporationCard {
             for (let foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {
                 player.cardsInHand.push(foundCard);
             }
+
+            const drawnCards = game.getCardsInHandByTag(player, Tags.VENUS).slice(-3);
+
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} drew ${1}, ${2} and ${3}",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name),
+                new LogMessageData(LogMessageDataType.CARD, drawnCards[2].name)
+            );
         }
-        game.logCorpFirstAction(player);
+
         return undefined;
     }
 

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -5,6 +5,9 @@ import { ColonyName } from './ColonyName';
 import { ResourceType } from '../ResourceType';
 import { CorporationName } from '../CorporationName';
 import { Resources } from '../Resources';
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
 
 export interface IColony {
     name: ColonyName;
@@ -79,6 +82,14 @@ export abstract class Colony  {
         if (colony.trackPosition < colony.colonies.length) {
             colony.trackPosition = colony.colonies.length;
         }
+
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} built a colony on ${1}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.COLONY, colony.name)
+          );
+
         // Poseidon hook
         let poseidon = game.getPlayers().filter(player => player.isCorporation(CorporationName.POSEIDON));
         if (poseidon.length > 0) {

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -7,6 +7,7 @@ import { LogMessageData } from "../LogMessageData";
 import { LogMessageDataType } from "../LogMessageDataType";
 import { Card } from "./Card";
 import { $t } from "../directives/i18n";
+import { getProjectCardByName } from "./../Dealer";
 
 export const LogPanel = Vue.component("log-panel", {
     props: ["messages", "players"],
@@ -65,6 +66,8 @@ export const LogPanel = Vue.component("log-panel", {
                             }
                         }
                     }
+                    let card = getProjectCardByName(data.value)
+                    if (card && card.cardType) return this.parseCardType(card.cardType, data.value);
                 } else if (translatableMessageDataTypes.includes(data.type)) {
                     return $t(data.value);
                 } else  {

--- a/src/interrupts/SelectColony.ts
+++ b/src/interrupts/SelectColony.ts
@@ -5,9 +5,6 @@ import { PlayerInterrupt } from './PlayerInterrupt';
 import { OrOptions } from '../inputs/OrOptions';
 import { IColony } from '../colonies/Colony';
 import { SelectOption } from '../inputs/SelectOption';
-import { LogMessageType } from "../LogMessageType";
-import { LogMessageData } from "../LogMessageData";
-import { LogMessageDataType } from "../LogMessageDataType";
 
 export class SelectColony implements PlayerInterrupt {
     public playerInput: PlayerInput;
@@ -22,12 +19,6 @@ export class SelectColony implements PlayerInterrupt {
               colony.name + " - (" + colony.description + ")", 
               () => {
                 colony.onColonyPlaced(player, game);
-                game.log(
-                  LogMessageType.DEFAULT,
-                  "${0} built a colony on ${1}",
-                  new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                  new LogMessageData(LogMessageDataType.COLONY, colony.name)
-                );
                 return undefined;
               }
             ));

--- a/tests/cards/corporation/Inventrix.spec.ts
+++ b/tests/cards/corporation/Inventrix.spec.ts
@@ -19,9 +19,8 @@ describe("Inventrix", function () {
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player,player], player);
         const action = card.initialAction(player, game);
-        expect(action).not.to.eq(undefined);
-        expect(player.cardsInHand.length).to.eq(0);
-        action.cb();
+        
+        expect(action).to.eq(undefined);
         expect(player.cardsInHand.length).to.eq(3);
     });
 });


### PR DESCRIPTION
**Context:**
- Add missing logs for several corporations' first actions
- For actions that explicitly reveal cards, the cards drawn into hand should be made known to other players
- Also removes Inventrix's unnecessary first action click in https://github.com/bafolts/terraforming-mars/issues/749 and logs Prelude revealed draws

<img width="424" alt="Screenshot 2020-06-01 at 3 26 34 PM" src="https://user-images.githubusercontent.com/2408094/83386048-eec2ba00-a41c-11ea-8731-9fe8f6cbbd9b.png">

<img width="605" alt="Screenshot 2020-06-01 at 3 54 17 PM" src="https://user-images.githubusercontent.com/2408094/83390948-52e97c00-a425-11ea-8b64-408997d67c8f.png">
