### PR TITLE
Fix: Experimental Forest should not trigger Greens policy

### DIFF
--- a/src/Phase.ts
+++ b/src/Phase.ts
@@ -4,5 +4,6 @@ export enum Phase {
     END = "end",
     PRODUCTION = "production",
     RESEARCH = "research",
-    DRAFTING = "drafting"
+    DRAFTING = "drafting",
+    PRELUDES = "preludes"
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2013,6 +2013,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
  
       // Prelude cards have to be played first
       if (this.preludeCardsInHand.length > 0) {
+        game.phase = Phase.PRELUDES;
         let preludeMcBonus = this.getPreludeMcBonus(this.preludeCardsInHand);
 
         // Remove unplayable prelude cards
@@ -2030,6 +2031,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             }
         });
         return;
+      } else {
+        game.phase = Phase.ACTION;
       }
 
       if (


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/900

As per rules, party ruling policies are only triggered during action phase, not during playing of initial preludes.