### PR TITLE
Added timestamps to log entries

### DIFF
--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -74,9 +74,10 @@ export const LogPanel = Vue.component("log-panel", {
             return '';
         },
         parseMessage: function(message: LogMessage) {
+            let logEntryBullet = (this.isNewGeneration(message.type)) ? '' : `<span title="${new Date(message.timestamp).toLocaleString()}">&#x1f551;</span>`;
             if (message.type !== undefined && message.message !== undefined) {
                 message.message = $t(message.message);
-                return message.message.replace(/\$\{([0-9]{1})\}/gi, (_match, idx) => {
+                return logEntryBullet+message.message.replace(/\$\{([0-9]{1})\}/gi, (_match, idx) => {
                     return this.parseData(message.data[idx]);
                 });
             }
@@ -110,7 +111,7 @@ export const LogPanel = Vue.component("log-panel", {
         <div class="panel log-panel">
             <div id="logpanel-scrollable" class="panel-body">
                 <ul v-if="messages">
-                    <li v-for="message in messages" v-on:click.prevent="cardClicked(message)" v-html="parseMessage(message)" :class="isNewGeneration(message.type) ? 'noBullet' : ''"></li>
+                    <li v-for="message in messages" v-on:click.prevent="cardClicked(message)" v-html="parseMessage(message)"></li>
                 </ul>
             </div>
         </div>

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -8,15 +8,18 @@
 
     li {
         margin-top: 0 !important;
+        list-style-type: none;
+
+        span {
+            margin-right: 5px;
+            font-size: 15px;
+        }
+
     }
 
     ul {
         margin: 0 !important;
     }
-}
-
-.log-panel .noBullet {
-    list-style-type: none;
 }
 
 log-player {


### PR DESCRIPTION
Changed the bullet in front of log level entries to a clock face which shows the timestamp for the log message on hover.

<img width="551" alt="timestamps" src="https://user-images.githubusercontent.com/547035/84137186-9dce4980-aa4c-11ea-9237-5a30348ca32b.png">