### PR TITLE
Improve visibility of global parameter current levels

### DIFF
--- a/src/styles/globs.less
+++ b/src/styles/globs.less
@@ -13,6 +13,7 @@
 
 	.val-is-active {
 		color: gold;
+		text-shadow: 2px 3px 2px #474747, 2px 2px 2px black;
 	}
 
 	.global-numbers-oceans {

--- a/src/styles/globs.less
+++ b/src/styles/globs.less
@@ -8,17 +8,17 @@
 	
 
 	.global-numbers-value {
-		filter: opacity(.4);
+		filter: opacity(1.0);
 	}
 
 	.val-is-active {
-		filter: opacity(1.0) !important;
+		color: gold;
 	}
 
 	.global-numbers-oceans {
 		position: absolute;
 		text-align: left;
-		color: #008ebd;
+		color: darkturquoise;
 		font-family: Prototype;
 		font-size: 24px;
 		margin: 531px 0 0 299px;


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/777

**Suggestion:** Use a different color plus text-shadow instead of opacity, so that it's clearer what the current level for each parameter is.

<img width="655" alt="Screenshot 2020-06-26 at 4 26 40 PM" src="https://user-images.githubusercontent.com/2408094/85839970-51b23180-b7ce-11ea-9f39-56eaeb4245bc.png">
