### PR TITLE
Improve logging

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -206,17 +206,20 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (resource === Resources.PLANTS) this.plants = Math.max(0, this.plants + amount);
       if (resource === Resources.ENERGY) this.energy = Math.max(0, this.energy + amount);
       if (resource === Resources.HEAT) this.heat = Math.max(0, this.heat + amount);
-      
+
+      const modifier = amount > 0 ? 'increased' : 'decreased';
+
       if (game !== undefined && fromPlayer !== undefined && amount < 0) {
         if (fromPlayer !== this && this.removingPlayers.indexOf(fromPlayer.id) === -1) {
           this.removingPlayers.push(fromPlayer.id);
         }
         game.log(
           LogMessageType.DEFAULT,
-          "${0}'s ${1} amount modified by ${2} by ${3}",
+          "${0}'s ${1} amount ${2} by ${3} by ${4}",
           new LogMessageData(LogMessageDataType.PLAYER, this.id),
           new LogMessageData(LogMessageDataType.STRING, resource),
-          new LogMessageData(LogMessageDataType.STRING, amount.toString()),
+          new LogMessageData(LogMessageDataType.STRING, modifier),
+          new LogMessageData(LogMessageDataType.STRING, Math.abs(amount).toString()),
           new LogMessageData(LogMessageDataType.PLAYER, fromPlayer.id)
         );
       }
@@ -225,10 +228,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (game !== undefined && globalEvent && amount < 0) {
         game.log(
           LogMessageType.DEFAULT,
-          "${0}'s ${1} amount modified by ${2} by Global Event",
+          "${0}'s ${1} amount ${2} by ${3} by Global Event",
           new LogMessageData(LogMessageDataType.PLAYER, this.id),
           new LogMessageData(LogMessageDataType.STRING, resource),
-          new LogMessageData(LogMessageDataType.STRING, amount.toString())
+          new LogMessageData(LogMessageDataType.STRING, modifier),
+          new LogMessageData(LogMessageDataType.STRING, Math.abs(amount).toString())
         );
       }      
 
@@ -247,16 +251,19 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (resource === Resources.ENERGY) this.energyProduction = Math.max(0, this.energyProduction + amount);
       if (resource === Resources.HEAT) this.heatProduction = Math.max(0, this.heatProduction + amount);
       
+      const modifier = amount > 0 ? 'increased' : 'decreased';
+
       if (game !== undefined && fromPlayer !== undefined && amount < 0) {
         if (fromPlayer !== this && this.removingPlayers.indexOf(fromPlayer.id) === -1) {
           this.removingPlayers.push(fromPlayer.id);
         }
         game.log(
           LogMessageType.DEFAULT,
-          "${0}'s ${1} production modified by ${2} by ${3}",
+          "${0}'s ${1} production ${2} by ${3} by ${4}",
           new LogMessageData(LogMessageDataType.PLAYER, this.id),
           new LogMessageData(LogMessageDataType.STRING, resource),
-          new LogMessageData(LogMessageDataType.STRING, amount.toString()),
+          new LogMessageData(LogMessageDataType.STRING, modifier),
+          new LogMessageData(LogMessageDataType.STRING, Math.abs(amount).toString()),
           new LogMessageData(LogMessageDataType.PLAYER, fromPlayer.id)
         );
       }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -207,7 +207,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (resource === Resources.ENERGY) this.energy = Math.max(0, this.energy + amount);
       if (resource === Resources.HEAT) this.heat = Math.max(0, this.heat + amount);
 
-      const modifier = amount > 0 ? 'increased' : 'decreased';
+      const modifier = amount > 0 ? "increased" : "decreased";
 
       if (game !== undefined && fromPlayer !== undefined && amount < 0) {
         if (fromPlayer !== this && this.removingPlayers.indexOf(fromPlayer.id) === -1) {
@@ -250,7 +250,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (resource === Resources.ENERGY) this.energyProduction = Math.max(0, this.energyProduction + amount);
       if (resource === Resources.HEAT) this.heatProduction = Math.max(0, this.heatProduction + amount);
       
-      const modifier = amount > 0 ? 'increased' : 'decreased';
+      const modifier = amount > 0 ? "increased" : "decreased";
 
       if (game !== undefined && fromPlayer !== undefined && amount < 0) {
         if (fromPlayer !== this && this.removingPlayers.indexOf(fromPlayer.id) === -1) {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -225,7 +225,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       // Global event logging
-      if (game !== undefined && globalEvent && amount < 0) {
+      if (game !== undefined && globalEvent && amount !== 0) {
         game.log(
           LogMessageType.DEFAULT,
           "${0}'s ${1} amount ${2} by ${3} by Global Event",
@@ -242,8 +242,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
     }
 
-    public setProduction(resource: Resources, amount : number = 1, game? : Game, fromPlayer? : Player) {
-
+    public setProduction(resource: Resources, amount : number = 1, game? : Game, fromPlayer? : Player, globalEvent? : boolean) {
       if (resource === Resources.MEGACREDITS) this.megaCreditProduction = Math.max(-5, this.megaCreditProduction + amount);
       if (resource === Resources.STEEL) this.steelProduction = Math.max(0, this.steelProduction + amount);
       if (resource === Resources.TITANIUM) this.titaniumProduction = Math.max(0, this.titaniumProduction + amount);
@@ -265,6 +264,18 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           new LogMessageData(LogMessageDataType.STRING, modifier),
           new LogMessageData(LogMessageDataType.STRING, Math.abs(amount).toString()),
           new LogMessageData(LogMessageDataType.PLAYER, fromPlayer.id)
+        );
+      }
+      
+      // Global event logging
+      if (game !== undefined && globalEvent && amount !== 0) {
+        game.log(
+          LogMessageType.DEFAULT,
+          "${0}'s ${1} amount ${2} by ${3} by Global Event",
+          new LogMessageData(LogMessageDataType.PLAYER, this.id),
+          new LogMessageData(LogMessageDataType.STRING, resource),
+          new LogMessageData(LogMessageDataType.STRING, modifier),
+          new LogMessageData(LogMessageDataType.STRING, Math.abs(amount).toString())
         );
       }
 

--- a/src/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
+++ b/src/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
@@ -13,8 +13,8 @@ export class AquiferReleasedByPublicCouncil implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.addOceanInterrupt(game.getPlayers()[0],"Select Ocean for Global Event",true);
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.PLANTS, turmoil.getPlayerInfluence(player), undefined, undefined, true);
-            player.setResource(Resources.STEEL, turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setResource(Resources.PLANTS, turmoil.getPlayerInfluence(player), game, undefined, true);
+            player.setResource(Resources.STEEL, turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/AsteroidMining.ts
+++ b/src/turmoil/globalEvents/AsteroidMining.ts
@@ -13,7 +13,7 @@ export class AsteroidMining implements IGlobalEvent {
     public currentDelegate = PartyName.UNITY;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.TITANIUM, Math.min(5, player.getTagCount(Tags.JOVIAN, false, false)) + turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setResource(Resources.TITANIUM, Math.min(5, player.getTagCount(Tags.JOVIAN, false, false)) + turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/CelebrityLeaders.ts
+++ b/src/turmoil/globalEvents/CelebrityLeaders.ts
@@ -14,7 +14,7 @@ export class CelebrityLeaders implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
             let eventsCards = player.playedCards.filter(card => card.cardType === CardType.EVENT).length;
-            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, eventsCards) + turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, eventsCards) + turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/CorrosiveRain.ts
+++ b/src/turmoil/globalEvents/CorrosiveRain.ts
@@ -21,7 +21,7 @@ export class CorrosiveRain implements IGlobalEvent {
                 && card.resourceCount != undefined 
                 && card.resourceCount >= 2);
             if (floaterCards.length === 0) {
-                player.setResource(Resources.MEGACREDITS, -10, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, -10, game, undefined, true);
             } else {
                 // Trigger interrupt
                 game.addInterrupt(new SelectRemoveFloaters(player, game, floaterCards));

--- a/src/turmoil/globalEvents/Diversity.ts
+++ b/src/turmoil/globalEvents/Diversity.ts
@@ -13,7 +13,7 @@ export class Diversity implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
             if (player.getDistinctTagCount(false) + turmoil.getPlayerInfluence(player) >= 9) {
-                player.setResource(Resources.MEGACREDITS, 10, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, 10, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/EcoSabotage.ts
+++ b/src/turmoil/globalEvents/EcoSabotage.ts
@@ -15,7 +15,7 @@ export class EcoSabotage implements IGlobalEvent {
             let plants = player.getResource(Resources.PLANTS);
             let maxPlants = 3 + turmoil.getPlayerInfluence(player);
             let plantDecrease = Math.max(0, plants - maxPlants);
-            player.setResource(Resources.PLANTS, -plantDecrease, undefined, undefined, true);
+            player.setResource(Resources.PLANTS, -plantDecrease, game, undefined, true);
         });    
     }
 }   

--- a/src/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/turmoil/globalEvents/GenerousFunding.ts
@@ -12,7 +12,7 @@ export class GenerousFunding implements IGlobalEvent {
     public currentDelegate = PartyName.UNITY;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, Math.floor((player.getTerraformRating() - 15) / 5)) + turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, Math.floor((player.getTerraformRating() - 15) / 5)) + turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/GlobalDustStorm.ts
+++ b/src/turmoil/globalEvents/GlobalDustStorm.ts
@@ -14,10 +14,10 @@ export class GlobalDustStorm implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
             if (player.getResource(Resources.HEAT) > 0) {
-                player.setResource(Resources.HEAT, -player.getResource(Resources.HEAT), undefined, undefined, true);
+                player.setResource(Resources.HEAT, -player.getResource(Resources.HEAT), game, undefined, true);
             }
             let maxedSteelTags = Math.min(5, player.getTagCount(Tags.STEEL, false, false));
-            player.setResource(Resources.MEGACREDITS, -2 * Math.max(0, maxedSteelTags - turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, -2 * Math.max(0, maxedSteelTags - turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/HomeworldSupport.ts
+++ b/src/turmoil/globalEvents/HomeworldSupport.ts
@@ -15,7 +15,7 @@ export class HomeworldSupport implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.min(5, player.getTagCount(Tags.EARTH)) + turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, 2 * amount, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, 2 * amount, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/ImprovedEnergyTemplates.ts
+++ b/src/turmoil/globalEvents/ImprovedEnergyTemplates.ts
@@ -13,7 +13,7 @@ export class ImprovedEnergyTemplates implements IGlobalEvent {
     public currentDelegate = PartyName.KELVINISTS;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setProduction(Resources.ENERGY, Math.floor((player.getTagCount(Tags.ENERGY, false, false) + turmoil.getPlayerInfluence(player)) / 2), undefined, undefined);
+            player.setProduction(Resources.ENERGY, Math.floor((player.getTagCount(Tags.ENERGY, false, false) + turmoil.getPlayerInfluence(player)) / 2), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/InterplanetaryTrade.ts
+++ b/src/turmoil/globalEvents/InterplanetaryTrade.ts
@@ -13,7 +13,7 @@ export class InterplanetaryTrade implements IGlobalEvent {
     public currentDelegate = PartyName.UNITY;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SPACE, false, false)) + turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SPACE, false, false)) + turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/JovianTaxRights.ts
+++ b/src/turmoil/globalEvents/JovianTaxRights.ts
@@ -16,8 +16,8 @@ export class JovianTaxRights implements IGlobalEvent {
             game.colonies.forEach(colony => { 
                 coloniesCount += colony.colonies.filter(owner => owner === player).length;
             });  
-            player.setProduction(Resources.MEGACREDITS, coloniesCount, undefined, undefined);
-            player.setResource(Resources.TITANIUM, turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setProduction(Resources.MEGACREDITS, coloniesCount, game, undefined, true);
+            player.setResource(Resources.TITANIUM, turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/MinersOnStrike.ts
+++ b/src/turmoil/globalEvents/MinersOnStrike.ts
@@ -15,7 +15,7 @@ export class MinersOnStrike implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             let amount = Math.min(5, player.getTagCount(Tags.JOVIAN, false, false)) - turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.TITANIUM, -amount, undefined, undefined, true);
+                player.setResource(Resources.TITANIUM, -amount, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/MudSlides.ts
+++ b/src/turmoil/globalEvents/MudSlides.ts
@@ -20,7 +20,7 @@ export class MudSlides implements IGlobalEvent {
                                ).length;
             const amount = Math.min(5, ocean) - turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, -4 * amount, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, -4 * amount, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/Pandemic.ts
+++ b/src/turmoil/globalEvents/Pandemic.ts
@@ -14,7 +14,7 @@ export class Pandemic implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
             let maxedSteelTags = Math.min(5, player.getTagCount(Tags.STEEL, false, false));
-            player.setResource(Resources.MEGACREDITS, -3 * Math.max(0, maxedSteelTags - turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, -3 * Math.max(0, maxedSteelTags - turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/ParadigmBreakdown.ts
+++ b/src/turmoil/globalEvents/ParadigmBreakdown.ts
@@ -19,7 +19,7 @@ export class ParadigmBreakdown implements IGlobalEvent {
             } else if (player.cardsInHand.length >= 1) {
                 game.addInterrupt(new SelectDiscard(player, game, 'Global Event - Select a card to discard'));
             }
-            player.setResource(Resources.MEGACREDITS, 2 * (turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, 2 * (turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/Productivity.ts
+++ b/src/turmoil/globalEvents/Productivity.ts
@@ -12,7 +12,7 @@ export class Productivity implements IGlobalEvent {
     public currentDelegate = PartyName.MARS;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.STEEL, Math.min(5, player.getProduction(Resources.STEEL)) + turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setResource(Resources.STEEL, Math.min(5, player.getProduction(Resources.STEEL)) + turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }   

--- a/src/turmoil/globalEvents/RedInfluence.ts
+++ b/src/turmoil/globalEvents/RedInfluence.ts
@@ -14,9 +14,9 @@ export class RedInfluence implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.floor((player.getTerraformRating() - 10)/5);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, amount * -3, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, amount * -3, game, undefined, true);
             }
-            player.setProduction(Resources.MEGACREDITS, turmoil.getPlayerInfluence(player), undefined, undefined);
+            player.setProduction(Resources.MEGACREDITS, turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/Riots.ts
+++ b/src/turmoil/globalEvents/Riots.ts
@@ -20,7 +20,7 @@ export class Riots implements IGlobalEvent {
             ).length;
             const amount = Math.min(5, city) - turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, -4 * amount, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, -4 * amount, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/Sabotage.ts
+++ b/src/turmoil/globalEvents/Sabotage.ts
@@ -12,9 +12,9 @@ export class Sabotage implements IGlobalEvent {
     public currentDelegate = PartyName.REDS;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setProduction(Resources.ENERGY, -1);
-            player.setProduction(Resources.STEEL, -1);
-            player.setResource(Resources.STEEL, turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setProduction(Resources.ENERGY, -1, game, undefined, true);
+            player.setProduction(Resources.STEEL, -1, game, undefined, true);
+            player.setResource(Resources.STEEL, turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/ScientificCommunity.ts
+++ b/src/turmoil/globalEvents/ScientificCommunity.ts
@@ -13,7 +13,7 @@ export class ScientificCommunity implements IGlobalEvent {
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
             const amount = player.cardsInHand.length + turmoil.getPlayerInfluence(player);
-            player.setResource(Resources.MEGACREDITS, amount, undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, amount, game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/SolarFlare.ts
+++ b/src/turmoil/globalEvents/SolarFlare.ts
@@ -15,7 +15,7 @@ export class SolarFlare implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.min(5, player.getTagCount(Tags.SPACE, false, false)) - turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, amount * -3, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, amount * -3, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/SolarnetShutdown.ts
+++ b/src/turmoil/globalEvents/SolarnetShutdown.ts
@@ -15,7 +15,7 @@ export class SolarnetShutdown implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.min(5, player.playedCards.filter((card) => card.cardType === CardType.ACTIVE).length) - turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, amount * -3, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, amount * -3, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/SpinoffProducts.ts
+++ b/src/turmoil/globalEvents/SpinoffProducts.ts
@@ -14,7 +14,7 @@ export class SpinoffProducts implements IGlobalEvent {
     public currentDelegate = PartyName.SCIENTISTS;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SCIENCE, false, false)) + turmoil.getPlayerInfluence(player)), undefined, undefined, true);
+            player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, player.getTagCount(Tags.SCIENCE, false, false)) + turmoil.getPlayerInfluence(player)), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/StrongSociety.ts
+++ b/src/turmoil/globalEvents/StrongSociety.ts
@@ -15,7 +15,7 @@ export class StrongSociety implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.min(5, game.getSpaceCount(TileType.CITY, player)) + turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, amount * 2, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, amount * 2, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/SucessfulOrganisms.ts
+++ b/src/turmoil/globalEvents/SucessfulOrganisms.ts
@@ -12,7 +12,7 @@ export class SucessfulOrganisms implements IGlobalEvent {
     public currentDelegate = PartyName.SCIENTISTS;
     public resolve(game: Game, turmoil: Turmoil) {
         game.getPlayers().forEach(player => {
-            player.setResource(Resources.PLANTS, Math.min(5, player.getProduction(Resources.PLANTS)) + turmoil.getPlayerInfluence(player), undefined, undefined, true);
+            player.setResource(Resources.PLANTS, Math.min(5, player.getProduction(Resources.PLANTS)) + turmoil.getPlayerInfluence(player), game, undefined, true);
         });    
     }
 }    

--- a/src/turmoil/globalEvents/VenusInfrastructure.ts
+++ b/src/turmoil/globalEvents/VenusInfrastructure.ts
@@ -15,7 +15,7 @@ export class VenusInfrastructure implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = Math.min(5, player.getTagCount(Tags.VENUS, false, false)) + turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setResource(Resources.MEGACREDITS, amount * 2, undefined, undefined, true);
+                player.setResource(Resources.MEGACREDITS, amount * 2, game, undefined, true);
             }
         });    
     }

--- a/src/turmoil/globalEvents/VolcanicEruptions.ts
+++ b/src/turmoil/globalEvents/VolcanicEruptions.ts
@@ -15,7 +15,7 @@ export class VolcanicEruptions implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             const amount = turmoil.getPlayerInfluence(player);
             if (amount > 0) {
-                player.setProduction(Resources.HEAT, amount);
+                player.setProduction(Resources.HEAT, amount, game, undefined, true);
             }
         });    
     }


### PR DESCRIPTION
**Scope:**
- Log resource and production changes as "increased" or "decreased" instead of "modified"
- Fix missing GlobalEvent logs (due to `game` not being passed in)
- Log decreased production from Global Events
- Log increased production and increased resources from Global Events

<img width="449" alt="Screenshot 2020-06-14 at 4 02 13 PM" src="https://user-images.githubusercontent.com/2408094/84589144-4884a480-ae5f-11ea-887a-55556f3edd59.png">

<img width="475" alt="Screenshot 2020-06-14 at 4 47 25 PM" src="https://user-images.githubusercontent.com/2408094/84589148-4b7f9500-ae5f-11ea-859b-00960b523604.png">

