### PR TITLE
Optimize json and clone game API

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,6 @@ import {ColonyModel} from './src/models/ColonyModel';
 import {Color} from './src/Color';
 import { Game, GameOptions } from './src/Game';
 import {ICard} from './src/cards/ICard';
-import {IColony} from './src/colonies/Colony';
 import {IProjectCard} from './src/cards/IProjectCard';
 import {ISpace} from './src/ISpace';
 import {OrOptions} from './src/inputs/OrOptions';
@@ -477,7 +476,7 @@ function getPlayer(player: Player, game: Game): string {
     venusNextExtension: game.venusNextExtension,
     venusScaleLevel: game.getVenusScaleLevel(),
     boardName: game.boardName,
-    colonies: getColonies(game.colonies),
+    colonies: getColonies(game),
     tags: player.getAllTags(),
     showOtherPlayersVP: game.showOtherPlayersVP,
     actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
@@ -629,7 +628,7 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       venusNextExtension: game.venusNextExtension,
       venusScaleLevel: game.getVenusScaleLevel(),
       boardName: game.boardName,
-      colonies: getColonies(game.colonies),
+      colonies: getColonies(game),
       tags: player.getAllTags(),
       showOtherPlayersVP: game.showOtherPlayersVP,
       actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
@@ -643,14 +642,14 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
   });
 }
 
-function getColonies(colonies: Array<IColony>): Array<ColonyModel> {
-    return colonies.map((colony): ColonyModel => ({
-        colonies: colony.colonies.map((player): Color => player.color),
-        isActive: colony.isActive,
-        name: colony.name,
-        trackPosition: colony.trackPosition,
-        visitor: colony.visitor === undefined ? undefined : colony.visitor.color
-    }));
+function getColonies(game: Game): Array<ColonyModel> {
+  return game.colonies.map((colony): ColonyModel => ({
+      colonies: colony.colonies.map((playerId): Color => game.getPlayerById(playerId).color),
+      isActive: colony.isActive,
+      name: colony.name,
+      trackPosition: colony.trackPosition,
+      visitor: colony.visitor === undefined ? undefined : game.getPlayerById(colony.visitor).color
+  }));
 }
 
 function getTurmoil(game: Game): TurmoilModel | undefined {

--- a/server.ts
+++ b/server.ts
@@ -661,7 +661,7 @@ function getTurmoil(game: Game): TurmoilModel | undefined {
         chairman = Color.NEUTRAL;
       }
       else {
-        chairman = game.turmoil.chairman.color;
+        chairman = game.getPlayerById(game.turmoil.chairman).color;
       }
     }
     if (game.turmoil.dominantParty){
@@ -676,7 +676,7 @@ function getTurmoil(game: Game): TurmoilModel | undefined {
     const reserve = game.turmoil.getPresentPlayers().map(player => {
       const number = game.turmoil!.getDelegates(player);
       if (player != "NEUTRAL") {
-        return {color: player.color, number: number};
+        return {color: game.getPlayerById(player).color, number: number};
       }
       else {
         return {color: Color.NEUTRAL, number: number};
@@ -738,7 +738,7 @@ function getParties(game: Game): Array<PartyModel> | undefined{
       party.getPresentPlayers().forEach(player => {
         const number = party.getDelegates(player);
         if (player != "NEUTRAL") {
-          delegates.push({color: player.color, number: number});
+          delegates.push({color: game.getPlayerById(player).color, number: number});
         }
         else {
           delegates.push({color: Color.NEUTRAL, number: number});
@@ -750,7 +750,7 @@ function getParties(game: Game): Array<PartyModel> | undefined{
           partyLeader = Color.NEUTRAL;
         }
         else {
-          partyLeader = party.partyLeader.color;
+          partyLeader = game.getPlayerById(party.partyLeader).color;
         }
       }
       return {

--- a/server.ts
+++ b/server.ts
@@ -308,7 +308,7 @@ function apiGetWaitingFor(
   res.setHeader('Content-Type', 'application/json');
   const answer = {
     "result": "WAIT",
-    "player": game.activePlayer.name
+    "player": game.getPlayerById(game.activePlayer).name
   }
   if (player.getWaitingFor() !== undefined || game.phase === Phase.END) {
     answer["result"] = "GO";
@@ -471,7 +471,7 @@ function getPlayer(player: Player, game: Game): string {
     gameLog: game.gameLog,
     isSoloModeWin: game.isSoloModeWin(),
     gameAge: game.gameAge,
-    isActive: player.id === game.activePlayer.id,
+    isActive: player.id === game.activePlayer,
     corporateEra: game.corporateEra,
     venusNextExtension: game.venusNextExtension,
     venusScaleLevel: game.getVenusScaleLevel(),
@@ -624,7 +624,7 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       titaniumProduction: player.getProduction(Resources.TITANIUM),
       titaniumValue: player.getTitaniumValue(game),
       victoryPointsBreakdown: player.getVictoryPoints(game),
-      isActive: player.id === game.activePlayer.id,
+      isActive: player.id === game.activePlayer,
       venusNextExtension: game.venusNextExtension,
       venusScaleLevel: game.getVenusScaleLevel(),
       boardName: game.boardName,
@@ -793,7 +793,7 @@ function getSpaces(spaces: Array<ISpace>): Array<SpaceModel> {
 
 function getGame(game: Game): string {
   const output = {
-    activePlayer: game.activePlayer.color,
+    activePlayer: game.getPlayerById(game.activePlayer).color,
     id: game.id,
     phase: game.phase,
     players: game.getPlayers()

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -97,7 +97,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     public gameAge: number = 0; // Each log event increases it
     private unDraftedCards: Map<Player, Array<IProjectCard>> = new Map ();
     public interrupts: Array<PlayerInterrupt> = [];
-    public monsInsuranceOwner: Player | undefined = undefined;
+    public monsInsuranceOwner: PlayerId | undefined = undefined;
     public colonies: Array<IColony> = [];
     public colonyDealer: ColonyDealer | undefined = undefined;
     public pendingOceans: number = 0;
@@ -1749,8 +1749,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
       this.unDraftedCards = new Map<Player, IProjectCard[]>();
 
       // Mons insurance
-      if (d.monsInsuranceOwner) {
-        this.monsInsuranceOwner = this.players.find((player) => player.id === d.monsInsuranceOwner!.id);
+      if (d.monsInsuranceOwner !== undefined) {
+        this.monsInsuranceOwner = this.players.find((player) => player.id === d.monsInsuranceOwner!)!.id;
       }
 
       // Define who is the active player and init the take action phase

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1748,11 +1748,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
       // Reinit undrafted cards map
       this.unDraftedCards = new Map<Player, IProjectCard[]>();
 
-      // Mons insurance
-      if (d.monsInsuranceOwner !== undefined) {
-        this.monsInsuranceOwner = this.players.find((player) => player.id === d.monsInsuranceOwner!)!.id;
-      }
-
       // Define who is the active player and init the take action phase
       const active = this.players.find((player) => player.id === d.activePlayer);
       if (active) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1,4 +1,4 @@
-import {Player} from "./Player";
+import { Player, PlayerId } from "./Player";
 import {Dealer, ALL_VENUS_CORPORATIONS, ALL_CORPORATION_CARDS, ALL_CORP_ERA_CORPORATION_CARDS, ALL_PRELUDE_CORPORATIONS, ALL_COLONIES_CORPORATIONS, ALL_TURMOIL_CORPORATIONS, ALL_PROMO_CORPORATIONS} from "./Dealer";
 import {ISpace} from "./ISpace";
 import {SpaceType} from "./SpaceType";
@@ -470,7 +470,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public addColonyInterrupt(player: Player, allowDuplicate: boolean = false, title: string): void {
       let openColonies = this.colonies.filter(colony => colony.colonies.length < 3 
-        && (colony.colonies.indexOf(player) === -1 || allowDuplicate)
+        && (colony.colonies.indexOf(player.id) === -1 || allowDuplicate)
         && colony.isActive);
       if (openColonies.length >0 ) {
         this.addInterrupt(new SelectColony(player, this, openColonies, title));
@@ -1595,15 +1595,15 @@ export class Game implements ILoadable<SerializedGame, Game> {
           Object.assign(colony, element);
 
           if (colony !== undefined) {
-            if (element.visitor){
-              const player = this.players.find((player) => player.id === element.visitor!.id);
-              colony.visitor = player;
+            if (element.visitor !== undefined){
+              const player = this.players.find((player) => player.id === element.visitor);
+              colony.visitor = player!.id;
             }
-            colony.colonies = new Array<Player>();
-            element.colonies.forEach((element: Player) => {
-              const player = this.players.find((player) => player.id === element.id);
+            colony.colonies = new Array<PlayerId>();
+            element.colonies.forEach((element: PlayerId) => {
+              const player = this.players.find((player) => player.id === element);
               if (player) {
-                colony!.colonies.push(player);
+                colony!.colonies.push(player.id);
               }
             });
             this.colonies.push(colony);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -415,7 +415,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
               if (game.turmoil !== undefined) {
                 game.turmoil.lobby.add(player.id);
                 for (let i = 0; i < 6; i++) {
-                  game.turmoil.delegate_reserve.push(player);   
+                  game.turmoil.delegate_reserve.push(player.id);   
                 }
               }
             });
@@ -1622,9 +1622,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
             this.turmoil.chairman = "NEUTRAL";
           }
           else {
-            const chairman_id = d.turmoil.chairman.id
+            const chairman_id = d.turmoil.chairman;
             const player = this.players.find((player) => player.id === chairman_id);
-            this.turmoil.chairman = player;
+            this.turmoil.chairman = player!.id;
           }
         }
 
@@ -1632,17 +1632,19 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.turmoil.lobby = new Set<string>(d.turmoil.lobby);
 
         // Rebuild delegate reserve
-        this.turmoil.delegate_reserve = d.turmoil.delegate_reserve.map((element: SerializedPlayer | "NEUTRAL")  => {
+        this.turmoil.delegate_reserve = d.turmoil.delegate_reserve.map((element: PlayerId | "NEUTRAL")  => {
           if(element === "NEUTRAL"){
             return "NEUTRAL";
           }
           else {
-            const player = this.players.find((player) => player.id === element.id);
+            const player = this.players.find((player) => player.id === element);
             if (player){
-              return player;
+              return player.id;
             }
             else {
-              throw "Player not found when rebuilding delegate reserve";
+              // Avoid breaking server, return neutral instead of error
+              console.log("Player not found when rebuilding delegate reserve");
+              return "NEUTRAL";
             }
           }
         });
@@ -1655,22 +1657,22 @@ export class Game implements ILoadable<SerializedGame, Game> {
               party!.partyLeader = "NEUTRAL";
             }
             else {
-              const partyLeaderId = element.partyLeader.id;
+              const partyLeaderId = element.partyLeader;
               const player = this.players.find((player) => player.id === partyLeaderId);
-              party!.partyLeader = player;
+              party!.partyLeader = player!.id;
             }
           }
 
           // Rebuild delegates
-          party!.delegates = new Array<Player>();
-          element.delegates.forEach((element: Player | "NEUTRAL") => {
+          party!.delegates = new Array<PlayerId>();
+          element.delegates.forEach((element: PlayerId | "NEUTRAL") => {
             if (element === "NEUTRAL") {
               party!.delegates.push("NEUTRAL");
             }
             else {
-              const player = this.players.find((player) => player.id === element.id);
+              const player = this.players.find((player) => player.id === element);
               if (player) {
-                party!.delegates.push(player);
+                party!.delegates.push(player.id);
               }
             }
           });

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1595,17 +1595,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
           Object.assign(colony, element);
 
           if (colony !== undefined) {
-            if (element.visitor !== undefined){
-              const player = this.players.find((player) => player.id === element.visitor);
-              colony.visitor = player!.id;
-            }
-            colony.colonies = new Array<PlayerId>();
-            element.colonies.forEach((element: PlayerId) => {
-              const player = this.players.find((player) => player.id === element);
-              if (player) {
-                colony!.colonies.push(player.id);
-              }
-            });
             this.colonies.push(colony);
           }
         });     

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1711,8 +1711,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Rebuild passed players set
       this.passedPlayers = new Set<PlayerId>();
-      d.passedPlayers.forEach((element: SerializedPlayer) => {
-        const player = this.players.find((player) => player.id === element.id);
+      d.passedPlayers.forEach((element: PlayerId) => {
+        const player = this.players.find((player) => player.id === element);
         if (player) {
           this.passedPlayers.add(player.id);
         }
@@ -1720,8 +1720,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Rebuild done players set
       this.donePlayers = new Set<Player>();
-      d.donePlayers.forEach((element: SerializedPlayer) => {
-        const player = this.players.find((player) => player.id === element.id);
+      d.donePlayers.forEach((element: PlayerId) => {
+        const player = this.players.find((player) => player.id === element);
         if (player) {
           this.donePlayers.add(player);
         }
@@ -1729,8 +1729,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Rebuild researched players set
       this.researchedPlayers = new Set<PlayerId>();
-      d.researchedPlayers.forEach((element: SerializedPlayer) => {
-        const player = this.players.find((player) => player.id === element.id);
+      d.researchedPlayers.forEach((element: PlayerId) => {
+        const player = this.players.find((player) => player.id === element);
         if (player) {
           this.researchedPlayers.add(player.id);
         }
@@ -1738,8 +1738,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Rebuild drafted players set
       this.draftedPlayers = new Set<PlayerId>();
-      d.draftedPlayers.forEach((element: SerializedPlayer) => {
-        const player = this.players.find((player) => player.id === element.id);
+      d.draftedPlayers.forEach((element: PlayerId) => {
+        const player = this.players.find((player) => player.id === element);
         if (player) {
           this.draftedPlayers.add(player.id);
         }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -290,7 +290,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
 
       // Save initial game state
-      Database.getInstance().saveGameState(this.id, this.lastSaveId,JSON.stringify(this,this.replacer));
+      Database.getInstance().saveGameState(this.id, this.lastSaveId,JSON.stringify(this,this.replacer), this.players.length);
 
       this.log(
         LogMessageType.NEW_GENERATION,
@@ -1073,7 +1073,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       // Save the game state after changing the current player
       // Increment the save id
       this.lastSaveId += 1;
-      Database.getInstance().saveGameState(this.id, this.lastSaveId,JSON.stringify(this,this.replacer));
+      Database.getInstance().saveGameState(this.id, this.lastSaveId,JSON.stringify(this,this.replacer), this.players.length);
 
       player.takeAction(this);
     }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1604,41 +1604,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
       if (this.turmoilExtension) {
         let turmoil = new Turmoil(this);
         this.turmoil = turmoil.loadFromJSON(d.turmoil);
-
-        // Rebuild chairman
-        if (d.turmoil.chairman) {
-          if (d.turmoil.chairman === "NEUTRAL"){
-            this.turmoil.chairman = "NEUTRAL";
-          }
-          else {
-            const chairman_id = d.turmoil.chairman;
-            const player = this.players.find((player) => player.id === chairman_id);
-            this.turmoil.chairman = player!.id;
-          }
-        }
-
+        
         // Rebuild lobby
         this.turmoil.lobby = new Set<string>(d.turmoil.lobby);
 
-        // Rebuild delegate reserve
-        this.turmoil.delegate_reserve = d.turmoil.delegate_reserve.map((element: PlayerId | "NEUTRAL")  => {
-          if(element === "NEUTRAL"){
-            return "NEUTRAL";
-          }
-          else {
-            const player = this.players.find((player) => player.id === element);
-            if (player){
-              return player.id;
-            }
-            else {
-              // Avoid breaking server, return neutral instead of error
-              console.log("Player not found when rebuilding delegate reserve");
-              return "NEUTRAL";
-            }
-          }
-        });
-
-        // Rebuild party leader
+        // Rebuild parties
         d.turmoil.parties.forEach((element: IParty) => {
           let party = this.turmoil?.getPartyByName(element.name);
           if (element.partyLeader) {
@@ -1652,7 +1622,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
             }
           }
 
-          // Rebuild delegates
+          // Rebuild parties delegates
           party!.delegates = new Array<PlayerId>();
           element.delegates.forEach((element: PlayerId | "NEUTRAL") => {
             if (element === "NEUTRAL") {
@@ -1665,7 +1635,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
               }
             }
           });
+
         });
+
       }
 
       // Rebuild claimed milestones

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -76,7 +76,7 @@ export interface GameOptions {
 }  
 
 export class Game implements ILoadable<SerializedGame, Game> {
-    public activePlayer: Player;
+    public activePlayer: PlayerId;
     public claimedMilestones: Array<ClaimedMilestone> = [];
     public milestones: Array<IMilestone> = [];
     public dealer: Dealer;
@@ -152,7 +152,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       this.board = this.boardConstructor(gameOptions.boardName);
 
-      this.activePlayer = first;
+      this.activePlayer = first.id;
       this.boardName = gameOptions.boardName;
       this.draftVariant = gameOptions.draftVariant;
       this.corporateEra = gameOptions.corporateEra;
@@ -405,7 +405,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           // Set active player
           let playerIndex = gameToRebuild.players.indexOf(gameToRebuild.first);
           game.first = game.players[playerIndex];
-          game.activePlayer = game.players[playerIndex];
+          game.activePlayer = game.players[playerIndex].id;
 
           // Recreate turmoil lobby and reserve (Turmoil stores some players ids)
           if (gameToRebuild.turmoilExtension && game.turmoil !== undefined) {
@@ -994,7 +994,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         return;
       }
 
-      const nextPlayer = this.getNextPlayer(this.players, this.activePlayer);
+      const nextPlayer = this.getNextPlayer(this.players, this.getPlayerById(this.activePlayer));
 
       // Defensive coding to fail fast, if we don't find the next
       // player we are in an unexpected game state
@@ -1006,7 +1006,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.startActionsForPlayer(nextPlayer);
       } else {
         // Recursively find the next player
-        this.activePlayer = nextPlayer;
+        this.activePlayer = nextPlayer.id;
         this.playerIsFinishedTakingActions();
       }
     }
@@ -1062,12 +1062,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     private startFinalGreeneryPlacement(player: Player) {
-      this.activePlayer = player;
+      this.activePlayer = player.id;
       player.takeActionForFinalGreenery(this);
     }
 
     private startActionsForPlayer(player: Player) {
-      this.activePlayer = player;
+      this.activePlayer = player.id;
       player.actionsTakenThisRound = 0;
 
       // Save the game state after changing the current player
@@ -1754,11 +1754,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
 
       // Define who is the active player and init the take action phase
-      const active = this.players.find((player) => player.id === d.activePlayer.id);
+      const active = this.players.find((player) => player.id === d.activePlayer);
       if (active) {
         // We have to switch active player because it's still the one that ended last turn
-        this.activePlayer = active;
-        this.activePlayer.takeAction(this);
+        this.activePlayer = active.id;
+        this.getPlayerById(this.activePlayer).takeAction(this);
       }
       else {
         throw "No Player found when rebuilding Active Player";

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -88,9 +88,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
     private donePlayers: Set<Player> = new Set<Player>();
     private oxygenLevel: number = constants.MIN_OXYGEN_LEVEL;
     private venusScaleLevel: number = constants.MIN_VENUS_SCALE;
-    private passedPlayers: Set<Player> = new Set<Player>();
-    private researchedPlayers: Set<Player> = new Set<Player>();
-    private draftedPlayers: Set<Player> = new Set<Player>();
+    private passedPlayers: Set<PlayerId> = new Set<PlayerId>();
+    private researchedPlayers: Set<PlayerId> = new Set<PlayerId>();
+    private draftedPlayers: Set<PlayerId> = new Set<PlayerId>();
     public board: Board;
     private temperature: number = constants.MIN_TEMPERATURE;
     public gameLog: Array<LogMessage> = [];
@@ -680,7 +680,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public hasPassedThisActionPhase(player: Player): boolean {
-      return this.passedPlayers.has(player);
+      return this.passedPlayers.has(player.id);
     }
 
     private incrementFirstPlayer(): void {
@@ -839,15 +839,15 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public playerHasPassed(player: Player): void {
-      this.passedPlayers.add(player);
+      this.passedPlayers.add(player.id);
     }
 
     private hasResearched(player: Player): boolean {
-      return this.researchedPlayers.has(player);
+      return this.researchedPlayers.has(player.id);
     }
 
     private hasDrafted(player: Player): boolean {
-      return this.draftedPlayers.has(player);
+      return this.draftedPlayers.has(player.id);
     }
 
     private allPlayersHaveFinishedResearch(): boolean {
@@ -869,14 +869,14 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public playerIsFinishedWithResearchPhase(player: Player): void {
-      this.researchedPlayers.add(player);
+      this.researchedPlayers.add(player.id);
       if (this.allPlayersHaveFinishedResearch()) {
         this.gotoActionPhase();
       }
     }
 
     public playerIsFinishedWithDraftingPhase(initialDraft: boolean, player: Player, cards : Array<IProjectCard>): void {
-      this.draftedPlayers.add(player);
+      this.draftedPlayers.add(player.id);
       this.unDraftedCards.set(player,cards);
 
       player.needsToDraft = false;
@@ -1710,11 +1710,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
       });
 
       // Rebuild passed players set
-      this.passedPlayers = new Set<Player>();
+      this.passedPlayers = new Set<PlayerId>();
       d.passedPlayers.forEach((element: SerializedPlayer) => {
         const player = this.players.find((player) => player.id === element.id);
         if (player) {
-          this.passedPlayers.add(player);
+          this.passedPlayers.add(player.id);
         }
       });
 
@@ -1728,20 +1728,20 @@ export class Game implements ILoadable<SerializedGame, Game> {
       });
 
       // Rebuild researched players set
-      this.researchedPlayers = new Set<Player>();
+      this.researchedPlayers = new Set<PlayerId>();
       d.researchedPlayers.forEach((element: SerializedPlayer) => {
         const player = this.players.find((player) => player.id === element.id);
         if (player) {
-          this.researchedPlayers.add(player);
+          this.researchedPlayers.add(player.id);
         }
       });
 
       // Rebuild drafted players set
-      this.draftedPlayers = new Set<Player>();
+      this.draftedPlayers = new Set<PlayerId>();
       d.draftedPlayers.forEach((element: SerializedPlayer) => {
         const player = this.players.find((player) => player.id === element.id);
         if (player) {
-          this.draftedPlayers.add(player);
+          this.draftedPlayers.add(player.id);
         }
       });
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -48,9 +48,11 @@ import { Aridor } from "./cards/colonies/Aridor";
 import { MiningArea } from "./cards/MiningArea";
 import { MiningRights } from "./cards/MiningRights";
 
+export type PlayerId = string;
+
 export class Player implements ILoadable<SerializedPlayer, Player>{
     public corporationCard: CorporationCard | undefined = undefined;
-    public id: string;
+    public id: PlayerId;
     public canUseHeatAsMegaCredits: boolean = false;
     public shouldTriggerCardEffect: boolean = true;
     public plantsNeededForGreenery: number = 8;
@@ -92,7 +94,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public colonyTradeOffset: number = 0;
     public colonyTradeDiscount: number = 0;
     private turmoilScientistsActionUsed: boolean = false;
-    public removingPlayers: Array<string> = [];
+    public removingPlayers: Array<PlayerId> = [];
     public needsToDraft: boolean | undefined = undefined;
 
     constructor(
@@ -1966,7 +1968,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if ( game.coloniesExtension &&
         this.canAfford(constants.BUILD_COLONY_COST)) {
         let openColonies = game.colonies.filter(colony => colony.colonies.length < 3 
-          && colony.colonies.indexOf(this) === -1
+          && colony.colonies.indexOf(this.id) === -1
           && colony.isActive);      
           if (openColonies.length > 0) {
             standardProjects.options.push(

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2153,7 +2153,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           const selectParty = new SelectParty(this, game, "Send a delegate in an area (from lobby)");
           action.options.push(selectParty.playerInput);
         }
-        else if (this.canAfford(5) && game.turmoil!.getDelegates(this) > 0){
+        else if (this.canAfford(5) && game.turmoil!.getDelegates(this.id) > 0){
           const selectParty = new SelectParty(this, game, "Send a delegate in an area (5MC)", 1, undefined, 5);
           action.options.push(selectParty.playerInput);
         }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -189,9 +189,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
     private resolveMonsInsurance(game: Game) {
       if (game.monsInsuranceOwner !== undefined) {
-        let retribution: number = Math.min(game.monsInsuranceOwner.megaCredits, 3);
+        let retribution: number = Math.min(game.getPlayerById(game.monsInsuranceOwner).megaCredits, 3);
         this.megaCredits += retribution;
-        game.monsInsuranceOwner.setResource(Resources.MEGACREDITS,-3);
+        game.getPlayerById(game.monsInsuranceOwner).setResource(Resources.MEGACREDITS,-3);
         if (retribution > 0) {
           game.log(
             LogMessageType.DEFAULT,
@@ -199,7 +199,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             new LogMessageData(LogMessageDataType.PLAYER, this.id),
             new LogMessageData(LogMessageDataType.STRING, retribution.toString()),
             new LogMessageData(LogMessageDataType.CARD, "Mons Insurance"),
-            new LogMessageData(LogMessageDataType.PLAYER, game.monsInsuranceOwner.id)
+            new LogMessageData(LogMessageDataType.PLAYER, game.monsInsuranceOwner)
           );
         }
       }  

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -28,7 +28,7 @@ export interface SerializedGame {
     corporationList: Array<CardName>;
     boardName: BoardName;
     seed?: number
-    activePlayer: SerializedPlayer;
+    activePlayer: PlayerId;
     claimedMilestones: Array<ClaimedMilestone>;
     milestones: Array<IMilestone>;
     dealer: SerializedDealer;

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -13,6 +13,7 @@ import { BoardName } from "./BoardName";
 import { SerializedPlayer } from "./SerializedPlayer";
 import { SerializedDealer } from "./SerializedDealer";
 import { SerializedTurmoil } from "./turmoil/SerializedTurmoil";
+import { PlayerId } from "./Player";
 
 export interface SerializedGame {
     id: string;
@@ -48,7 +49,7 @@ export interface SerializedGame {
     gameAge: number;
     unDraftedCards: Map<SerializedPlayer, Array<IProjectCard>>;
     interrupts: Array<PlayerInterrupt>;
-    monsInsuranceOwner: SerializedPlayer | undefined;
+    monsInsuranceOwner: PlayerId | undefined;
     colonies: Array<IColony>;
     colonyDealer: ColonyDealer | undefined;
     pendingOceans: number;

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -37,12 +37,12 @@ export interface SerializedGame {
     generation: number;
     draftRound: number;
     phase: Phase;
-    donePlayers: Set<SerializedPlayer>;
+    donePlayers: Set<PlayerId>;
     oxygenLevel: number;
     venusScaleLevel: number;
-    passedPlayers: Set<SerializedPlayer>;
-    researchedPlayers: Set<SerializedPlayer>;
-    draftedPlayers: Set<SerializedPlayer>;
+    passedPlayers: Set<PlayerId>;
+    researchedPlayers: Set<PlayerId>;
+    draftedPlayers: Set<PlayerId>;
     board: Board;
     temperature: number;
     gameLog: Array<String>;

--- a/src/cards/colonies/EcologyResearch.ts
+++ b/src/cards/colonies/EcologyResearch.ts
@@ -17,7 +17,7 @@ export class EcologyResearch implements IProjectCard {
     public play(player: Player, game: Game) {
         let coloniesCount: number = 0;
         game.colonies.forEach(colony => { 
-          coloniesCount += colony.colonies.filter(owner => owner === player).length;
+          coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
         });  
         player.setProduction(Resources.PLANTS, coloniesCount);
 

--- a/src/cards/colonies/PioneerSettlement.ts
+++ b/src/cards/colonies/PioneerSettlement.ts
@@ -15,7 +15,7 @@ export class PioneerSettlement implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         let coloniesCount: number = 0;
         game.colonies.forEach(colony => { 
-          coloniesCount += colony.colonies.filter(owner => owner === player).length;
+          coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
         }); 
         return coloniesCount < 2;
     }

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -14,7 +14,7 @@ export class Poseidon implements CorporationCard {
     public initialAction(player: Player, game: Game) {
         if (game.coloniesExtension) {
           let openColonies = game.colonies.filter(colony => colony.colonies.length < 3 
-            && colony.colonies.indexOf(player) === -1 
+            && colony.colonies.indexOf(player.id) === -1 
             && colony.isActive);
           let buildColony = new OrOptions();
           buildColony.title = "Poseidon first action - Select where to build colony";

--- a/src/cards/colonies/ProductiveOutpost.ts
+++ b/src/cards/colonies/ProductiveOutpost.ts
@@ -13,8 +13,8 @@ export class ProductiveOutpost implements IProjectCard {
 
     public play(player: Player, game: Game) {
       game.colonies.forEach(colony => {
-          colony.colonies.filter(owner => owner === player).forEach(owner => {
-            colony.giveTradeBonus(owner, game);
+          colony.colonies.filter(owner => owner === player.id).forEach(owner => {
+            colony.giveTradeBonus(game.getPlayerById(owner), game);
           });
       }); 
       return undefined;

--- a/src/cards/colonies/SpacePort.ts
+++ b/src/cards/colonies/SpacePort.ts
@@ -18,7 +18,7 @@ export class SpacePort implements IProjectCard {
         if (game.board.getAvailableSpacesForCity(player).length === 0) return false;
         let coloniesCount: number = 0;
         game.colonies.forEach(colony => { 
-          coloniesCount += colony.colonies.filter(owner => owner === player).length;
+          coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
         }); 
         return coloniesCount > 0 && player.getProduction(Resources.ENERGY) > 0;
     }

--- a/src/cards/colonies/SpacePortColony.ts
+++ b/src/cards/colonies/SpacePortColony.ts
@@ -14,7 +14,7 @@ export class SpacePortColony implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         let coloniesCount: number = 0;
         game.colonies.forEach(colony => { 
-          coloniesCount += colony.colonies.filter(owner => owner === player).length;
+          coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
         }); 
         return coloniesCount > 0;
     }

--- a/src/cards/colonies/UrbanDecomposers.ts
+++ b/src/cards/colonies/UrbanDecomposers.ts
@@ -18,7 +18,7 @@ export class UrbanDecomposers implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         let coloniesCount: number = 0;
         game.colonies.forEach(colony => { 
-          coloniesCount += colony.colonies.filter(owner => owner === player).length;
+          coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
         });
         return coloniesCount > 0 && game.getSpaceCount(TileType.CITY, player) > 0;
     }

--- a/src/cards/promo/MonsInsurance.ts
+++ b/src/cards/promo/MonsInsurance.ts
@@ -15,7 +15,7 @@ export class MonsInsurance implements CorporationCard {
         for (let player of game.getPlayers()) {
             player.setProduction(Resources.MEGACREDITS,-2);
         }
-        game.monsInsuranceOwner = player;
+        game.monsInsuranceOwner = player.id;
         return undefined;
     }
 }    

--- a/src/cards/turmoil/BannedDelegate.ts
+++ b/src/cards/turmoil/BannedDelegate.ts
@@ -2,7 +2,7 @@ import { IProjectCard } from "../IProjectCard";
 import { Tags } from "../Tags";
 import { CardName } from "../../CardName";
 import { CardType } from "../CardType";
-import { Player } from "../../Player";
+import { Player, PlayerId } from "../../Player";
 import { Game } from '../../Game';
 import { OrOptions } from "../../inputs/OrOptions";
 import { SelectDelegate } from "../../inputs/SelectDelegate";
@@ -19,7 +19,7 @@ export class BannedDelegate implements IProjectCard {
 
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
-            return game.turmoil.chairman === player
+            return game.turmoil.chairman === player.id
         }
         return false;
     }
@@ -32,10 +32,25 @@ export class BannedDelegate implements IProjectCard {
             // Remove the party leader from available choices
             const delegates = party.delegates.slice();
             delegates.splice(party.delegates.indexOf(party.partyLeader!),1);
-            const players = Array.from(new Set<Player | "NEUTRAL">(delegates));
+            const playersId = Array.from(new Set<PlayerId | "NEUTRAL">(delegates));
+            let players = new Array<Player | "NEUTRAL">();
+            playersId.forEach(playerId => {
+              if (playerId === "NEUTRAL") {
+                players.push("NEUTRAL");
+              } else {
+                players.push(game.getPlayerById(playerId));
+              }  
+            });
+
             if (players.length > 0) {
               let selectDelegate = new SelectDelegate(players, "Select player delegate to remove from " + party.name + " party", (selectedPlayer: Player | "NEUTRAL") => {
-                game.turmoil!.removeDelegateFromParty(selectedPlayer, party.name, game);
+                let playerToRemove = "";
+                if (selectedPlayer === "NEUTRAL") {
+                  playerToRemove = "NEUTRAL";
+                } else {
+                  playerToRemove = selectedPlayer.id;
+                }
+                game.turmoil!.removeDelegateFromParty(playerToRemove, party.name, game);
                 this.log(game, player, party);
                 return undefined;
               });

--- a/src/cards/turmoil/PublicCelebrations.ts
+++ b/src/cards/turmoil/PublicCelebrations.ts
@@ -13,7 +13,7 @@ export class PublicCelebrations implements IProjectCard {
 
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
-            return game.turmoil.chairman === player;
+            return game.turmoil.chairman === player.id;
         }
         return false;
     }

--- a/src/cards/turmoil/SeptumTribus.ts
+++ b/src/cards/turmoil/SeptumTribus.ts
@@ -20,7 +20,7 @@ export class SeptumTribus implements IActionCard, CorporationCard {
 
     public action(player: Player, game: Game) {
         if (game.turmoil !== undefined) {
-            const partiesWithPresence = game.turmoil.parties.filter((party) => party.delegates.includes(player));
+            const partiesWithPresence = game.turmoil.parties.filter((party) => party.delegates.includes(player.id));
             player.megaCredits += partiesWithPresence.length * 2;
         }
         

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -13,16 +13,16 @@ export class VoteOfNoConfidence implements IProjectCard {
     public hasRequirements = false;
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
-            const parties = game.turmoil.parties.filter(party => party.partyLeader === player);
-            return game.turmoil.chairman === "NEUTRAL" && parties.length > 0 &&  game.turmoil.delegate_reserve.indexOf(player) > -1;
+            const parties = game.turmoil.parties.filter(party => party.partyLeader === player.id);
+            return game.turmoil.chairman === "NEUTRAL" && parties.length > 0 &&  game.turmoil.delegate_reserve.indexOf(player.id) > -1;
         }
         return false;
     }
 
     public play(player: Player, game: Game) {
         if (game.turmoil !== undefined) {
-            game.turmoil.chairman! = player;
-            const index = game.turmoil.delegate_reserve.indexOf(player);
+            game.turmoil.chairman! = player.id;
+            const index = game.turmoil.delegate_reserve.indexOf(player.id);
             if (index > -1) {
                 game.turmoil.delegate_reserve.splice(index, 1);
             }

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -1,4 +1,4 @@
-import { Player } from '../Player';
+import { Player, PlayerId } from "../Player";
 import { SelectSpace } from '../inputs/SelectSpace';
 import { Game } from '../Game';
 import { ColonyName } from './ColonyName';
@@ -13,9 +13,9 @@ export interface IColony {
     name: ColonyName;
     description: string;
     isActive: boolean;
-    visitor: undefined | Player;
+    visitor: undefined | PlayerId;
     trackPosition: number;
-    colonies: Array<Player>;
+    colonies: Array<PlayerId>;
     resourceType?: ResourceType;
     trade: (player: Player, game: Game) => void;
     onColonyPlaced: (player: Player, game: Game) => undefined | SelectSpace;
@@ -27,8 +27,8 @@ export interface IColony {
 
 export abstract class Colony  {
     public isActive: boolean = true;
-    public visitor: undefined | Player = undefined;
-    public colonies: Array<Player> = [];
+    public visitor: undefined | PlayerId = undefined;
+    public colonies: Array<PlayerId> = [];
     public trackPosition: number = 1;
 
     public endGeneration(): void {
@@ -67,18 +67,18 @@ export abstract class Colony  {
 
     public afterTrade(colony: IColony, player: Player, game: Game): void {
         colony.trackPosition = this.colonies.length;
-        colony.visitor = player;
+        colony.visitor = player.id;
         player.tradesThisTurn++;
         // Trigger current player interrupts first
-        colony.colonies.filter(colonyPlayer => colonyPlayer === player).forEach(player => {
-            colony.giveTradeBonus(player, game);
+        colony.colonies.filter(colonyPlayerId => colonyPlayerId === player.id).forEach(playerId => {
+            colony.giveTradeBonus(game.getPlayerById(playerId), game);
         });
-        colony.colonies.filter(colonyPlayer => colonyPlayer !== player).forEach(player => {
-            colony.giveTradeBonus(player, game);
+        colony.colonies.filter(colonyPlayerId => colonyPlayerId !== player.id).forEach(playerId => {
+            colony.giveTradeBonus(game.getPlayerById(playerId), game);
         });
     }
     public addColony(colony: IColony, player: Player, game: Game): void {
-        colony.colonies.push(player);
+        colony.colonies.push(player.id);
         if (colony.trackPosition < colony.colonies.length) {
             colony.trackPosition = colony.colonies.length;
         }

--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -9,7 +9,7 @@ export interface IDatabase {
     cleanSaves(game_id: string, save_id: number): void;
     restoreGame(game_id: string, save_id: number, game: Game): void;
     restoreGameLastSave(game_id:string, game: Game, cb:(err: any) => void): void;
-    saveGameState(game_id: string, save_id: number, game: string): void;
+    saveGameState(game_id: string, save_id: number, game: string, players: number): void;
     getGames(cb:(err: any, allGames:Array<string>) => void): void;
     restoreReferenceGame(game_id:string, game: Game, cb:(err: any) => void): void;
     getClonableGames( cb:(err: any, allGames:Array<IGameData>)=> void) : void;

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -15,17 +15,23 @@ export class PostgreSQL implements IDatabase {
             }
         });
         this.client.connect();
-        this.client.query("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', created_time timestamp default now(), PRIMARY KEY (game_id, save_id))", (err) => {
+        this.client.query("CREATE TABLE IF NOT EXISTS games(game_id varchar, players integer, save_id integer, game text, status text default 'running', created_time timestamp default now(), PRIMARY KEY (game_id, save_id))", (err) => {
             if (err) {
                 throw err;
             }
             console.log("Connected to PostgreSQL");
         });
+        this.client.query("CREATE INDEX IF NOT EXISTS games_i1 on games(save_id)", (err) => {
+            if (err) {
+                throw err;
+            }
+            console.log("Connected to PostgreSQL");
+        });        
     }
 
     getClonableGames( cb:(err: any, allGames:Array<IGameData>)=> void) {
         const allGames:Array<IGameData> = [];
-        const sql = "SELECT distinct game_id game_id, game FROM games WHERE status = 'running' and save_id = 0 order by game_id asc";
+        const sql = "SELECT distinct game_id game_id, players players FROM games WHERE status = 'running' and save_id = 0 order by game_id asc";
 
         this.client.query(sql, (err, res) => {
             if (err) {
@@ -35,7 +41,7 @@ export class PostgreSQL implements IDatabase {
             }
             for (const row of res.rows) {
                 const gameId:string = row.game_id;
-                const playerCount: number = JSON.parse(row.game).players.length;
+                const playerCount: number = row.players;
                 const gameData:IGameData = {
                     gameId,
                     playerCount
@@ -143,9 +149,9 @@ export class PostgreSQL implements IDatabase {
         });
     }
 
-    saveGameState(game_id: string, save_id: number, game: string): void {
+    saveGameState(game_id: string, save_id: number, game: string, players: number): void {
         // Insert
-        this.client.query("INSERT INTO games(game_id, save_id, game) VALUES($1, $2, $3)", [game_id, save_id, game], (err) => {
+        this.client.query("INSERT INTO games(game_id, save_id, game, players) VALUES($1, $2, $3, $4)", [game_id, save_id, game, players], (err) => {
             if (err) {
                 //Should be a duplicate, does not matter
                 return;

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -17,18 +17,18 @@ export class SQLite implements IDatabase {
             fs.mkdirSync(dbFolder);
         }
         this.db = new sqlite3.Database(dbPath);
-        this.db.run("CREATE TABLE IF NOT EXISTS games(game_id varchar, save_id integer, game text, status text default 'running', created_time timestamp default (strftime('%s', 'now')), PRIMARY KEY (game_id, save_id))");
+        this.db.run("CREATE TABLE IF NOT EXISTS games(game_id varchar, players integer, save_id integer, game text, status text default 'running', created_time timestamp default (strftime('%s', 'now')), PRIMARY KEY (game_id, save_id))");
     }
 
     getClonableGames( cb:(err: any, allGames:Array<IGameData>)=> void) {
         var allGames:Array<IGameData> = [];
-        var sql = "SELECT distinct game_id game_id, game FROM games WHERE status = 'running' and save_id = 0 order by game_id asc";
+        var sql = "SELECT distinct game_id game_id, players players FROM games WHERE status = 'running' and save_id = 0 order by game_id asc";
   
         this.db.all(sql, [], (err, rows) => {
             if (rows) {
                 rows.forEach((row) => {
                     let gameId:string = row.game_id;
-                    let playerCount: number = JSON.parse(row.game).players.length;
+                    let playerCount: number = row.players;
                     let gameData:IGameData = {
                         gameId,
                         playerCount
@@ -116,9 +116,9 @@ export class SQLite implements IDatabase {
         });
     }
 
-    saveGameState(game_id: string, save_id: number, game: string): void {
+    saveGameState(game_id: string, save_id: number, game: string, players: number): void {
         // Insert
-        this.db.run("INSERT INTO games(game_id, save_id, game) VALUES(?, ?, ?)", [game_id, save_id, game], function(err: { message: any; }) {
+        this.db.run("INSERT INTO games(game_id, save_id, game, players) VALUES(?, ?, ?, ?)", [game_id, save_id, game, players], function(err: { message: any; }) {
             if (err) {
                 //Should be a duplicate, does not matter
                 return;  

--- a/src/interrupts/SelectParty.ts
+++ b/src/interrupts/SelectParty.ts
@@ -1,6 +1,6 @@
 import { Game } from '../Game';
 import { PlayerInput } from '../PlayerInput';
-import { Player } from '../Player';
+import { Player, PlayerId } from "../Player";
 import { PlayerInterrupt } from './PlayerInterrupt';
 import { OrOptions } from '../inputs/OrOptions';
 import { SelectOption } from '../inputs/SelectOption';
@@ -15,7 +15,7 @@ export class SelectParty implements PlayerInterrupt {
         public game: Game,
         public title: string = "Select where to send a delegate",
         public nbr: number = 1,
-        public replace: "NEUTRAL" | Player | undefined = undefined,
+        public replace: "NEUTRAL" | PlayerId | undefined = undefined,
         public price: number | undefined = undefined,
         public fromLobby: boolean = true
     ){
@@ -49,7 +49,7 @@ export class SelectParty implements PlayerInterrupt {
                   if (replace) {
                     game.turmoil?.removeDelegateFromParty(replace, party.name, game);
                   }
-                  game.turmoil?.sendDelegateToParty(player, party.name, game, fromLobby);
+                  game.turmoil?.sendDelegateToParty(player.id, party.name, game, fromLobby);
                 }
                 game.log(
                   LogMessageType.DEFAULT,

--- a/src/turmoil/SerializedTurmoil.ts
+++ b/src/turmoil/SerializedTurmoil.ts
@@ -1,14 +1,14 @@
 import { IParty } from "./parties/IParty";
 import { GlobalEventDealer } from "./globalEvents/GlobalEventDealer";
 import { IGlobalEvent } from "./globalEvents/IGlobalEvent";
-import { SerializedPlayer } from "../SerializedPlayer";
+import { PlayerId } from "../Player";
 
 export interface SerializedTurmoil {
-    chairman: undefined | SerializedPlayer | "NEUTRAL";
+    chairman: undefined | PlayerId | "NEUTRAL";
     rulingParty: undefined | IParty;
     dominantParty: undefined | IParty;
     lobby: Set<string>;
-    delegate_reserve: Array<SerializedPlayer | "NEUTRAL">;
+    delegate_reserve: Array<PlayerId | "NEUTRAL">;
     parties: Array<IParty>;
     playersInfluenceBonus: Map<string, number>;
     globalEventDealer: GlobalEventDealer;

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -6,7 +6,7 @@ import { Unity } from "./parties/Unity";
 import { Kelvinists } from "./parties/Kelvinists";
 import { Reds } from "./parties/Reds";
 import { Greens } from "./parties/Greens";
-import { Player } from "../Player";
+import { Player, PlayerId } from "../Player";
 import { Game } from "../Game";
 import { GlobalEventDealer, getGlobalEventByName } from "./globalEvents/GlobalEventDealer";
 import { IGlobalEvent } from "./globalEvents/IGlobalEvent";
@@ -31,11 +31,11 @@ export const ALL_PARTIES: Array<IPartyFactory<IParty>> = [
 ];
 
 export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
-    public chairman: undefined | Player | "NEUTRAL" = undefined;
+    public chairman: undefined | PlayerId | "NEUTRAL" = undefined;
     public rulingParty: undefined | IParty = undefined;
     public dominantParty: undefined | IParty = undefined;
-    public lobby: Set<string> = new Set<string>();
-    public delegate_reserve: Array<Player | "NEUTRAL"> = new Array<Player | "NEUTRAL">();
+    public lobby: Set<PlayerId> = new Set<PlayerId>();
+    public delegate_reserve: Array<PlayerId | "NEUTRAL"> = new Array<PlayerId | "NEUTRAL">();
     public parties: Array<IParty> = [];
     public playersInfluenceBonus: Map<string, number> = new Map<string, number>();
     public globalEventDealer: GlobalEventDealer;
@@ -52,7 +52,7 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
             this.lobby.add(player.id);
             // Begin with six delegates in the delegate reserve
             for (let i = 0; i < 6; i++) {
-                this.delegate_reserve.push(player);   
+                this.delegate_reserve.push(player.id);   
             }
         });
 
@@ -91,19 +91,19 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
     }
 
     // Use to send a delegate to a specific party
-    public sendDelegateToParty(player: Player | "NEUTRAL", partyName: PartyName, game: Game, fromLobby: boolean = true): void {
+    public sendDelegateToParty(playerId: PlayerId | "NEUTRAL", partyName: PartyName, game: Game, fromLobby: boolean = true): void {
         const party = this.getPartyByName(partyName);
         if (party) {
-            if (player != "NEUTRAL" && this.lobby.has(player.id) && fromLobby) {
-                this.lobby.delete(player.id);
+            if (playerId != "NEUTRAL" && this.lobby.has(playerId) && fromLobby) {
+                this.lobby.delete(playerId);
             }
             else {
-                const index = this.delegate_reserve.indexOf(player);
+                const index = this.delegate_reserve.indexOf(playerId);
                 if (index > -1) {
                     this.delegate_reserve.splice(index, 1);
                 }
             }
-            party.sendDelegate(player, game);
+            party.sendDelegate(playerId, game);
             this.checkDominantParty(party);
         }
         else {
@@ -112,11 +112,11 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
     }
 
     // Use to remove a delegate from a specific party
-    public removeDelegateFromParty(player: Player | "NEUTRAL", partyName: PartyName, game: Game): void {
+    public removeDelegateFromParty(playerId: PlayerId | "NEUTRAL", partyName: PartyName, game: Game): void {
         const party = this.getPartyByName(partyName);
         if (party) {
-            this.delegate_reserve.push(player);
-            party.removeDelegate(player, game);
+            this.delegate_reserve.push(playerId);
+            party.removeDelegate(playerId, game);
             this.checkDominantParty(party);
         }
         else {
@@ -202,13 +202,13 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
 
         // 3.c - Fill the lobby
         this.lobby.forEach(playerId => {
-            this.delegate_reserve.push(game.getPlayerById(playerId));
+            this.delegate_reserve.push(playerId);
         });
         this.lobby = new Set<string>();
 
         game.getPlayers().forEach(player => {
-            if (this.getDelegates(player) > 0) { 
-                const index = this.delegate_reserve.indexOf(player);
+            if (this.getDelegates(player.id) > 0) { 
+                const index = this.delegate_reserve.indexOf(player.id);
                 if (index > -1) {
                     this.delegate_reserve.splice(index, 1);
                 }
@@ -250,13 +250,13 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
             
             this.chairman = this.rulingParty.partyLeader;
             if (this.chairman) {
-                if (this.chairman instanceof Player) {
-                    this.chairman.increaseTerraformRating(game);
+                if (this.chairman !== "NEUTRAL") {
+                    game.getPlayerById(this.chairman).increaseTerraformRating(game);
 
                     game.log(
                         LogMessageType.DEFAULT,
                         "${0} is the new chairman and got 1 TR increase",
-                        new LogMessageData(LogMessageDataType.PLAYER, this.chairman.id));
+                        new LogMessageData(LogMessageDataType.PLAYER, this.chairman));
                 }
             }
             else {
@@ -271,15 +271,15 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
 
             // Clean the party
             this.rulingParty.partyLeader = undefined;
-            this.rulingParty.delegates = new Array<Player>();
+            this.rulingParty.delegates = new Array<PlayerId>();
         }
     }
 
     public getPlayerInfluence(player: Player) {
         let influence: number = 0;
-        if (this.chairman !== undefined && this.chairman === player) influence++;
-        if (this.dominantParty !== undefined && this.dominantParty.partyLeader === player) influence++;
-        if (this.dominantParty !== undefined && this.dominantParty.delegates.indexOf(player) !== -1) influence++;
+        if (this.chairman !== undefined && this.chairman === player.id) influence++;
+        if (this.dominantParty !== undefined && this.dominantParty.partyLeader === player.id) influence++;
+        if (this.dominantParty !== undefined && this.dominantParty.delegates.indexOf(player.id) !== -1) influence++;
         if (this.playersInfluenceBonus.has(player.id)) {
             const bonus = this.playersInfluenceBonus.get(player.id);
             if (bonus) {
@@ -307,7 +307,7 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
         }
         
         let party = this.getPartyByName(partyName);
-        if (party !== undefined && party.getDelegates(player) >= 2) {
+        if (party !== undefined && party.getDelegates(player.id) >= 2) {
             return true;
         }
 
@@ -315,22 +315,22 @@ export class Turmoil implements ILoadable<SerializedTurmoil, Turmoil> {
     }
 
     // List players present in the reserve
-    public getPresentPlayers(): Array<Player | "NEUTRAL"> {
+    public getPresentPlayers(): Array<PlayerId | "NEUTRAL"> {
         return Array.from(new Set(this.delegate_reserve));
     }
 
     // Return number of delegate
-    public getDelegates(player: Player | "NEUTRAL"): number {
-        let delegates = this.delegate_reserve.filter(p => p === player).length;
+    public getDelegates(playerId: PlayerId | "NEUTRAL"): number {
+        let delegates = this.delegate_reserve.filter(p => p === playerId).length;
         return delegates;
     }
 
     // Get Victory Points
     public getPlayerVictoryPoints(player: Player): number {
         let victory: number = 0;
-        if (this.chairman !== undefined && this.chairman === player) victory++;
+        if (this.chairman !== undefined && this.chairman === player.id) victory++;
         this.parties.forEach(function(party) {
-            if (party.partyLeader === player) {
+            if (party.partyLeader === player.id) {
                 victory++;
             }
         });

--- a/src/turmoil/globalEvents/JovianTaxRights.ts
+++ b/src/turmoil/globalEvents/JovianTaxRights.ts
@@ -14,7 +14,7 @@ export class JovianTaxRights implements IGlobalEvent {
         game.getPlayers().forEach(player => {
             let coloniesCount: number = 0;
             game.colonies.forEach(colony => { 
-                coloniesCount += colony.colonies.filter(owner => owner === player).length;
+                coloniesCount += colony.colonies.filter(owner => owner === player.id).length;
             });  
             player.setProduction(Resources.MEGACREDITS, coloniesCount, game, undefined, true);
             player.setResource(Resources.TITANIUM, turmoil.getPlayerInfluence(player), game, undefined, true);

--- a/src/turmoil/parties/IParty.ts
+++ b/src/turmoil/parties/IParty.ts
@@ -1,17 +1,16 @@
 import { PartyName } from "./PartyName";
-import { Player } from '../../Player';
+import { PlayerId } from "../../Player";
 import { Game } from '../../Game';
 
 
 export interface IParty {
     name: PartyName;
     description: string;
-    delegates: Array<Player | "NEUTRAL">;
-    partyLeader: undefined | Player | "NEUTRAL";
-    sendDelegate: (player: Player | "NEUTRAL", game: Game) => void;
-    removeDelegate: (player: Player | "NEUTRAL", game: Game) => void;
+    delegates: Array<PlayerId | "NEUTRAL">;
+    partyLeader: undefined | PlayerId | "NEUTRAL";
+    sendDelegate: (playerId: PlayerId | "NEUTRAL", game: Game) => void;
+    removeDelegate: (playerId: PlayerId | "NEUTRAL", game: Game) => void;
     rulingBonus: (game: Game) => void;
-    //rulingPolicy: (player: Player, game: Game) => void;
-    getPresentPlayers(): Array<Player | "NEUTRAL">;
-    getDelegates:(player: Player | "NEUTRAL") => number;
+    getPresentPlayers(): Array<PlayerId | "NEUTRAL">;
+    getDelegates:(player: PlayerId | "NEUTRAL") => number;
 }

--- a/src/turmoil/parties/Party.ts
+++ b/src/turmoil/parties/Party.ts
@@ -30,7 +30,7 @@ export abstract class Party  {
                 if (this.getDelegates(this.partyLeader) != max) {
                     let currentIndex = 0;
                     if (this.partyLeader === "NEUTRAL") {
-                        currentIndex = game.getPlayers().indexOf(game.activePlayer);
+                        currentIndex = game.getPlayers().indexOf(game.getPlayerById(game.activePlayer));
                     }
                     else {
                         currentIndex = game.getPlayers().indexOf(game.getPlayerById(this.partyLeader));

--- a/src/turmoil/parties/Party.ts
+++ b/src/turmoil/parties/Party.ts
@@ -1,24 +1,24 @@
-import { Player } from '../../Player';
+import { Player, PlayerId } from "../../Player";
 import { Game } from '../../Game';
 
 export abstract class Party  {
-    public partyLeader: undefined | Player | "NEUTRAL" = undefined;
-    public delegates: Array<Player|"NEUTRAL"> = [];
+    public partyLeader: undefined | PlayerId | "NEUTRAL" = undefined;
+    public delegates: Array<PlayerId|"NEUTRAL"> = [];
 
     // Send a delegate in the area
-    public sendDelegate(player: Player | "NEUTRAL", game: Game): void {
-        this.delegates.push(player);
-        this.checkPartyLeader(player, game);
+    public sendDelegate(playerId: PlayerId | "NEUTRAL", game: Game): void {
+        this.delegates.push(playerId);
+        this.checkPartyLeader(playerId, game);
     }
 
     // Remove a delegate from the area
-    public removeDelegate(player: Player | "NEUTRAL", game: Game): void {
-        this.delegates.splice(this.delegates.indexOf(player),1);
-        this.checkPartyLeader(player, game);
+    public removeDelegate(playerId: PlayerId | "NEUTRAL", game: Game): void {
+        this.delegates.splice(this.delegates.indexOf(playerId),1);
+        this.checkPartyLeader(playerId, game);
     }
 
     // Check if you are the new party leader 
-    public checkPartyLeader(newPlayer: Player | "NEUTRAL", game: Game): void {
+    public checkPartyLeader(newPlayer: PlayerId | "NEUTRAL", game: Game): void {
         // If there is a party leader
         if (this.partyLeader) {
             if (game) {
@@ -33,7 +33,7 @@ export abstract class Party  {
                         currentIndex = game.getPlayers().indexOf(game.activePlayer);
                     }
                     else {
-                        currentIndex = game.getPlayers().indexOf(this.partyLeader);
+                        currentIndex = game.getPlayers().indexOf(game.getPlayerById(this.partyLeader));
                     }
             
                     let playersToCheck = new Array<Player | "NEUTRAL">();
@@ -56,8 +56,14 @@ export abstract class Party  {
                     playersToCheck.push("NEUTRAL");
                     
                     playersToCheck.some(nextPlayer => {
-                        if (this.getDelegates(nextPlayer) === max) {
-                            this.partyLeader = nextPlayer;
+                        let nextPlayerId = "";
+                        if (nextPlayer === "NEUTRAL") {
+                          nextPlayerId = "NEUTRAL";
+                        } else {
+                          nextPlayerId = nextPlayer.id;
+                        }
+                        if (this.getDelegates(nextPlayerId) === max) {
+                            this.partyLeader = nextPlayerId;
                             return true;
                         }
                         return false;
@@ -71,12 +77,12 @@ export abstract class Party  {
     }
 
     // List players present in this party
-    public getPresentPlayers(): Array<Player | "NEUTRAL"> {
+    public getPresentPlayers(): Array<PlayerId | "NEUTRAL"> {
         return Array.from(new Set(this.delegates));
     }
 
     // Return number of delegate
-    public getDelegates(player: Player | "NEUTRAL"): number {
+    public getDelegates(player: PlayerId | "NEUTRAL"): number {
         let delegates = this.delegates.filter(p => p === player).length;
         return delegates;
     }

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -64,9 +64,9 @@ describe("Turmoil", function () {
             const greens = turmoil.getPartyByName(PartyName.GREENS);
             if (greens) {
                 greens.delegates = [];
-                turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+                turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
                 expect(greens.delegates.length).to.eq(1);
-                expect(greens.delegates[0]).to.eq(player);
+                expect(game.getPlayerById(greens.delegates[0])).to.eq(player);
             }
         }
     });
@@ -101,15 +101,15 @@ describe("Turmoil", function () {
                 greens.delegates = [];
                 reds.delegates = [];
             }
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
             expect(turmoil.dominantParty).to.eq(greens);
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
             expect(turmoil.dominantParty).to.eq(greens);
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
             expect(turmoil.dominantParty).to.eq(reds);     
         }   
     });
@@ -137,10 +137,10 @@ describe("Turmoil", function () {
         const game = new Game("foobar", [player], player, gameOptions);  
         let turmoil = game.turmoil;
         if (turmoil) {
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            expect(turmoil.getPartyByName(PartyName.GREENS)!.partyLeader).to.eq(player);   
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            expect(game.getPlayerById(turmoil.getPartyByName(PartyName.GREENS)!.partyLeader!)).to.eq(player);   
         } 
     });
 
@@ -167,15 +167,16 @@ describe("Turmoil", function () {
         const game = new Game("foobar", [player], player, gameOptions);  
         let turmoil = game.turmoil;
         if (turmoil) {
-            turmoil.sendDelegateToParty(player, PartyName.MARS, game);
-            turmoil.sendDelegateToParty(player, PartyName.MARS, game);
-            turmoil.sendDelegateToParty(player, PartyName.MARS, game);
-            turmoil.sendDelegateToParty(player, PartyName.MARS, game);
-            turmoil.sendDelegateToParty(player, PartyName.MARS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.MARS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.MARS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.MARS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.MARS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.MARS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
             turmoil.endGeneration(game);
-            expect(turmoil.chairman).to.eq(player);
+            expect(game.getPlayerById(turmoil.chairman!)).to.eq(player);
+
             expect(turmoil.lobby.size).to.eq(1);
             expect(turmoil.rulingParty).to.eq(turmoil.getPartyByName(PartyName.MARS));
             expect(turmoil.dominantParty).to.eq(turmoil.getPartyByName(PartyName.GREENS));

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -20,8 +20,8 @@ describe("EcologyResearch", function () {
         let colony1 = new Luna();
         let colony2 = new Triton();
 
-        colony1.colonies.push(player);
-        colony2.colonies.push(player);
+        colony1.colonies.push(player.id);
+        colony2.colonies.push(player.id);
 
         game.colonies.push(colony1);
         game.colonies.push(colony2);
@@ -38,7 +38,7 @@ describe("EcologyResearch", function () {
         const game = new Game("foobar", [player], player);
 
         let colony1 = new Luna();
-        colony1.colonies.push(player);
+        colony1.colonies.push(player.id);
         game.colonies.push(colony1);
 
         const tardigrades = new Tardigrades();
@@ -59,7 +59,7 @@ describe("EcologyResearch", function () {
         const game = new Game("foobar", [player], player);
 
         let colony1 = new Luna();
-        colony1.colonies.push(player);
+        colony1.colonies.push(player.id);
         game.colonies.push(colony1);
 
         const tardigrades = new Tardigrades();

--- a/tests/cards/colonies/MolecularPrinting.spec.ts
+++ b/tests/cards/colonies/MolecularPrinting.spec.ts
@@ -16,8 +16,8 @@ describe("MolecularPrinting", function () {
         let colony1 = new Luna();
         let colony2 = new Triton();
 
-        colony1.colonies.push(player);
-        colony2.colonies.push(player);
+        colony1.colonies.push(player.id);
+        colony2.colonies.push(player.id);
 
         game.colonies.push(colony1);
         game.colonies.push(colony2);

--- a/tests/cards/colonies/ProductiveOutpost.spec.ts
+++ b/tests/cards/colonies/ProductiveOutpost.spec.ts
@@ -15,8 +15,8 @@ describe("ProductiveOutpost", function () {
         let colony1 = new Luna();
         let colony2 = new Triton();
 
-        colony1.colonies.push(player);
-        colony2.colonies.push(player);
+        colony1.colonies.push(player.id);
+        colony2.colonies.push(player.id);
 
         game.colonies.push(colony1);
         game.colonies.push(colony2);

--- a/tests/cards/colonies/QuantumCommunications.spec.ts
+++ b/tests/cards/colonies/QuantumCommunications.spec.ts
@@ -16,8 +16,8 @@ describe("QuantumCommunications", function () {
         let colony1 = new Luna();
         let colony2 = new Triton();
 
-        colony1.colonies.push(player);
-        colony2.colonies.push(player);
+        colony1.colonies.push(player.id);
+        colony2.colonies.push(player.id);
 
         game.colonies.push(colony1);
         game.colonies.push(colony2);

--- a/tests/cards/colonies/SpacePort.spec.ts
+++ b/tests/cards/colonies/SpacePort.spec.ts
@@ -20,7 +20,7 @@ describe("SpacePort", function () {
         const game = new Game("foobar", [player,player2], player);
         player.setProduction(Resources.ENERGY);
         let colony = new Ceres();
-        colony.colonies.push(player);
+        colony.colonies.push(player.id);
         game.colonies.push(colony);
         expect(card.canPlay(player,game)).to.eq(true);
         const action = card.play(player, game);

--- a/tests/cards/colonies/UrbanDecomposers.spec.ts
+++ b/tests/cards/colonies/UrbanDecomposers.spec.ts
@@ -24,7 +24,7 @@ describe("UrbanDecomposers", function () {
         lands[0].tile = { tileType: TileType.CITY };
 
         let colony = new Luna();
-        colony.colonies.push(player);
+        colony.colonies.push(player.id);
         game.colonies.push(colony);
         
         expect(card.canPlay(player, game)).to.eq(true);

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -34,7 +34,7 @@ describe("AerialLenses", function () {
         if (game.turmoil !== undefined) {
             let kelvinists = game.turmoil.getPartyByName(PartyName.KELVINISTS);
             if (kelvinists !== undefined) {
-                kelvinists.delegates.push(player, player);
+                kelvinists.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -30,7 +30,7 @@ describe("Banned Delegate", function () {
         const game = new Game("foobar", [player,player], player, gameOptions);  
         expect(card.canPlay(player, game)).to.eq(false);
         if (game.turmoil !== undefined) {
-            game.turmoil.chairman = player;
+            game.turmoil.chairman = player.id;
             expect(card.canPlay(player, game)).to.eq(true);
         }
     });

--- a/tests/cards/turmoil/DiasporaMovement.spec.ts
+++ b/tests/cards/turmoil/DiasporaMovement.spec.ts
@@ -39,7 +39,7 @@ describe("DiasporaMovement", function () {
         if (game.turmoil !== undefined) {
             let reds = game.turmoil.getPartyByName(PartyName.REDS);
             if (reds !== undefined) {
-                reds.delegates.push(player, player);
+                reds.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/EventAnalysts.spec.ts
+++ b/tests/cards/turmoil/EventAnalysts.spec.ts
@@ -31,9 +31,9 @@ describe("EventAnalysts", function () {
         const game = new Game("foobar", [player], player, gameOptions);  
         expect(card.canPlay(player, game)).to.eq(false);
         if (game.turmoil !== undefined) {
-            game.turmoil.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
-            game.turmoil.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
-            game.turmoil.sendDelegateToParty(player, PartyName.SCIENTISTS, game);
+            game.turmoil.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
+            game.turmoil.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
+            game.turmoil.sendDelegateToParty(player.id, PartyName.SCIENTISTS, game);
             expect(card.canPlay(player, game)).to.eq(true); 
             card.play(player, game);
             expect(game.turmoil.getPlayerInfluence(player)).to.eq(3);

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -34,7 +34,7 @@ describe("GMOContract", function () {
             expect(card.canPlay(player, game)).to.eq(false);
             let greens = game.turmoil.getPartyByName(PartyName.GREENS);
             if (greens !== undefined) {
-                greens.delegates.push(player, player);
+                greens.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
             card.play();

--- a/tests/cards/turmoil/MartianMediaCenter.spec.ts
+++ b/tests/cards/turmoil/MartianMediaCenter.spec.ts
@@ -34,7 +34,7 @@ describe("MartianMediaCenter", function () {
         if (game.turmoil !== undefined) {
             let mars = game.turmoil.getPartyByName(PartyName.MARS);
             if (mars !== undefined) {
-                mars.delegates.push(player, player);
+                mars.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
             card.play(player);

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -38,7 +38,7 @@ describe("PROffice", function () {
         if (game.turmoil !== undefined) {
             let unity = game.turmoil.getPartyByName(PartyName.UNITY);
             if (unity !== undefined) {
-                unity.delegates.push(player, player);
+                unity.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/ParliamentHall.spec.ts
+++ b/tests/cards/turmoil/ParliamentHall.spec.ts
@@ -38,7 +38,7 @@ describe("ParliamentHall", function () {
         if (game.turmoil !== undefined) {
             let mars = game.turmoil.getPartyByName(PartyName.MARS);
             if (mars !== undefined) {
-                mars.delegates.push(player, player);
+                mars.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/PublicCelebrations.spec.ts
+++ b/tests/cards/turmoil/PublicCelebrations.spec.ts
@@ -30,7 +30,7 @@ describe("PublicCelebrations", function () {
         const game = new Game("foobar", [player], player, gameOptions);  
         expect(card.canPlay(player, game)).to.eq(false);
         if (game.turmoil !== undefined) {
-            game.turmoil.chairman = player;
+            game.turmoil.chairman = player.id;
             expect(card.canPlay(player, game)).to.eq(true); 
         } 
         card.play();

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -36,7 +36,7 @@ describe("RedTourismWave", function () {
         if (game.turmoil !== undefined) {
             let reds = game.turmoil.getPartyByName(PartyName.REDS);
             if (reds !== undefined) {
-                reds.delegates.push(player, player);
+                reds.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/SeptumTribus.spec.ts
+++ b/tests/cards/turmoil/SeptumTribus.spec.ts
@@ -40,14 +40,14 @@ describe("SeptumTribus", function () {
         expect(game.turmoil).not.to.eq(undefined);
 
         if (turmoil) {
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
-            turmoil.sendDelegateToParty(player, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.REDS, game);
             card.action(player, game);
             expect(player.megaCredits).to.eq(2);
 
             player.megaCredits = 0;
-            turmoil.sendDelegateToParty(player, PartyName.KELVINISTS, game);
-            turmoil.sendDelegateToParty(player, PartyName.GREENS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.KELVINISTS, game);
+            turmoil.sendDelegateToParty(player.id, PartyName.GREENS, game);
             card.action(player, game);
             expect(player.megaCredits).to.eq(6);
         }

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -34,7 +34,7 @@ describe("SponsoredMohole", function () {
         if (game.turmoil !== undefined) {
             let kelvinists = game.turmoil.getPartyByName(PartyName.KELVINISTS);
             if (kelvinists !== undefined) {
-                kelvinists.delegates.push(player, player);
+                kelvinists.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -33,7 +33,7 @@ describe("SupportedResearch", function () {
         if (game.turmoil !== undefined) {
             let scientists = game.turmoil.getPartyByName(PartyName.SCIENTISTS);
             if (scientists !== undefined) {
-                scientists.delegates.push(player, player);
+                scientists.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -35,11 +35,11 @@ describe("VoteOfNoConfidence", function () {
             expect(card.canPlay(player, game)).to.eq(false);
             let greens = game.turmoil.getPartyByName(PartyName.GREENS);
             if (greens !== undefined) {
-                greens.partyLeader = player;
+                greens.partyLeader = player.id;
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
             card.play(player, game);
-            expect(game.turmoil.chairman).to.eq(player);
+            expect(game.getPlayerById(game.turmoil.chairman)).to.eq(player);           
             expect(player.getTerraformRating()).to.eq(15);
         }
     });

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -34,7 +34,7 @@ describe("WildlifeDome", function () {
             expect(card.canPlay(player, game)).to.eq(false);
             let greens = game.turmoil.getPartyByName(PartyName.GREENS);
             if (greens !== undefined) {
-                greens.delegates.push(player, player);
+                greens.delegates.push(player.id, player.id);
                 expect(card.canPlay(player, game)).to.eq(true); 
             }
         } 

--- a/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
+++ b/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
@@ -15,11 +15,11 @@ describe("AquiferReleasedByPublicCouncil", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player);
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player.id);
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.STEEL)).to.eq(1);
         expect(player2.getResource(Resources.STEEL)).to.eq(3);

--- a/tests/globalEvents/AsteroidMining.spec.ts
+++ b/tests/globalEvents/AsteroidMining.spec.ts
@@ -19,10 +19,10 @@ describe("AsteroidMining", function () {
         player.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.TITANIUM)).to.eq(1);
         expect(player2.getResource(Resources.TITANIUM)).to.eq(5);

--- a/tests/globalEvents/CelebrityLeaders.spec.ts
+++ b/tests/globalEvents/CelebrityLeaders.spec.ts
@@ -19,10 +19,10 @@ describe("CelebrityLeaders", function () {
         player.playedCards.push(new Virus());
         player2.playedCards.push(new Virus());
         player2.playedCards.push(new Virus());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 10;
         player2.megaCredits = 10;
         card.resolve(game, turmoil);

--- a/tests/globalEvents/CloudSocieties.spec.ts
+++ b/tests/globalEvents/CloudSocieties.spec.ts
@@ -14,10 +14,10 @@ describe("CloudSocieties", function () {
         const game = new Game("foobar", [player], player);
         const turmoil = new Turmoil(game);
         player.playedCards.push(new FloatingHabs());
-        turmoil.chairman = player;
+        turmoil.chairman = player.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player;
-        turmoil.dominantParty.delegates.push(player);
+        turmoil.dominantParty.partyLeader = player.id;
+        turmoil.dominantParty.delegates.push(player.id);
         card.resolve(game, turmoil);
         expect(player.playedCards[0].resourceCount).to.eq(1);
     });

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -13,10 +13,10 @@ describe("CorrosiveRain", function () {
         const player2 = new Player("test2", Color.RED, false);
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 15;
         player2.megaCredits = 15;
         card.resolve(game, turmoil);

--- a/tests/globalEvents/Diversity.spec.ts
+++ b/tests/globalEvents/Diversity.spec.ts
@@ -21,10 +21,10 @@ describe("Diversity", function () {
         player2.playedCards.push(new AdvancedEcosystems());
         player2.playedCards.push(new EarlySettlement());
         player2.playedCards.push(new SolarWindPower());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(0);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(10);

--- a/tests/globalEvents/EcoSabotage.spec.ts
+++ b/tests/globalEvents/EcoSabotage.spec.ts
@@ -15,10 +15,10 @@ describe("EcoSabotage", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.plants = 5;
         player2.plants = 5;
         card.resolve(game, turmoil);

--- a/tests/globalEvents/Election.spec.ts
+++ b/tests/globalEvents/Election.spec.ts
@@ -20,10 +20,10 @@ describe("Election", function () {
         player2.playedCards.push(new StripMine());
         player2.playedCards.push(new StripMine());
         game.addCityTile(player3, game.board.getAvailableSpacesOnLand(player3)[0].id);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getTerraformRating()).to.eq(21);
         expect(player2.getTerraformRating()).to.eq(22);

--- a/tests/globalEvents/GenerousFunding.spec.ts
+++ b/tests/globalEvents/GenerousFunding.spec.ts
@@ -15,10 +15,10 @@ describe("GenerousFunding", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 10;
         player2.megaCredits = 10;
         player.setTerraformRating(25);

--- a/tests/globalEvents/GlobalDustStorm.spec.ts
+++ b/tests/globalEvents/GlobalDustStorm.spec.ts
@@ -19,10 +19,10 @@ describe("GlobalDustStorm", function () {
         player.playedCards.push(new StripMine());
         player2.playedCards.push(new StripMine());
         player2.playedCards.push(new StripMine());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 10;
         player2.megaCredits = 10;
         player.heat = 7;

--- a/tests/globalEvents/HomeworldSupport.spec.ts
+++ b/tests/globalEvents/HomeworldSupport.spec.ts
@@ -19,10 +19,10 @@ describe("HomeworldSupport", function () {
         player.playedCards.push(new Sponsors());
         player2.playedCards.push(new Sponsors());
         player2.playedCards.push(new Sponsors());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(2);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(10);

--- a/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
+++ b/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
@@ -19,10 +19,10 @@ describe("ImprovedEnergyTemplates", function () {
         player.playedCards.push(new SolarWindPower());
         player2.playedCards.push(new SolarWindPower());
         player2.playedCards.push(new SolarWindPower());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player2.getProduction(Resources.ENERGY)).to.eq(2);

--- a/tests/globalEvents/InterplanetaryTrade.spec.ts
+++ b/tests/globalEvents/InterplanetaryTrade.spec.ts
@@ -19,10 +19,10 @@ describe("InterplanetaryTrade", function () {
         player.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(2);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(10);

--- a/tests/globalEvents/JovianTaxRights.spec.ts
+++ b/tests/globalEvents/JovianTaxRights.spec.ts
@@ -22,10 +22,10 @@ describe("JovianTaxRights", function () {
         colony2.colonies.push(player2.id);
         game.colonies.push(colony1);
         game.colonies.push(colony2);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.TITANIUM)).to.eq(0);
         expect(player2.getResource(Resources.TITANIUM)).to.eq(3);

--- a/tests/globalEvents/JovianTaxRights.spec.ts
+++ b/tests/globalEvents/JovianTaxRights.spec.ts
@@ -18,8 +18,8 @@ describe("JovianTaxRights", function () {
         const turmoil = new Turmoil(game);
         let colony1 = new Luna();
         let colony2 = new Triton();
-        colony1.colonies.push(player2);
-        colony2.colonies.push(player2);
+        colony1.colonies.push(player2.id);
+        colony2.colonies.push(player2.id);
         game.colonies.push(colony1);
         game.colonies.push(colony2);
         turmoil.chairman = player2;

--- a/tests/globalEvents/MinersOnStrike.spec.ts
+++ b/tests/globalEvents/MinersOnStrike.spec.ts
@@ -21,10 +21,10 @@ describe("MinersOnStrike", function () {
         player.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
         player2.playedCards.push(new MethaneFromTitan());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.TITANIUM)).to.eq(4);
         expect(player2.getResource(Resources.TITANIUM)).to.eq(5);

--- a/tests/globalEvents/Pandemic.spec.ts
+++ b/tests/globalEvents/Pandemic.spec.ts
@@ -19,10 +19,10 @@ describe("Pandemic", function () {
         player.playedCards.push(new StripMine());
         player2.playedCards.push(new StripMine());
         player2.playedCards.push(new StripMine());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 10;
         player2.megaCredits = 10;
         card.resolve(game, turmoil);

--- a/tests/globalEvents/ParadigmBreakdown.spec.ts
+++ b/tests/globalEvents/ParadigmBreakdown.spec.ts
@@ -15,11 +15,11 @@ describe("ParadigmBreakdown", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player);
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player.id);
+        turmoil.dominantParty.delegates.push(player2.id);
         player.megaCredits = 10;
         player2.megaCredits = 10;
         card.resolve(game, turmoil);

--- a/tests/globalEvents/Productivity.spec.ts
+++ b/tests/globalEvents/Productivity.spec.ts
@@ -15,10 +15,10 @@ describe("Productivity", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.setProduction(Resources.STEEL, 3);
         player2.setProduction(Resources.STEEL, 3);       
         card.resolve(game, turmoil);

--- a/tests/globalEvents/RedInfluence.spec.ts
+++ b/tests/globalEvents/RedInfluence.spec.ts
@@ -17,10 +17,10 @@ describe("RedInfluence", function () {
         player.setTerraformRating(23);
         player.megaCredits = 10;
         player2.megaCredits = 10;
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(4);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(4);

--- a/tests/globalEvents/Revolution.spec.ts
+++ b/tests/globalEvents/Revolution.spec.ts
@@ -17,11 +17,11 @@ describe("Revolution", function () {
         turmoil.initGlobalEvent(game);
         player.playedCards.push(new Sponsors());
         player2.playedCards.push(new Sponsors());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
+        turmoil.dominantParty.partyLeader = player2.id;
         
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getTerraformRating()).to.eq(19);
         expect(player2.getTerraformRating()).to.eq(18);

--- a/tests/globalEvents/Sabotage.spec.ts
+++ b/tests/globalEvents/Sabotage.spec.ts
@@ -17,10 +17,10 @@ describe("Sabotage", function () {
         turmoil.initGlobalEvent(game);
         player.setProduction(Resources.ENERGY, 1);
         player2.setProduction(Resources.STEEL, 3);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.STEEL)).to.eq(0);
         expect(player2.getResource(Resources.STEEL)).to.eq(3);

--- a/tests/globalEvents/ScientificCommunity.spec.ts
+++ b/tests/globalEvents/ScientificCommunity.spec.ts
@@ -18,10 +18,10 @@ describe("ScientificCommunity", function () {
         const turmoil = new Turmoil(game);
         player.cardsInHand.push(new Ants());
         player2.cardsInHand.push(new SecurityFleet(), new Ants());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(1);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(5);

--- a/tests/globalEvents/SnowCover.spec.ts
+++ b/tests/globalEvents/SnowCover.spec.ts
@@ -13,10 +13,10 @@ describe("SnowCover", function () {
         const player2 = new Player("test2", Color.RED, false);
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player2.cardsInHand.length).to.eq(3);
         expect(game.getTemperature()).to.eq(-30);

--- a/tests/globalEvents/SolarFlare.spec.ts
+++ b/tests/globalEvents/SolarFlare.spec.ts
@@ -19,10 +19,10 @@ describe("SolarFlare", function () {
         player2.playedCards.push(new SpaceStation(), new SpaceStation(), new SpaceStation());
         player.megaCredits = 10;
         player2.megaCredits = 10;
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(7);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(10);

--- a/tests/globalEvents/SolarnetShutdown.spec.ts
+++ b/tests/globalEvents/SolarnetShutdown.spec.ts
@@ -21,10 +21,10 @@ describe("SolarnetShutdown", function () {
         player2.playedCards.push(new InventorsGuild(), new InventorsGuild(), new InventorsGuild());
         player.megaCredits = 10;
         player2.megaCredits = 10;
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(7);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(10);

--- a/tests/globalEvents/SpinoffProducts.spec.ts
+++ b/tests/globalEvents/SpinoffProducts.spec.ts
@@ -19,10 +19,10 @@ describe("SpinoffProducts", function () {
         player.playedCards.push(new Research());
         player2.playedCards.push(new Research());
         player2.playedCards.push(new Research());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(4);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(14);

--- a/tests/globalEvents/SponsoredProjects.spec.ts
+++ b/tests/globalEvents/SponsoredProjects.spec.ts
@@ -25,10 +25,10 @@ describe("SponsoredProjects", function () {
             player2.playedCards[0].resourceCount++;
         }
         player2.playedCards.push(new Fish());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.playedCards[0].resourceCount).to.eq(2);
         expect(player2.playedCards[0].resourceCount).to.eq(2);

--- a/tests/globalEvents/StrongSociety.spec.ts
+++ b/tests/globalEvents/StrongSociety.spec.ts
@@ -15,10 +15,10 @@ describe("StrongSociety", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(2);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(6);

--- a/tests/globalEvents/SucessfulOrganisms.spec.ts
+++ b/tests/globalEvents/SucessfulOrganisms.spec.ts
@@ -15,10 +15,10 @@ describe("SucessfulOrganisms", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.setProduction(Resources.PLANTS, 3);
         player2.setProduction(Resources.PLANTS, 3);       
         card.resolve(game, turmoil);

--- a/tests/globalEvents/VenusInfrastructure.spec.ts
+++ b/tests/globalEvents/VenusInfrastructure.spec.ts
@@ -17,10 +17,10 @@ describe("VenusInfrastructure", function () {
         const turmoil = new Turmoil(game);
         player.playedCards.push(new CorroderSuits());
         player2.playedCards.push(new CorroderSuits(), new CorroderSuits(), new CorroderSuits());
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getResource(Resources.MEGACREDITS)).to.eq(2);
         expect(player2.getResource(Resources.MEGACREDITS)).to.eq(12);

--- a/tests/globalEvents/VolcanicEruptions.spec.ts
+++ b/tests/globalEvents/VolcanicEruptions.spec.ts
@@ -15,10 +15,10 @@ describe("VolcanicEruptions", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         card.resolve(game, turmoil);
         expect(player.getProduction(Resources.HEAT)).to.eq(0);
         expect(player2.getProduction(Resources.HEAT)).to.eq(3);

--- a/tests/globalEvents/WarOnEarth.spec.ts
+++ b/tests/globalEvents/WarOnEarth.spec.ts
@@ -14,10 +14,10 @@ describe("WarOnEarth", function () {
         const game = new Game("foobar", [player,player2], player);
         const turmoil = new Turmoil(game);
         turmoil.initGlobalEvent(game);
-        turmoil.chairman = player2;
+        turmoil.chairman = player2.id;
         turmoil.dominantParty = new Kelvinists();
-        turmoil.dominantParty.partyLeader = player2;
-        turmoil.dominantParty.delegates.push(player2);
+        turmoil.dominantParty.partyLeader = player2.id;
+        turmoil.dominantParty.delegates.push(player2.id);
         player.setTerraformRating(15);
         player2.setTerraformRating(15);
         card.resolve(game, turmoil);


### PR DESCRIPTION
WARNING : this change will make all pending games incompatible with reload. The database must be purged before server restart (drop table games)

Only @bafolts should merge this in master.

This one is big...

Add a players column to the games table. This will avoid clone game API to parse a lot of JSON to extract players count.
Also add an index that will speed up clone game API query.

Use player ids instead on player objects in turmoil, colonies and main game class.

Average 3 player games, with all expansions : JSON save file is 14 701 lines long
After update, JSON save file is 5444 lines long

It will save some space on the database and make JSON processing for reload faster.

Game.first is still a Player because changing this will require to update all create game calls...



