### PR TITLE
Update placement restriction for Deimos Down promo

### DIFF
--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -20,7 +20,7 @@ export class DeimosDownPromo implements IProjectCard {
       game.addResourceDecreaseInterrupt(player, Resources.PLANTS, 6);
       player.steel += 4;
 
-      const availableSpaces = game.board.getAvailableSpacesOnLand(player);
+      const availableSpaces = game.board.getAvailableSpacesForCity(player);
       if (availableSpaces.length < 1) return undefined;
       
       return new SelectSpace("Select space for tile", availableSpaces, (foundSpace: ISpace) => {


### PR DESCRIPTION
**Ref:** https://www.kickstarter.com/projects/strongholdgames/terraforming-mars-big-box/posts/2869228

When played, you gain 4 steel and bring the moon Deimos Down to the surface creating a massive crater and raising the temperature by 3. You **cannot place this next to a city tile** and it will cost 6 plants from any player.