### PR TITLE
Move Save button to directly below selected action

### DIFF
--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -59,10 +59,10 @@ export const OrOptions = Vue.component("or-options", {
             subchildren.push(createElement("div", { style: { display: displayStyle, marginLeft: "30px" } }, [this.$data.childComponents[this.$data.childComponents.length - 1]]));
             optionElements.push(subchildren[subchildren.length - 1]);
             children.push(createElement("div", subchildren));
+            if (this.showsave && this.$data.selectedOption === idx) {
+                children.push(createElement("div", { style: {"margin": "5px 30px 10px"}, "class": "wf-action"}, [createElement("button", { domProps: { className: "btn btn-primary" }, on: { click: () => { this.saveData(); } } }, "Save")]));
+            }
         });
-        if (this.showsave) {
-            children.push(createElement("div", {"class": "wf-action"}, [createElement("button", { domProps: { className: "btn btn-primary" }, on: { click: () => { this.saveData(); } } }, "Save")]));
-        }
         return createElement("div", {"class": "wf-options"}, children);
     }
 });


### PR DESCRIPTION
**Context:** Move the "Save" button for taking player actions to directly below the selected action

**Ref:**
https://github.com/bafolts/terraforming-mars/issues/360
https://github.com/bafolts/terraforming-mars/issues/749

<img width="761" alt="Screenshot 2020-06-02 at 12 13 09 AM" src="https://user-images.githubusercontent.com/2408094/83429440-a4662b00-a466-11ea-8212-f4d25c2393b8.png">

<img width="490" alt="Screenshot 2020-06-02 at 12 13 36 AM" src="https://user-images.githubusercontent.com/2408094/83429449-a5975800-a466-11ea-8b25-b11cda555d8a.png">

<img width="908" alt="Screenshot 2020-06-02 at 12 14 39 AM" src="https://user-images.githubusercontent.com/2408094/83429455-a7611b80-a466-11ea-8b93-52485c75fb6c.png">
