### PR TITLE
Local Heat Trapping should give 4 plants directly if player has no animals

### DIFF
--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -66,8 +66,8 @@ export class LocalHeatTrapping implements IProjectCard {
                   }
                   player.removeResourceFrom(player.corporationCard as ICard, floaterAmount);
                   player.heat -= heatAmount;
-                  
-                  if (availableActions.options.length === 1) return gain4Plants();
+
+                  if (availableActions.options.length === 1) return availableActions.options[0].cb();
                   return availableActions;
                 },
                 new SelectAmount("Select amount of heat to spend", (amount: number) => {
@@ -91,7 +91,7 @@ export class LocalHeatTrapping implements IProjectCard {
           player.megaCredits -= shortfall;
         }
         
-        if (availableActions.options.length === 1) return gain4Plants();
+        if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;
     }
 }

--- a/tests/cards/LocalHeatTrapping.spec.ts
+++ b/tests/cards/LocalHeatTrapping.spec.ts
@@ -7,6 +7,7 @@ import { Pets } from "../../src/cards/Pets";
 import { OrOptions } from '../../src/inputs/OrOptions';
 import { Helion } from "../../src/cards/corporation/Helion";
 import { Game } from "../../src/Game";
+import { Fish } from "../../src/cards/Fish";
 
 describe("LocalHeatTrapping", function () {
     it("Can't play", function () {
@@ -15,7 +16,17 @@ describe("LocalHeatTrapping", function () {
         const game = new Game("foobar", [player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
+    it("Should play - no animal targets", function () {
+        const card = new LocalHeatTrapping();
+        const player = new Player("test", Color.BLUE, false);
+        player.heat = 5;
+        player.playedCards.push(card);
+
+        card.play(player);
+        expect(player.plants).to.eq(4);
+        expect(player.heat).to.eq(0);
+    });
+    it("Should play - single animal target", function () {
         const card = new LocalHeatTrapping();
         const player = new Player("test", Color.BLUE, false);
         player.heat = 5;
@@ -25,11 +36,26 @@ describe("LocalHeatTrapping", function () {
         const orOptions = card.play(player) as OrOptions;
         expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
+        
         orOptions.options[0].cb();
         expect(player.plants).to.eq(4);
         expect(player.heat).to.eq(0);
-        orOptions.options[1].cb([pets]);
+
+        orOptions.options[1].cb();
         expect(player.getResourcesOnCard(pets)).to.eq(2);
+    });
+    it("Should play - multiple animal targets", function () {
+        const card = new LocalHeatTrapping();
+        const player = new Player("test", Color.BLUE, false);
+        player.heat = 5;
+        const pets = new Pets();
+        const fish = new Fish();
+        player.playedCards.push(card, pets, fish);
+
+        const orOptions = card.play(player) as OrOptions;
+        expect(player.heat).to.eq(0);
+        orOptions.options[1].cb([fish]);
+        expect(player.getResourcesOnCard(fish)).to.eq(2);
     });
     it("Can't play as Helion if not enough heat left after paying for card", function () {
         const card = new LocalHeatTrapping();


### PR DESCRIPTION
**Context:** Local Heat Trapping should give 4 plants directly if player has no animal cards; this does not need to be a click.