### PR TITLE
Fix wrong default MC value in SelectHowToPay

### DIFF
--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -99,7 +99,7 @@ export const SelectHowToPay = Vue.component("select-how-to-pay", {
               this.$data.heat = 0;
           }
 
-          let discountedCost = this.$data.cost - this.$data.heat;
+          let discountedCost = this.$data.cost - (this.$data.steel * this.player.steelValue) - (this.$data.titanium * this.player.titaniumValue) - this.$data.heat;
           this.$data.megaCredits = Math.max(discountedCost, 0);
         },
         canAffordWithMcOnly: function() {


### PR DESCRIPTION
**Example:** Water Import from Europa always shows default value of 12 for MC. The default MC value that is set should take Steel and Titanium into account. 

<img width="249" alt="Screenshot 2020-06-28 at 12 28 21 AM" src="https://user-images.githubusercontent.com/2408094/85929123-e018d700-b8e4-11ea-9693-f981cea4cc5b.png">
