### PR TITLE
Improvement: Auto add resources if card has no resources

### DIFF
--- a/src/cards/colonies/RedSpotObservatory.ts
+++ b/src/cards/colonies/RedSpotObservatory.ts
@@ -26,6 +26,11 @@ export class RedSpotObservatory implements IProjectCard, IResourceCard {
     }
 
     public action(player: Player, game: Game) {
+        if (this.resourceCount < 1) {
+            this.resourceCount++;
+            return undefined;
+        }
+
         var opts: Array<SelectOption> = [];
         const addResource = new SelectOption("Add 1 floater on this card", () => {
             this.resourceCount++;

--- a/src/cards/venusNext/LocalShading.ts
+++ b/src/cards/venusNext/LocalShading.ts
@@ -24,6 +24,11 @@ export class LocalShading implements IActionCard,IProjectCard,IResourceCard {
         return true;
     }    
     public action(player: Player) {
+        if (this.resourceCount < 1) {
+            this.resourceCount++;
+            return undefined;
+        }
+        
         var opts: Array<SelectOption> = [];
         const addResource = new SelectOption("Add 1 floater to this card", () => {
             this.resourceCount++;

--- a/tests/cards/venusNext/LocalShading.spec.ts
+++ b/tests/cards/venusNext/LocalShading.spec.ts
@@ -3,7 +3,6 @@ import { LocalShading } from "../../../src/cards/venusNext/LocalShading";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { OrOptions } from "../../../src/inputs/OrOptions";
-import { SelectOption } from '../../../src/inputs/SelectOption';
 import { Resources } from "../../../src/Resources";
 
 describe("LocalShading", function () {
@@ -16,9 +15,8 @@ describe("LocalShading", function () {
         const card = new LocalShading();
         const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const action = card.action(player) as SelectOption;
-        expect(action instanceof SelectOption).to.eq(true);
-        action.cb();
+        expect(card.canAct()).to.eq(true);
+        card.action(player);
         expect(card.resourceCount).to.eq(1);
 
         const orOptions = card.action(player) as OrOptions;


### PR DESCRIPTION
**Context:**
- Most cards that collect resources (e.g. Deuterium Exports) automatically add a resource to the card if it is the only valid target, and the card has 0 resources
- This behaviour can also be implemented for **Red Spot Observatory** and **Local Shading**