### PR TITLE
Fix edge cases for Moss and Nitrophilic Moss

### DIFF
--- a/src/cards/Moss.ts
+++ b/src/cards/Moss.ts
@@ -13,7 +13,11 @@ export class Moss implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.MOSS;
     public canPlay(player: Player, game: Game): boolean {
-        return game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game) && player.plants >= 1;
+        const meetsOceanRequirements = game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game);
+        const hasViralEnhancers = player.playedCards.find((card) => card.name === CardName.VIRAL_ENHANCERS);
+        const hasEnoughPlants = player.plants >= 1 || hasViralEnhancers !== undefined;
+        
+        return meetsOceanRequirements && hasEnoughPlants;
     }
     public play(player: Player) {
         player.plants--;

--- a/src/cards/NitrophilicMoss.ts
+++ b/src/cards/NitrophilicMoss.ts
@@ -13,7 +13,11 @@ export class NitrophilicMoss implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.NITROPHILIC_MOSS;
     public canPlay(player: Player, game: Game): boolean {
-        return game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game) && player.plants >= 2;
+        const meetsOceanRequirements = game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game);
+        const hasViralEnhancers = player.playedCards.find((card) => card.name === CardName.VIRAL_ENHANCERS);
+        const hasEnoughPlants = player.plants >= 2 || player.plants >= 1 && hasViralEnhancers !== undefined;
+
+        return meetsOceanRequirements && hasEnoughPlants;
     }
     public play(player: Player) {
         player.plants -= 2;

--- a/tests/cards/Moss.spec.ts
+++ b/tests/cards/Moss.spec.ts
@@ -5,6 +5,7 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { ViralEnhancers } from "../../src/cards/ViralEnhancers";
 
 describe("Moss", function () {
     it("Can't play", function () {
@@ -23,6 +24,29 @@ describe("Moss", function () {
         const action = card.play(player);
         expect(action).to.eq(undefined);
         expect(player.plants).to.eq(-1);
+        expect(player.getProduction(Resources.PLANTS)).to.eq(1);
+    });
+    it("Can play with 0 plants if have Viral Enhancers", function () {
+        const card = new Moss();
+        const viralEnhancers = new ViralEnhancers();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+
+        // meet min. requirements
+        game.addOceanTile(player, "06");
+        game.addOceanTile(player, "07");
+        game.addOceanTile(player, "34");
+
+        // setup player with viral enhancers in play and no plants
+        player.plants = 0;
+        player.playedCards.push(viralEnhancers);
+        
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+        
+        expect(player.plants).to.eq(-1);
+        viralEnhancers.onCardPlayed(player, game, card);
+        expect(player.plants).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });
 });

--- a/tests/cards/NitrophilicMoss.spec.ts
+++ b/tests/cards/NitrophilicMoss.spec.ts
@@ -5,6 +5,7 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { ViralEnhancers } from "../../src/cards/ViralEnhancers";
 
 describe("NitrophilicMoss", function () {
     it("Can't play", function () {
@@ -24,6 +25,29 @@ describe("NitrophilicMoss", function () {
         const action = card.play(player);
         expect(action).to.eq(undefined);
         expect(player.plants).to.eq(-2);
+        expect(player.getProduction(Resources.PLANTS)).to.eq(2);
+    });
+    it("Can play with 1 plant if have Viral Enhancers", function () {
+        const card = new NitrophilicMoss();
+        const viralEnhancers = new ViralEnhancers();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+
+        // meet min. requirements
+        game.addOceanTile(player, "06");
+        game.addOceanTile(player, "07");
+        game.addOceanTile(player, "34");
+
+        // setup player with viral enhancers in play and 1 plant
+        player.plants = 1;
+        player.playedCards.push(viralEnhancers);
+        
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+        
+        expect(player.plants).to.eq(-1);
+        viralEnhancers.onCardPlayed(player, game, card);
+        expect(player.plants).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
     });
 });


### PR DESCRIPTION
**Context:** If player has Viral Enhancers in play, he should be able to play **Moss** with 0 plants and **Nitrophilic Moss** with 1 plant. Due to the bonus plant gained from Viral Enhancer's effect.