### PR TITLE
Fix: Preludes should be playable if player can afford by playing the other prelude first

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1149,7 +1149,6 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }    
 
     public playCard(game: Game, selectedCard: IProjectCard, howToPay?: HowToPay): undefined { 
-
         // Pay for card
         if (howToPay !== undefined) {
             this.steel -= howToPay.steel;
@@ -1952,8 +1951,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
     }
 
-    public takeAction(game: Game): void {
+    private getPreludeMcBonus(preludeCards: IProjectCard[]) {
+      return preludeCards.map((card) => card.bonusMc || 0).reduce((a, b) => Math.max(a, b));
+    }
 
+    public takeAction(game: Game): void {
       if (this.hasInterrupt(game)) {
         this.runInterrupt(game, () => this.takeAction(game));
         return;
@@ -1961,8 +1963,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
  
       // Prelude cards have to be played first
       if (this.preludeCardsInHand.length > 0) {
+        let preludeMcBonus = this.getPreludeMcBonus(this.preludeCardsInHand);
+
         // Remove unplayable prelude cards
-        this.preludeCardsInHand = this.preludeCardsInHand.filter(card => card.canPlay === undefined || card.canPlay(this, game));
+        this.preludeCardsInHand = this.preludeCardsInHand.filter(card => card.canPlay === undefined || card.canPlay(this, game, preludeMcBonus));
         if (this.preludeCardsInHand.length === 0) {
           game.playerIsFinishedTakingActions();
           return;

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -7,11 +7,12 @@ import { ResourceType } from "../ResourceType";
 import { Resources } from '../Resources';
 
 export interface IProjectCard extends ICard {
-    canPlay?: (player: Player, game: Game) => boolean;
+    canPlay?: (player: Player, game: Game, bonusMc?: number) => boolean;
     cardType: CardType;
     cost: number;
     resourceType?: ResourceType;
     hasRequirements?: boolean;
     bonusResource?: Resources | undefined;
+    bonusMc?: number | undefined;
 }
 

--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -8,9 +8,11 @@ import { CardName } from '../../CardName';
 export class AlliedBanks extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: CardName = CardName.ALLIED_BANKS;
+    public bonusMc: number = 3;
+
     public play(player: Player) {
         player.setProduction(Resources.MEGACREDITS,4);
-	    player.megaCredits += 3; 
+	    player.megaCredits += this.bonusMc; 
 	    return undefined;   
     }
 }

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -9,8 +9,9 @@ import { CardName } from '../../CardName';
 export class AquiferTurbines extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: CardName = CardName.AQUIFER_TURBINES;
-    public canPlay(player: Player) {
-        return player.canAfford(3);
+    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+        let requiredPayment = 3 - (bonusMc || 0);
+        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
     }
     public play(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,2);

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -4,12 +4,14 @@ import { PreludeCard } from "./PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { Game } from "../../Game";
 
 export class BusinessEmpire extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: CardName = CardName.BUSINESS_EMPIRE;
-    public canPlay(player: Player) {
-        return player.canAfford(6);
+    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+        let requiredPayment = 6 - (bonusMc || 0); 
+        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
     }
     public play(player: Player) {
 	    player.megaCredits -= 6;

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -5,12 +5,15 @@ import { IProjectCard } from "../IProjectCard";
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
 import { Game } from "../../Game";
+import { CorporationName } from "../../CorporationName";
 
 export class BusinessEmpire extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: CardName = CardName.BUSINESS_EMPIRE;
     public canPlay(player: Player, _game: Game, bonusMc?: number) {
-        let requiredPayment = 6 - (bonusMc || 0); 
+        let requiredPayment = 6 - (bonusMc || 0);
+        if (player.isCorporation(CorporationName.MANUTECH)) return requiredPayment - 6 <= 0;
+        
         return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
     }
     public play(player: Player) {

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -7,8 +7,10 @@ import { CardName } from '../../CardName';
 export class Donation extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.DONATION;
+    public bonusMc: number = 21;
+
     public play(player: Player) {     
-        player.megaCredits += 21;
+        player.megaCredits += this.bonusMc;
         return undefined;
     }
 }

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -4,12 +4,14 @@ import { PreludeCard } from "./PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { Game } from "../../Game";
 
 export class GalileanMining extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN];
     public name: CardName = CardName.GALILEAN_MINING;
-    public canPlay(player: Player) {
-        return player.canAfford(5);
+    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+        let requiredPayment = 5 - (bonusMc || 0);
+        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
     }
     public play(player: Player) {
         player.setProduction(Resources.TITANIUM,2);

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -8,8 +8,9 @@ import { CardName } from '../../CardName';
 export class HugeAsteroid extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.HUGE_ASTEROID;
-    public canPlay(player: Player) {
-        return player.canAfford(5);
+    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+        let requiredPayment = 5 - (bonusMc || 0);
+        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
     }
     public play(player: Player, game: Game) {
         player.megaCredits -= 5;

--- a/src/cards/prelude/Loan.ts
+++ b/src/cards/prelude/Loan.ts
@@ -8,12 +8,14 @@ import { CardName } from '../../CardName';
 export class Loan extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.LOAN;
+    public bonusMc: number = 30;
+
     public canPlay(player: Player): boolean {
         return player.getProduction(Resources.MEGACREDITS) >= -3;
     }    
     public play(player: Player) {
         player.setProduction(Resources.MEGACREDITS,-2);
-        player.megaCredits += 30;
+        player.megaCredits += this.bonusMc;
         return undefined;
     }
 }

--- a/src/cards/prelude/MartianIndustries.ts
+++ b/src/cards/prelude/MartianIndustries.ts
@@ -8,10 +8,12 @@ import { CardName } from '../../CardName';
 export class MartianIndustries extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.MARTIAN_INDUSTRIES;
+    public bonusMc: number = 6;
+
     public play(player: Player) {
         player.setProduction(Resources.ENERGY);
         player.setProduction(Resources.STEEL);
-        player.megaCredits += 6;
+        player.megaCredits += this.bonusMc;
         return undefined;
     }
 }

--- a/src/cards/prelude/NitrogenDelivery.ts
+++ b/src/cards/prelude/NitrogenDelivery.ts
@@ -9,8 +9,10 @@ import { Game } from '../../Game';
 export class NitrogenDelivery extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.NITROGEN_SHIPMENT;
+    public bonusMc: number = 5;
+
     public play(player: Player, game: Game) {     
-        player.megaCredits += 5;
+        player.megaCredits += this.bonusMc;
         player.increaseTerraformRating(game);
         player.setProduction(Resources.PLANTS);
         return undefined;

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -1,11 +1,12 @@
 import { CardType } from "../CardType";
 import { Player } from "../../Player";
+import { Game } from "../../Game";
 
 export abstract class PreludeCard  {
     public cost: number = 0;
     public cardType: CardType = CardType.PRELUDE;
     public hasRequirements = false;
-    public canPlay(_player: Player): boolean {
+    public canPlay(_player: Player, _game: Game, _bonusMc: number = 0): boolean {
         return true;
     }
 }

--- a/tests/cards/prelude/AquiferTurbines.spec.ts
+++ b/tests/cards/prelude/AquiferTurbines.spec.ts
@@ -11,7 +11,9 @@ describe("AquiferTurbines", function () {
         const card = new AquiferTurbines();
         const player = new Player("test", Color.BLUE, false);
         player.megaCredits = 3;
-        expect(card.canPlay(player)).to.eq(true);
+        const game = new Game("foobar", [player], player);
+
+        expect(card.canPlay(player, game)).to.eq(true);
     });
     it("Should play", function () {
         const card = new AquiferTurbines();

--- a/tests/cards/prelude/BusinessEmpire.spec.ts
+++ b/tests/cards/prelude/BusinessEmpire.spec.ts
@@ -4,14 +4,17 @@ import { BusinessEmpire } from "../../../src/cards/prelude/BusinessEmpire";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Resources } from '../../../src/Resources';
+import { Game } from "../../../src/Game";
 
 describe("BusinessEmpire", function () {
     it("Can play", function () {
         const card = new BusinessEmpire();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
+        const game = new Game("foobar", [player], player);
+
+        expect(card.canPlay(player, game)).to.eq(false);
         player.megaCredits = 6;
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
     });
     it("Should play", function () {
         const card = new BusinessEmpire();

--- a/tests/cards/prelude/GalileanMining.spec.ts
+++ b/tests/cards/prelude/GalileanMining.spec.ts
@@ -4,14 +4,17 @@ import { GalileanMining } from "../../../src/cards/prelude/GalileanMining";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Resources } from '../../../src/Resources';
+import { Game } from "../../../src/Game";
 
 describe("GalileanMining", function () {
     it("Can play", function () {
         const card = new GalileanMining();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
+        const game = new Game("foobar", [player], player);
+
+        expect(card.canPlay(player, game)).to.eq(false);
         player.megaCredits = 5;
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
     });
     it("Should play", function () {
         const card = new GalileanMining();

--- a/tests/cards/prelude/HugeAsteroid.spec.ts
+++ b/tests/cards/prelude/HugeAsteroid.spec.ts
@@ -9,9 +9,11 @@ describe("HugeAsteroid", function () {
     it("Can play", function () {
         const card = new HugeAsteroid();
         const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
+        const game = new Game("foobar", [player], player);
+
+        expect(card.canPlay(player, game)).to.eq(false);
         player.megaCredits = 5;
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
     });
     it("Should play", function () {


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/761

Worst edge case is Manutech keeping 10 cards with Galilean Mining and Business Empire. Both Preludes should be playable due to Manutech's effect.

<img width="1102" alt="Screenshot 2020-06-05 at 1 04 34 PM" src="https://user-images.githubusercontent.com/2408094/83839384-7fa3d900-a72e-11ea-8583-96369d2086fd.png">

**Note:** MC can temporarily show as negative after playing first Prelude if it deducts MC, but will always be 0 or net positive after both Preludes are played.