### PR TITLE
Add created_time to games table

### DIFF
--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -15,7 +15,7 @@ export class PostgreSQL implements IDatabase {
             }
         });
         this.client.connect();
-        this.client.query("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', PRIMARY KEY (game_id, save_id))", (err) => {
+        this.client.query("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', created_time timestamp default now(), PRIMARY KEY (game_id, save_id))", (err) => {
             if (err) {
                 throw err;
             }

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -17,7 +17,7 @@ export class SQLite implements IDatabase {
             fs.mkdirSync(dbFolder);
         }
         this.db = new sqlite3.Database(dbPath);
-        this.db.run("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', PRIMARY KEY (game_id, save_id))");
+        this.db.run("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', created_time timestamp default (strftime('%s', 'now')), PRIMARY KEY (game_id, save_id))");
     }
 
     getClonableGames( cb:(err: any, allGames:Array<IGameData>)=> void) {


### PR DESCRIPTION
Add a created_time that default to now() to the table. It will be useful for housekeeping.
If the postgres database is already up and running it will not do anything, the table could be modified from the command line. I can take care of this if needed.