### PR TITLE
Remove select space button to save clicks

### DIFF
--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -19,6 +19,46 @@ export const SelectSpace = Vue.component("select-space", {
             this.onsave([[this.$data.spaceId]]);
         }
     },
+    mounted: function() {
+        const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
+        const setOfSpaces: {[x: string]: boolean} = {};
+
+        if (playerInput.availableSpaces !== undefined) {
+            playerInput.availableSpaces.forEach((spaceId: string) => {
+                setOfSpaces[spaceId] = true;
+            });
+        }
+
+        const clearAllAvailableSpaces = function() {
+            const elTiles = document.getElementsByClassName("board_selectable");
+            for (let i = 0; i < elTiles.length; i++) {
+                elTiles[i].classList.remove("board_space--available");
+                elTiles[i].classList.remove("board_space--selected");
+            }
+        };
+
+        {
+            clearAllAvailableSpaces();
+            const elTiles = document.getElementsByClassName("board_selectable");
+            for (let i = 0; i < elTiles.length; i++) {
+                const elTile = elTiles[i] as HTMLElement;
+                var el_id = elTile.getAttribute("data_space_id");
+                if ( ! el_id || ! setOfSpaces[el_id]) continue;
+                
+                elTile.classList.add("board_space--available");
+
+                elTile.onclick = () => {
+                    clearAllAvailableSpaces();
+                    for (let j = 0; j < elTiles.length; j++) {
+                        (elTiles[j] as HTMLElement).onclick = null;
+                    }
+                    this.$data.spaceId = elTile.getAttribute("data_space_id");
+                    elTile.classList.add("board_space--selected")
+                    this.saveData();
+                }
+            }
+        }
+    },
     render: function (createElement) {
         const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
         const children: Array<VNode> = [];
@@ -28,42 +68,7 @@ export const SelectSpace = Vue.component("select-space", {
         if (this.$data.warning) {
             children.push(createElement("div", { domProps: { className: "nes-container is-rounded" } }, [createElement("span", { domProps: { className: "nes-text is-warning" } }, this.$data.warning)]));
         }
-        const clearAllAvailableSpaces = function() {
-            const elTiles = document.getElementsByClassName("board_selectable");
-            for (let i = 0; i < elTiles.length; i++) {
-                elTiles[i].classList.remove("board_space--available");
-                elTiles[i].classList.remove("board_space--selected");
-            }
-        };
 
-
-        const setOfSpaces: {[x: string]: boolean} = {};
-        if (playerInput.availableSpaces !== undefined) {
-            playerInput.availableSpaces.forEach((spaceId: string) => {
-                setOfSpaces[spaceId] = true;
-            });
-            children.push(createElement("button", { domProps: { className: "btn btn-lg btn-primary" }, on: { click: () => {
-                clearAllAvailableSpaces();
-                const elTiles = document.getElementsByClassName("board_selectable");
-                for (let i = 0; i < elTiles.length; i++) {
-                    const elTile = elTiles[i] as HTMLElement;
-                    var el_id = elTile.getAttribute("data_space_id");
-                    if ( ! el_id || ! setOfSpaces[el_id]) continue;
-                    
-                    elTile.classList.add("board_space--available");
-
-                    elTile.onclick = () => {
-                        clearAllAvailableSpaces();
-                        for (let j = 0; j < elTiles.length; j++) {
-                            (elTiles[j] as HTMLElement).onclick = null;
-                        }
-                        this.$data.spaceId = elTile.getAttribute("data_space_id");
-                        elTile.classList.add("board_space--selected")
-                        this.saveData();
-                    }
-                }
-            } } }, "Select Space"));
-        }
         return createElement("div", children);
     }
 });


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/494

**Context:**
- Go straight to allowing player to select an available space when the next step is to place a tile
- This saves a lot of unnecessary clicks and scrolling

<img width="302" alt="Screenshot 2020-05-30 at 4 31 55 PM" src="https://user-images.githubusercontent.com/2408094/83323826-dc694480-a293-11ea-9d83-205220f730d2.png">
<img width="251" alt="Screenshot 2020-05-30 at 4 32 08 PM" src="https://user-images.githubusercontent.com/2408094/83323828-de330800-a293-11ea-8167-ba53513ccfab.png">
<img width="618" alt="Screenshot 2020-05-30 at 4 33 31 PM" src="https://user-images.githubusercontent.com/2408094/83323829-dffccb80-a293-11ea-8237-95af0caf8cd3.png">
