### PR TITLE
Add one-time alert when Mars is terraformed

### DIFF
--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -11,8 +11,12 @@ class GlobalParamLevel {
     }
 }
 
+class AlertDialog {
+    static shouldAlert = true;
+}
+
 export const Board = Vue.component("board", {
-    props: ["spaces", "venusNextExtension", "venusScaleLevel","boardName", "oceans_count", "oxygen_level", "temperature"],
+    props: ["spaces", "venusNextExtension", "venusScaleLevel","boardName", "oceans_count", "oxygen_level", "temperature", "shouldNotify"],
     components: {
         "board-space": BoardSpace
     },
@@ -20,6 +24,12 @@ export const Board = Vue.component("board", {
         return {
             "constants": constants
         }
+    },
+    mounted: function () {
+        if (this.marsIsTerraformed() && this.shouldNotify && AlertDialog.shouldAlert) {
+            alert("Mars is Terraformed!");
+            AlertDialog.shouldAlert = false;
+        };
     },
     methods: {
         getAllSpacesOnMars: function (): Array<SpaceModel> {
@@ -82,6 +92,18 @@ export const Board = Vue.component("board", {
                 css += "val-is-active";
             }
             return css
+        },
+        marsIsTerraformed: function () {
+            const temperatureMaxed = this.temperature === constants.MAX_TEMPERATURE;
+            const oceansMaxed = this.oceans_count === constants.MAX_OCEAN_TILES;
+            const oxygenMaxed = this.oxygen_level === constants.MAX_OXYGEN_LEVEL;
+            const venusMaxed = this.venusScaleLevel === constants.MAX_VENUS_SCALE;
+
+            if (this.venusNextExtension) {
+                return temperatureMaxed && oceansMaxed && oxygenMaxed && venusMaxed;
+            } else {
+                return temperatureMaxed && oceansMaxed && oxygenMaxed;
+            }
         }
     },
     template: `

--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -4,6 +4,7 @@ import * as constants from '../constants';
 import { BoardSpace } from "./BoardSpace";
 import { SpaceModel } from "../models/SpaceModel";
 import { SpaceType } from "../SpaceType";
+import { PreferencesManager } from "./PreferencesManger";
 
 class GlobalParamLevel {
     constructor(public value: number, public isActive: boolean, public strValue: string) {
@@ -26,7 +27,7 @@ export const Board = Vue.component("board", {
         }
     },
     mounted: function () {
-        if (this.marsIsTerraformed() && this.shouldNotify && AlertDialog.shouldAlert) {
+        if (this.marsIsTerraformed() && this.shouldNotify && AlertDialog.shouldAlert && PreferencesManager.loadValue("alert_mars_terraformed") === "1") {
             alert("Mars is Terraformed!");
             AlertDialog.shouldAlert = false;
         };

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -123,7 +123,8 @@ export const GameEnd = Vue.component("game-end", {
                         :boardName ="player.boardName"
                         :oceans_count="player.oceans" 
                         :oxygen_level="player.oxygenLevel" 
-                        :temperature="player.temperature"></board>
+                        :temperature="player.temperature"
+                        :shouldNotify="false"></board>
                 </div>
                 <br/>
                 <div class="game_end_block--log">

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -100,7 +100,8 @@ export const PlayerHome = Vue.component("player-home", {
                         :boardName ="player.boardName"
                         :oceans_count="player.oceans" 
                         :oxygen_level="player.oxygenLevel" 
-                        :temperature="player.temperature"></board>
+                        :temperature="player.temperature"
+                        :shouldNotify="true"></board>
 
                     <turmoil v-if="player.turmoil" :turmoil="player.turmoil"></turmoil>
 

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -19,6 +19,7 @@ export const Preferences = Vue.component("preferences", {
             "remove_background": false,
             "magnify_cards": true,
             "magnify_card_descriptions": true,
+            "alert_mars_terraformed": true,
             "lang": "en",
             "langs": LANGUAGES
         };
@@ -146,6 +147,12 @@ export const Preferences = Vue.component("preferences", {
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="magnify_card_descriptions" />
                             <i class="form-icon"></i> <span v-i18n>Magnify card descriptions on hover</span>
+                        </label>
+                    </div>
+                    <div class="preferences_panel_item">
+                        <label class="form-switch">
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="alert_mars_terraformed" />
+                            <i class="form-icon"></i> <span v-i18n>Alert when Terraforming completed</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item form-group">

--- a/src/components/PreferencesManger.ts
+++ b/src/components/PreferencesManger.ts
@@ -1,5 +1,5 @@
 export class PreferencesManager {
-    static keys: Array<string> = ["hide_corporation", "hide_hand", "hide_cards", "hide_awards_and_milestones", "hide_turnorder", "small_cards", "remove_background", "magnify_cards", "magnify_card_descriptions", "lang"];
+    static keys: Array<string> = ["hide_corporation", "hide_hand", "hide_cards", "hide_awards_and_milestones", "hide_turnorder", "small_cards", "remove_background", "magnify_cards", "magnify_card_descriptions", "alert_mars_terraformed", "lang"];
     static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();
     static localStorageSupported: boolean = typeof window["localStorage"] !== undefined && window["localStorage"] !== null;
 


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/777

- Show an alert only once when Mars is fully terraformed
- Don't show the alert on game_end screen
- Basic alert for now, in future this can be a nicer styled onscreen animation with sound

<img width="895" alt="Screenshot 2020-06-30 at 6 48 56 PM" src="https://user-images.githubusercontent.com/2408094/86118266-1338b180-bb03-11ea-8296-dbefde62f95a.png">
