### PR TITLE
Improve Imported Hydrogen: Don't show invalid options

### DIFF
--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -19,23 +19,55 @@ export class ImportedHydrogen implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
 
     public play(player: Player, game: Game): undefined | PlayerInput {
+        const availableMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
+        const availableAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
+        
+        if (availableMicrobeCards.length === 0 && availableAnimalCards.length === 0) {
+            player.plants += 3;
+            game.addOceanInterrupt(player);
+            return undefined;
+        }
 
-        return new OrOptions(
-            new SelectOption("Gain 3 plants", () => {
-                player.plants += 3;
+        let availableActions = new Array<SelectOption | SelectCard<ICard>>();
+
+        const gainPlantsOption = new SelectOption("Gain 3 plants", () => {
+            player.plants += 3;
+            game.addOceanInterrupt(player);
+            return undefined;
+        })
+
+        availableActions.push(gainPlantsOption);
+
+        if (availableMicrobeCards.length === 1) {
+            const targetMicrobeCard = availableMicrobeCards[0];
+            availableActions.push(new SelectOption("Add 3 microbes to " + targetMicrobeCard.name, () => {
+                player.addResourceTo(targetMicrobeCard, 3);
                 game.addOceanInterrupt(player);
                 return undefined;
-            }),
-            new SelectCard("Add 3 microbes to card", player.getResourceCards(ResourceType.MICROBE), (foundCards: Array<ICard>) => {
+            }))
+        } else if (availableMicrobeCards.length > 1) {
+            availableActions.push(new SelectCard("Add 3 microbes to card", availableMicrobeCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 3);
                 game.addOceanInterrupt(player);
                 return undefined;
-            }),
-            new SelectCard("Add 2 animals to card", player.getResourceCards(ResourceType.ANIMAL), (foundCards: Array<ICard>) => {
+            }))
+        }
+
+        if (availableAnimalCards.length === 1) {
+            const targetAnimalCard = availableAnimalCards[0];
+            availableActions.push(new SelectOption("Add 2 animals to " + targetAnimalCard.name, () => {
+                player.addResourceTo(targetAnimalCard, 2);
+                game.addOceanInterrupt(player);
+                return undefined;
+            }))
+        } else if (availableAnimalCards.length > 1) {
+            availableActions.push(new SelectCard("Add 2 animals to card", availableAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
                 game.addOceanInterrupt(player);
                 return undefined;
-            })
-        )
+            }))
+        }
+
+        return new OrOptions(...availableActions);   
     }
 }

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -21,21 +21,20 @@ export class ImportedHydrogen implements IProjectCard {
     public play(player: Player, game: Game): undefined | PlayerInput {
         const availableMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
         const availableAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
-        
-        if (availableMicrobeCards.length === 0 && availableAnimalCards.length === 0) {
+
+        const gainPlants = function () {
             player.plants += 3;
             game.addOceanInterrupt(player);
             return undefined;
+        };
+        
+        if (availableMicrobeCards.length === 0 && availableAnimalCards.length === 0) {
+            return gainPlants();
         }
 
         let availableActions = new Array<SelectOption | SelectCard<ICard>>();
 
-        const gainPlantsOption = new SelectOption("Gain 3 plants", () => {
-            player.plants += 3;
-            game.addOceanInterrupt(player);
-            return undefined;
-        })
-
+        const gainPlantsOption = new SelectOption("Gain 3 plants", gainPlants);
         availableActions.push(gainPlantsOption);
 
         if (availableMicrobeCards.length === 1) {
@@ -46,7 +45,7 @@ export class ImportedHydrogen implements IProjectCard {
                 return undefined;
             }))
         } else if (availableMicrobeCards.length > 1) {
-            availableActions.push(new SelectCard("Add 3 microbes to card", availableMicrobeCards, (foundCards: Array<ICard>) => {
+            availableActions.push(new SelectCard("Add 3 microbes to a card", availableMicrobeCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 3);
                 game.addOceanInterrupt(player);
                 return undefined;
@@ -61,7 +60,7 @@ export class ImportedHydrogen implements IProjectCard {
                 return undefined;
             }))
         } else if (availableAnimalCards.length > 1) {
-            availableActions.push(new SelectCard("Add 2 animals to card", availableAnimalCards, (foundCards: Array<ICard>) => {
+            availableActions.push(new SelectCard("Add 2 animals to a card", availableAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
                 game.addOceanInterrupt(player);
                 return undefined;

--- a/tests/cards/ImportedHydrogen.spec.ts
+++ b/tests/cards/ImportedHydrogen.spec.ts
@@ -8,6 +8,8 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Tardigrades } from "../../src/cards/Tardigrades";
 import { Pets } from "../../src/cards/Pets";
 import { SelectCard } from "../../src/inputs/SelectCard";
+import { Decomposers } from "../../src/cards/Decomposers";
+import { SelectOption } from "../../src/inputs/SelectOption";
 
 describe("ImportedHydrogen", function () {
     it("Should play", function () {
@@ -18,7 +20,8 @@ describe("ImportedHydrogen", function () {
 
         const pets = new Pets();
         const tardigrades = new Tardigrades();
-        player.playedCards.push(pets, tardigrades);
+        const decomposers = new Decomposers();
+        player.playedCards.push(pets, tardigrades, decomposers);
 
         var action = card.play(player, game);
 
@@ -30,16 +33,25 @@ describe("ImportedHydrogen", function () {
         (action as OrOptions).options[0].cb();
         expect(player.plants).to.eq(3);
 
-        const selectAnimal = (action as OrOptions).options[2] as SelectCard<any>;
+        const selectAnimal = (action as OrOptions).options[2] as SelectOption;
         const selectMicrobe = (action as OrOptions).options[1] as SelectCard<any>;
 
-        expect(selectMicrobe.cards.length).to.eq(1);
+        expect(selectMicrobe.cards.length).to.eq(2);
         expect(selectMicrobe.cards[0]).to.eq(tardigrades);
-        expect(selectAnimal.cards.length).to.eq(1);
-        expect(selectAnimal.cards[0]).to.eq(pets);
         selectMicrobe.cb([tardigrades]);
         expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
-        selectAnimal.cb([pets]);
+        selectAnimal.cb();
         expect(player.getResourcesOnCard(pets)).to.eq(2);
+    });
+
+    it("Should add plants directly if no microbe or animal cards available", function () {
+        const card = new ImportedHydrogen();
+        const player = new Player("test", Color.BLUE, false);
+        const player2 = new Player("test2", Color.RED, false);
+        const game = new Game("foobar", [player,player2], player);
+
+        expect(player.plants).to.eq(0);
+        card.play(player, game);
+        expect(player.plants).to.eq(3);
     });
 });


### PR DESCRIPTION
**Context:** Currently, Imported Hydrogen always shows options to add microbes and animals even if the player has no microbe cards or animal cards. This PR improves the card's behaviour to only show valid options to the player.

<img width="339" alt="Screenshot 2020-06-14 at 11 41 13 AM" src="https://user-images.githubusercontent.com/2408094/84584502-cfbe2200-ae37-11ea-9190-05fa263d3520.png">

<img width="351" alt="Screenshot 2020-06-14 at 12 31 40 PM" src="https://user-images.githubusercontent.com/2408094/84584807-7ce66980-ae3b-11ea-8f8a-80a52b84f5c9.png">
