### PR TITLE
Log error instead of crashing process when game can't be rebuilt

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -236,9 +236,10 @@ function loadAllGames(): void {
       let gameToRebuild = new Game(game_id,[player,player2], player);
       Database.getInstance().restoreGameLastSave(game_id, gameToRebuild, function (err) {
         if (err) {
+          console.error("unable to load game " + game_id, err);
           return;
         }
-        console.log("load game "+ game_id);
+        console.log("load game " + game_id);
         games.set(gameToRebuild.id, gameToRebuild);
         gameToRebuild.getPlayers().forEach((player) => {
           playersToGame.set(player.id, gameToRebuild);

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -96,7 +96,12 @@ export class PostgreSQL implements IDatabase {
             let gameToRestore = JSON.parse(res.rows[0].game);
 
             // Rebuild each objects
-            game.loadFromJSON(gameToRestore);
+            try {
+                game.loadFromJSON(gameToRestore);
+            } catch (e) {
+                cb(e);
+                return;
+            }
 
             return cb(err);
         });


### PR DESCRIPTION
I will most likely merge this without approval to get the server back up. We are gaining probably 200-300 games per day. One of those games did not reload when the game server started back up. We weren't catching the error and the node process was crashing. This change catches the error and logs it. This will allow the game server to start up and will avoid this crash in the future.