### PR TITLE
Add game option to randomize milestones and awards

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -377,7 +377,8 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
         startingCorporations: gameReq.startingCorporations,
         soloTR: gameReq.soloTR,
         clonedGamedId: gameReq.clonedGamedId,
-        initialDraftVariant: gameReq.initialDraft
+        initialDraftVariant: gameReq.initialDraft,
+        randomMA: gameReq.randomMA
       } as GameOptions;
     
       const game = new Game(gameId, players, firstPlayer, gameOptions);
@@ -490,7 +491,8 @@ function getPlayer(player: Player, game: Game): string {
     dealtPreludeCards: player.dealtPreludeCards,
     initialDraft: game.initialDraft,
     needsToDraft: player.needsToDraft,
-    deckSize: game.dealer.getDeckSize()
+    deckSize: game.dealer.getDeckSize(),
+    randomMA: game.randomMA
   } as PlayerModel;
   return JSON.stringify(output);
 }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -444,7 +444,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
           game.turmoil = gameToRebuild.turmoil;
 
           if(gameToRebuild.venusNextExtension) {
-            game.setVenusElements(gameToRebuild.randomMA);
+            game.board.spaces.push(
+              new BoardColony(SpaceName.DAWN_CITY),
+              new BoardColony(SpaceName.LUNA_METROPOLIS),
+              new BoardColony(SpaceName.MAXWELL_BASE),
+              new BoardColony(SpaceName.STRATOPOLIS)
+          );
           }
 
           // Set active player
@@ -1588,13 +1593,45 @@ export class Game implements ILoadable<SerializedGame, Game> {
       });
       
       // Rebuild milestones, awards and board elements
-      this.milestones = []; // TODO: Store and fetch M&A data on rebuild
+      if (d.boardName === BoardName.ELYSIUM) {
+        this.board = new ElysiumBoard();
+      } else if (d.boardName === BoardName.HELLAS) {
+        this.board = new HellasBoard();
+      } else {        
+        this.board = new OriginalBoard();
+      }  
+
+      this.milestones = [];
       this.awards = [];
-      this.board = this.boardConstructor(d.boardName, false, this.venusNextExtension);
+
+      let allMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES);
+
+      d.milestones.forEach((element: IMilestone) => {
+        allMilestones.forEach((ms: IMilestone) => {
+          if (ms.name === element.name) {
+            this.milestones.push(ms);
+          }
+        });
+      });  
+
+      let allAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS);
+
+      d.awards.forEach((element: IAward) => {
+        allAwards.forEach((award: IAward) => {
+          if (award.name === element.name) {
+            this.awards.push(award);
+          }
+        });
+      });
 
       // Reload venus elements if needed
       if(this.venusNextExtension) {
-        this.setVenusElements(this.randomMA);
+        this.board.spaces.push(
+          new BoardColony(SpaceName.DAWN_CITY),
+          new BoardColony(SpaceName.LUNA_METROPOLIS),
+          new BoardColony(SpaceName.MAXWELL_BASE),
+          new BoardColony(SpaceName.STRATOPOLIS)
+      );
       }
 
       d.board.spaces.forEach((element: ISpace) => {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -24,7 +24,7 @@ import {IAward} from "./awards/IAward";
 import {Tags} from "./cards/Tags";
 import {Resources} from "./Resources";
 import {ORIGINAL_MILESTONES, VENUS_MILESTONES, ELYSIUM_MILESTONES, HELLAS_MILESTONES} from "./milestones/Milestones";
-import { ORIGINAL_AWARDS, VENUS_AWARDS, ELYSIUM_AWARDS, HELLAS_AWARDS } from './awards/Awards';
+import {ORIGINAL_AWARDS, VENUS_AWARDS, ELYSIUM_AWARDS, HELLAS_AWARDS} from "./awards/Awards";
 import {SpaceName} from "./SpaceName";
 import {BoardColony, Board} from "./Board";
 import {CorporationName} from "./CorporationName";

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -24,7 +24,7 @@ import {IAward} from "./awards/IAward";
 import {Tags} from "./cards/Tags";
 import {Resources} from "./Resources";
 import {ORIGINAL_MILESTONES, VENUS_MILESTONES, ELYSIUM_MILESTONES, HELLAS_MILESTONES} from "./milestones/Milestones";
-import {ORIGINAL_AWARDS, VENUS_AWARDS, ELYSIUM_AWARDS, HELLAS_AWARDS} from "./awards/Awards";
+import { ORIGINAL_AWARDS, VENUS_AWARDS, ELYSIUM_AWARDS, HELLAS_AWARDS } from './awards/Awards';
 import {SpaceName} from "./SpaceName";
 import {BoardColony, Board} from "./Board";
 import {CorporationName} from "./CorporationName";
@@ -356,10 +356,20 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public getRandomMilestonesAndAwards() {
-      const shuffledMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES).sort(() => 0.5 - Math.random());
+      let shuffledMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES); 
+      if (this.venusNextExtension) {
+        shuffledMilestones = shuffledMilestones.concat(VENUS_MILESTONES).sort(() => 0.5 - Math.random());
+      } else {
+        shuffledMilestones = shuffledMilestones.sort(() => 0.5 - Math.random());
+      }
       this.milestones.push(...shuffledMilestones.slice(0, 5));
 
-      const shuffledAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS).sort(() => 0.5 - Math.random());
+      let shuffledAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS);
+      if (this.venusNextExtension) {
+        shuffledAwards = shuffledAwards.concat(VENUS_AWARDS).sort(() => 0.5 - Math.random());
+      } else {
+        shuffledAwards = shuffledAwards.sort(() => 0.5 - Math.random());
+      }      
       this.awards.push(...shuffledAwards.slice(0, 5));
     }
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -384,11 +384,15 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.awards.push(...VENUS_AWARDS);
       }
 
+      this.addVenusBoardSpaces();
+    }
+
+    private addVenusBoardSpaces() {
       this.board.spaces.push(
-          new BoardColony(SpaceName.DAWN_CITY),
-          new BoardColony(SpaceName.LUNA_METROPOLIS),
-          new BoardColony(SpaceName.MAXWELL_BASE),
-          new BoardColony(SpaceName.STRATOPOLIS)
+        new BoardColony(SpaceName.DAWN_CITY),
+        new BoardColony(SpaceName.LUNA_METROPOLIS),
+        new BoardColony(SpaceName.MAXWELL_BASE),
+        new BoardColony(SpaceName.STRATOPOLIS)
       );
     }
 
@@ -444,12 +448,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           game.turmoil = gameToRebuild.turmoil;
 
           if(gameToRebuild.venusNextExtension) {
-            game.board.spaces.push(
-              new BoardColony(SpaceName.DAWN_CITY),
-              new BoardColony(SpaceName.LUNA_METROPOLIS),
-              new BoardColony(SpaceName.MAXWELL_BASE),
-              new BoardColony(SpaceName.STRATOPOLIS)
-          );
+            game.addVenusBoardSpaces();
           }
 
           // Set active player
@@ -1626,12 +1625,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Reload venus elements if needed
       if(this.venusNextExtension) {
-        this.board.spaces.push(
-          new BoardColony(SpaceName.DAWN_CITY),
-          new BoardColony(SpaceName.LUNA_METROPOLIS),
-          new BoardColony(SpaceName.MAXWELL_BASE),
-          new BoardColony(SpaceName.STRATOPOLIS)
-      );
+        this.addVenusBoardSpaces();
       }
 
       d.board.spaces.forEach((element: ISpace) => {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -153,7 +153,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         } as GameOptions
       }
 
-      this.board = this.boardConstructor(gameOptions.boardName, gameOptions.randomMA);
+      this.board = this.boardConstructor(gameOptions.boardName, gameOptions.randomMA, gameOptions.venusNextExtension);
 
       this.activePlayer = first;
       this.boardName = gameOptions.boardName;
@@ -209,7 +209,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       // Add Venus Next corporations cards, board colonies and milestone / award
       if (this.venusNextExtension) {
         corporationCards.push(...ALL_VENUS_CORPORATIONS.map((cf) => new cf.factory()));
-        this.setVenusElements();
+        this.setVenusElements(this.randomMA);
       }
 
       // Add colonies stuff
@@ -324,10 +324,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     // Function to construct the board and milestones/awards list
-    public boardConstructor(boardName: BoardName, randomMA: boolean): Board {
+    public boardConstructor(boardName: BoardName, randomMA: boolean, hasVenus: boolean): Board {
+      const requiredQty = 5;
+
       if (boardName === BoardName.ELYSIUM) {
         if (randomMA) {
-          this.getRandomMilestonesAndAwards();
+          this.getRandomMilestonesAndAwards(hasVenus, requiredQty);
         } else {
           this.milestones.push(...ELYSIUM_MILESTONES);
           this.awards.push(...ELYSIUM_AWARDS);
@@ -336,7 +338,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         return new ElysiumBoard();
       } else if (boardName === BoardName.HELLAS) {
         if (randomMA) {
-          this.getRandomMilestonesAndAwards();
+          this.getRandomMilestonesAndAwards(hasVenus, requiredQty);
         } else {
           this.milestones.push(...HELLAS_MILESTONES);
           this.awards.push(...HELLAS_AWARDS);
@@ -345,7 +347,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         return new HellasBoard();
       } else {        
         if (randomMA) {
-          this.getRandomMilestonesAndAwards();
+          this.getRandomMilestonesAndAwards(hasVenus, requiredQty);
         } else {
           this.milestones.push(...ORIGINAL_MILESTONES);
           this.awards.push(...ORIGINAL_AWARDS);
@@ -355,28 +357,33 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
     }
 
-    public getRandomMilestonesAndAwards() {
-      let shuffledMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES); 
-      if (this.venusNextExtension) {
-        shuffledMilestones = shuffledMilestones.concat(VENUS_MILESTONES).sort(() => 0.5 - Math.random());
-      } else {
-        shuffledMilestones = shuffledMilestones.sort(() => 0.5 - Math.random());
-      }
-      this.milestones.push(...shuffledMilestones.slice(0, 5));
+    public getRandomMilestonesAndAwards(hasVenus: boolean, requiredQty: number) {
+      let availableMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES);
+      if (hasVenus) availableMilestones = availableMilestones.concat(VENUS_MILESTONES);
 
-      let shuffledAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS);
-      if (this.venusNextExtension) {
-        shuffledAwards = shuffledAwards.concat(VENUS_AWARDS).sort(() => 0.5 - Math.random());
-      } else {
-        shuffledAwards = shuffledAwards.sort(() => 0.5 - Math.random());
-      }      
-      this.awards.push(...shuffledAwards.slice(0, 5));
+      availableMilestones = availableMilestones.filter((milestone) => !this.milestones.includes(milestone));
+
+      const shuffledMilestones = availableMilestones.sort(() => 0.5 - Math.random());
+      this.milestones.push(...shuffledMilestones.slice(0, requiredQty));
+
+      let availableAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS);
+      if (hasVenus) availableAwards = availableAwards.concat(VENUS_AWARDS);
+
+      availableAwards = availableAwards.filter((award) => !this.awards.includes(award));
+
+      const shuffledAwards = availableAwards.sort(() => 0.5 - Math.random());
+      this.awards.push(...shuffledAwards.slice(0, requiredQty));
     }
 
     // Add Venus Next board colonies and milestone / award
-    public setVenusElements() {
-      this.milestones.push(...VENUS_MILESTONES);
-      this.awards.push(...VENUS_AWARDS);
+    public setVenusElements(randomMA: boolean) {
+      if (randomMA) {
+        this.getRandomMilestonesAndAwards(true, 1);
+      } else {
+        this.milestones.push(...VENUS_MILESTONES);
+        this.awards.push(...VENUS_AWARDS);
+      }
+
       this.board.spaces.push(
           new BoardColony(SpaceName.DAWN_CITY),
           new BoardColony(SpaceName.LUNA_METROPOLIS),
@@ -437,7 +444,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           game.turmoil = gameToRebuild.turmoil;
 
           if(gameToRebuild.venusNextExtension) {
-            game.setVenusElements();
+            game.setVenusElements(gameToRebuild.randomMA);
           }
 
           // Set active player
@@ -1583,11 +1590,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
       // Rebuild milestones, awards and board elements
       this.milestones = []; // TODO: Store and fetch M&A data on rebuild
       this.awards = [];
-      this.board = this.boardConstructor(d.boardName, false);
+      this.board = this.boardConstructor(d.boardName, false, this.venusNextExtension);
 
       // Reload venus elements if needed
       if(this.venusNextExtension) {
-        this.setVenusElements();
+        this.setVenusElements(this.randomMA);
       }
 
       d.board.spaces.forEach((element: ISpace) => {

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -18,6 +18,7 @@ interface CreateGameModel {
     prelude: boolean;
     draftVariant: boolean;
     initialDraft: boolean;
+    randomMA: boolean;
     randomFirstPlayer: boolean;
     showOtherPlayersVP: boolean;
     venusNext: boolean;
@@ -62,6 +63,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
             prelude: false,
             draftVariant: true,
             initialDraft: false,
+            randomMA: false,
             randomFirstPlayer: true,
             showOtherPlayersVP: false,
             venusNext: false,
@@ -153,6 +155,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
             const prelude = component.prelude;
             const draftVariant = component.draftVariant;
             const initialDraft = component.initialDraft;
+            const randomMA = component.randomMA;
             const showOtherPlayersVP = component.showOtherPlayersVP;
             const venusNext = component.venusNext;
             const colonies = component.colonies;
@@ -178,7 +181,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
             }
 
             const dataToSend = JSON.stringify({
-                players: players, corporateEra, prelude, draftVariant, showOtherPlayersVP, venusNext, colonies, turmoil, customCorporationsList, board, seed, solarPhaseOption, promoCardsOption, undoOption, startingCorporations, soloTR, clonedGamedId, initialDraft 
+                players: players, corporateEra, prelude, draftVariant, showOtherPlayersVP, venusNext, colonies, turmoil, customCorporationsList, board, seed, solarPhaseOption, promoCardsOption, undoOption, startingCorporations, soloTR, clonedGamedId, initialDraft, randomMA 
             });
 
             const onSucces = (response: any) => {
@@ -290,6 +293,11 @@ export const CreateGameForm = Vue.component("create-game-form", {
                             <label class="form-switch" v-if="playersCount > 1">
                                 <input type="checkbox" v-model="randomFirstPlayer">
                                 <i class="form-icon"></i> <span v-i18n>Random first player</span>
+                            </label>
+
+                            <label class="form-switch" v-if="playersCount > 1">
+                                <input type="checkbox" name="randomMA" v-model="randomMA">
+                                <i class="form-icon"></i> <span v-i18n>Random Milestones/Awards</span>
                             </label>
 
                             <label class="form-switch" v-if="playersCount > 1">

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -47,6 +47,7 @@ describe("Game", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: false,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -192,11 +192,8 @@ describe("Turmoil", function () {
         const gameOptions = {
             draftVariant: false,
             initialDraftVariant: false,
-<<<<<<< HEAD
             corporateEra: true,
-=======
             randomMA: false,
->>>>>>> [WIP] Game option to randomize milestones and awards
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -17,6 +17,7 @@ describe("Turmoil", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,
@@ -44,6 +45,7 @@ describe("Turmoil", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,
@@ -77,6 +79,7 @@ describe("Turmoil", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,
@@ -120,6 +123,7 @@ describe("Turmoil", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,
@@ -150,6 +154,7 @@ describe("Turmoil", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,
@@ -187,7 +192,11 @@ describe("Turmoil", function () {
         const gameOptions = {
             draftVariant: false,
             initialDraftVariant: false,
+<<<<<<< HEAD
             corporateEra: true,
+=======
+            randomMA: false,
+>>>>>>> [WIP] Game option to randomize milestones and awards
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -15,6 +15,7 @@ describe("AerialLenses", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -13,6 +13,7 @@ describe("Banned Delegate", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -14,6 +14,7 @@ describe("Cultural Metropolis", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/DiasporaMovement.spec.ts
+++ b/tests/cards/turmoil/DiasporaMovement.spec.ts
@@ -20,6 +20,7 @@ describe("DiasporaMovement", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/EventAnalysts.spec.ts
+++ b/tests/cards/turmoil/EventAnalysts.spec.ts
@@ -14,6 +14,7 @@ describe("EventAnalysts", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -14,6 +14,7 @@ describe("GMOContract", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/MartianMediaCenter.spec.ts
+++ b/tests/cards/turmoil/MartianMediaCenter.spec.ts
@@ -15,6 +15,7 @@ describe("MartianMediaCenter", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -19,6 +19,7 @@ describe("PROffice", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/ParliamentHall.spec.ts
+++ b/tests/cards/turmoil/ParliamentHall.spec.ts
@@ -19,6 +19,7 @@ describe("ParliamentHall", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/PublicCelebrations.spec.ts
+++ b/tests/cards/turmoil/PublicCelebrations.spec.ts
@@ -13,6 +13,7 @@ describe("PublicCelebrations", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/Recruitment.spec.ts
+++ b/tests/cards/turmoil/Recruitment.spec.ts
@@ -14,6 +14,7 @@ describe("Recruitment", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -17,6 +17,7 @@ describe("RedTourismWave", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/SeptumTribus.spec.ts
+++ b/tests/cards/turmoil/SeptumTribus.spec.ts
@@ -27,7 +27,8 @@ describe("SeptumTribus", function () {
             startingCorporations: 2,
             soloTR: false,
             clonedGamedId: undefined,
-            initialDraftVariant: false
+            initialDraftVariant: false,
+            randomMA: false
           } as GameOptions;
 
         const game = new Game("foobar", [player,player2], player, gameOptions);
@@ -72,7 +73,8 @@ describe("SeptumTribus", function () {
             startingCorporations: 2,
             soloTR: false,
             clonedGamedId: undefined,
-            initialDraftVariant: false
+            initialDraftVariant: false,
+            randomMA: false
           } as GameOptions;
 
         const game = new Game("foobar", [player], player, gameOptions);

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -15,6 +15,7 @@ describe("SponsoredMohole", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -14,6 +14,7 @@ describe("SupportedResearch", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -14,6 +14,7 @@ describe("VoteOfNoConfidence", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -14,6 +14,7 @@ describe("WildlifeDome", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/venusNext/DawnCity.spec.ts
+++ b/tests/cards/venusNext/DawnCity.spec.ts
@@ -15,6 +15,7 @@ describe("DawnCity", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/venusNext/LunaMetropolis.spec.ts
+++ b/tests/cards/venusNext/LunaMetropolis.spec.ts
@@ -14,6 +14,7 @@ describe("LunaMetropolis", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -20,6 +20,7 @@ describe("MaxwellBase", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,

--- a/tests/cards/venusNext/Stratopolis.spec.ts
+++ b/tests/cards/venusNext/Stratopolis.spec.ts
@@ -16,6 +16,7 @@ describe("Stratopolis", function () {
             draftVariant: false,
             initialDraftVariant: false,
             corporateEra: true,
+            randomMA: false,
             preludeExtension: false,
             venusNextExtension: true,
             coloniesExtension: false,


### PR DESCRIPTION
**Scope:**
- Add option to randomize milestones and awards (default: OFF)
- Without Venus Next: Randomize all 5 milestones and awards
- With Venus Next: Randomize all 6 milestones and awards
- Milestones and awards set for each game will persist across reloads and predefined cloned games. Thanks @vincentneko for help!