### PR TITLE
Minor fix: change display of required tags from "<required tag> <required tag>" to "<amount> <required tag>"

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -253,7 +253,7 @@ export const HTML_DATA: Map<string, string> =
             <div class="tile city-tile " style="margin-left:20px;margin-bottom:5px;"></div><br>
             <div class="plant resource "></div><div class="plant resource "></div><div class="plant resource "></div>
             <div class="description " style="margin-top:-5px;font-size:11px;text-align: left; line-height: 12px;">
-                <div>Oxygen must be 7% or less.</div> 
+                <div>Oxygen must be 7% or less.</div>
                 <div style="width:140px;">Gain 3 plants. Place a City tile. Decrease your Energy production 1 step and increase your MC production 3 steps.</div>
             </div>
         </div>
@@ -3916,7 +3916,7 @@ export const HTML_DATA: Map<string, string> =
               </div>
               &nbsp;<div class="tile city-tile"></div>*
                 <div class="description " style="text-align:left;margin-top:-58px; width: 92px;">
-                  Requires 2 science tags. Increase your MC production 2 steps. 
+                  Requires 2 science tags. Increase your MC production 2 steps.
                 </div>
                 <div class="description" style="text-align:left; width: 117px; margin-left: 19px;">
                   Place a City tile ON THE RESERVED AREA. 1 VP for every 3rd Floater on this card.
@@ -6727,7 +6727,7 @@ export const HTML_DATA: Map<string, string> =
     <div class="promo-icon project-icon"></div>
     <div class="card-number">X01</div>
     <div class="content">
-        <div class="requirements">Science Science</div>
+        <div class="requirements">2 Science</div>
         <div class="production-box production-box-size1a">
             <div class="production-prefix">&#x2796;&#xFE0E;</div><div class="production energy"></div><br/>
             <div class="production-prefix">&#x2795;&#xFE0E;</div><div class="production titanium"></div>

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -4581,7 +4581,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="colonies-icon project-icon"></div>
               <div class="card-number">C20</div>
               <div class="content ">
-                <div class="requirements">2 Earth Earth</div>
+                <div class="requirements">3 Earth</div>
                 <div class="production-box"><div class="production money">2</div></div>
                   <div class="description ">
                     (Requires 3 Earth tags. Increase your MC production 2 steps.)

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -4258,7 +4258,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="prelude-icon project-icon"></div>
               <div class="card-number">P42</div>
               <div class="content ">
-                <div class="requirements">Earth Earth</div>
+                <div class="requirements">2 Earth</div>
                 <div class="production-box">
                   <div class="production money">4</div>
                 </div><br>
@@ -4341,7 +4341,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="card-number">C05</div>
               <div class="content ">
                 <div class="points points-big">-1</div>
-                <div class="requirements">Earth Earth</div>
+                <div class="requirements">2 Earth</div>
                 <span style="font-size:14px;">NEXT CARD: </span> <div class="resource money">-16</div>
                   <div class="description ">
                     (Requires 2 Earth tags. The next card you play this generation costs 16 MC less.)
@@ -4481,7 +4481,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="card-number">C14</div>
               <div class="content ">
                 <div class="points points-big">-1</div>
-                <div class="requirements">Earth Earth</div>
+                <div class="requirements">2 Earth</div>
                 <div class="production-box"><div class="production money">2</div></div> <div style="margin-left:20px;" class="resource money">4</div>
                   <div class="description ">
                     (Requires 2 Earth tags. Increase your MC production 2 steps, and gain 4MC.)
@@ -4581,7 +4581,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="colonies-icon project-icon"></div>
               <div class="card-number">C20</div>
               <div class="content ">
-                <div class="requirements">Earth Earth Earth</div>
+                <div class="requirements">2 Earth Earth</div>
                 <div class="production-box"><div class="production money">2</div></div>
                   <div class="description ">
                     (Requires 3 Earth tags. Increase your MC production 2 steps.)
@@ -4835,7 +4835,7 @@ export const HTML_DATA: Map<string, string> =
               <div class="card-number">C36</div>
               <div class="content ">
                 <div class="points points-big">2</div>
-                <div class="requirements">Earth Earth</div>
+                <div class="requirements">2 Earth</div>
                   : <span class="money resource ">-1</span>
                   <div class="description ">
                       (Effect: When you play a card, you pay 1 MC less for it.)

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -4039,7 +4039,7 @@ export const HTML_DATA: Map<string, string> =
             <div class="venus-icon project-icon"></div>
       <div class="card-number">255</div>
             <div class="content ">
-              <div class="requirements">Venus Venus</div>
+              <div class="requirements">2 Venus</div>
               <div class="production-box">
                   <div class="money production">2</div>
               </div>


### PR DESCRIPTION
Change "Science Science" 

<img width="291" alt="Screenshot 2020-06-14 at 22 42 46" src="https://user-images.githubusercontent.com/2966599/84604140-3b35dd00-ae94-11ea-890c-3ee898432cb8.png">

to "2 Science" 

<img width="280" alt="Screenshot 2020-06-14 at 23 09 13" src="https://user-images.githubusercontent.com/2966599/84604150-4852cc00-ae94-11ea-8612-7abbcce05035.png">

like with the other cards. Maybe @ssimeonoff wants to update this in his cards list too?