### PR TITLE
Cache db directory for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
   "bugs": {
     "url": "https://github.com/bafolts/terraforming-mars/issues"
   },
-  "homepage": "https://github.com/bafolts/terraforming-mars#readme"
+  "homepage": "https://github.com/bafolts/terraforming-mars#readme",
+  "cacheDirectories": ["db"]
 }


### PR DESCRIPTION
We added a local database on disk for storing games that are being played for the undo operation. When the app starts we attempt to repopulate games from that database. The idea was on our heroku server we would load any games which were ongoing. Reading through the heroku documentation today I believe we have to define our `db` directory as a `cacheDirectories` in our top level `package.json` to keep the database file around.

Eventually this database will grow too large to be stored on disk and we will need to consider pruning it in some way. For the time being this should allow games to be played while we update `master` without losing the games.

https://devcenter.heroku.com/articles/nodejs-support#custom-caching