### PR TITLE
Swap final greenery placement options

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1780,12 +1780,6 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         const action: OrOptions = new OrOptions();
         action.title = "Place any final greenery from plants";
         action.options.push(
-            new SelectOption("Don't place a greenery", () => {
-              game.playerIsDoneWithGame(this);
-              return undefined;
-            })
-        );
-        action.options.push(
             new SelectSpace(
                 "Select space for greenery",
                 game.board.getAvailableSpacesForGreenery(this), (space) => {
@@ -1796,6 +1790,12 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
                 }
             )
         );
+        action.options.push(
+          new SelectOption("Don't place a greenery", () => {
+            game.playerIsDoneWithGame(this);
+            return undefined;
+          })
+      );
         this.setWaitingFor(action, () => {});
         return;
       }


### PR DESCRIPTION
**Context:**
- We can save one click for the user by making the default selection for final greenery placement to be "Select space for greenery" instead of "Don't place a greenery"
- There are hardly any scenarios where a player would not want to place final greenery if they are able to do so