### PR TITLE
Switch default selected option for Artificial Photosynthesis

### DIFF
--- a/src/cards/ArtificialPhotosynthesis.ts
+++ b/src/cards/ArtificialPhotosynthesis.ts
@@ -15,12 +15,12 @@ export class ArtificialPhotosynthesis implements IProjectCard {
 
     public play(player: Player) {
       return new OrOptions(
-          new SelectOption('Increase your plant production 1 step', () => {
-            player.setProduction(Resources.PLANTS);
-            return undefined;
-          }),
           new SelectOption('Increase your energy production 2 steps', () => {
             player.setProduction(Resources.ENERGY,2);
+            return undefined;
+          }),
+          new SelectOption('Increase your plant production 1 step', () => {
+            player.setProduction(Resources.PLANTS);
             return undefined;
           })
       );

--- a/tests/cards/ArtificialPhotosynthesis.spec.ts
+++ b/tests/cards/ArtificialPhotosynthesis.spec.ts
@@ -15,8 +15,8 @@ describe("ArtificialPhotosynthesis", function () {
         expect(action instanceof OrOptions).to.eq(true);
         expect(action.options.length).to.eq(2);
         action.options[0].cb();
-        expect(player.getProduction(Resources.PLANTS)).to.eq(1);
-        action.options[1].cb();
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
+        action.options[1].cb();
+        expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });
 });


### PR DESCRIPTION
Increasing 2 Energy production is usually preferred in most cases; it's rarer to pick the other option of increasing 1 plant production