### PR TITLE
Component updates for vuejs warnings

### DIFF
--- a/src/components/AndOptions.ts
+++ b/src/components/AndOptions.ts
@@ -7,8 +7,6 @@ export const AndOptions = Vue.component("and-options", {
     props: ["player", "players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
-            childComponents: [],
-            responded: {} as {[x: string]: Array<string>}
         };
     },
     methods: {
@@ -23,7 +21,7 @@ export const AndOptions = Vue.component("and-options", {
             }
             const res: Array<Array<string>> = [];
             for (let i = 0; i < this.playerinput.options.length; i++) {
-                res.push(this.responded["" + i]);
+                res.push(this.$data.responded["" + i]);
             }
             this.onsave(res);
         }
@@ -32,15 +30,16 @@ export const AndOptions = Vue.component("and-options", {
         const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
         const children: Array<VNode> = [];
         this.$data.childComponents = [];
+        this.$data.responded = [];
         if (this.showtitle) {
             children.push(createElement("div", {"class": "wf-title"}, playerInput.title));
         }
         if (playerInput.options !== undefined) {
             const options = playerInput.options;
             options.forEach((option, idx: number) => {
-                if (this.responded[idx] === undefined) {
+                if (this.$data.responded[idx] === undefined) {
                     children.push(new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
-                        this.responded[idx] = out[0];
+                        this.$data.responded[idx] = out[0];
                     }, false, true));
                     this.$data.childComponents.push(children[children.length - 1]);
                 }

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -9,7 +9,6 @@ export const OrOptions = Vue.component("or-options", {
     props: ["player", "players", "playerinput", "onsave", "showsave", "showtitle"],
     data: function () {
         return {
-            childComponents: [],
             selectedOption: 0
         };
     },

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -24,7 +24,7 @@ export const SelectCard = Vue.component("select-card", {
     },
     template: `<div class="wf-component wf-component--select-card">
         <div v-if="showtitle === true" class="nofloat wf-component-title" v-i18n>{{playerinput.title}}</div>
-        <label v-for="card in playerinput.cards" :key="card" class="cardbox">
+        <label v-for="card in playerinput.cards" class="cardbox">
             <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" type="radio" v-model="cards" :value="card" />
             <input v-else type="checkbox" v-model="cards" :value="card" :disabled="cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
             <card :card="card.name" :resources="card.resources"></card>

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -160,7 +160,7 @@ export const SelectHowToPayForCard = Vue.component("select-how-to-pay-for-card",
 
   <div v-if="showtitle === true">{{playerinput.title}}</div>
 
-  <label v-for="availableCard in playerinput.cards" :key="availableCard" class="payments_cards">
+  <label v-for="availableCard in playerinput.cards" class="payments_cards">
     <input class="hidden" type="radio" v-model="card" v-on:change="cardChanged()" :value="availableCard" />
     <card class="cardbox" :card="availableCard.name" :resources="availableCard.resources"></card>
   </label>


### PR DESCRIPTION
We run vuejs in development mode which is slower and outputs a lot of warnings. I want to eventually run this in production mode. If you look at the console while playing a game you will see warnings logged that we recursively make calls to render from `AndOptions` and `OrOptions`. A data property is being updated which existed when the vue instance was instantiated. When these properties are updated vue renders the component. To resolve this warning the properties we use during render are added at the time of render so they do not trigger subsequent updates. In production mode the app currently gets stuck in an infinite loop, it works in develop mode since vuejs prevents the looping.

The other warning resolved is our usage of the `:key` property which is unnecessary since we have strings. There will be more warnings but with these changes the first warnings seen while starting the game are now gone. This should be a performance improvement and eventually allow us to build in production mode.