### PR TITLE
Add Diversity Support promo card (?)

### DIFF
--- a/src/CardName.ts
+++ b/src/CardName.ts
@@ -385,6 +385,7 @@ export enum CardName {
     MAGNETIC_SHIELD = "Magnetic Shield",
     MELTWORKS = "Meltworks",
     MOHOLE_LAKE = "Mohole Lake",
+    DIVERSITY_SUPPORT = "Diversity Support",
     INDUSTRIAL_CENTER = "Industrial Center",
     FACTORUM = "Factorum",
     LAKEFRONT_RESORTS = "Lakefront Resorts",

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -450,6 +450,7 @@ import { FieldCappedCity } from "./cards/promo/FieldCappedCity";
 import { MagneticShield } from "./cards/promo/MagneticShield";
 import { Meltworks } from "./cards/promo/Meltworks";
 import { MoholeLake } from "./cards/promo/MoholeLake";
+import { DiversitySupport } from "./cards/promo/DiversitySupport";
 
 
 export interface ICardFactory<T> {
@@ -711,6 +712,7 @@ export const ALL_PROMO_PROJECTS_CARDS: Array<ICardFactory<IProjectCard>> = [
     { cardName: CardName.MAGNETIC_SHIELD, factory: MagneticShield },
     { cardName: CardName.MELTWORKS, factory: Meltworks },
     { cardName: CardName.MOHOLE_LAKE, factory: MoholeLake },
+    { cardName: CardName.DIVERSITY_SUPPORT, factory: DiversitySupport },
     { cardName: CardName.ADVERTISING, factory: Advertising },
     { cardName: CardName.DEIMOS_DOWN_PROMO, factory: DeimosDownPromo },
     { cardName: CardName.GREAT_DAM_PROMO, factory: GreatDamPromo },

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -6959,6 +6959,19 @@ export const HTML_DATA: Map<string, string> =
         </div>
     </div>
 `],
+[CardName.DIVERSITY_SUPPORT,`
+        <div class="title background-color-events">Diversity Support</div>
+        <div class="price">1</div>
+        <div class="tag tag1 tag-event"></div>
+        <div class="promo-icon project-icon"></div>
+        <div class="content">
+            <div class="requirements">9 Resources</div>
+            <div class="tile rating"></div>
+            <div class="description ">
+                (Requires that you have 9 resources on cards. Raise your terraform rating 1 step.)
+            </div>
+        </div>
+`],
 [CardName.MERCURIAN_ALLOYS,`
     <div class="title background-color-active">Mercurian Alloys</div>
     <div class="price">3</div>

--- a/src/cards/promo/DiversitySupport.ts
+++ b/src/cards/promo/DiversitySupport.ts
@@ -1,0 +1,25 @@
+
+import { IProjectCard } from "./../IProjectCard";
+import { Tags } from "./../Tags";
+import { CardType } from "./../CardType";
+import { Player } from "../../Player";
+import { Game } from "../../Game";
+import { CardName } from '../../CardName';
+
+export class DiversitySupport implements IProjectCard {
+    public cost: number = 1;
+    public tags: Array<Tags> = [];
+    public name: CardName = CardName.DIVERSITY_SUPPORT;
+    public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player) {
+        const cardsWithResources = player.getCardsWithResources();
+        const resourceCount = cardsWithResources.map((card) => card.resourceCount!).reduce((c1, c2) => c1 + c2, 0);
+        return resourceCount >= 9;
+    }
+
+    public play(player: Player, game: Game) {
+        player.increaseTerraformRating(game);
+        return undefined;
+    }
+}

--- a/tests/cards/promo/DiversitySupport.spec.ts
+++ b/tests/cards/promo/DiversitySupport.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { DiversitySupport } from "../../../src/cards/promo/DiversitySupport";
+import { Color } from "../../../src/Color";
+import { Player } from "../../../src/Player";
+import { Game } from "../../../src/Game";
+import { Ants } from "../../../src/cards/Ants";
+import { Fish } from "../../../src/cards/Fish";
+import { Dirigibles } from "../../../src/cards/venusNext/Dirigibles";
+
+describe("DiversitySupport", function () {
+    it("Can't play", function () {
+        const card = new DiversitySupport();
+        const player = new Player("test", Color.BLUE, false);
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
+    it("Can play", function () {
+        const card = new DiversitySupport();
+        const player = new Player("test", Color.BLUE, false);
+        const game = new Game("foobar", [player,player], player);
+
+        const ants = new Ants();
+        const fish = new Fish();
+        const dirigibles = new Dirigibles();
+        player.playedCards.push(ants, fish, dirigibles);
+        dirigibles.resourceCount = 4;
+        fish.resourceCount = 3;
+        ants.resourceCount = 2;
+
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player, game);
+        expect(player.getTerraformRating()).to.eq(21);
+    });
+});


### PR DESCRIPTION
<img width="681" alt="Screenshot 2020-06-29 at 9 08 32 AM" src="https://user-images.githubusercontent.com/2408094/85973971-da1b1700-ba06-11ea-9c25-4f0ffdb35974.png">
<img width="222" alt="Screenshot 2020-06-29 at 11 11 14 AM" src="https://user-images.githubusercontent.com/2408094/85973984-df786180-ba06-11ea-9fcf-61ab0fbf68ff.png">

**Note:** This has at least two possibilities:
- Total of 9 resources collected on cards
- 9 different cards with resources on them

It is not entirely clear at the moment which one is the actual card effect