### PR TITLE
Improvement: Payment UI automatically uses other available resources

### DIFF
--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -34,30 +34,19 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         app.$data.cost = app.playerinput.amount;
         app.$data.megaCredits = (app as any).getMegaCreditsMax();
 
-        app.setDefaultHeatValue();
         app.setDefaultSteelValue();
         app.setDefaultTitaniumValue();
+        app.setDefaultHeatValue();
       });
     },
     methods: {
         hasWarning: function () {
             return this.$data.warning !== undefined;
         },
-        setDefaultHeatValue: function() {
-          // automatically use available heat for Helion if not enough MC
-          if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-              this.$data.heat =  this.$data.cost - this.player.megaCredits;
-          } else {
-              this.$data.heat = 0;
-          }
-
-          let discountedCost = this.$data.cost - this.$data.heat;
-          this.$data.megaCredits = Math.max(discountedCost, 0);
-        },
         setDefaultSteelValue: function() {
           // automatically use available steel to pay if not enough MC
           if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
-              let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - this.$data.heat, 0) / this.player.steelValue);
+              let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits, 0) / this.player.steelValue);
               
               if (requiredSteelQty > this.player.steel) {
                   this.$data.steel = this.player.steel;
@@ -65,7 +54,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                   this.$data.steel = requiredSteelQty;
               }
               
-              let discountedCost = this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue);
+              let discountedCost = this.$data.cost - (this.$data.steel * this.player.steelValue);
               this.$data.megaCredits = Math.max(discountedCost, 0);
           } else {
               this.$data.steel = 0;
@@ -74,7 +63,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         setDefaultTitaniumValue: function() {
           // automatically use available titanium to pay if not enough MC
           if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
-              let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - this.$data.heat - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
+              let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
               
               if (requiredTitaniumQty > this.player.titanium) {
                   this.$data.titanium = this.player.titanium;
@@ -82,11 +71,22 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                   this.$data.titanium = requiredTitaniumQty;
               }
               
-              let discountedCost = this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
+              let discountedCost = this.$data.cost - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
               this.$data.megaCredits = Math.max(discountedCost, 0);
           } else {
               this.$data.titanium = 0;
           }
+        },
+        setDefaultHeatValue: function() {
+          // automatically use available heat for Helion if not enough MC
+          if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
+              this.$data.heat =  Math.max(this.$data.cost - this.player.megaCredits - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue), 0);
+          } else {
+              this.$data.heat = 0;
+          }
+
+          let discountedCost = this.$data.cost - this.$data.heat;
+          this.$data.megaCredits = Math.max(discountedCost, 0);
         },
         canAffordWithMcOnly: function() {
           return this.player.megaCredits >= this.$data.cost;

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -36,6 +36,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
 
         app.setDefaultHeatValue();
         app.setDefaultSteelValue();
+        app.setDefaultTitaniumValue();
       });
     },
     methods: {
@@ -49,6 +50,8 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
           } else {
               this.$data.heat = 0;
           }
+
+          this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat, 0);
         },
         setDefaultSteelValue: function() {
           // automatically use available steel to pay if not enough MC
@@ -61,11 +64,27 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                   this.$data.steel = requiredSteelQty;
               }
               
-              this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.steel * this.player.steelValue), 0);
+              this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue), 0);
           } else {
               this.$data.steel = 0;
           }
-      },
+        },
+        setDefaultTitaniumValue: function() {
+          // automatically use available titanium to pay if not enough MC
+          if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
+              let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - this.$data.heat - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
+              
+              if (requiredTitaniumQty > this.player.titanium) {
+                  this.$data.titanium = this.player.titanium;
+              } else {
+                  this.$data.titanium = requiredTitaniumQty;
+              }
+              
+              this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue), 0);
+          } else {
+              this.$data.titanium = 0;
+          }
+        },
         canAffordWithMcOnly: function() {
           return this.player.megaCredits >= this.$data.cost;
         },
@@ -74,7 +93,10 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         },
         canUseSteel: function () {
           return this.playerinput.canUseSteel && this.player.steel > 0;
-        }, 
+        },
+        canUseTitanium: function () {
+          return this.playerinput.canUseTitanium && this.player.titanium > 0;
+        },
         saveData: function () {
             const htp: HowToPay = {
                 heat: this.$data.heat,

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -43,11 +43,14 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         },
         setDefaultHeatValue: function() {
           // automatically use heat for Helion if not enough MC
-          if (this.$data.cost > this.player.megaCredits && this.canUseHeat()) {
+          if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
               this.$data.heat =  this.$data.cost - this.player.megaCredits;
           } else {
               this.$data.heat = 0;
           }
+        },
+        canAffordWithMcOnly: function() {
+          return this.player.megaCredits >= this.$data.cost;
         },
         canUseHeat: function () {
           return this.playerinput.canUseHeat && this.player.heat > 0;

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -33,11 +33,24 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
       Vue.nextTick(function () {
         app.$data.cost = app.playerinput.amount;
         app.$data.megaCredits = (app as any).getMegaCreditsMax();
+
+        app.setDefaultHeatValue();
       });
     },
     methods: {
         hasWarning: function () {
             return this.$data.warning !== undefined;
+        },
+        setDefaultHeatValue: function() {
+          // automatically use heat for Helion if not enough MC
+          if (this.$data.cost > this.player.megaCredits && this.canUseHeat()) {
+              this.$data.heat =  this.$data.cost - this.player.megaCredits;
+          } else {
+              this.$data.heat = 0;
+          }
+        },
+        canUseHeat: function () {
+          return this.playerinput.canUseHeat && this.player.heat > 0;
         },
         saveData: function () {
             const htp: HowToPay = {

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -35,6 +35,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
         app.$data.megaCredits = (app as any).getMegaCreditsMax();
 
         app.setDefaultHeatValue();
+        app.setDefaultSteelValue();
       });
     },
     methods: {
@@ -42,19 +43,38 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
             return this.$data.warning !== undefined;
         },
         setDefaultHeatValue: function() {
-          // automatically use heat for Helion if not enough MC
+          // automatically use available heat for Helion if not enough MC
           if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
               this.$data.heat =  this.$data.cost - this.player.megaCredits;
           } else {
               this.$data.heat = 0;
           }
         },
+        setDefaultSteelValue: function() {
+          // automatically use available steel to pay if not enough MC
+          if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
+              let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - this.$data.heat, 0) / this.player.steelValue);
+              
+              if (requiredSteelQty > this.player.steel) {
+                  this.$data.steel = this.player.steel;
+              } else {
+                  this.$data.steel = requiredSteelQty;
+              }
+              
+              this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.steel * this.player.steelValue), 0);
+          } else {
+              this.$data.steel = 0;
+          }
+      },
         canAffordWithMcOnly: function() {
           return this.player.megaCredits >= this.$data.cost;
         },
         canUseHeat: function () {
           return this.playerinput.canUseHeat && this.player.heat > 0;
         },
+        canUseSteel: function () {
+          return this.playerinput.canUseSteel && this.player.steel > 0;
+        }, 
         saveData: function () {
             const htp: HowToPay = {
                 heat: this.$data.heat,

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -51,6 +51,13 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
               if (requiredSteelQty > this.player.steel) {
                   this.$data.steel = this.player.steel;
               } else {
+                  // use as much steel as possible without overpaying by default
+                  let currentSteelValue = requiredSteelQty * this.player.steelValue;
+                  while (currentSteelValue <= this.$data.cost - this.player.steelValue && requiredSteelQty < this.player.steel) {
+                      requiredSteelQty++;
+                      currentSteelValue = requiredSteelQty * this.player.steelValue;
+                  }
+
                   this.$data.steel = requiredSteelQty;
               }
               
@@ -68,6 +75,13 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
               if (requiredTitaniumQty > this.player.titanium) {
                   this.$data.titanium = this.player.titanium;
               } else {
+                  // use as much titanium as possible without overpaying by default
+                  let currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
+                  while (currentTitaniumValue <= this.$data.cost - this.player.titaniumValue && requiredTitaniumQty < this.player.titanium) {
+                      requiredTitaniumQty++;
+                      currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
+                  }
+
                   this.$data.titanium = requiredTitaniumQty;
               }
               

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -51,7 +51,8 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
               this.$data.heat = 0;
           }
 
-          this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat, 0);
+          let discountedCost = this.$data.cost - this.$data.heat;
+          this.$data.megaCredits = Math.max(discountedCost, 0);
         },
         setDefaultSteelValue: function() {
           // automatically use available steel to pay if not enough MC
@@ -64,7 +65,8 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                   this.$data.steel = requiredSteelQty;
               }
               
-              this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue), 0);
+              let discountedCost = this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue);
+              this.$data.megaCredits = Math.max(discountedCost, 0);
           } else {
               this.$data.steel = 0;
           }
@@ -80,7 +82,8 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
                   this.$data.titanium = requiredTitaniumQty;
               }
               
-              this.$data.megaCredits = Math.max(this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue), 0);
+              let discountedCost = this.$data.cost - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
+              this.$data.megaCredits = Math.max(discountedCost, 0);
           } else {
               this.$data.titanium = 0;
           }

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -60,7 +60,14 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultMicrobesValue: function() {
             // automatically use microbes to pay for card if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
-                this.$data.microbes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
+                let requiredMicrobes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
+
+                if (requiredMicrobes > this.playerinput.microbes) {
+                    this.$data.microbes = this.playerinput.microbes;
+                } else {
+                    this.$data.microbes = requiredMicrobes;
+                }
+
                 this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2), 0);
             } else {
                 this.$data.microbes = 0;
@@ -69,7 +76,14 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultFloatersValue: function() {
             // automatically use floaters to pay for card if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseFloaters()) {
-                this.$data.floaters = Math.ceil((this.$data.cost - this.player.megaCredits) / 3);
+                let requiredFloaters = Math.ceil((this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2)) / 3)
+
+                if (requiredFloaters > this.playerinput.floaters) {
+                    this.$data.floaters = this.playerinput.floaters;
+                } else {
+                    this.$data.floaters = requiredFloaters;
+                }
+
                 this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
             } else {
                 this.$data.floaters = 0;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -43,6 +43,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             app.$data.megaCredits = (app as any).getMegaCreditsMax();
 
             app.setDefaultMicrobesValue();
+            app.setDefaultFloatersValue();
             app.setDefaultHeatValue();
         });
     },
@@ -60,15 +61,30 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             // automatically use microbes to pay for card if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
                 this.$data.microbes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
-                this.$data.megaCredits = this.$data.cost - (this.$data.microbes * 2);
+                this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2), 0);
             } else {
                 this.$data.microbes = 0;
+            }
+        },
+        setDefaultFloatersValue: function() {
+            // automatically use floaters to pay for card if not enough MC
+            if (!this.canAffordWithMcOnly() && this.canUseFloaters()) {
+                this.$data.floaters = Math.ceil((this.$data.cost - this.player.megaCredits) / 3);
+                this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
+            } else {
+                this.$data.floaters = 0;
             }
         },
         setDefaultHeatValue: function() {
             // automatically use heat for Helion if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-                this.$data.heat =  this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2);
+                let requiredHeatAmt = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
+                
+                if (requiredHeatAmt > this.player.heat) {
+                    this.$data.heat = this.player.heat;
+                } else {
+                    this.$data.heat = requiredHeatAmt;
+                }
             } else {
                 this.$data.heat = 0;
             }
@@ -129,9 +145,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
             this.titanium = 0;
             this.steel = 0;
-            this.floaters = 0;
 
             this.setDefaultMicrobesValue();
+            this.setDefaultFloatersValue();
             this.setDefaultHeatValue();
         },
         hasWarning: function () {

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -45,6 +45,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             app.setDefaultMicrobesValue();
             app.setDefaultFloatersValue();
             app.setDefaultHeatValue();
+            app.setDefaultSteelValue();
         });
     },
     methods: {
@@ -58,7 +59,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             return this.player.selfReplicatingRobotsCardCost;
         },
         setDefaultMicrobesValue: function() {
-            // automatically use microbes to pay for card if not enough MC
+            // automatically use available microbes to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
                 let requiredMicrobes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
 
@@ -74,7 +75,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             }
         },
         setDefaultFloatersValue: function() {
-            // automatically use floaters to pay for card if not enough MC
+            // automatically use available floaters to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseFloaters()) {
                 let requiredFloaters = Math.ceil((this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2)) / 3)
 
@@ -90,17 +91,31 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             }
         },
         setDefaultHeatValue: function() {
-            // automatically use heat for Helion if not enough MC
+            // automatically use available heat for Helion if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-                let requiredHeatAmt = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
+                let requiredHeat = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
                 
-                if (requiredHeatAmt > this.player.heat) {
+                if (requiredHeat > this.player.heat) {
                     this.$data.heat = this.player.heat;
                 } else {
-                    this.$data.heat = requiredHeatAmt;
+                    this.$data.heat = requiredHeat;
                 }
             } else {
                 this.$data.heat = 0;
+            }
+        },
+        setDefaultSteelValue: function() {
+            // automatically use available steel to pay if not enough MC
+            if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
+                let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat, 0) / this.player.steelValue);
+                
+                if (requiredSteelQty > this.player.steel) {
+                    this.$data.steel = this.player.steel;
+                } else {
+                    this.$data.steel = requiredSteelQty;
+                }
+            } else {
+                this.$data.steel = 0;
             }
         },
         canAffordWithMcOnly: function() {
@@ -163,6 +178,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             this.setDefaultMicrobesValue();
             this.setDefaultFloatersValue();
             this.setDefaultHeatValue();
+            this.setDefaultSteelValue();
         },
         hasWarning: function () {
             return this.$data.warning !== undefined;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -41,6 +41,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         Vue.nextTick(function () {
             app.$data.cost = app.getCardCost();
             app.$data.megaCredits = (app as any).getMegaCreditsMax();
+
+            app.setDefaultHeatValue();
         });
     },
     methods: {
@@ -52,6 +54,14 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             }
             // If not found, it should be self replication robot stored card
             return this.player.selfReplicatingRobotsCardCost;
+        },
+        setDefaultHeatValue: function() {
+            // automatically use heat for Helion if not enough MC
+            if (this.$data.cost > this.player.megaCredits && this.canUseHeat()) {
+                this.$data.heat =  this.$data.cost - this.player.megaCredits;
+            } else {
+                this.$data.heat = 0;
+            }
         },
         canUseHeat: function () {
             return this.playerinput.canUseHeat && this.player.heat > 0;
@@ -106,9 +116,10 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
             this.titanium = 0;
             this.steel = 0;
-            this.heat = 0;
             this.microbes = 0;
             this.floaters = 0;
+
+            this.setDefaultHeatValue();
         },
         hasWarning: function () {
             return this.$data.warning !== undefined;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -62,7 +62,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultMicrobesValue: function() {
             // automatically use available microbes to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
-                let requiredMicrobes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
+                let remainingCostToPay = this.$data.cost - this.player.megaCredits;
+                let requiredMicrobes = Math.ceil(remainingCostToPay / 2);
 
                 if (requiredMicrobes > this.playerinput.microbes) {
                     this.$data.microbes = this.playerinput.microbes;
@@ -79,7 +80,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultFloatersValue: function() {
             // automatically use available floaters to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseFloaters()) {
-                let requiredFloaters = Math.ceil((this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2)) / 3)
+                let remainingCostToPay = this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2);
+                let requiredFloaters = Math.ceil(Math.max(remainingCostToPay, 0) / 3)
 
                 if (requiredFloaters > this.playerinput.floaters) {
                     this.$data.floaters = this.playerinput.floaters;
@@ -96,7 +98,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultSteelValue: function() {
             // automatically use available steel to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
-                let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0) / this.player.steelValue);
+                let remainingCostToPay = this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3);
+                let requiredSteelQty = Math.ceil(Math.max(remainingCostToPay, 0) / this.player.steelValue);
                 
                 if (requiredSteelQty > this.player.steel) {
                     this.$data.steel = this.player.steel;
@@ -113,7 +116,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultTitaniumValue: function() {
             // automatically use available titanium to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
-                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
+                let remainingCostToPay = this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue);
+                let requiredTitaniumQty = Math.ceil(Math.max(remainingCostToPay, 0) / this.player.titaniumValue);
                 
                 if (requiredTitaniumQty > this.player.titanium) {
                     this.$data.titanium = this.player.titanium;
@@ -130,7 +134,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultHeatValue: function() {
             // automatically use available heat for Helion if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-                let requiredHeat = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue), 0);
+                let remainingCostToPay = this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
+                let requiredHeat = Math.max(remainingCostToPay, 0);
                 
                 if (requiredHeat > this.player.heat) {
                     this.$data.heat = this.player.heat;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -44,9 +44,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
             app.setDefaultMicrobesValue();
             app.setDefaultFloatersValue();
-            app.setDefaultHeatValue();
             app.setDefaultSteelValue();
             app.setDefaultTitaniumValue();
+            app.setDefaultHeatValue();
         });
     },
     methods: {
@@ -93,27 +93,10 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 this.$data.floaters = 0;
             }
         },
-        setDefaultHeatValue: function() {
-            // automatically use available heat for Helion if not enough MC
-            if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-                let requiredHeat = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
-                
-                if (requiredHeat > this.player.heat) {
-                    this.$data.heat = this.player.heat;
-                } else {
-                    this.$data.heat = requiredHeat;
-                }
-
-                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat;
-                this.$data.megaCredits = Math.max(discountedCost, 0);
-            } else {
-                this.$data.heat = 0;
-            }
-        },
         setDefaultSteelValue: function() {
             // automatically use available steel to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
-                let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat, 0) / this.player.steelValue);
+                let requiredSteelQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0) / this.player.steelValue);
                 
                 if (requiredSteelQty > this.player.steel) {
                     this.$data.steel = this.player.steel;
@@ -121,7 +104,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     this.$data.steel = requiredSteelQty;
                 }
 
-                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue);
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue);
                 this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.steel = 0;
@@ -130,7 +113,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultTitaniumValue: function() {
             // automatically use available titanium to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
-                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
+                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
                 
                 if (requiredTitaniumQty > this.player.titanium) {
                     this.$data.titanium = this.player.titanium;
@@ -138,10 +121,27 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     this.$data.titanium = requiredTitaniumQty;
                 }
 
-                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
                 this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.titanium = 0;
+            }
+        },
+        setDefaultHeatValue: function() {
+            // automatically use available heat for Helion if not enough MC
+            if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
+                let requiredHeat = Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue), 0);
+                
+                if (requiredHeat > this.player.heat) {
+                    this.$data.heat = this.player.heat;
+                } else {
+                    this.$data.heat = requiredHeat;
+                }
+
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue) - this.$data.heat;
+                this.$data.megaCredits = Math.max(discountedCost, 0);
+            } else {
+                this.$data.heat = 0;
             }
         },
         canAffordWithMcOnly: function() {
@@ -200,9 +200,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
             this.setDefaultMicrobesValue();
             this.setDefaultFloatersValue();
-            this.setDefaultHeatValue();
             this.setDefaultSteelValue();
             this.setDefaultTitaniumValue();
+            this.setDefaultHeatValue();
         },
         hasWarning: function () {
             return this.$data.warning !== undefined;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -70,7 +70,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     this.$data.microbes = requiredMicrobes;
                 }
 
-                this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2), 0);
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2);
+                this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.microbes = 0;
             }
@@ -86,7 +87,8 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                     this.$data.floaters = requiredFloaters;
                 }
 
-                this.$data.megaCredits = Math.max(this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3), 0);
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3);
+                this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.floaters = 0;
             }
@@ -101,6 +103,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 } else {
                     this.$data.heat = requiredHeat;
                 }
+
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat;
+                this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.heat = 0;
             }
@@ -115,6 +120,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 } else {
                     this.$data.steel = requiredSteelQty;
                 }
+
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue);
+                this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.steel = 0;
             }
@@ -122,13 +130,16 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         setDefaultTitaniumValue: function() {
             // automatically use available titanium to pay if not enough MC
             if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
-                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.Steel * this.player.steelValue), 0) / this.player.titaniumValue);
+                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue), 0) / this.player.titaniumValue);
                 
                 if (requiredTitaniumQty > this.player.titanium) {
                     this.$data.titanium = this.player.titanium;
                 } else {
                     this.$data.titanium = requiredTitaniumQty;
                 }
+
+                let discountedCost = this.$data.cost - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue);
+                this.$data.megaCredits = Math.max(discountedCost, 0);
             } else {
                 this.$data.titanium = 0;
             }
@@ -186,9 +197,6 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
         cardChanged: function () {
             this.$data.cost = this.getCardCost();
             this.$data.megaCredits = (this as any).getMegaCreditsMax();
-
-            this.titanium = 0;
-            this.steel = 0;
 
             this.setDefaultMicrobesValue();
             this.setDefaultFloatersValue();

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -42,6 +42,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             app.$data.cost = app.getCardCost();
             app.$data.megaCredits = (app as any).getMegaCreditsMax();
 
+            app.setDefaultMicrobesValue();
             app.setDefaultHeatValue();
         });
     },
@@ -55,13 +56,25 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             // If not found, it should be self replication robot stored card
             return this.player.selfReplicatingRobotsCardCost;
         },
+        setDefaultMicrobesValue: function() {
+            // automatically use microbes to pay for card if not enough MC
+            if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
+                this.$data.microbes = Math.ceil((this.$data.cost - this.player.megaCredits) / 2);
+                this.$data.megaCredits = this.$data.cost - (this.$data.microbes * 2);
+            } else {
+                this.$data.microbes = 0;
+            }
+        },
         setDefaultHeatValue: function() {
             // automatically use heat for Helion if not enough MC
-            if (this.$data.cost > this.player.megaCredits && this.canUseHeat()) {
-                this.$data.heat =  this.$data.cost - this.player.megaCredits;
+            if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
+                this.$data.heat =  this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2);
             } else {
                 this.$data.heat = 0;
             }
+        },
+        canAffordWithMcOnly: function() {
+            return this.player.megaCredits >= this.$data.cost;
         },
         canUseHeat: function () {
             return this.playerinput.canUseHeat && this.player.heat > 0;
@@ -116,9 +129,9 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
             this.titanium = 0;
             this.steel = 0;
-            this.microbes = 0;
             this.floaters = 0;
 
+            this.setDefaultMicrobesValue();
             this.setDefaultHeatValue();
         },
         hasWarning: function () {

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -46,6 +46,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             app.setDefaultFloatersValue();
             app.setDefaultHeatValue();
             app.setDefaultSteelValue();
+            app.setDefaultTitaniumValue();
         });
     },
     methods: {
@@ -118,6 +119,20 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 this.$data.steel = 0;
             }
         },
+        setDefaultTitaniumValue: function() {
+            // automatically use available titanium to pay if not enough MC
+            if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
+                let requiredTitaniumQty = Math.ceil(Math.max(this.$data.cost - this.player.megaCredits - (this.$data.microbes * 2) - (this.$data.floaters * 3) - this.$data.heat - (this.$data.Steel * this.player.steelValue), 0) / this.player.titaniumValue);
+                
+                if (requiredTitaniumQty > this.player.titanium) {
+                    this.$data.titanium = this.player.titanium;
+                } else {
+                    this.$data.titanium = requiredTitaniumQty;
+                }
+            } else {
+                this.$data.titanium = 0;
+            }
+        },
         canAffordWithMcOnly: function() {
             return this.player.megaCredits >= this.$data.cost;
         },
@@ -179,6 +194,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
             this.setDefaultFloatersValue();
             this.setDefaultHeatValue();
             this.setDefaultSteelValue();
+            this.setDefaultTitaniumValue();
         },
         hasWarning: function () {
             return this.$data.warning !== undefined;

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -104,6 +104,13 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 if (requiredSteelQty > this.player.steel) {
                     this.$data.steel = this.player.steel;
                 } else {
+                    // use as much steel as possible without overpaying by default
+                    let currentSteelValue = requiredSteelQty * this.player.steelValue;
+                    while (currentSteelValue <= remainingCostToPay + this.player.megaCredits - this.player.steelValue && requiredSteelQty < this.player.steel) {
+                        requiredSteelQty++;
+                        currentSteelValue = requiredSteelQty * this.player.steelValue;
+                    }
+
                     this.$data.steel = requiredSteelQty;
                 }
 
@@ -122,6 +129,13 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
                 if (requiredTitaniumQty > this.player.titanium) {
                     this.$data.titanium = this.player.titanium;
                 } else {
+                    // use as much titanium as possible without overpaying by default
+                    let currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
+                    while (currentTitaniumValue <= remainingCostToPay + this.player.megaCredits - this.player.titaniumValue && requiredTitaniumQty < this.player.titanium) {
+                        requiredTitaniumQty++;
+                        currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
+                    }
+
                     this.$data.titanium = requiredTitaniumQty;
                 }
 


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/749

### Context
If a player cannot pay for a card using only MC, other valid and available resources will be used for payment in the following order:

1. Microbes from Psychrophiles for Plant cards (first priority since they can be removed by Ants)
2. Floaters from Dirigibles
3. Steel ("greedy" implementation, use as much as possible without overpaying by default)
4. Titanium ("greedy" implementation, use as much as possible without overpaying by default)
5. Heat (last priority since it can be used for temperature raise)

<img width="486" alt="Screenshot 2020-06-02 at 11 06 48 AM" src="https://user-images.githubusercontent.com/2408094/83528269-80185600-a51b-11ea-98ab-a5d6b94c3587.png">

<img width="866" alt="Screenshot 2020-06-02 at 12 29 27 PM" src="https://user-images.githubusercontent.com/2408094/83528311-8ad2eb00-a51b-11ea-8e0d-a571c9a42d8a.png">

<img width="456" alt="Screenshot 2020-06-02 at 9 49 54 PM" src="https://user-images.githubusercontent.com/2408094/83528320-8dcddb80-a51b-11ea-98da-daf19e8c6baa.png">

<img width="409" alt="Screenshot 2020-06-02 at 10 29 03 PM" src="https://user-images.githubusercontent.com/2408094/83532461-db007c00-a520-11ea-8c8e-65ad17dbe599.png">
