### PR TITLE
Improvement: Swap action order to save clicks

### DIFF
--- a/src/cards/GHGProducingBacteria.ts
+++ b/src/cards/GHGProducingBacteria.ts
@@ -29,13 +29,13 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
     public action(player: Player, game: Game) {
         if (this.resourceCount > 1) {
             return new OrOptions(
-                new SelectOption("Add 1 microbe to this card", () => {
-                    this.resourceCount++;
-                    return undefined;
-                }),
                 new SelectOption("Remove 2 microbes to raise temperature 1 step", () => {
                     player.removeResourceFrom(this,2);
                     return game.increaseTemperature(player, 1);
+                }),
+                new SelectOption("Add 1 microbe to this card", () => {
+                    this.resourceCount++;
+                    return undefined;
                 })
             );
         }

--- a/src/cards/NitriteReducingBacteria.ts
+++ b/src/cards/NitriteReducingBacteria.ts
@@ -31,13 +31,13 @@ export class NitriteReducingBacteria implements IActionCard, IProjectCard, IReso
             return undefined;
         }
         return new OrOptions(
-            new SelectOption("Add 1 microbe to this card", () => {
-                this.resourceCount++;
-                return undefined;
-            }),
             new SelectOption("Remove 3 microbes to increase your terraform rating 1 step", () => {
                 this.resourceCount -= 3;
                 player.increaseTerraformRating(game);
+                return undefined;
+            }),
+            new SelectOption("Add 1 microbe to this card", () => {
+                this.resourceCount++;
                 return undefined;
             })
         );

--- a/src/cards/OlympusConference.ts
+++ b/src/cards/OlympusConference.ts
@@ -33,14 +33,14 @@ export class OlympusConference implements IProjectCard, IResourceCard {
       }
 
       game.addInterrupt({ player, playerInput: new OrOptions(
-        new SelectOption("Add a science resource to this card", () => {
-          this.resourceCount++;
-          this.runInterrupts(player, game, scienceTags - 1);
-          return undefined;
-        }),
         new SelectOption("Remove a science resource from this card to draw a card", () => {
           player.removeResourceFrom(this);
           player.cardsInHand.push(game.dealer.dealCard());
+          this.runInterrupts(player, game, scienceTags - 1);
+          return undefined;
+        }),
+        new SelectOption("Add a science resource to this card", () => {
+          this.resourceCount++;
           this.runInterrupts(player, game, scienceTags - 1);
           return undefined;
         })

--- a/src/cards/RegolithEaters.ts
+++ b/src/cards/RegolithEaters.ts
@@ -30,13 +30,13 @@ export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard 
             return undefined;
         }
         return new OrOptions(
-            new SelectOption("Add 1 microbe to this card", () => {
-                this.resourceCount++;
-                return undefined;
-            }),
             new SelectOption("Remove 2 microbes to raise oxygen level 1 step", () => {
                 player.removeResourceFrom(this, 2);
                 return game.increaseOxygenLevel(player, 1);
+            }),
+            new SelectOption("Add 1 microbe to this card", () => {
+                this.resourceCount++;
+                return undefined;
             })
         );
     }

--- a/src/cards/colonies/AtmoCollectors.ts
+++ b/src/cards/colonies/AtmoCollectors.ts
@@ -27,10 +27,6 @@ export class AtmoCollectors implements IProjectCard, IResourceCard {
             return undefined;
         }
         return new OrOptions(
-            new SelectOption("Add 1 floater to this card", () => {
-                this.resourceCount++;
-                return undefined;
-            }),
             new SelectOption("Remove 1 floater to gain 2 titanium", () => {
                 this.resourceCount--;
                 player.titanium += 2;
@@ -44,6 +40,10 @@ export class AtmoCollectors implements IProjectCard, IResourceCard {
             new SelectOption("Remove 1 floater to gain 4 heat", () => {
                 this.resourceCount--;
                 player.heat += 4;
+                return undefined;
+            }),
+            new SelectOption("Add 1 floater to this card", () => {
+                this.resourceCount++;
                 return undefined;
             })
         );

--- a/src/cards/colonies/RedSpotObservatory.ts
+++ b/src/cards/colonies/RedSpotObservatory.ts
@@ -43,10 +43,9 @@ export class RedSpotObservatory implements IProjectCard, IResourceCard {
             return undefined;
         });
 
-        opts.push(addResource);
-
         if (this.resourceCount > 0 ) {
             opts.push(spendResource);
+            opts.push(addResource);
         } else {
             return addResource;
         }

--- a/src/cards/colonies/RedSpotObservatory.ts
+++ b/src/cards/colonies/RedSpotObservatory.ts
@@ -36,12 +36,8 @@ export class RedSpotObservatory implements IProjectCard, IResourceCard {
         const addResource = new SelectOption("Add 1 floater on this card", () => this.addResource());
         const spendResource = new SelectOption("Remove 1 floater on this card to draw a card", () => this.spendResource(player, game));
 
-        if (this.resourceCount > 0 ) {
-            opts.push(spendResource);
-            opts.push(addResource);
-        } else {
-            this.addResource();
-        }
+        opts.push(spendResource);
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/src/cards/colonies/RedSpotObservatory.ts
+++ b/src/cards/colonies/RedSpotObservatory.ts
@@ -32,25 +32,29 @@ export class RedSpotObservatory implements IProjectCard, IResourceCard {
         }
 
         var opts: Array<SelectOption> = [];
-        const addResource = new SelectOption("Add 1 floater on this card", () => {
-            this.resourceCount++;
-            return undefined;
-        });
 
-        const spendResource = new SelectOption("Remove 1 floater on this card to draw a card", () => {
-            this.resourceCount--;
-            player.cardsInHand.push(game.dealer.dealCard());
-            return undefined;
-        });
+        const addResource = new SelectOption("Add 1 floater on this card", () => this.addResource());
+        const spendResource = new SelectOption("Remove 1 floater on this card to draw a card", () => this.spendResource(player, game));
 
         if (this.resourceCount > 0 ) {
             opts.push(spendResource);
             opts.push(addResource);
         } else {
-            return addResource;
+            this.addResource();
         }
 
         return new OrOptions(...opts);
+    }
+
+    private addResource() {
+        this.resourceCount++;
+        return undefined;
+    }
+
+    private spendResource(player: Player, game: Game) {
+        this.resourceCount--;
+        player.cardsInHand.push(game.dealer.dealCard());
+        return undefined;
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/colonies/TitanAirScrapping.ts
+++ b/src/cards/colonies/TitanAirScrapping.ts
@@ -23,28 +23,32 @@ export class TitanAirScrapping implements IProjectCard, IResourceCard {
 
     public action(player: Player, game: Game) {
         var opts: Array<SelectOption> = [];
-        const addResource = new SelectOption("Spend 1 titanium to add 2 floaters on this card", () => {
-            this.resourceCount += 2;
-            player.titanium--;
-            return undefined;
-        });
 
-        const spendResource = new SelectOption("Remove 2 floaters on this card to increase your TR 1 step", () => {
-            this.resourceCount -= 2;
-            player.increaseTerraformRating(game);
-            return undefined;
-        });
+        const addResource = new SelectOption("Spend 1 titanium to add 2 floaters on this card", () => this.addResource(player));
+        const spendResource = new SelectOption("Remove 2 floaters on this card to increase your TR 1 step", () => this.spendResource(player, game));
 
         if (this.resourceCount >= 2 && player.titanium > 0) {
             opts.push(spendResource);
             opts.push(addResource);
         } else if (player.titanium > 0) {
-            return addResource;
+            this.addResource(player);
         } else {
-            return spendResource;
+            this.spendResource(player, game);
         }
 
         return new OrOptions(...opts);
+    }
+
+    private addResource(player: Player) {
+        this.resourceCount += 2;
+        player.titanium--;
+        return undefined;
+    }
+
+    private spendResource(player: Player, game: Game) {
+        this.resourceCount -= 2;
+        player.increaseTerraformRating(game);
+        return undefined;
     }
 
     public play() {

--- a/src/cards/colonies/TitanAirScrapping.ts
+++ b/src/cards/colonies/TitanAirScrapping.ts
@@ -36,8 +36,8 @@ export class TitanAirScrapping implements IProjectCard, IResourceCard {
         });
 
         if (this.resourceCount >= 2 && player.titanium > 0) {
-            opts.push(addResource);
             opts.push(spendResource);
+            opts.push(addResource);
         } else if (player.titanium > 0) {
             return addResource;
         } else {

--- a/src/cards/colonies/TitanFloatingLaunchPad.ts
+++ b/src/cards/colonies/TitanFloatingLaunchPad.ts
@@ -35,13 +35,13 @@ export class TitanFloatingLaunchPad implements IProjectCard,IResourceCard {
             return undefined;
         });
 
-        opts.push(addResource);
-
         let openColonies = game.colonies.filter(colony => colony.isActive && colony.visitor === undefined);
         if (openColonies.length > 0 
           && player.fleetSize > player.tradesThisTurn && this.resourceCount > 0 ){
             opts.push(spendResource);
         }
+
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/src/cards/colonies/TitanShuttles.ts
+++ b/src/cards/colonies/TitanShuttles.ts
@@ -30,17 +30,17 @@ export class TitanShuttles implements IProjectCard, IResourceCard {
             return undefined;
         });
 
-        const spendResource = new SelectAmount("Remove X floater on this card to gain X titanium", (amount: number) => {
+        const spendResource = new SelectAmount("Remove X floaters on this card to gain X titanium", (amount: number) => {
             player.removeResourceFrom(this, amount);
             player.titanium += amount; 
             return undefined;
         }, this.resourceCount);
 
-        opts.push(addResource);
-
         if (this.resourceCount > 0){
             opts.push(spendResource);
         }
+
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/src/cards/promo/Recyclon.ts
+++ b/src/cards/promo/Recyclon.ts
@@ -40,6 +40,6 @@ export class Recyclon implements CorporationCard, IResourceCard {
             player.setProduction(Resources.PLANTS);
             return undefined;
         });
-        return new OrOptions(addResource, spendResource);
+        return new OrOptions(spendResource, addResource);
     }
 }

--- a/src/cards/venusNext/DeuteriumExport.ts
+++ b/src/cards/venusNext/DeuteriumExport.ts
@@ -29,13 +29,13 @@ export class DeuteriumExport implements IActionCard,IProjectCard, IResourceCard 
             return undefined;
         }
         return new OrOptions(
-            new SelectOption("Add 1 floater to this card", () => {
-                this.resourceCount++;
-                return undefined;
-            }),
             new SelectOption("Remove 1 floater to raise energy production 1 step", () => {
                 this.resourceCount--;
                 player.setProduction(Resources.ENERGY);
+                return undefined;
+            }),
+            new SelectOption("Add 1 floater to this card", () => {
+                this.resourceCount++;
                 return undefined;
             })
         );

--- a/src/cards/venusNext/ExtractorBalloons.ts
+++ b/src/cards/venusNext/ExtractorBalloons.ts
@@ -30,13 +30,13 @@ export class ExtractorBalloons implements IActionCard,IProjectCard, IResourceCar
             return undefined;
         }
         return new OrOptions(
-            new SelectOption("Add 1 floater to this card", () => {
-                this.resourceCount++;
-                return undefined;
-            }),
             new SelectOption("Remove 2 floaters to raise Venus scale 1 step", () => {
                 this.resourceCount -= 2;
                 game.increaseVenusScaleLevel(player,1);
+                return undefined;
+            }),
+            new SelectOption("Add 1 floater to this card", () => {
+                this.resourceCount++;
                 return undefined;
             })
         );

--- a/src/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/cards/venusNext/ForcedPrecipitation.ts
@@ -57,13 +57,13 @@ export class ForcedPrecipitation implements IActionCard,IProjectCard, IResourceC
             return undefined;
         });
 
-        if (player.canAfford(2)) {
-            opts.push(addResource);
-        } else return spendResource;
-
         if (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
         } else return addResource;
+
+        if (player.canAfford(2)) {
+            opts.push(addResource);
+        } else return spendResource;
 
         return new OrOptions(...opts);
     }

--- a/src/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/cards/venusNext/ForcedPrecipitation.ts
@@ -28,43 +28,52 @@ export class ForcedPrecipitation implements IActionCard,IProjectCard, IResourceC
     }  
     
     public action(player: Player, game: Game) {
-        var opts: Array<SelectOption> = []; 
-        const addResource = new SelectOption("Pay 2 to add 1 floater to this card", () => {
-            if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-                return new SelectHowToPay(
-                    'Select how to pay ', false, false,
-                    player.canUseHeatAsMegaCredits,
-                    2,
-                    (htp) => {
-                        if (htp.heat + htp.megaCredits < 2) {
-                            throw new Error('Not enough for action');
-                        }
-                        player.megaCredits -= htp.megaCredits;
-                        player.heat -= htp.heat;
-                        this.resourceCount++;
-                        return undefined;
-                    }
-                );
-            }
-            player.megaCredits -= 2;
-            this.resourceCount++;
-            return undefined;
-        });
+        var opts: Array<SelectOption> = [];
 
-        const spendResource = new SelectOption("Remove 2 floaters to raise Venus 1 step", () => {
-            player.removeResourceFrom(this,2);
-            game.increaseVenusScaleLevel(player, 1);
-            return undefined;
-        });
+        const addResource = new SelectOption("Pay 2 to add 1 floater to this card", () => this.addResource(player));
+        const spendResource = new SelectOption("Remove 2 floaters to raise Venus 1 step", () => this.spendResource(player, game));
 
         if (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
-        } else return addResource;
+        } else {
+            this.addResource(player);
+        };
 
         if (player.canAfford(2)) {
             opts.push(addResource);
-        } else return spendResource;
+        } else {
+            this.spendResource(player, game);
+        }
 
         return new OrOptions(...opts);
+    }
+
+    private addResource(player: Player) {
+        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
+            return new SelectHowToPay(
+                'Select how to pay ', false, false,
+                player.canUseHeatAsMegaCredits,
+                2,
+                (htp) => {
+                    if (htp.heat + htp.megaCredits < 2) {
+                        throw new Error('Not enough for action');
+                    }
+                    player.megaCredits -= htp.megaCredits;
+                    player.heat -= htp.heat;
+                    this.resourceCount++;
+                    return undefined;
+                }
+            );
+        }
+
+        player.megaCredits -= 2;
+        this.resourceCount++;
+        return undefined;
+    }
+
+    private spendResource(player: Player, game: Game) {
+        player.removeResourceFrom(this,2);
+        game.increaseVenusScaleLevel(player, 1);
+        return undefined;
     }
 }

--- a/src/cards/venusNext/JetStreamMicroscrappers.ts
+++ b/src/cards/venusNext/JetStreamMicroscrappers.ts
@@ -27,27 +27,34 @@ export class JetStreamMicroscrappers implements IActionCard,IProjectCard, IResou
     }    
     public action(player: Player, game: Game) {
         var opts: Array<SelectOption> = [];
-        const addResource = new SelectOption("Spend one titanium to add 2 floaters to this card", () => {
-            this.resourceCount += 2;
-            player.titanium--;
-            return undefined;
-        });
 
-        const spendResource = new SelectOption("Remove 2 floaters to raise Venus 1 step", () => {
-            this.resourceCount -= 2;
-            game.increaseVenusScaleLevel(player, 1);
-            return undefined;
-        });
+        const addResource = new SelectOption("Spend one titanium to add 2 floaters to this card", () => this.addResource(player));
+        const spendResource = new SelectOption("Remove 2 floaters to raise Venus 1 step", () => this.spendResource(player, game));
 
         if (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
-        } else return addResource;
+        } else {
+            this.addResource(player);
+        }
 
         if (player.titanium > 0) {
             opts.push(addResource);
-        } else return spendResource;
+        } else {
+            this.spendResource(player, game);
+        }
 
         return new OrOptions(...opts);
+    }
 
+    private addResource(player: Player) {
+        this.resourceCount += 2;
+        player.titanium--;
+        return undefined;
+    }
+
+    private spendResource(player: Player, game: Game) {
+        this.resourceCount -= 2;
+        game.increaseVenusScaleLevel(player, 1);
+        return undefined;
     }
 }

--- a/src/cards/venusNext/JetStreamMicroscrappers.ts
+++ b/src/cards/venusNext/JetStreamMicroscrappers.ts
@@ -39,13 +39,13 @@ export class JetStreamMicroscrappers implements IActionCard,IProjectCard, IResou
             return undefined;
         });
 
-        if (player.titanium > 0) {
-            opts.push(addResource);
-        } else return spendResource;
-
         if (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
         } else return addResource;
+
+        if (player.titanium > 0) {
+            opts.push(addResource);
+        } else return spendResource;
 
         return new OrOptions(...opts);
 

--- a/src/cards/venusNext/LocalShading.ts
+++ b/src/cards/venusNext/LocalShading.ts
@@ -41,11 +41,11 @@ export class LocalShading implements IActionCard,IProjectCard,IResourceCard {
             return undefined;
         });
 
-        opts.push(addResource);
-
         if (this.resourceCount > 0) {
             opts.push(spendResource);
         } else return addResource;
+
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/src/cards/venusNext/LocalShading.ts
+++ b/src/cards/venusNext/LocalShading.ts
@@ -30,23 +30,29 @@ export class LocalShading implements IActionCard,IProjectCard,IResourceCard {
         }
         
         var opts: Array<SelectOption> = [];
-        const addResource = new SelectOption("Add 1 floater to this card", () => {
-            this.resourceCount++;
-            return undefined;
-        });
 
-        const spendResource = new SelectOption("Remove 1 floater to increase MC production 1 step", () => {
-            player.removeResourceFrom(this);
-            player.setProduction(Resources.MEGACREDITS);
-            return undefined;
-        });
+        const addResource = new SelectOption("Add 1 floater to this card", () => this.addResource());
+        const spendResource = new SelectOption("Remove 1 floater to increase MC production 1 step", () => this.spendResource(player));
 
         if (this.resourceCount > 0) {
             opts.push(spendResource);
-        } else return addResource;
+        } else {
+            this.addResource();
+        }
 
         opts.push(addResource);
 
         return new OrOptions(...opts);
+    }
+
+    private addResource() {
+        this.resourceCount++;
+        return undefined;
+    }
+
+    private spendResource(player: Player) {
+        player.removeResourceFrom(this);
+        player.setProduction(Resources.MEGACREDITS);
+        return undefined;
     }
 }

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -30,43 +30,51 @@ export class RotatorImpacts implements IActionCard,IProjectCard, IResourceCard {
     }  
     
     public action(player: Player, game: Game) {
-        var opts: Array<SelectOption> = []; 
-        const addResource = new SelectOption("Pay 6 to add 1 asteroid to this card", () => {
-            return new SelectHowToPay(
-                'Select how to pay ', false, true,
-                player.canUseHeatAsMegaCredits,
-                6,
-                (htp) => {
-                    if (htp.heat + htp.megaCredits + htp.titanium * player.getTitaniumValue(game) < 6) {
-                        throw new Error('Not enough for action');
-                    }
-                    player.megaCredits -= htp.megaCredits;
-                    player.heat -= htp.heat;
-                    player.titanium -= htp.titanium;
-                    this.resourceCount++;
-                    return undefined;
-                }
-            );
-        });
+        var opts: Array<SelectOption> = [];
 
-        const spendResource = new SelectOption("Remove 1 asteroid to raise Venus 1 step", () => {
-            player.removeResourceFrom(this);
-            game.increaseVenusScaleLevel(player, 1);
-            return undefined;
-        });
+        const addResource = new SelectOption("Pay 6 to add 1 asteroid to this card", () => this.addResource(player, game));
+        const spendResource = new SelectOption("Remove 1 asteroid to raise Venus 1 step", () => this.spendResource(player, game));
 
         if (this.resourceCount > 0 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
-        };
+        } else {
+            this.addResource(player, game);
+        }
 
         if (player.canAfford(6, game, false, true)) {
             opts.push(addResource);
-        };
+        } else {
+            this.spendResource(player, game);
+        }
 
         if (opts.length === 0) return undefined;
 
         if (opts.length === 1) return opts[0];
 
         return new OrOptions(...opts);
+    }
+
+    private addResource(player: Player, game: Game) {
+        return new SelectHowToPay(
+            'Select how to pay ', false, true,
+            player.canUseHeatAsMegaCredits,
+            6,
+            (htp) => {
+                if (htp.heat + htp.megaCredits + htp.titanium * player.getTitaniumValue(game) < 6) {
+                    throw new Error('Not enough for action');
+                }
+                player.megaCredits -= htp.megaCredits;
+                player.heat -= htp.heat;
+                player.titanium -= htp.titanium;
+                this.resourceCount++;
+                return undefined;
+            }
+        );
+    }
+
+    private spendResource(player: Player, game: Game) {
+        player.removeResourceFrom(this);
+        game.increaseVenusScaleLevel(player, 1);
+        return undefined;
     }
 }

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -55,12 +55,12 @@ export class RotatorImpacts implements IActionCard,IProjectCard, IResourceCard {
             return undefined;
         });
 
-        if (player.canAfford(6, game, false, true)) {
-            opts.push(addResource);
-        };
-
         if (this.resourceCount > 0 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
+        };
+
+        if (player.canAfford(6, game, false, true)) {
+            opts.push(addResource);
         };
 
         if (opts.length === 0) return undefined;

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -28,23 +28,29 @@ export class SulphurEatingBacteria implements IActionCard,IProjectCard, IResourc
     }    
     public action(player: Player) {
         var opts: Array<SelectOption | SelectAmount> = [];
-        const addResource = new SelectOption("Add 1 microbe to this card", () => {
-            this.resourceCount++;
-            return undefined;
-        });
 
-        const spendResource = new SelectAmount("Remove any number of microbes to gain 3 MC per microbe removed", (amount: number) => {
-            player.removeResourceFrom(this,amount);
-            player.megaCredits += 3 * amount;
-            return undefined;
-        }, this.resourceCount);
+        const addResource = new SelectOption("Add 1 microbe to this card", () => this.addResource());
+        const spendResource = new SelectAmount("Remove any number of microbes to gain 3 MC per microbe removed", (amount: number) => this.spendResource(player, amount), this.resourceCount);
 
         if (this.resourceCount > 0) {
             opts.push(spendResource);
-        } else return addResource;
+        } else {
+            this.addResource();
+        }
 
         opts.push(addResource);
 
         return new OrOptions(...opts);
+    }
+
+    private addResource() {
+        this.resourceCount++;
+        return undefined;
+    }
+
+    private spendResource(player: Player, amount: number) {
+        player.removeResourceFrom(this,amount);
+        player.megaCredits += 3 * amount;
+        return undefined;
     }
 }

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -38,11 +38,12 @@ export class SulphurEatingBacteria implements IActionCard,IProjectCard, IResourc
             player.megaCredits += 3 * amount;
             return undefined;
         }, this.resourceCount);
-        opts.push(addResource);
 
         if (this.resourceCount > 0) {
             opts.push(spendResource);
         } else return addResource;
+
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/src/cards/venusNext/Thermophiles.ts
+++ b/src/cards/venusNext/Thermophiles.ts
@@ -45,11 +45,11 @@ export class Thermophiles implements IActionCard,IProjectCard, IResourceCard {
             return undefined;
         });
 
-        opts.push(addResource);
-
         if (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE) {
             opts.push(spendResource);
         } else return addResource;
+
+        opts.push(addResource);
 
         return new OrOptions(...opts);
     }

--- a/tests/cards/GHGProducingBacteria.spec.ts
+++ b/tests/cards/GHGProducingBacteria.spec.ts
@@ -35,9 +35,9 @@ describe("GHGProducingBacteria", function () {
         const orAction = card.action(player, game) as OrOptions;
         expect(orAction).not.to.eq(undefined);
         expect(orAction instanceof OrOptions).to.eq(true);
-        orAction.options[0].cb();
-        expect(card.resourceCount).to.eq(3);
         orAction.options[1].cb();
+        expect(card.resourceCount).to.eq(3);
+        orAction.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(game.getTemperature()).to.eq(-28);
     });

--- a/tests/cards/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/NitriteReducingBacteria.spec.ts
@@ -27,9 +27,9 @@ describe("NitriteReducingBacteria", function () {
         let orOptions = card.action(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[0].cb();
-        expect(card.resourceCount).to.eq(5);
         orOptions.options[1].cb();
+        expect(card.resourceCount).to.eq(5);
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(2);
         expect(player.getTerraformRating()).to.eq(21);
     });

--- a/tests/cards/OlympusConference.spec.ts
+++ b/tests/cards/OlympusConference.spec.ts
@@ -24,9 +24,9 @@ describe("OlympusConference", function () {
         card.onCardPlayed(player, game, card);
         expect(game.interrupts.length).to.eq(1);
         const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
-        orOptions.options[0].cb();
-        expect(card.resourceCount).to.eq(2);
         orOptions.options[1].cb();
+        expect(card.resourceCount).to.eq(2);
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(player.cardsInHand.length).to.eq(1);
         expect(game.interrupts.length).to.eq(1);
@@ -41,7 +41,7 @@ describe("OlympusConference", function () {
         expect(card.resourceCount).to.eq(1);
         const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
         game.interrupts.splice(0, 1);
-        orOptions.options[0].cb();
+        orOptions.options[1].cb();
         expect(card.resourceCount).to.eq(2);
         expect(game.interrupts.length).to.eq(0);
     });

--- a/tests/cards/RegolithEaters.spec.ts
+++ b/tests/cards/RegolithEaters.spec.ts
@@ -27,9 +27,9 @@ describe("RegolithEaters", function () {
         const orOptions = card.action(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[0].cb();
-        expect(card.resourceCount).to.eq(3);
         orOptions.options[1].cb();
+        expect(card.resourceCount).to.eq(3);
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(game.getOxygenLevel()).to.eq(1);
     });

--- a/tests/cards/colonies/AtmoCollectors.spec.ts
+++ b/tests/cards/colonies/AtmoCollectors.spec.ts
@@ -27,7 +27,7 @@ describe("AtmoCollectors", function () {
         const orOptions = card.action(player) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(player.titanium).to.eq(2);
     });

--- a/tests/cards/colonies/RedSpotObservatory.spec.ts
+++ b/tests/cards/colonies/RedSpotObservatory.spec.ts
@@ -25,7 +25,7 @@ describe("RedSpotObservatory", function () {
         const orOptions = card.action(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(player.cardsInHand.length).to.eq(1);
         expect(player.getResourcesOnCard(card)).to.eq(2);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/colonies/TitanAirScrapping.spec.ts
+++ b/tests/cards/colonies/TitanAirScrapping.spec.ts
@@ -23,7 +23,7 @@ describe("TitanAirScrapping", function () {
         const orOptions = card.action(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(player.getTerraformRating()).to.eq(21);
         expect(player.getResourcesOnCard(card)).to.eq(5);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/colonies/TitanShuttles.spec.ts
+++ b/tests/cards/colonies/TitanShuttles.spec.ts
@@ -22,7 +22,7 @@ describe("TitanShuttles", function () {
         const orOptions = card.action(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb(6);
+        orOptions.options[0].cb(6);
         expect(card.resourceCount).to.eq(1);
         expect(player.titanium).to.eq(6);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/venusNext/DeuteriumExport.spec.ts
+++ b/tests/cards/venusNext/DeuteriumExport.spec.ts
@@ -23,7 +23,7 @@ describe("DeuteriumExport", function () {
         const orOptions = card.action(player) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     });

--- a/tests/cards/venusNext/ExtractorBalloons.spec.ts
+++ b/tests/cards/venusNext/ExtractorBalloons.spec.ts
@@ -21,7 +21,7 @@ describe("ExtractorBalloons", function () {
         const orOptions = card.action(player,game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(game.getVenusScaleLevel()).to.eq(2);
     });

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -4,7 +4,6 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from '../../../src/Game';
 import { OrOptions } from '../../../src/inputs/OrOptions';
-import { SelectOption } from '../../../src/inputs/SelectOption';
 
 describe("ForcedPrecipitation", function () {
     it("Should play", function () {
@@ -21,9 +20,7 @@ describe("ForcedPrecipitation", function () {
         player.playedCards.push(card);
         player.megaCredits = 10;
 
-        const selectOption = card.action(player,game) as SelectOption;
-        expect(selectOption instanceof SelectOption).to.eq(true);
-        selectOption.cb();
+        card.action(player,game);
         expect(card.resourceCount).to.eq(1);
         expect(player.megaCredits).to.eq(8);
 

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -32,7 +32,7 @@ describe("ForcedPrecipitation", function () {
 
         const orOptions2 = card.action(player,game) as OrOptions;
         expect(orOptions2 instanceof OrOptions).to.eq(true);
-        orOptions2.options[1].cb();
+        orOptions2.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(game.getVenusScaleLevel()).to.eq(2);
     });

--- a/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
+++ b/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
@@ -27,7 +27,7 @@ describe("JetStreamMicroscrappers", function () {
         const orOptions = card.action(player,game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(game.getVenusScaleLevel()).to.eq(2);
     });

--- a/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
+++ b/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
@@ -4,7 +4,6 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { OrOptions } from "../../../src/inputs/OrOptions";
 import { Game } from "../../../src/Game";
-import { SelectOption } from '../../../src/inputs/SelectOption';
 
 describe("JetStreamMicroscrappers", function () {
     it("Should play", function () {
@@ -18,9 +17,8 @@ describe("JetStreamMicroscrappers", function () {
         const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
         player.titanium = 2;
-        const action = card.action(player,game) as SelectOption;
-        expect(action instanceof SelectOption).to.eq(true);
-        action.cb();
+
+        card.action(player,game)
         expect(card.resourceCount).to.eq(2);
         expect(player.titanium).to.eq(1);
 

--- a/tests/cards/venusNext/LocalShading.spec.ts
+++ b/tests/cards/venusNext/LocalShading.spec.ts
@@ -22,7 +22,7 @@ describe("LocalShading", function () {
         const orOptions = card.action(player) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
     });

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -37,7 +37,7 @@ describe("RotatorImpacts", function () {
 
         const orOptions2 = card.action(player,game) as OrOptions;
         expect(orOptions2 instanceof OrOptions).to.eq(true);
-        orOptions2.options[1].cb();
+        orOptions2.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(game.getVenusScaleLevel()).to.eq(2);
     });

--- a/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
+++ b/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
@@ -19,7 +19,7 @@ describe("SulphurEatingBacteria", function () {
         player.playedCards.push(card);
         player.addResourceTo(card,5);
         const action = card.action(player) as OrOptions;
-        action.options[1].cb(3);
+        action.options[0].cb(3);
         expect(player.megaCredits).to.eq(9);
         expect(card.resourceCount).to.eq(2);
     });

--- a/tests/cards/venusNext/Thermophiles.spec.ts
+++ b/tests/cards/venusNext/Thermophiles.spec.ts
@@ -33,7 +33,7 @@ describe("Thermophiles", function () {
         const orOptions = card.action(player,game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
         expect(game.getVenusScaleLevel()).to.eq(2);
     });


### PR DESCRIPTION
**Context:** If a player is able to spend resources on cards added previously, he will usually want to do that in most cases, barring certain exceptions like Hoverlord award and Excentric milestone.

**Scope:**
- Make "Remove resource to do X" option the default action if available
- Skip confirmation click if played card has only 1 choice of action available

<img width="556" alt="Screenshot 2020-06-12 at 11 17 49 PM" src="https://user-images.githubusercontent.com/2408094/84519810-2a0a9600-ad05-11ea-965f-904611d40e57.png">
