### PR TITLE
Improvement for Aerial Mappers

### DIFF
--- a/src/cards/venusNext/AerialMappers.ts
+++ b/src/cards/venusNext/AerialMappers.ts
@@ -30,6 +30,18 @@ export class AerialMappers implements IActionCard,IProjectCard, IResourceCard {
     public action(player: Player, game: Game) {
         const floaterCards = player.getResourceCards(ResourceType.FLOATER);
         var opts: Array<SelectOption | SelectCard<ICard>> = [];
+
+        // only one valid target - itself
+        if (floaterCards.length === 1 && this.resourceCount === 0) {
+            this.resourceCount++;
+            return undefined;
+        }
+
+        const addResourceToSelf = new SelectOption("Add 1 floater to this card", () => {
+            this.resourceCount++;
+            return undefined;
+        });
+
         const addResource = new SelectCard(
             'Select card to add 1 floater',
             floaterCards,
@@ -45,11 +57,12 @@ export class AerialMappers implements IActionCard,IProjectCard, IResourceCard {
             return undefined;
         });
 
-        opts.push(addResource);
-
         if (this.resourceCount > 0) {
              opts.push(spendResource);
-        } else return addResource;
+             floaterCards.length === 1 ? opts.push(addResourceToSelf) : opts.push(addResource);
+        } else {
+            return addResource;
+        };
 
         return new OrOptions(...opts);
     }

--- a/tests/cards/venusNext/AerialMappers.spec.ts
+++ b/tests/cards/venusNext/AerialMappers.spec.ts
@@ -7,6 +7,7 @@ import { Player } from "../../../src/Player";
 import { OrOptions } from "../../../src/inputs/OrOptions";
 import { Game } from "../../../src/Game";
 import { SelectCard } from '../../../src/inputs/SelectCard';
+import { Dirigibles } from '../../../src/cards/venusNext/Dirigibles';
 
 describe("AerialMappers", function () {
     it("Should play", function () {
@@ -14,11 +15,13 @@ describe("AerialMappers", function () {
         const action = card.play();
         expect(action).to.eq(undefined);
     });
-    it("Should act", function () {
+    it("Should act - multiple targets", function () {
         const card = new AerialMappers();
+        const card2 = new Dirigibles();
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
+        player.playedCards.push(card2);
         const action = card.action(player,game) as SelectCard<ICard>;
         expect(action instanceof SelectCard).to.eq(true);
         action.cb([card]);
@@ -27,7 +30,23 @@ describe("AerialMappers", function () {
         const orOptions = card.action(player,game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+        orOptions.options[0].cb([card]);
+        expect(card.resourceCount).to.eq(0);
+        expect(player.cardsInHand.length).to.eq(1);
+    });
+    it("Should act - single target", function () {
+        const card = new AerialMappers();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+        player.playedCards.push(card);
+
+        card.action(player,game)
+        expect(card.resourceCount).to.eq(1);
+
+        const orOptions = card.action(player,game) as OrOptions;
+        expect(orOptions).not.to.eq(undefined);
+        expect(orOptions instanceof OrOptions).to.eq(true);
+        orOptions.options[0].cb([card]);
         expect(card.resourceCount).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });


### PR DESCRIPTION
**Scope:**
- Automatically add floater if there is only one possible valid action (i.e. this card is the only floater card, and it has no floaters on it)
- Replace "Select card" step with SelectOption if this card is the only possible target