### PR TITLE
Fix: Don't raise oxygen or give TR for final greeneries

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1325,7 +1325,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
     public addGreenery(
         player: Player, spaceId: string,
-        spaceType: SpaceType = SpaceType.LAND): undefined {
+        spaceType: SpaceType = SpaceType.LAND,
+        shouldRaiseOxygen: boolean = true): undefined {
       this.addTile(player, spaceType, this.getSpace(spaceId), {
         tileType: TileType.GREENERY
       });
@@ -1337,7 +1338,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
         && this.phase ===  Phase.ACTION) {
           player.setResource(Resources.MEGACREDITS, 4);
       }
-      return this.increaseOxygenLevel(player, 1);
+      if (shouldRaiseOxygen) return this.increaseOxygenLevel(player, 1);
+      return undefined;
     }
     public addCityTile(
         player: Player, spaceId: string, spaceType: SpaceType = SpaceType.LAND,

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1807,7 +1807,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             new SelectSpace(
                 "Select space for greenery",
                 game.board.getAvailableSpacesForGreenery(this), (space) => {
-                  game.addGreenery(this, space.id);
+                  // Do not raise oxygen or award TR for final greenery placements
+                  game.addGreenery(this, space.id, SpaceType.LAND, false);
                   this.plants -= this.plantsNeededForGreenery;
                   this.takeActionForFinalGreenery(game);
                   


### PR DESCRIPTION
**Context:** A solo game today finished two oxygens short, with 5 plants and 9 plant production. In the greenery conversion phase, two TR was awarded for the two greeneries placed and the game was wrongly counted as a "win." This game id was **cf9acd27f381**.

**Fix:** According to rulebook pg 13, final greenery placements should not raise the oxygen level or award TR for solo games.

_"After generation 14, you may convert plants into greenery tiles, following normal rules but without raising the oxygen"_