### PR TITLE
Fix bug with custom corps option and 1 starting corp

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -212,7 +212,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }  
 
       // Setup custom corporation list
-      if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length >= players.length * 2) {
+      const minCorpsRequired = players.length * this.startingCorporations;
+      if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length >= minCorpsRequired) {
 
         // Init all available corporation cards to choose from
         corporationCards = ALL_CORPORATION_CARDS.map((cf) => new cf.factory());


### PR DESCRIPTION
**Scenario:**
- Custom corps option is enabled
- Player selects only 1 corporation (e.g. Credicor in below screenshot)
- Starting corps quantity is set to 1

**Expected:** Player should be dealt the selected custom corporation
**Actual:** Player is dealt a random corporation

<img width="762" alt="Screenshot 2020-06-05 at 6 53 48 PM" src="https://user-images.githubusercontent.com/2408094/83869281-ee992600-a75e-11ea-9f3f-ab5a16f168b1.png">
