### PR TITLE
Add more detailed logs for base game

### DIFF
--- a/src/cards/AerobrakedAmmoniaAsteroid.ts
+++ b/src/cards/AerobrakedAmmoniaAsteroid.ts
@@ -7,6 +7,10 @@ import {SelectCard} from '../inputs/SelectCard';
 import { Resources } from "../Resources";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
+import { Game } from '../Game';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class AerobrakedAmmoniaAsteroid implements IProjectCard {
     public cost: number = 26;
@@ -14,17 +18,16 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
     public name: CardName = CardName.AEROBRAKED_AMMONIA_ASTEROID;
     public cardType: CardType = CardType.EVENT;
 
-    public play(player: Player) {
+    public play(player: Player, game: Game) {
       const cardsToPick = player.getResourceCards(ResourceType.MICROBE);
       player.setProduction(Resources.HEAT,3);
       player.setProduction(Resources.PLANTS);
 
-      // It's not required to have card to place microbes
-      // Rules pg. 9
       if (cardsToPick.length < 1) return undefined;
 
       if (cardsToPick.length === 1) {
         player.addResourceTo(cardsToPick[0], 2);
+        this.logCardEffect(game, player, cardsToPick[0]);
         return undefined;
       }
 
@@ -32,8 +35,18 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
           'Select card to add 2 microbes', cardsToPick,
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 2);
+            this.logCardEffect(game, player, foundCards[0]);
             return undefined;
           }
+      );
+    }
+
+    private logCardEffect(game: Game, player: Player, card: ICard) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} added 2 microbes to ${1}",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.CARD, card.name)
       );
     }
 }

--- a/src/cards/AerobrakedAmmoniaAsteroid.ts
+++ b/src/cards/AerobrakedAmmoniaAsteroid.ts
@@ -8,9 +8,7 @@ import { Resources } from "../Resources";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class AerobrakedAmmoniaAsteroid implements IProjectCard {
     public cost: number = 26;
@@ -27,7 +25,7 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
 
       if (cardsToPick.length === 1) {
         player.addResourceTo(cardsToPick[0], 2);
-        this.log(game, player, cardsToPick[0]);
+        LogHelper.logAddResource(game, player, cardsToPick[0], 2);
         return undefined;
       }
 
@@ -35,18 +33,9 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
           'Select card to add 2 microbes', cardsToPick,
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 2);
-            this.log(game, player, foundCards[0]);
+            LogHelper.logAddResource(game, player, foundCards[0], 2);
             return undefined;
           }
-      );
-    }
-
-    private log(game: Game, player: Player, card: ICard) {
-      game.log(
-        LogMessageType.DEFAULT,
-        "${0} added 2 microbes to ${1}",
-        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.CARD, card.name)
       );
     }
 }

--- a/src/cards/AerobrakedAmmoniaAsteroid.ts
+++ b/src/cards/AerobrakedAmmoniaAsteroid.ts
@@ -27,7 +27,7 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
 
       if (cardsToPick.length === 1) {
         player.addResourceTo(cardsToPick[0], 2);
-        this.logCardEffect(game, player, cardsToPick[0]);
+        this.log(game, player, cardsToPick[0]);
         return undefined;
       }
 
@@ -35,13 +35,13 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
           'Select card to add 2 microbes', cardsToPick,
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 2);
-            this.logCardEffect(game, player, foundCards[0]);
+            this.log(game, player, foundCards[0]);
             return undefined;
           }
       );
     }
 
-    private logCardEffect(game: Game, player: Player, card: ICard) {
+    private log(game: Game, player: Player, card: ICard) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} added 2 microbes to ${1}",

--- a/src/cards/CEOsFavoriteProject.ts
+++ b/src/cards/CEOsFavoriteProject.ts
@@ -27,13 +27,13 @@ export class CEOsFavoriteProject implements IProjectCard {
           player.getCardsWithResources(),
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
-            this.logCardEffect(game, player, foundCards[0]);
+            this.log(game, player, foundCards[0]);
             return undefined;
           }
       );
     }
 
-    private logCardEffect(game: Game, player: Player, card: ICard) {
+    private log(game: Game, player: Player, card: ICard) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} added 1 resource to ${1}",

--- a/src/cards/CEOsFavoriteProject.ts
+++ b/src/cards/CEOsFavoriteProject.ts
@@ -1,5 +1,4 @@
 import {ICard} from './ICard';
-
 import {IProjectCard} from './IProjectCard';
 import {CardType} from './CardType';
 import {Player} from '../Player';
@@ -7,9 +6,7 @@ import {Tags} from './Tags';
 import {SelectCard} from '../inputs/SelectCard';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class CEOsFavoriteProject implements IProjectCard {
     public cost: number = 1;
@@ -27,18 +24,9 @@ export class CEOsFavoriteProject implements IProjectCard {
           player.getCardsWithResources(),
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
-            this.log(game, player, foundCards[0]);
+            LogHelper.logAddResource(game, player, foundCards[0]);
             return undefined;
           }
-      );
-    }
-
-    private log(game: Game, player: Player, card: ICard) {
-      game.log(
-        LogMessageType.DEFAULT,
-        "${0} added 1 resource to ${1}",
-        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.CARD, card.name)
       );
     }
 }

--- a/src/cards/CEOsFavoriteProject.ts
+++ b/src/cards/CEOsFavoriteProject.ts
@@ -6,6 +6,10 @@ import {Player} from '../Player';
 import {Tags} from './Tags';
 import {SelectCard} from '../inputs/SelectCard';
 import { CardName } from '../CardName';
+import { Game } from '../Game';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class CEOsFavoriteProject implements IProjectCard {
     public cost: number = 1;
@@ -17,14 +21,24 @@ export class CEOsFavoriteProject implements IProjectCard {
       return player.getCardsWithResources().length > 0;
     }
 
-    public play(player: Player) {
+    public play(player: Player, game: Game) {
       return new SelectCard(
           'Select card to add resource',
           player.getCardsWithResources(),
           (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
+            this.logCardEffect(game, player, foundCards[0]);
             return undefined;
           }
+      );
+    }
+
+    private logCardEffect(game: Game, player: Player, card: ICard) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} added 1 resource to ${1}",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.CARD, card.name)
       );
     }
 }

--- a/src/cards/EOSChasmaNationalPark.ts
+++ b/src/cards/EOSChasmaNationalPark.ts
@@ -9,10 +9,7 @@ import {SelectCard} from '../inputs/SelectCard';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 import { ResourceType } from '../ResourceType';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
-
+import { LogHelper } from '../components/LogHelper';
 
 export class EosChasmaNationalPark implements IProjectCard {
   public cost: number = 16;
@@ -36,28 +33,18 @@ export class EosChasmaNationalPark implements IProjectCard {
 
     if (cards.length === 1) {
       player.addResourceTo(cards[0], 1);
-      this.log(game, player, cards[0]);
+      LogHelper.logAddResource(game, player, cards[0]);
       return undefined;
     }
    
     return new SelectCard("Add 1 animal to a card",  cards, (foundCards: Array<ICard>) => {
         player.addResourceTo(foundCards[0], 1);
-        this.log(game, player, foundCards[0]);
+        LogHelper.logAddResource(game, player, foundCards[0]);
         return undefined;
     });
-       
   }
 
   public getVictoryPoints() {
     return 1;
-  }
-
-  private log(game: Game, player: Player, card: ICard) {
-    game.log(
-      LogMessageType.DEFAULT,
-      "${0} added 1 animal to ${1}",
-      new LogMessageData(LogMessageDataType.PLAYER, player.id),
-      new LogMessageData(LogMessageDataType.CARD, card.name)
-    );
   }
 }

--- a/src/cards/EOSChasmaNationalPark.ts
+++ b/src/cards/EOSChasmaNationalPark.ts
@@ -9,6 +9,9 @@ import {SelectCard} from '../inputs/SelectCard';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 import { ResourceType } from '../ResourceType';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 
 export class EosChasmaNationalPark implements IProjectCard {
@@ -24,7 +27,7 @@ export class EosChasmaNationalPark implements IProjectCard {
     );
   }
 
-  public play(player: Player) {
+  public play(player: Player, game: Game) {
     const cards = player.getResourceCards(ResourceType.ANIMAL);
     player.plants += 3;
     player.setProduction(Resources.MEGACREDITS,2);
@@ -33,11 +36,13 @@ export class EosChasmaNationalPark implements IProjectCard {
 
     if (cards.length === 1) {
       player.addResourceTo(cards[0], 1);
+      this.logCardEffect(game, player, cards[0]);
       return undefined;
     }
    
     return new SelectCard("Add 1 animal to a card",  cards, (foundCards: Array<ICard>) => {
         player.addResourceTo(foundCards[0], 1);
+        this.logCardEffect(game, player, foundCards[0]);
         return undefined;
     });
        
@@ -47,4 +52,12 @@ export class EosChasmaNationalPark implements IProjectCard {
     return 1;
   }
 
+  private logCardEffect(game: Game, player: Player, card: ICard) {
+    game.log(
+      LogMessageType.DEFAULT,
+      "${0} added 1 animal to ${1}",
+      new LogMessageData(LogMessageDataType.PLAYER, player.id),
+      new LogMessageData(LogMessageDataType.CARD, card.name)
+    );
+  }
 }

--- a/src/cards/EOSChasmaNationalPark.ts
+++ b/src/cards/EOSChasmaNationalPark.ts
@@ -36,13 +36,13 @@ export class EosChasmaNationalPark implements IProjectCard {
 
     if (cards.length === 1) {
       player.addResourceTo(cards[0], 1);
-      this.logCardEffect(game, player, cards[0]);
+      this.log(game, player, cards[0]);
       return undefined;
     }
    
     return new SelectCard("Add 1 animal to a card",  cards, (foundCards: Array<ICard>) => {
         player.addResourceTo(foundCards[0], 1);
-        this.logCardEffect(game, player, foundCards[0]);
+        this.log(game, player, foundCards[0]);
         return undefined;
     });
        
@@ -52,7 +52,7 @@ export class EosChasmaNationalPark implements IProjectCard {
     return 1;
   }
 
-  private logCardEffect(game: Game, player: Player, card: ICard) {
+  private log(game: Game, player: Player, card: ICard) {
     game.log(
       LogMessageType.DEFAULT,
       "${0} added 1 animal to ${1}",

--- a/src/cards/ElectroCatapult.ts
+++ b/src/cards/ElectroCatapult.ts
@@ -31,23 +31,23 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
             new SelectOption('Spend 1 plant to gain 7 mega credit', () => {
               player.plants--;
               player.megaCredits += 7;
-              this.logCardAction(game, player, Resources.PLANTS);
+              this.log(game, player, Resources.PLANTS);
               return undefined;
             }),
             new SelectOption('Spend 1 steel to gain 7 mega credit', () => {
               player.steel--;
               player.megaCredits += 7;
-              this.logCardAction(game, player, Resources.STEEL);
+              this.log(game, player, Resources.STEEL);
               return undefined;
             })
         );
       } else if (player.plants > 0) {
         player.plants--;
-        this.logCardAction(game, player, Resources.PLANTS);
+        this.log(game, player, Resources.PLANTS);
         player.megaCredits += 7;
       } else if (player.steel > 0) {
         player.steel--;
-        this.logCardAction(game, player, Resources.STEEL);
+        this.log(game, player, Resources.STEEL);
         player.megaCredits += 7;
       }
       return undefined;
@@ -60,7 +60,7 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
       return 1;
     }
     
-    private logCardAction(game: Game, player: Player, resource: string) {
+    private log(game: Game, player: Player, resource: string) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} spent 1 ${1} to gain 7 MC",

--- a/src/cards/ElectroCatapult.ts
+++ b/src/cards/ElectroCatapult.ts
@@ -65,7 +65,7 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
         LogMessageType.DEFAULT,
         "${0} spent 1 ${1} to gain 7 MC",
         new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.STRING, resource)
+        new LogMessageData(LogMessageDataType.STRING, resource.slice(0, -1))
       );
     }
 }

--- a/src/cards/ElectroCatapult.ts
+++ b/src/cards/ElectroCatapult.ts
@@ -9,6 +9,9 @@ import {OrOptions} from '../inputs/OrOptions';
 import {SelectOption} from '../inputs/SelectOption';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class ElectroCatapult implements IActionCard, IProjectCard {
     public cost: number = 17;
@@ -22,25 +25,29 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
     public canAct(player: Player): boolean {
       return player.plants > 0 || player.steel > 0;
     }
-    public action(player: Player) {
+    public action(player: Player, game: Game) {
       if (player.plants > 0 && player.steel > 0) {
         return new OrOptions(
             new SelectOption('Spend 1 plant to gain 7 mega credit', () => {
               player.plants--;
               player.megaCredits += 7;
+              this.logCardAction(game, player, Resources.PLANTS);
               return undefined;
             }),
             new SelectOption('Spend 1 steel to gain 7 mega credit', () => {
               player.steel--;
               player.megaCredits += 7;
+              this.logCardAction(game, player, Resources.STEEL);
               return undefined;
             })
         );
       } else if (player.plants > 0) {
         player.plants--;
+        this.logCardAction(game, player, Resources.PLANTS);
         player.megaCredits += 7;
       } else if (player.steel > 0) {
         player.steel--;
+        this.logCardAction(game, player, Resources.STEEL);
         player.megaCredits += 7;
       }
       return undefined;
@@ -51,5 +58,14 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
     }
     public getVictoryPoints() {
       return 1;
+    }
+    
+    private logCardAction(game: Game, player: Player, resource: string) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} spent 1 ${1} to gain 7 MC",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.STRING, resource)
+      );
     }
 }

--- a/src/cards/ExtremeColdFungus.ts
+++ b/src/cards/ExtremeColdFungus.ts
@@ -10,6 +10,9 @@ import {SelectCard} from '../inputs/SelectCard';
 import {IProjectCard} from './IProjectCard';
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class ExtremeColdFungus implements IActionCard, IProjectCard {
     public cost: number = 13;
@@ -27,16 +30,18 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
     public canAct(): boolean {
       return true;
     }
-    public action(player: Player) {
+    public action(player: Player, game: Game) {
       const otherMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
 
       if (otherMicrobeCards.length === 0) {
         player.plants++;
+        this.logGainPlantAction(game, player);
         return undefined;
       }
 
       const gainPlantOption = new SelectOption('Gain 1 plant', () => {
         player.plants++;
+        this.logGainPlantAction(game, player);
         return undefined;
       })
 
@@ -46,6 +51,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
         return new OrOptions(
           new SelectOption('Add 2 microbes to ' + targetCard.name, () => {
             player.addResourceTo(targetCard, 2);
+            this.logAddMicrobeAction(game, player, targetCard);
             return undefined;
           }),
           gainPlantOption
@@ -58,10 +64,29 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
           otherMicrobeCards,
           (foundCards: Array<ICard>) => {
               player.addResourceTo(foundCards[0], 2);
+              this.logAddMicrobeAction(game, player, foundCards[0]);
               return undefined;
           }
         ),
         gainPlantOption
+      );
+    }
+
+    private logAddMicrobeAction(game: Game, player: Player, card: ICard) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} added 2 microbes to ${1}",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.CARD, card.name)
+      );
+    }
+
+    private logGainPlantAction(game: Game, player: Player) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} gained 1 plant using ${1}",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.CARD, this.name)
       );
     }
 }

--- a/src/cards/ExtremeColdFungus.ts
+++ b/src/cards/ExtremeColdFungus.ts
@@ -35,13 +35,13 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
 
       if (otherMicrobeCards.length === 0) {
         player.plants++;
-        this.logGainPlantAction(game, player);
+        this.logGainPlant(game, player);
         return undefined;
       }
 
       const gainPlantOption = new SelectOption('Gain 1 plant', () => {
         player.plants++;
-        this.logGainPlantAction(game, player);
+        this.logGainPlant(game, player);
         return undefined;
       })
 
@@ -51,7 +51,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
         return new OrOptions(
           new SelectOption('Add 2 microbes to ' + targetCard.name, () => {
             player.addResourceTo(targetCard, 2);
-            this.logAddMicrobeAction(game, player, targetCard);
+            this.logAddMicrobe(game, player, targetCard);
             return undefined;
           }),
           gainPlantOption
@@ -64,7 +64,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
           otherMicrobeCards,
           (foundCards: Array<ICard>) => {
               player.addResourceTo(foundCards[0], 2);
-              this.logAddMicrobeAction(game, player, foundCards[0]);
+              this.logAddMicrobe(game, player, foundCards[0]);
               return undefined;
           }
         ),
@@ -72,7 +72,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
       );
     }
 
-    private logAddMicrobeAction(game: Game, player: Player, card: ICard) {
+    private logAddMicrobe(game: Game, player: Player, card: ICard) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} added 2 microbes to ${1}",
@@ -81,7 +81,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
       );
     }
 
-    private logGainPlantAction(game: Game, player: Player) {
+    private logGainPlant(game: Game, player: Player) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} gained 1 plant using ${1}",

--- a/src/cards/ExtremeColdFungus.ts
+++ b/src/cards/ExtremeColdFungus.ts
@@ -10,9 +10,7 @@ import {SelectCard} from '../inputs/SelectCard';
 import {IProjectCard} from './IProjectCard';
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class ExtremeColdFungus implements IActionCard, IProjectCard {
     public cost: number = 13;
@@ -35,13 +33,13 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
 
       if (otherMicrobeCards.length === 0) {
         player.plants++;
-        this.logGainPlant(game, player);
+        LogHelper.logGainPlants(game, player);
         return undefined;
       }
 
       const gainPlantOption = new SelectOption('Gain 1 plant', () => {
         player.plants++;
-        this.logGainPlant(game, player);
+        LogHelper.logGainPlants(game, player);
         return undefined;
       })
 
@@ -51,7 +49,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
         return new OrOptions(
           new SelectOption('Add 2 microbes to ' + targetCard.name, () => {
             player.addResourceTo(targetCard, 2);
-            this.logAddMicrobe(game, player, targetCard);
+            LogHelper.logAddResource(game, player, targetCard, 2);
             return undefined;
           }),
           gainPlantOption
@@ -64,29 +62,11 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
           otherMicrobeCards,
           (foundCards: Array<ICard>) => {
               player.addResourceTo(foundCards[0], 2);
-              this.logAddMicrobe(game, player, foundCards[0]);
+              LogHelper.logAddResource(game, player, foundCards[0], 2);
               return undefined;
           }
         ),
         gainPlantOption
-      );
-    }
-
-    private logAddMicrobe(game: Game, player: Player, card: ICard) {
-      game.log(
-        LogMessageType.DEFAULT,
-        "${0} added 2 microbes to ${1}",
-        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.CARD, card.name)
-      );
-    }
-
-    private logGainPlant(game: Game, player: Player) {
-      game.log(
-        LogMessageType.DEFAULT,
-        "${0} gained 1 plant using ${1}",
-        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.CARD, this.name)
       );
     }
 }

--- a/src/cards/GHGProducingBacteria.ts
+++ b/src/cards/GHGProducingBacteria.ts
@@ -44,17 +44,17 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
                 }),
                 new SelectOption("Add 1 microbe to this card", () => {
                     this.resourceCount++;
-                    this.logAddMicrobeAction(game, player);
+                    this.logAddMicrobe(game, player);
                     return undefined;
                 })
             );
         }
 
         this.resourceCount++;
-        this.logAddMicrobeAction(game, player);
+        this.logAddMicrobe(game, player);
         return undefined;
     }
-    private logAddMicrobeAction(game: Game, player: Player) {
+    private logAddMicrobe(game: Game, player: Player) {
         game.log(
             LogMessageType.DEFAULT,
             "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",

--- a/src/cards/GHGProducingBacteria.ts
+++ b/src/cards/GHGProducingBacteria.ts
@@ -9,6 +9,9 @@ import { OrOptions } from "../inputs/OrOptions";
 import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 8;
@@ -31,15 +34,32 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
             return new OrOptions(
                 new SelectOption("Remove 2 microbes to raise temperature 1 step", () => {
                     player.removeResourceFrom(this,2);
+                    game.log(
+                        LogMessageType.DEFAULT,
+                        "${0} removed 2 microbes from ${1} to raise temperature 1 step",
+                        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                        new LogMessageData(LogMessageDataType.CARD, this.name)
+                    )
                     return game.increaseTemperature(player, 1);
                 }),
                 new SelectOption("Add 1 microbe to this card", () => {
                     this.resourceCount++;
+                    this.logAddMicrobeAction(game, player);
                     return undefined;
                 })
             );
         }
+
         this.resourceCount++;
+        this.logAddMicrobeAction(game, player);
         return undefined;
+    }
+    private logAddMicrobeAction(game: Game, player: Player) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, this.name)
+        )
     }
 }

--- a/src/cards/GHGProducingBacteria.ts
+++ b/src/cards/GHGProducingBacteria.ts
@@ -9,9 +9,7 @@ import { OrOptions } from "../inputs/OrOptions";
 import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 8;
@@ -34,32 +32,19 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
             return new OrOptions(
                 new SelectOption("Remove 2 microbes to raise temperature 1 step", () => {
                     player.removeResourceFrom(this,2);
-                    game.log(
-                        LogMessageType.DEFAULT,
-                        "${0} removed 2 microbes from ${1} to raise temperature 1 step",
-                        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                        new LogMessageData(LogMessageDataType.CARD, this.name)
-                    )
+                    LogHelper.logRemoveResource(game, player, this, 2, "raise temperature 1 step");
                     return game.increaseTemperature(player, 1);
                 }),
                 new SelectOption("Add 1 microbe to this card", () => {
                     this.resourceCount++;
-                    this.logAddMicrobe(game, player);
+                    LogHelper.logAddResource(game, player, this);
                     return undefined;
                 })
             );
         }
 
         this.resourceCount++;
-        this.logAddMicrobe(game, player);
+        LogHelper.logAddResource(game, player, this);
         return undefined;
-    }
-    private logAddMicrobe(game: Game, player: Player) {
-        game.log(
-            LogMessageType.DEFAULT,
-            "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, this.name)
-        )
     }
 }

--- a/src/cards/Greenhouses.ts
+++ b/src/cards/Greenhouses.ts
@@ -5,6 +5,7 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { LogHelper } from "../components/LogHelper";
 
 export class Greenhouses implements IProjectCard {
     public cost: number = 6;
@@ -13,7 +14,9 @@ export class Greenhouses implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
 
     public play(player: Player, game: Game) {
-        player.plants += game.getCitiesInPlay();
+        const qty = game.getCitiesInPlay();
+        player.plants += qty;
+        LogHelper.logGainPlants(game, player, qty);
         return undefined;
     }
 }

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -11,9 +11,7 @@ import { SelectCard } from "../inputs/SelectCard";
 import { PlayerInput } from "../PlayerInput";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class ImportedHydrogen implements IProjectCard {
     public cost: number = 16;
@@ -26,12 +24,9 @@ export class ImportedHydrogen implements IProjectCard {
         const availableAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
 
         const gainPlants = function () {
-            player.plants += 3;
-            game.log(
-                LogMessageType.DEFAULT,
-                "${0} gained 3 plants",
-                new LogMessageData(LogMessageDataType.PLAYER, player.id)
-            )
+            const qty = 3;
+            player.plants += qty;
+            LogHelper.logGainPlants(game, player, qty);
             game.addOceanInterrupt(player);
             return undefined;
         };
@@ -49,14 +44,14 @@ export class ImportedHydrogen implements IProjectCard {
             const targetMicrobeCard = availableMicrobeCards[0];
             availableActions.push(new SelectOption("Add 3 microbes to " + targetMicrobeCard.name, () => {
                 player.addResourceTo(targetMicrobeCard, 3);
-                this.logGainResource(game, player, targetMicrobeCard, 3);
+                LogHelper.logAddResource(game, player, targetMicrobeCard, 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableMicrobeCards.length > 1) {
             availableActions.push(new SelectCard("Add 3 microbes to a card", availableMicrobeCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 3);
-                this.logGainResource(game, player, foundCards[0], 3);
+                LogHelper.logAddResource(game, player, foundCards[0], 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -66,32 +61,19 @@ export class ImportedHydrogen implements IProjectCard {
             const targetAnimalCard = availableAnimalCards[0];
             availableActions.push(new SelectOption("Add 2 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 2);
-                this.logGainResource(game, player, targetAnimalCard, 2);
+                LogHelper.logAddResource(game, player, targetAnimalCard, 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableAnimalCards.length > 1) {
             availableActions.push(new SelectCard("Add 2 animals to a card", availableAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
-                this.logGainResource(game, player, foundCards[0], 2);
+                LogHelper.logAddResource(game, player, foundCards[0], 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         }
 
         return new OrOptions(...availableActions);   
-    }
-
-    private logGainResource(game: Game, player: Player, card: ICard, qty: number) {
-        let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
-
-        game.log(
-          LogMessageType.DEFAULT,
-          "${0} added ${1} ${2} to ${3}",
-          new LogMessageData(LogMessageDataType.PLAYER, player.id),
-          new LogMessageData(LogMessageDataType.STRING, qty.toString()),
-          new LogMessageData(LogMessageDataType.STRING, resource),
-          new LogMessageData(LogMessageDataType.CARD, card.name)
-        );
     }
 }

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -49,14 +49,14 @@ export class ImportedHydrogen implements IProjectCard {
             const targetMicrobeCard = availableMicrobeCards[0];
             availableActions.push(new SelectOption("Add 3 microbes to " + targetMicrobeCard.name, () => {
                 player.addResourceTo(targetMicrobeCard, 3);
-                this.logGainResourcesEffect(game, player, targetMicrobeCard, 3);
+                this.logGainResource(game, player, targetMicrobeCard, 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableMicrobeCards.length > 1) {
             availableActions.push(new SelectCard("Add 3 microbes to a card", availableMicrobeCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 3);
-                this.logGainResourcesEffect(game, player, foundCards[0], 3);
+                this.logGainResource(game, player, foundCards[0], 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -66,14 +66,14 @@ export class ImportedHydrogen implements IProjectCard {
             const targetAnimalCard = availableAnimalCards[0];
             availableActions.push(new SelectOption("Add 2 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 2);
-                this.logGainResourcesEffect(game, player, targetAnimalCard, 2);
+                this.logGainResource(game, player, targetAnimalCard, 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableAnimalCards.length > 1) {
             availableActions.push(new SelectCard("Add 2 animals to a card", availableAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
-                this.logGainResourcesEffect(game, player, foundCards[0], 2);
+                this.logGainResource(game, player, foundCards[0], 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -82,7 +82,7 @@ export class ImportedHydrogen implements IProjectCard {
         return new OrOptions(...availableActions);   
     }
 
-    private logGainResourcesEffect(game: Game, player: Player, card: ICard, qty: number) {
+    private logGainResource(game: Game, player: Player, card: ICard, qty: number) {
         let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
 
         game.log(

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -11,6 +11,9 @@ import { SelectCard } from "../inputs/SelectCard";
 import { PlayerInput } from "../PlayerInput";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class ImportedHydrogen implements IProjectCard {
     public cost: number = 16;
@@ -24,6 +27,11 @@ export class ImportedHydrogen implements IProjectCard {
 
         const gainPlants = function () {
             player.plants += 3;
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} gained 3 plants",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id)
+            )
             game.addOceanInterrupt(player);
             return undefined;
         };
@@ -41,12 +49,14 @@ export class ImportedHydrogen implements IProjectCard {
             const targetMicrobeCard = availableMicrobeCards[0];
             availableActions.push(new SelectOption("Add 3 microbes to " + targetMicrobeCard.name, () => {
                 player.addResourceTo(targetMicrobeCard, 3);
+                this.logGainResourcesEffect(game, player, targetMicrobeCard, 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableMicrobeCards.length > 1) {
             availableActions.push(new SelectCard("Add 3 microbes to a card", availableMicrobeCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 3);
+                this.logGainResourcesEffect(game, player, foundCards[0], 3);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -56,17 +66,32 @@ export class ImportedHydrogen implements IProjectCard {
             const targetAnimalCard = availableAnimalCards[0];
             availableActions.push(new SelectOption("Add 2 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 2);
+                this.logGainResourcesEffect(game, player, targetAnimalCard, 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         } else if (availableAnimalCards.length > 1) {
             availableActions.push(new SelectCard("Add 2 animals to a card", availableAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
+                this.logGainResourcesEffect(game, player, foundCards[0], 2);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
         }
 
         return new OrOptions(...availableActions);   
+    }
+
+    private logGainResourcesEffect(game: Game, player: Player, card: ICard, qty: number) {
+        let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
+
+        game.log(
+          LogMessageType.DEFAULT,
+          "${0} added ${1} ${2} to ${3}",
+          new LogMessageData(LogMessageDataType.PLAYER, player.id),
+          new LogMessageData(LogMessageDataType.STRING, qty.toString()),
+          new LogMessageData(LogMessageDataType.STRING, resource),
+          new LogMessageData(LogMessageDataType.CARD, card.name)
+        );
     }
 }

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -9,6 +9,9 @@ import { SelectCard } from "../inputs/SelectCard";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class ImportedNitrogen implements IProjectCard {
     public cost: number = 23;
@@ -32,22 +35,39 @@ export class ImportedNitrogen implements IProjectCard {
                 () => this.giveResources(player, game),
                 new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 3);
+                    this.logGainResourcesEffect(game, player, foundCards[0], 3);
                     return undefined;
                 }),
                 new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 2);
+                    this.logGainResourcesEffect(game, player, foundCards[0], 2);
                     return undefined;
                 })
             );
         } else if (otherAnimalCards.length > 0) {
             return new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
+                this.logGainResourcesEffect(game, player, foundCards[0], 2);
                 return this.giveResources(player, game);
             });
         }
         return new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 3);
+            this.logGainResourcesEffect(game, player, foundCards[0], 3);
             return this.giveResources(player, game);
         });
+    }
+
+    private logGainResourcesEffect(game: Game, player: Player, card: ICard, qty: number) {
+        let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
+
+        game.log(
+          LogMessageType.DEFAULT,
+          "${0} added ${1} ${2} to ${3}",
+          new LogMessageData(LogMessageDataType.PLAYER, player.id),
+          new LogMessageData(LogMessageDataType.STRING, qty.toString()),
+          new LogMessageData(LogMessageDataType.STRING, resource),
+          new LogMessageData(LogMessageDataType.CARD, card.name)
+        );
     }
 }

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -35,30 +35,30 @@ export class ImportedNitrogen implements IProjectCard {
                 () => this.giveResources(player, game),
                 new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 3);
-                    this.logGainResourcesEffect(game, player, foundCards[0], 3);
+                    this.logGainResource(game, player, foundCards[0], 3);
                     return undefined;
                 }),
                 new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 2);
-                    this.logGainResourcesEffect(game, player, foundCards[0], 2);
+                    this.logGainResource(game, player, foundCards[0], 2);
                     return undefined;
                 })
             );
         } else if (otherAnimalCards.length > 0) {
             return new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
-                this.logGainResourcesEffect(game, player, foundCards[0], 2);
+                this.logGainResource(game, player, foundCards[0], 2);
                 return this.giveResources(player, game);
             });
         }
         return new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 3);
-            this.logGainResourcesEffect(game, player, foundCards[0], 3);
+            this.logGainResource(game, player, foundCards[0], 3);
             return this.giveResources(player, game);
         });
     }
 
-    private logGainResourcesEffect(game: Game, player: Player, card: ICard, qty: number) {
+    private logGainResource(game: Game, player: Player, card: ICard, qty: number) {
         let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
 
         game.log(

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -1,5 +1,4 @@
 import {ICard} from './ICard';
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -9,9 +8,7 @@ import { SelectCard } from "../inputs/SelectCard";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class ImportedNitrogen implements IProjectCard {
     public cost: number = 23;
@@ -35,39 +32,26 @@ export class ImportedNitrogen implements IProjectCard {
                 () => this.giveResources(player, game),
                 new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 3);
-                    this.logGainResource(game, player, foundCards[0], 3);
+                    LogHelper.logAddResource(game, player, foundCards[0], 3);
                     return undefined;
                 }),
                 new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 2);
-                    this.logGainResource(game, player, foundCards[0], 2);
+                    LogHelper.logAddResource(game, player, foundCards[0], 2);
                     return undefined;
                 })
             );
         } else if (otherAnimalCards.length > 0) {
             return new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 2);
-                this.logGainResource(game, player, foundCards[0], 2);
+                LogHelper.logAddResource(game, player, foundCards[0], 2);
                 return this.giveResources(player, game);
             });
         }
         return new SelectCard("Select card to add 3 microbes", otherMicrobeCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 3);
-            this.logGainResource(game, player, foundCards[0], 3);
+            LogHelper.logAddResource(game, player, foundCards[0], 3);
             return this.giveResources(player, game);
         });
-    }
-
-    private logGainResource(game: Game, player: Player, card: ICard, qty: number) {
-        let resource = card.resourceType === ResourceType.MICROBE ? "microbes" : "animals";
-
-        game.log(
-          LogMessageType.DEFAULT,
-          "${0} added ${1} ${2} to ${3}",
-          new LogMessageData(LogMessageDataType.PLAYER, player.id),
-          new LogMessageData(LogMessageDataType.STRING, qty.toString()),
-          new LogMessageData(LogMessageDataType.STRING, resource),
-          new LogMessageData(LogMessageDataType.CARD, card.name)
-        );
     }
 }

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -11,6 +11,9 @@ import { SelectOption } from "../inputs/SelectOption";
 import { PlayerInput } from "../PlayerInput";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class LargeConvoy implements IProjectCard {
     public cost: number = 36;
@@ -25,6 +28,11 @@ export class LargeConvoy implements IProjectCard {
 
         const gainPlants = function() {
             player.plants += 5;
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} gained 5 plants",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id)
+            )
             game.addOceanInterrupt(player);
             return undefined;
         }
@@ -40,6 +48,7 @@ export class LargeConvoy implements IProjectCard {
             const targetAnimalCard = animalCards[0];
             availableActions.push(new SelectOption("Add 4 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 4);
+                this.logGainAnimalsEffect(game, player, targetAnimalCard);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -50,6 +59,7 @@ export class LargeConvoy implements IProjectCard {
                     animalCards, 
                     (foundCards: Array<ICard>) => { 
                         player.addResourceTo(foundCards[0], 4);
+                        this.logGainAnimalsEffect(game, player, foundCards[0]);
                         game.addOceanInterrupt(player);
                         return undefined;
                     }
@@ -61,5 +71,13 @@ export class LargeConvoy implements IProjectCard {
     }
     public getVictoryPoints() {
         return 2;
+    }
+    private logGainAnimalsEffect(game: Game, player: Player, card: ICard) {
+        game.log(
+          LogMessageType.DEFAULT,
+          "${0} added 4 animals to ${1}",
+          new LogMessageData(LogMessageDataType.PLAYER, player.id),
+          new LogMessageData(LogMessageDataType.CARD, card.name)
+        );
     }
 }

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -1,5 +1,4 @@
 import {ICard} from './ICard';
-
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { IProjectCard } from "./IProjectCard";
@@ -11,9 +10,7 @@ import { SelectOption } from "../inputs/SelectOption";
 import { PlayerInput } from "../PlayerInput";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class LargeConvoy implements IProjectCard {
     public cost: number = 36;
@@ -28,11 +25,7 @@ export class LargeConvoy implements IProjectCard {
 
         const gainPlants = function() {
             player.plants += 5;
-            game.log(
-                LogMessageType.DEFAULT,
-                "${0} gained 5 plants",
-                new LogMessageData(LogMessageDataType.PLAYER, player.id)
-            )
+            LogHelper.logGainPlants(game, player, 5);
             game.addOceanInterrupt(player);
             return undefined;
         }
@@ -48,7 +41,7 @@ export class LargeConvoy implements IProjectCard {
             const targetAnimalCard = animalCards[0];
             availableActions.push(new SelectOption("Add 4 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 4);
-                this.logGainAnimals(game, player, targetAnimalCard);
+                LogHelper.logAddResource(game, player, targetAnimalCard, 4);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -59,7 +52,7 @@ export class LargeConvoy implements IProjectCard {
                     animalCards, 
                     (foundCards: Array<ICard>) => { 
                         player.addResourceTo(foundCards[0], 4);
-                        this.logGainAnimals(game, player, foundCards[0]);
+                        LogHelper.logAddResource(game, player, foundCards[0], 4);
                         game.addOceanInterrupt(player);
                         return undefined;
                     }
@@ -71,13 +64,5 @@ export class LargeConvoy implements IProjectCard {
     }
     public getVictoryPoints() {
         return 2;
-    }
-    private logGainAnimals(game: Game, player: Player, card: ICard) {
-        game.log(
-          LogMessageType.DEFAULT,
-          "${0} added 4 animals to ${1}",
-          new LogMessageData(LogMessageDataType.PLAYER, player.id),
-          new LogMessageData(LogMessageDataType.CARD, card.name)
-        );
     }
 }

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -48,7 +48,7 @@ export class LargeConvoy implements IProjectCard {
             const targetAnimalCard = animalCards[0];
             availableActions.push(new SelectOption("Add 4 animals to " + targetAnimalCard.name, () => {
                 player.addResourceTo(targetAnimalCard, 4);
-                this.logGainAnimalsEffect(game, player, targetAnimalCard);
+                this.logGainAnimals(game, player, targetAnimalCard);
                 game.addOceanInterrupt(player);
                 return undefined;
             }))
@@ -59,7 +59,7 @@ export class LargeConvoy implements IProjectCard {
                     animalCards, 
                     (foundCards: Array<ICard>) => { 
                         player.addResourceTo(foundCards[0], 4);
-                        this.logGainAnimalsEffect(game, player, foundCards[0]);
+                        this.logGainAnimals(game, player, foundCards[0]);
                         game.addOceanInterrupt(player);
                         return undefined;
                     }
@@ -72,7 +72,7 @@ export class LargeConvoy implements IProjectCard {
     public getVictoryPoints() {
         return 2;
     }
-    private logGainAnimalsEffect(game: Game, player: Player, card: ICard) {
+    private logGainAnimals(game: Game, player: Player, card: ICard) {
         game.log(
           LogMessageType.DEFAULT,
           "${0} added 4 animals to ${1}",

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -45,22 +45,26 @@ export class LocalHeatTrapping implements IProjectCard {
             )
             return undefined;
         };
-
-        availableActions.options.push(new SelectOption("Gain 4 plants", gain4Plants));
-
-        if (animalCards.length === 1) {
-          availableActions.options.push(new SelectOption("Add 2 animals to " + animalCards[0].name, () => {
-            player.addResourceTo(animalCards[0], 2);
-            this.logAddAnimals(game, player, animalCards[0]);
-            return undefined;
-          }));
-        } else if (animalCards.length > 1) {
-          availableActions.options.push(new SelectCard("Select card to add 2 animals", animalCards, (foundCards: Array<ICard>) => {
-            player.addResourceTo(foundCards[0], 2);
-            this.logAddAnimals(game, player, foundCards[0]);
-            return undefined;
-          }));
-        }
+        if (otherAnimalCards.length === 0) {
+            options = new SelectOption("Gain 4 plants", gain4Plants);
+        } else if (otherAnimalCards.length === 1) {
+            const targetCard = otherAnimalCards[0];
+            options = new OrOptions(
+              new SelectOption("Gain 4 plants", gain4Plants),
+              new SelectOption("Add 2 animals to " + targetCard.name, () => {
+                  player.addResourceTo(targetCard, 2);
+                  this.logGainAnimalsEffect(game, player, targetCard);
+                  return undefined;
+              }));
+          } else {
+            options = new OrOptions(
+              new SelectOption("Gain 4 plants", gain4Plants),
+              new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
+                  player.addResourceTo(foundCards[0], 2);
+                  this.logGainAnimalsEffect(game, player, foundCards[0]);
+                  return undefined;
+              }));
+          };
         
         if (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) 
           && player.getResourcesOnCorporation() > 0) {
@@ -105,12 +109,12 @@ export class LocalHeatTrapping implements IProjectCard {
         return availableActions;
     }
 
-    private logAddAnimals(game: Game, player: Player, card: ICard) {
+    private logGainAnimalsEffect(game: Game, player: Player, card: ICard) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} spent 5 heat to add 2 animals to ${1}",
         new LogMessageData(LogMessageDataType.PLAYER, player.id),
         new LogMessageData(LogMessageDataType.CARD, card.name)
       );
-    }
+  }
 }

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -12,6 +12,9 @@ import { SelectAmount } from "../inputs/SelectAmount";
 import { ICard } from './ICard';
 import { CardName } from '../CardName';
 import { Game } from "../Game";
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
 
 export class LocalHeatTrapping implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
@@ -29,12 +32,17 @@ export class LocalHeatTrapping implements IProjectCard {
 
         return player.heat >= requiredHeatAmt || (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && (player.getResourcesOnCorporation() * 2) + player.heat >= 5 );
     }
-    public play(player: Player) {
+    public play(player: Player, game: Game) {
         const animalCards: Array<ICard> = player.getResourceCards(ResourceType.ANIMAL);
         let availableActions = new OrOptions();
 
         const gain4Plants = function () {
             player.plants += 4;
+            game.log(
+              LogMessageType.DEFAULT,
+              "${0} spent 5 heat to gain 4 plants",
+              new LogMessageData(LogMessageDataType.PLAYER, player.id)
+            )
             return undefined;
         };
 
@@ -43,11 +51,13 @@ export class LocalHeatTrapping implements IProjectCard {
         if (animalCards.length === 1) {
           availableActions.options.push(new SelectOption("Add 2 animals to " + animalCards[0].name, () => {
             player.addResourceTo(animalCards[0], 2);
+            this.logAddAnimals(game, player, animalCards[0]);
             return undefined;
           }));
         } else if (animalCards.length > 1) {
           availableActions.options.push(new SelectCard("Select card to add 2 animals", animalCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0], 2);
+            this.logAddAnimals(game, player, foundCards[0]);
             return undefined;
           }));
         }
@@ -93,5 +103,14 @@ export class LocalHeatTrapping implements IProjectCard {
         
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;
+    }
+
+    private logAddAnimals(game: Game, player: Player, card: ICard) {
+      game.log(
+        LogMessageType.DEFAULT,
+        "${0} spent 5 heat to add 2 animals to ${1}",
+        new LogMessageData(LogMessageDataType.PLAYER, player.id),
+        new LogMessageData(LogMessageDataType.CARD, card.name)
+      );
     }
 }

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -12,9 +12,7 @@ import { SelectAmount } from "../inputs/SelectAmount";
 import { ICard } from './ICard';
 import { CardName } from '../CardName';
 import { Game } from "../Game";
-import { LogMessageType } from "../LogMessageType";
-import { LogMessageData } from "../LogMessageData";
-import { LogMessageDataType } from "../LogMessageDataType";
+import { LogHelper } from "../components/LogHelper";
 
 export class LocalHeatTrapping implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
@@ -38,11 +36,7 @@ export class LocalHeatTrapping implements IProjectCard {
 
         const gain4Plants = function () {
             player.plants += 4;
-            game.log(
-              LogMessageType.DEFAULT,
-              "${0} spent 5 heat to gain 4 plants",
-              new LogMessageData(LogMessageDataType.PLAYER, player.id)
-            )
+            LogHelper.logGainPlants(game, player, 4);
             return undefined;
         };
         if (otherAnimalCards.length === 0) {
@@ -53,7 +47,7 @@ export class LocalHeatTrapping implements IProjectCard {
               new SelectOption("Gain 4 plants", gain4Plants),
               new SelectOption("Add 2 animals to " + targetCard.name, () => {
                   player.addResourceTo(targetCard, 2);
-                  this.logGainAnimals(game, player, targetCard);
+                  LogHelper.logAddResource(game, player, targetCard, 2);
                   return undefined;
               }));
           } else {
@@ -61,7 +55,7 @@ export class LocalHeatTrapping implements IProjectCard {
               new SelectOption("Gain 4 plants", gain4Plants),
               new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                   player.addResourceTo(foundCards[0], 2);
-                  this.logGainAnimals(game, player, foundCards[0]);
+                  LogHelper.logAddResource(game, player, foundCards[0], 2);
                   return undefined;
               }));
           };
@@ -108,12 +102,4 @@ export class LocalHeatTrapping implements IProjectCard {
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;
     }
-    private logGainAnimals(game: Game, player: Player, card: ICard) {
-      game.log(
-        LogMessageType.DEFAULT,
-        "${0} spent 5 heat to add 2 animals to ${1}",
-        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-        new LogMessageData(LogMessageDataType.CARD, card.name)
-      );
-  }
 }

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -53,7 +53,7 @@ export class LocalHeatTrapping implements IProjectCard {
               new SelectOption("Gain 4 plants", gain4Plants),
               new SelectOption("Add 2 animals to " + targetCard.name, () => {
                   player.addResourceTo(targetCard, 2);
-                  this.logGainAnimalsEffect(game, player, targetCard);
+                  this.logGainAnimals(game, player, targetCard);
                   return undefined;
               }));
           } else {
@@ -61,7 +61,7 @@ export class LocalHeatTrapping implements IProjectCard {
               new SelectOption("Gain 4 plants", gain4Plants),
               new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
                   player.addResourceTo(foundCards[0], 2);
-                  this.logGainAnimalsEffect(game, player, foundCards[0]);
+                  this.logGainAnimals(game, player, foundCards[0]);
                   return undefined;
               }));
           };
@@ -108,8 +108,7 @@ export class LocalHeatTrapping implements IProjectCard {
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;
     }
-
-    private logGainAnimalsEffect(game: Game, player: Player, card: ICard) {
+    private logGainAnimals(game: Game, player: Player, card: ICard) {
       game.log(
         LogMessageType.DEFAULT,
         "${0} spent 5 heat to add 2 animals to ${1}",

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -39,11 +39,11 @@ export class LocalHeatTrapping implements IProjectCard {
             LogHelper.logGainPlants(game, player, 4);
             return undefined;
         };
-        if (otherAnimalCards.length === 0) {
-            options = new SelectOption("Gain 4 plants", gain4Plants);
-        } else if (otherAnimalCards.length === 1) {
-            const targetCard = otherAnimalCards[0];
-            options = new OrOptions(
+        if (animalCards.length === 0) {
+          availableActions.options.push(new SelectOption("Gain 4 plants", gain4Plants));
+        } else if (animalCards.length === 1) {
+            const targetCard = animalCards[0];
+            availableActions.options.push(
               new SelectOption("Gain 4 plants", gain4Plants),
               new SelectOption("Add 2 animals to " + targetCard.name, () => {
                   player.addResourceTo(targetCard, 2);
@@ -51,9 +51,9 @@ export class LocalHeatTrapping implements IProjectCard {
                   return undefined;
               }));
           } else {
-            options = new OrOptions(
+            availableActions.options.push(
               new SelectOption("Gain 4 plants", gain4Plants),
-              new SelectCard("Select card to add 2 animals", otherAnimalCards, (foundCards: Array<ICard>) => {
+              new SelectCard("Select card to add 2 animals", animalCards, (foundCards: Array<ICard>) => {
                   player.addResourceTo(foundCards[0], 2);
                   LogHelper.logAddResource(game, player, foundCards[0], 2);
                   return undefined;

--- a/src/cards/NitriteReducingBacteria.ts
+++ b/src/cards/NitriteReducingBacteria.ts
@@ -9,9 +9,7 @@ import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
 import { Game } from '../Game';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class NitriteReducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 11;
@@ -31,35 +29,21 @@ export class NitriteReducingBacteria implements IActionCard, IProjectCard, IReso
     public action(player: Player, game: Game) {
         if (this.resourceCount < 3) {
             this.resourceCount++;
-            this.logAddMicrobe(game, player);
+            LogHelper.logAddResource(game, player, this);
             return undefined;
         }
         return new OrOptions(
             new SelectOption("Remove 3 microbes to increase your terraform rating 1 step", () => {
                 this.resourceCount -= 3;
-                game.log(
-                    LogMessageType.DEFAULT,
-                    "${0} removed 3 microbes from ${1} to gain 1 TR",
-                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                    new LogMessageData(LogMessageDataType.CARD, this.name)
-                )
+                LogHelper.logRemoveResource(game, player, this, 3, "gain 1 TR");
                 player.increaseTerraformRating(game);
                 return undefined;
             }),
             new SelectOption("Add 1 microbe to this card", () => {
                 this.resourceCount++;
-                this.logAddMicrobe(game, player);
+                LogHelper.logAddResource(game, player, this);
                 return undefined;
             })
         );
-    }
-
-    private logAddMicrobe(game: Game, player: Player) {
-        game.log(
-            LogMessageType.DEFAULT,
-            "${0} added 1 microbe to ${1}",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, this.name)
-        )
     }
 }

--- a/src/cards/NitriteReducingBacteria.ts
+++ b/src/cards/NitriteReducingBacteria.ts
@@ -9,6 +9,9 @@ import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class NitriteReducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 11;
@@ -28,18 +31,35 @@ export class NitriteReducingBacteria implements IActionCard, IProjectCard, IReso
     public action(player: Player, game: Game) {
         if (this.resourceCount < 3) {
             this.resourceCount++;
+            this.logAddMicrobe(game, player);
             return undefined;
         }
         return new OrOptions(
             new SelectOption("Remove 3 microbes to increase your terraform rating 1 step", () => {
                 this.resourceCount -= 3;
+                game.log(
+                    LogMessageType.DEFAULT,
+                    "${0} removed 3 microbes from ${1} to gain 1 TR",
+                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                    new LogMessageData(LogMessageDataType.CARD, this.name)
+                )
                 player.increaseTerraformRating(game);
                 return undefined;
             }),
             new SelectOption("Add 1 microbe to this card", () => {
                 this.resourceCount++;
+                this.logAddMicrobe(game, player);
                 return undefined;
             })
         );
+    }
+
+    private logAddMicrobe(game: Game, player: Player) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} added 1 microbe to ${1}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, this.name)
+        )
     }
 }

--- a/src/cards/RegolithEaters.ts
+++ b/src/cards/RegolithEaters.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard, IResourceCard } from './ICard';
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -9,9 +8,7 @@ import { OrOptions } from "../inputs/OrOptions";
 import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
-import { LogMessageType } from '../LogMessageType';
-import { LogMessageData } from '../LogMessageData';
-import { LogMessageDataType } from '../LogMessageDataType';
+import { LogHelper } from '../components/LogHelper';
 
 export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 13;
@@ -30,33 +27,20 @@ export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard 
     public action(player: Player, game: Game) {
         if (this.resourceCount < 2) {
             this.resourceCount++;
-            this.logAddMicrobe(game, player);
+            LogHelper.logAddResource(game, player, this);
             return undefined;
         }
         return new OrOptions(
             new SelectOption("Remove 2 microbes to raise oxygen level 1 step", () => {
                 player.removeResourceFrom(this, 2);
-                game.log(
-                    LogMessageType.DEFAULT,
-                    "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
-                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                    new LogMessageData(LogMessageDataType.CARD, this.name)
-                )
+                LogHelper.logRemoveResource(game, player, this, 2, "raise oxygen 1 step");
                 return game.increaseOxygenLevel(player, 1);
             }),
             new SelectOption("Add 1 microbe to this card", () => {
                 this.resourceCount++;
-                this.logAddMicrobe(game, player);
+                LogHelper.logAddResource(game, player, this);
                 return undefined;
             })
         );
-    }
-    private logAddMicrobe(game: Game, player: Player) {
-        game.log(
-            LogMessageType.DEFAULT,
-            "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, this.name)
-        )
     }
 }

--- a/src/cards/RegolithEaters.ts
+++ b/src/cards/RegolithEaters.ts
@@ -30,7 +30,7 @@ export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard 
     public action(player: Player, game: Game) {
         if (this.resourceCount < 2) {
             this.resourceCount++;
-            this.logAddMicrobeAction(game, player);
+            this.logAddMicrobe(game, player);
             return undefined;
         }
         return new OrOptions(
@@ -46,12 +46,12 @@ export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard 
             }),
             new SelectOption("Add 1 microbe to this card", () => {
                 this.resourceCount++;
-                this.logAddMicrobeAction(game, player);
+                this.logAddMicrobe(game, player);
                 return undefined;
             })
         );
     }
-    private logAddMicrobeAction(game: Game, player: Player) {
+    private logAddMicrobe(game: Game, player: Player) {
         game.log(
             LogMessageType.DEFAULT,
             "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",

--- a/src/cards/RegolithEaters.ts
+++ b/src/cards/RegolithEaters.ts
@@ -9,6 +9,9 @@ import { OrOptions } from "../inputs/OrOptions";
 import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
+import { LogMessageType } from '../LogMessageType';
+import { LogMessageData } from '../LogMessageData';
+import { LogMessageDataType } from '../LogMessageDataType';
 
 export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 13;
@@ -27,17 +30,33 @@ export class RegolithEaters implements IActionCard, IProjectCard, IResourceCard 
     public action(player: Player, game: Game) {
         if (this.resourceCount < 2) {
             this.resourceCount++;
+            this.logAddMicrobeAction(game, player);
             return undefined;
         }
         return new OrOptions(
             new SelectOption("Remove 2 microbes to raise oxygen level 1 step", () => {
                 player.removeResourceFrom(this, 2);
+                game.log(
+                    LogMessageType.DEFAULT,
+                    "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
+                    new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                    new LogMessageData(LogMessageDataType.CARD, this.name)
+                )
                 return game.increaseOxygenLevel(player, 1);
             }),
             new SelectOption("Add 1 microbe to this card", () => {
                 this.resourceCount++;
+                this.logAddMicrobeAction(game, player);
                 return undefined;
             })
         );
+    }
+    private logAddMicrobeAction(game: Game, player: Player) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} removed 2 microbes from ${1} to raise oxygen level 1 step",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, this.name)
+        )
     }
 }

--- a/src/cards/SymbioticFungus.ts
+++ b/src/cards/SymbioticFungus.ts
@@ -8,6 +8,9 @@ import { CardType } from "./CardType";
 import { SelectCard } from "../inputs/SelectCard";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
 
 export class SymbioticFungus implements IActionCard, IProjectCard {
     public cost: number = 4;
@@ -23,18 +26,28 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
     public canAct(player: Player): boolean {
         return player.getResourceCards(ResourceType.MICROBE).length > 0;
     }
-    public action(player: Player) {
+    public action(player: Player, game: Game) {
         const availableCards = player.getResourceCards(ResourceType.MICROBE);
 
         if (availableCards.length === 1) {
             player.addResourceTo(availableCards[0]);
+            this.logAddMicrobeAction(game, player, availableCards[0]);
             return undefined;
         }
 
         return new SelectCard("Select card to add microbe", availableCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
+            this.logAddMicrobeAction(game, player, foundCards[0]);
             return undefined;
         });
+    }
+    private logAddMicrobeAction(game: Game, player: Player, card: ICard) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} added 1 microbe to ${1}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, card.name)
+        )
     }
 }
  

--- a/src/cards/SymbioticFungus.ts
+++ b/src/cards/SymbioticFungus.ts
@@ -1,4 +1,3 @@
-
 import { Tags } from "./Tags";
 import { IActionCard, ICard } from './ICard';
 import { IProjectCard } from "./IProjectCard";
@@ -8,9 +7,7 @@ import { CardType } from "./CardType";
 import { SelectCard } from "../inputs/SelectCard";
 import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
-import { LogMessageType } from "../LogMessageType";
-import { LogMessageData } from "../LogMessageData";
-import { LogMessageDataType } from "../LogMessageDataType";
+import { LogHelper } from "../components/LogHelper";
 
 export class SymbioticFungus implements IActionCard, IProjectCard {
     public cost: number = 4;
@@ -31,23 +28,15 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
 
         if (availableCards.length === 1) {
             player.addResourceTo(availableCards[0]);
-            this.logAddMicrobe(game, player, availableCards[0]);
+            LogHelper.logAddResource(game, player, availableCards[0]);
             return undefined;
         }
 
         return new SelectCard("Select card to add microbe", availableCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
-            this.logAddMicrobe(game, player, foundCards[0]);
+            LogHelper.logAddResource(game, player, foundCards[0]);
             return undefined;
         });
-    }
-    private logAddMicrobe(game: Game, player: Player, card: ICard) {
-        game.log(
-            LogMessageType.DEFAULT,
-            "${0} added 1 microbe to ${1}",
-            new LogMessageData(LogMessageDataType.PLAYER, player.id),
-            new LogMessageData(LogMessageDataType.CARD, card.name)
-        )
     }
 }
  

--- a/src/cards/SymbioticFungus.ts
+++ b/src/cards/SymbioticFungus.ts
@@ -31,17 +31,17 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
 
         if (availableCards.length === 1) {
             player.addResourceTo(availableCards[0]);
-            this.logAddMicrobeAction(game, player, availableCards[0]);
+            this.logAddMicrobe(game, player, availableCards[0]);
             return undefined;
         }
 
         return new SelectCard("Select card to add microbe", availableCards, (foundCards: Array<ICard>) => {
             player.addResourceTo(foundCards[0]);
-            this.logAddMicrobeAction(game, player, foundCards[0]);
+            this.logAddMicrobe(game, player, foundCards[0]);
             return undefined;
         });
     }
-    private logAddMicrobeAction(game: Game, player: Player, card: ICard) {
+    private logAddMicrobe(game: Game, player: Player, card: ICard) {
         game.log(
             LogMessageType.DEFAULT,
             "${0} added 1 microbe to ${1}",

--- a/src/cards/TerraformingGanymede.ts
+++ b/src/cards/TerraformingGanymede.ts
@@ -5,6 +5,9 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
 
 export class TerraformingGanymede implements IProjectCard {
     public cost: number = 33;
@@ -13,7 +16,14 @@ export class TerraformingGanymede implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
 
     public play(player: Player, game: Game) {
-        player.increaseTerraformRatingSteps(1 + player.getTagCount(Tags.JOVIAN), game);
+        const steps = 1 + player.getTagCount(Tags.JOVIAN);
+        player.increaseTerraformRatingSteps(steps, game);
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} gained ${1} TR",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.STRING, steps.toString())
+        );
         return undefined;
     }
     public getVictoryPoints() {

--- a/src/components/LogHelper.ts
+++ b/src/components/LogHelper.ts
@@ -1,0 +1,52 @@
+import { Game } from "../Game";
+import { Player } from "../Player";
+import { ICard } from "../cards/ICard";
+import { LogMessageType } from "../LogMessageType";
+import { LogMessageData } from "../LogMessageData";
+import { LogMessageDataType } from "../LogMessageDataType";
+
+export class LogHelper {
+    static logAddResource(game: Game, player: Player, card: ICard, qty: number = 1): void {
+        let resourceType = "resource(s)"
+
+        if (card.resourceType) {
+            resourceType = card.resourceType.toLowerCase() + "(s)";
+        }
+
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} added ${1} ${2} to ${3}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.STRING, qty.toString()),
+            new LogMessageData(LogMessageDataType.STRING, resourceType),
+            new LogMessageData(LogMessageDataType.CARD, card.name)
+        );
+    }
+
+    static logRemoveResource(game: Game, player: Player, card: ICard, qty: number = 1, effect: string): void {
+        let resourceType = "resource(s)"
+
+        if (card.resourceType) {
+            resourceType = card.resourceType.toLowerCase() + "(s)";
+        }
+
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} removed ${1} ${2} from ${3} to ${4}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.STRING, qty.toString()),
+            new LogMessageData(LogMessageDataType.STRING, resourceType),
+            new LogMessageData(LogMessageDataType.CARD, card.name),
+            new LogMessageData(LogMessageDataType.STRING, effect)
+        );
+    }
+
+    static logGainPlants(game: Game, player: Player, qty: number = 1) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} gained ${1} plant(s)",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.STRING, qty.toString())
+        )
+    }
+}

--- a/tests/cards/AerobrakedAmmoniaAsteroid.spec.ts
+++ b/tests/cards/AerobrakedAmmoniaAsteroid.spec.ts
@@ -6,13 +6,15 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 import { Decomposers } from "../../src/cards/Decomposers";
+import { Game } from "../../src/Game";
 
 describe("AerobrakedAmmoniaAsteroid", function () {
     it("Should play without microbe cards", function () {
         const card = new AerobrakedAmmoniaAsteroid();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
-        const action = card.play(player);
+        const action = card.play(player, game);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
 
@@ -22,12 +24,13 @@ describe("AerobrakedAmmoniaAsteroid", function () {
     it("Adds microbes automatically if only 1 target", function () {
         const card = new AerobrakedAmmoniaAsteroid();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
 
         const selectedCard = new Ants();
         player.playedCards.push(selectedCard);
 
-        card.play(player);
+        card.play(player, game);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.getResourcesOnCard(selectedCard)).to.eq(2);
@@ -35,6 +38,7 @@ describe("AerobrakedAmmoniaAsteroid", function () {
     it("Adds microbes to another card", function () {
         const card = new AerobrakedAmmoniaAsteroid();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
 
         // Add card to collect Microbes on
@@ -42,7 +46,7 @@ describe("AerobrakedAmmoniaAsteroid", function () {
         const otherMicrobeCard = new Decomposers();
         player.playedCards.push(selectedCard, otherMicrobeCard);
 
-        const action = card.play(player);
+        const action = card.play(player, game);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
 

--- a/tests/cards/CEOsFavoriteProject.spec.ts
+++ b/tests/cards/CEOsFavoriteProject.spec.ts
@@ -8,6 +8,7 @@ import { SearchForLife } from "../../src/cards/SearchForLife";
 import { Birds } from "../../src/cards/Birds";
 import { Decomposers } from "../../src/cards/Decomposers";
 import { SecurityFleet } from "../../src/cards/SecurityFleet";
+import { Game } from "../../src/Game";
 
 describe("CEOsFavoriteProject", function () {
     it("Can't play", function () {
@@ -18,6 +19,8 @@ describe("CEOsFavoriteProject", function () {
     it("Should play", function () {
         const card = new CEOsFavoriteProject();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+        
         const searchForLife = new SearchForLife();
         const securityFleet = new SecurityFleet();
         player.playedCards.push(searchForLife, securityFleet);
@@ -28,7 +31,7 @@ describe("CEOsFavoriteProject", function () {
         const birds = new Birds();
         player.playedCards.push(decomposers, birds);
         player.addResourceTo(birds);
-        const action = card.play(player);
+        const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
         action.cb([searchForLife]);

--- a/tests/cards/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/EOSChasmaNationalPark.spec.ts
@@ -32,7 +32,7 @@ describe("EosChasmaNationalPark", function () {
         player.playedCards.push(fish);
 
         expect(card.canPlay(player, game)).to.eq(true);
-        const action = card.play(player);
+        const action = card.play(player, game);
         expect(action instanceof SelectCard).to.eq(true);
         if (action === undefined) return;
         player.playedCards.push(card);
@@ -59,7 +59,7 @@ describe("EosChasmaNationalPark", function () {
         player.playedCards.push(birds);
 
         expect(card.canPlay(player, game)).to.eq(true);
-        card.play(player);
+        card.play(player, game);
         player.playedCards.push(card);
         player.getVictoryPoints(game);
 

--- a/tests/cards/ElectroCatapult.spec.ts
+++ b/tests/cards/ElectroCatapult.spec.ts
@@ -34,9 +34,10 @@ describe("ElectroCatapult", function () {
     it("Should act", function () {
         const card = new ElectroCatapult();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.plants = 1;
         player.steel = 1;
-        const action = card.action(player);
+        const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);

--- a/tests/cards/ExtremeColdFungus.spec.ts
+++ b/tests/cards/ExtremeColdFungus.spec.ts
@@ -27,11 +27,12 @@ describe("ExtremeColdFungus", function () {
     it("Should act - single target", function () {
         const card = new ExtremeColdFungus();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
 
         const tardigrades = new Tardigrades();
         player.playedCards.push(tardigrades);
         
-        const action = card.action(player);
+        const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);
@@ -44,11 +45,13 @@ describe("ExtremeColdFungus", function () {
     it("Should act - multiple targets", function () {
         const card = new ExtremeColdFungus();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+        
         player.playedCards.push(new Ants());
         const tardigrades = new Tardigrades();
         player.playedCards.push(tardigrades);
         player.addResourceTo(tardigrades, 4);
-        const action = card.action(player);
+        const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);

--- a/tests/cards/LocalHeatTrapping.spec.ts
+++ b/tests/cards/LocalHeatTrapping.spec.ts
@@ -19,10 +19,11 @@ describe("LocalHeatTrapping", function () {
     it("Should play - no animal targets", function () {
         const card = new LocalHeatTrapping();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player], player);
         player.heat = 5;
         player.playedCards.push(card);
 
-        card.play(player);
+        card.play(player, game);
         expect(player.plants).to.eq(4);
         expect(player.heat).to.eq(0);
     });
@@ -49,12 +50,14 @@ describe("LocalHeatTrapping", function () {
     it("Should play - multiple animal targets", function () {
         const card = new LocalHeatTrapping();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player], player);
+
         player.heat = 5;
         const pets = new Pets();
         const fish = new Fish();
         player.playedCards.push(card, pets, fish);
 
-        const orOptions = card.play(player) as OrOptions;
+        const orOptions = card.play(player, game) as OrOptions;
         expect(player.heat).to.eq(0);
         orOptions.options[1].cb([fish]);
         expect(player.getResourcesOnCard(fish)).to.eq(2);

--- a/tests/cards/LocalHeatTrapping.spec.ts
+++ b/tests/cards/LocalHeatTrapping.spec.ts
@@ -29,11 +29,13 @@ describe("LocalHeatTrapping", function () {
     it("Should play - single animal target", function () {
         const card = new LocalHeatTrapping();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+        
         player.heat = 5;
         const pets = new Pets();
         player.playedCards.push(card, pets);
 
-        const orOptions = card.play(player) as OrOptions;
+        const orOptions = card.play(player, game) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
         

--- a/tests/cards/SymbioticFungus.spec.ts
+++ b/tests/cards/SymbioticFungus.spec.ts
@@ -22,17 +22,19 @@ describe("SymbioticFungus", function () {
     it("Should act - single target", function () {
         const card = new SymbioticFungus();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new Ants());
-        card.action(player);
+        card.action(player, game);
         expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);
     });
     it("Should act - multiple targets", function () {
         const card = new SymbioticFungus();
         const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new Ants());
         player.playedCards.push(new Decomposers());
         
-        const action = card.action(player);
+        const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
         action!.cb([player.playedCards[0]]);
         expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);


### PR DESCRIPTION
Part of https://github.com/bafolts/terraforming-mars/issues/428#issuecomment-608305941

This change covers only cards in the base game.

<img width="402" alt="Screenshot 2020-06-20 at 5 25 17 AM" src="https://user-images.githubusercontent.com/2408094/85181595-e7266080-b2b8-11ea-82f7-d3bf4a53edb4.png">
<img width="331" alt="Screenshot 2020-06-20 at 5 36 33 AM" src="https://user-images.githubusercontent.com/2408094/85181598-e988ba80-b2b8-11ea-9fc6-91c1d289a772.png">
<img width="265" alt="Screenshot 2020-06-20 at 5 38 08 AM" src="https://user-images.githubusercontent.com/2408094/85181599-eab9e780-b2b8-11ea-91eb-4706f8a9d9f7.png">

