### PR TITLE
Remove target selection step if there is only 1 valid microbe card

### DIFF
--- a/src/cards/ExtremeColdFungus.ts
+++ b/src/cards/ExtremeColdFungus.ts
@@ -29,22 +29,39 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
     }
     public action(player: Player) {
       const otherMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
-      if (otherMicrobeCards.length > 0) {
+
+      if (otherMicrobeCards.length === 0) {
+        player.plants++;
+        return undefined;
+      }
+
+      const gainPlantOption = new SelectOption('Gain 1 plant', () => {
+        player.plants++;
+        return undefined;
+      })
+
+      if (otherMicrobeCards.length === 1) {
+        const targetCard = otherMicrobeCards[0];
+
         return new OrOptions(
-            new SelectOption('Gain 1 plant', () => {
-              player.plants++; return undefined;
-            }),
-            new SelectCard(
-                'Select card to add 2 microbes',
-                otherMicrobeCards,
-                (foundCards: Array<ICard>) => {
-                  player.addResourceTo(foundCards[0], 2);
-                  return undefined;
-                }
-            )
+          gainPlantOption,
+          new SelectOption('Add 2 microbes to ' + targetCard.name, () => {
+            player.addResourceTo(targetCard, 2);
+            return undefined;
+          })
         );
       }
-      player.plants++;
-      return undefined;
+
+      return new OrOptions(
+        gainPlantOption,
+        new SelectCard(
+          'Select card to add 2 microbes',
+          otherMicrobeCards,
+          (foundCards: Array<ICard>) => {
+              player.addResourceTo(foundCards[0], 2);
+              return undefined;
+          }
+        )
+      );
     }
 }

--- a/src/cards/SymbioticFungus.ts
+++ b/src/cards/SymbioticFungus.ts
@@ -25,6 +25,12 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
     }
     public action(player: Player) {
         const availableCards = player.getResourceCards(ResourceType.MICROBE);
+
+        if (availableCards.length === 1) {
+            player.addResourceTo(availableCards[0]);
+            return undefined;
+        }
+
         return new SelectCard("Select card to add microbe", availableCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
             return undefined;

--- a/tests/cards/ExtremeColdFungus.spec.ts
+++ b/tests/cards/ExtremeColdFungus.spec.ts
@@ -24,17 +24,34 @@ describe("ExtremeColdFungus", function () {
         const action = card.play();
         expect(action).to.eq(undefined);
     });
-    it("Should act", function () {
+    it("Should act - single target", function () {
         const card = new ExtremeColdFungus();
         const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(new Ants());
+
+        const tardigrades = new Tardigrades();
+        player.playedCards.push(tardigrades);
+        
         const action = card.action(player);
         expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);
+        
+        action!.options[1].cb();
+        expect(player.getResourcesOnCard(tardigrades)).to.eq(2);
+        action!.options[0].cb();
+        expect(player.plants).to.eq(1);
+    });
+    it("Should act - multiple targets", function () {
+        const card = new ExtremeColdFungus();
+        const player = new Player("test", Color.BLUE, false);
+        player.playedCards.push(new Ants());
         const tardigrades = new Tardigrades();
         player.playedCards.push(tardigrades);
         player.addResourceTo(tardigrades, 4);
+        const action = card.action(player);
+        expect(action).not.to.eq(undefined);
+        expect(action instanceof OrOptions).to.eq(true);
+        expect(action!.options.length).to.eq(2);
         action!.options[1].cb([tardigrades]);
         expect(player.getResourcesOnCard(tardigrades)).to.eq(6);
         action!.options[0].cb();

--- a/tests/cards/SymbioticFungus.spec.ts
+++ b/tests/cards/SymbioticFungus.spec.ts
@@ -5,6 +5,7 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Ants } from "../../src/cards/Ants";
+import { Decomposers } from "../../src/cards/Decomposers";
 
 describe("SymbioticFungus", function () {
     it("Can't act or play", function () {
@@ -18,13 +19,22 @@ describe("SymbioticFungus", function () {
         const card = new SymbioticFungus();
         expect(card.play()).to.eq(undefined);
     });
-    it("Should act", function () {
+    it("Should act - single target", function () {
         const card = new SymbioticFungus();
         const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(new Ants());
+        card.action(player);
+        expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);
+    });
+    it("Should act - multiple targets", function () {
+        const card = new SymbioticFungus();
+        const player = new Player("test", Color.BLUE, false);
+        player.playedCards.push(new Ants());
+        player.playedCards.push(new Decomposers());
+        
         const action = card.action(player);
         expect(action).not.to.eq(undefined);
-        action.cb([player.playedCards[0]]);
+        action!.cb([player.playedCards[0]]);
         expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);
     });
 });


### PR DESCRIPTION
**Scope:** Remove target selection step if "Add microbe" option is selected for Extreme Cold Fungus and Symbiotic Fungus and there is only one valid target