### PR TITLE
Fixes to Celestic

### DIFF
--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -36,22 +36,24 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
         const requiredCardsCount = 2;
         if (game.hasCardsWithResource(ResourceType.FLOATER, requiredCardsCount)) {
             let drawnCount = 0;
+            let floaterCards: Array<CardName> = [];
             while (drawnCount < requiredCardsCount) {
                 let card = game.dealer.dealCard();
                 if (Celestic.floaterCards.has(card.name) || card.resourceType === ResourceType.FLOATER) {
                     player.cardsInHand.push(card);
                     drawnCount++;
+                    floaterCards.push(card.name);
+                } else {
+                    game.dealer.discard(card);
                 }
             }
-
-            const drawnCards = game.getCardsInHandByResource(player, ResourceType.FLOATER).slice(-2);
 
             game.log(
                 LogMessageType.DEFAULT,
                 "${0} drew ${1} and ${2}",
                 new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                new LogMessageData(LogMessageDataType.CARD, drawnCards[0].name),
-                new LogMessageData(LogMessageDataType.CARD, drawnCards[1].name)
+                new LogMessageData(LogMessageDataType.CARD, floaterCards[0]),
+                new LogMessageData(LogMessageDataType.CARD, floaterCards[1])
             );
         }
         


### PR DESCRIPTION
When the server is starting up errors while populating games are ignored but logged. There is an error logged for a game with the celestic card. Two resource cards were not found in the hand and an error that `name` can not be read from `undefined` was logged. I have updated the card to log the cards that it added. I also saw we weren't discarding the drawn cards so I also updated the card to discard the drawn cards so they are not lost.