### PR TITLE
DRY base game tests using beforeEach() hook; Increase test coverage

### DIFF
--- a/tests/cards/AICentral.spec.ts
+++ b/tests/cards/AICentral.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { AICentral } from "../../src/cards/AICentral";
 import { Color } from "../../src/Color";
@@ -7,32 +6,34 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("AICentral", function () {
+    let card : AICentral, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new AICentral();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play if not enough science tags to play", function () {
-        const card = new AICentral();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false); 
     });
+
     it("Can't play if no energy production", function () {
-        const card = new AICentral();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card, card, card);
         expect(card.canPlay(player)).to.eq(false); 
     });
+
     it("Should play", function () {
-        const card = new AICentral();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card, card, card);
         player.setProduction(Resources.ENERGY);
+
         card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });
+
     it("Should take action", function () {
-        const card = new AICentral();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(player.cardsInHand.length).to.eq(0);
         card.action(player, game);
         expect(player.cardsInHand.length).to.eq(2);
     });

--- a/tests/cards/AdvancedEcosystems.spec.ts
+++ b/tests/cards/AdvancedEcosystems.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { AdvancedEcosystems } from "../../src/cards/AdvancedEcosystems";
 import { Color } from "../../src/Color";
@@ -9,30 +8,31 @@ import { ResearchCoordination } from "../../src/cards/prelude/ResearchCoordinati
 import { ResearchNetwork } from '../../src/cards/prelude/ResearchNetwork';
 
 describe("AdvancedEcosystems", function () {
+    let card : AdvancedEcosystems, player : Player
+
+    beforeEach(function() {
+        card = new AdvancedEcosystems();
+        player = new Player("test", Color.BLUE, false);
+        player.playedCards.push(new TundraFarming(), new ResearchNetwork());
+    });
+
+    it("Can't play if tag requirements is unmet", function () {
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new AdvancedEcosystems();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(new TundraFarming);
         expect(card.canPlay(player)).to.eq(false);
-        player.playedCards.push(new ResearchNetwork());
-        expect(card.canPlay(player)).to.eq(false);
+
         player.playedCards.push(new Tardigrades());
         expect(card.canPlay(player)).to.eq(true);
+
         card.play();
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(3);
     });
-    it("Can't play if tag requirements is unmet", function () {
-        const card = new AdvancedEcosystems();
-        const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(false);
-    });
+
     it("Can play with two wildcards", function () {
-        const card = new AdvancedEcosystems();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(new ResearchCoordination());
-        player.playedCards.push(new ResearchNetwork());
-        player.playedCards.push(new TundraFarming());
         expect(card.canPlay(player)).to.eq(true); 
     });
 });

--- a/tests/cards/AerobrakedAmmoniaAsteroid.spec.ts
+++ b/tests/cards/AerobrakedAmmoniaAsteroid.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { AerobrakedAmmoniaAsteroid } from "../../src/cards/AerobrakedAmmoniaAsteroid";
 import { Ants } from "../../src/cards/Ants";
@@ -9,10 +8,15 @@ import { Decomposers } from "../../src/cards/Decomposers";
 import { Game } from "../../src/Game";
 
 describe("AerobrakedAmmoniaAsteroid", function () {
+    let card : AerobrakedAmmoniaAsteroid, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new AerobrakedAmmoniaAsteroid();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play without microbe cards", function () {
-        const card = new AerobrakedAmmoniaAsteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
         const action = card.play(player, game);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
@@ -21,10 +25,8 @@ describe("AerobrakedAmmoniaAsteroid", function () {
          // It's okay to not have a card to collect Microbes on
         expect(action).to.eq(undefined); 
     });
+
     it("Adds microbes automatically if only 1 target", function () {
-        const card = new AerobrakedAmmoniaAsteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
 
         const selectedCard = new Ants();
@@ -35,10 +37,8 @@ describe("AerobrakedAmmoniaAsteroid", function () {
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.getResourcesOnCard(selectedCard)).to.eq(2);
     });
+
     it("Adds microbes to another card", function () {
-        const card = new AerobrakedAmmoniaAsteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
 
         // Add card to collect Microbes on

--- a/tests/cards/Algae.spec.ts
+++ b/tests/cards/Algae.spec.ts
@@ -1,21 +1,32 @@
-
 import { expect } from "chai";
 import { Algae } from "../../src/cards/Algae";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { TileType } from "../../src/TileType";
 
 describe("Algae", function () {
+    let card : Algae, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Algae();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Algae();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Algae();
-        const player = new Player("test", Color.BLUE, false);
+        const oceanSpaces = game.board.getAvailableSpacesForOcean(player);
+        for (let i = 0; i < 5; i++) {
+            oceanSpaces[i].tile = { tileType: TileType.OCEAN };
+        }
+
+        expect(card.canPlay(player, game)).to.eq(true);
+        
         card.play(player);
         expect(player.plants).to.eq(1);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);

--- a/tests/cards/AntiGravityTechnology.spec.ts
+++ b/tests/cards/AntiGravityTechnology.spec.ts
@@ -1,19 +1,24 @@
-
 import { expect } from "chai";
 import { AntiGravityTechnology } from "../../src/cards/AntiGravityTechnology";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 
 describe("AntiGravityTechnology", function () {
+    let card : AntiGravityTechnology, player : Player;
+
+    beforeEach(function() {
+        card = new AntiGravityTechnology();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new AntiGravityTechnology();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new AntiGravityTechnology();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card, card, card, card, card, card, card);
+        expect(card.canPlay(player)).to.eq(true);
+
         card.play();
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(3);

--- a/tests/cards/Ants.spec.ts
+++ b/tests/cards/Ants.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Ants } from "../../src/cards/Ants";
 import { Color } from "../../src/Color";
@@ -12,94 +11,78 @@ import { Fish } from "../../src/cards/Fish";
 import { SecurityFleet } from "../../src/cards/SecurityFleet";
 
 describe("Ants", function () {
+    let card : Ants, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Ants();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+    
     it("Can't play without oxygen", function () {
-        const card = new Ants();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        (game as any).oxygenLevel = 3;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Ants();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
+        (game as any).oxygenLevel = 4;
+        expect(card.canPlay(player, game)).to.eq(true);
+
         card.play();
         card.resourceCount += 5;
         expect(card.getVictoryPoints()).to.eq(2);
     });
-    it("Should action with multiple valid targets", function () {
-        const card = new Ants();
-        const cardTardigrades = new Tardigrades();
-        const cardNitriteReducingBacteria = new NitriteReducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("ants_action_game", [player, player2], player);
 
-        expect(card.canAct(player, game)).to.eq(false);
+    it("Should action with multiple valid targets", function () {
+        const tardigrades = new Tardigrades();
+        const nitriteReducingBacteria = new NitriteReducingBacteria();
 
         player.playedCards.push(card);
         expect(card.canAct(player, game)).to.eq(false);
 
-        player.playedCards.push(cardTardigrades);
-        cardTardigrades.resourceCount++;
-
-        player.playedCards.push(cardNitriteReducingBacteria);
-        cardNitriteReducingBacteria.resourceCount++;
+        player.playedCards.push(tardigrades, nitriteReducingBacteria);
+        tardigrades.resourceCount++;
+        nitriteReducingBacteria.resourceCount++;
         
         expect(card.canAct(player, game)).to.eq(true);
 
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
-
         expect(action instanceof SelectCard).to.eq(true);
-        if (action !== undefined) {
-            expect(action.cards.length).to.eq(2);
 
-            expect(action.cards[0]).to.eq(cardTardigrades);
-            action.cb([action.cards[0]]);
-            expect(card.resourceCount).to.eq(1);
-            expect(cardTardigrades.resourceCount).to.eq(0);
-        }
+        expect(action!.cards.length).to.eq(2);
+        expect(action!.cards[0]).to.eq(tardigrades);
+        action!.cb([action!.cards[0]]);
+        expect(card.resourceCount).to.eq(1);
+        expect(tardigrades.resourceCount).to.eq(0);
     });
-    it("Respects protected habitats", function () {
-        const card = new Ants();
-        const protectedHabitatsCard = new ProtectedHabitats();
-        const cardTardigrades = new Tardigrades();
 
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("ants_vs_protected_habitats_game", [player, player2], player);
+    it("Respects protected habitats", function () {
+        const protectedHabitats = new ProtectedHabitats();
+        const tardigrades = new Tardigrades();
 
         player.playedCards.push(card);
-        player2.playedCards.push(cardTardigrades);
-        cardTardigrades.resourceCount += 2;
-
+        player2.playedCards.push(tardigrades);
+        tardigrades.resourceCount += 2;
         expect(card.canAct(player, game)).to.eq(true);
-        player2.playedCards.push(protectedHabitatsCard);
 
+        player2.playedCards.push(protectedHabitats);
         expect(card.canAct(player, game)).to.eq(false);
     });
-    it("Only microbes are available to steal", function () {
-        const card = new Ants();
-        const cardTardigrades = new Tardigrades(); // card with microbes
-        const cardFish = new Fish() // card with animals
-        const securityFleetCard = new SecurityFleet() // card with fighters
 
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("only_microbes_game", [player, player2], player);
+    it("Only microbes are available to steal", function () {
+        const tardigrades = new Tardigrades(); // card with microbes
+        const fish = new Fish() // card with animals
+        const securityFleet = new SecurityFleet() // card with fighters
 
         player.playedCards.push(card);
-        player2.playedCards.push(cardTardigrades);
-        player2.addResourceTo(cardTardigrades);
-
-        player2.playedCards.push(cardFish);
-        player2.addResourceTo(cardFish);
-
-        player2.playedCards.push(securityFleetCard);
-        player2.addResourceTo(securityFleetCard);
+        player2.playedCards.push(tardigrades, fish, securityFleet);
+        player2.addResourceTo(tardigrades);
+        player2.addResourceTo(fish);
+        player2.addResourceTo(securityFleet);
 
         card.action(player, game);
         expect(card.resourceCount).to.eq(1);
-        expect(cardTardigrades.resourceCount).to.eq(0);
+        expect(tardigrades.resourceCount).to.eq(0);
     });
 });

--- a/tests/cards/AquiferPumping.spec.ts
+++ b/tests/cards/AquiferPumping.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { AquiferPumping } from "../../src/cards/AquiferPumping";
 import { Color } from "../../src/Color";
@@ -6,25 +5,46 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("AquiferPumping", function () {
+    let card : AquiferPumping, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new AquiferPumping();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new AquiferPumping();
         expect(card.play()).to.eq(undefined);
     });
+
     it("Should action", function () {
-        const card = new AquiferPumping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
         player.megaCredits = 8;
+
         action.options[0].cb({
             heat: 0,
             steel: 0,
             titanium: 0,
             megaCredits: 8
         });
+
         action.cb();
         expect(player.megaCredits).to.eq(0);
+
+        action.options[0].cb({
+            heat: 0,
+            steel: 0,
+            titanium: 0,
+            megaCredits: 7
+        });
+        expect(function () { action.cb(); }).to.throw("Need to pay 8");
+    });
+
+    it("Cannot action if not enough to pay", function () {
+        expect(card.canAct(player, game)).to.eq(false);
+        const action = card.action(player, game);
+        
         action.options[0].cb({
             heat: 0,
             steel: 0,

--- a/tests/cards/ArchaeBacteria.spec.ts
+++ b/tests/cards/ArchaeBacteria.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ArchaeBacteria } from "../../src/cards/ArchaeBacteria";
 import { Color } from "../../src/Color";
@@ -7,18 +6,20 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("ArchaeBacteria", function () {
+    let card : ArchaeBacteria, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ArchaeBacteria();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new ArchaeBacteria();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseTemperature(player, 3); // -24
-        game.increaseTemperature(player, 3); // -18
-        game.increaseTemperature(player, 3); // -12
+        (game as any).temperature = -12;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+    
     it("Should play", function () {
-        const card = new ArchaeBacteria();
-        const player = new Player("test", Color.BLUE, false);
         card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });

--- a/tests/cards/ArcticAlgae.spec.ts
+++ b/tests/cards/ArcticAlgae.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ArcticAlgae } from "../../src/cards/ArcticAlgae";
 import { Color } from "../../src/Color";
@@ -6,25 +5,26 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("ArcticAlgae", function () {
+    let card : ArcticAlgae, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ArcticAlgae();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Can't play", function () {
-        const card = new ArcticAlgae();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseTemperature(player, 3); // -24
-        game.increaseTemperature(player, 3); // -18
-        game.increaseTemperature(player, 3); // -12
-        game.increaseTemperature(player, 1); // -10
+        (game as any).temperature = -10;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new ArcticAlgae();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         card.play(player);
         expect(player.plants).to.eq(1);
         player.playedCards.push(card);
-        game.addOceanTile(player, game.board.getAvailableSpacesForOcean(player)[0].id);
+
+        game.addOceanTile(player2, game.board.getAvailableSpacesForOcean(player2)[0].id);
         expect(player.plants).to.eq(3); 
     });
 });

--- a/tests/cards/ArtificialLake.spec.ts
+++ b/tests/cards/ArtificialLake.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ArtificialLake } from "../../src/cards/ArtificialLake";
 import { Color } from "../../src/Color";
@@ -10,34 +9,35 @@ import { TileType } from "../../src/TileType";
 import * as constants from '../../src/constants';
 
 describe("ArtificialLake", function () {
+    let card : ArtificialLake, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ArtificialLake();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new ArtificialLake();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new ArtificialLake();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
         expect(action instanceof SelectSpace).to.eq(true);
-        action.availableSpaces.forEach((space) => {
+
+        action!.availableSpaces.forEach((space) => {
             expect(space.spaceType).to.eq(SpaceType.LAND);
         });
-        action.cb(action.availableSpaces[0]);
-        expect(action.availableSpaces[0].tile).not.to.eq(undefined);
-        expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.OCEAN);
+
+        action!.cb(action!.availableSpaces[0]);
+        const placedTile = action!.availableSpaces[0].tile;
+        expect(placedTile!.tileType).to.eq(TileType.OCEAN);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });
-    it("Does not suggest a place for an ocean if all oceans are already placed", function () {
-        const card = new ArtificialLake();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("no_oceans_game", [player,player], player);
 
+    it("Cannot place ocean if all oceans are already placed", function () {
         // Set temperature level to fit requirements
         (game as any).temperature = -6;
 

--- a/tests/cards/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/AsteroidMiningConsortium.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { AsteroidMiningConsortium } from "../../src/cards/AsteroidMiningConsortium";
 import { Color } from "../../src/Color";
@@ -7,28 +6,25 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("AsteroidMiningConsortium", function () {
-    it("Shouldn't play, solo mode but not requirements", function () {
-        const card = new AsteroidMiningConsortium();
-        const player = new Player("test", Color.BLUE, false);
+    let card : AsteroidMiningConsortium, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new AsteroidMiningConsortium();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Can't play if no titanium production", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
-    it("Should play, player has production", function () {
-        const card = new AsteroidMiningConsortium();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player, player2, player3], player);
+
+    it("Can play if player has titanium production", function () {
         player.setProduction(Resources.TITANIUM);
         expect(card.canPlay(player)).to.eq(true);
+
         card.play(player, game);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
-    });
-    it("Should throw, player doesn't meet requirements", function () {
-        const card = new AsteroidMiningConsortium();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        player2.setProduction(Resources.TITANIUM);
-        expect(card.canPlay(player)).to.eq(false);
     });
 });

--- a/tests/cards/BeamFromAThoriumAsteroid.spec.ts
+++ b/tests/cards/BeamFromAThoriumAsteroid.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BeamFromAThoriumAsteroid } from "../../src/cards/BeamFromAThoriumAsteroid";
 import { Color } from "../../src/Color";
@@ -6,20 +5,26 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("BeamFromAThoriumAsteroid", function () {
-    it("Should throw", function () {
-        const card = new BeamFromAThoriumAsteroid();
-        const player = new Player("test", Color.BLUE, false);
+    let card : BeamFromAThoriumAsteroid, player : Player;
+
+    beforeEach(function() {
+        card = new BeamFromAThoriumAsteroid();
+        player = new Player("test", Color.BLUE, false);
+    });
+
+    it("Cannot play without a Jovian tag", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new BeamFromAThoriumAsteroid();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
-        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
-        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
         expect(player.getProduction(Resources.ENERGY)).to.eq(3);
+
+        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });
 });

--- a/tests/cards/BiomassCombustors.spec.ts
+++ b/tests/cards/BiomassCombustors.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BiomassCombustors } from "../../src/cards/BiomassCombustors";
 import { Color } from "../../src/Color";
@@ -7,27 +6,38 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("BiomassCombustors", function () {
-    it("Should throw", function () {
-        const card = new BiomassCombustors();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        expect(game.getOxygenLevel()).to.eq(6);
-        card.play(player, game);
+    let card : BiomassCombustors, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new BiomassCombustors();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
     });
+
+    it("Cannot play if oxygen requirement not met", function () {
+        player2.setProduction(Resources.PLANTS, 1);
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Cannot play if no one has plant production", function () {
+        (game as any).oxygenLevel = 6;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Can play in solo mode if oxygen requirement is met", function () {
+        const game = new Game("foobar", [player], player);
+        (game as any).oxygenLevel = 6;
+        expect(card.canPlay(player, game)).to.eq(true);
+    });
+
     it("Should play", function () {
-        const card = new BiomassCombustors();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        expect(game.getOxygenLevel()).to.eq(6);
+        (game as any).oxygenLevel = 6;
+        player2.setProduction(Resources.PLANTS, 1);
+
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
     });

--- a/tests/cards/Birds.spec.ts
+++ b/tests/cards/Birds.spec.ts
@@ -1,46 +1,46 @@
-
 import { expect } from "chai";
 import { Birds } from "../../src/cards/Birds";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("Birds", function () {
-    it("Should throw", function () {
-        const card = new Birds();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.RED, false);
-        const game = new Game("foobar", [player, player2], player);
+    let card : Birds, player : Player, player2 : Player, game : Game;
 
+    beforeEach(function() {
+        card = new Birds();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Cannot play without oxygen", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new Birds();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("victim", Color.RED, false);
-        const player3 = new Player("safe", Color.RED, false);
 
+    it("Should play", function () {
+        const player3 = new Player("safe", Color.RED, false);
         const game = new Game("foobar", [player, player2, player3], player);
 
-        // requirements
         player2.setProduction(Resources.PLANTS,2);
         player3.setProduction(Resources.PLANTS,7);
         (game as any).oxygenLevel = 13;
+        expect(card.canPlay(player, game)).to.eq(true);
 
-        // Play card
         card.play(player, game);
-        player.playedCards.push(card);
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
 
-        // Check victory points assignment
-        player.addResourceTo(card, 2); 
-        expect(card.getVictoryPoints()).to.eq(2);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
+        expect(player3.getProduction(Resources.PLANTS)).to.eq(7);
     });
+
     it("Should act", function () {
-        const card = new Birds();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
         card.action();
-        expect(card.resourceCount).to.eq(1); 
+        expect(card.resourceCount).to.eq(1);
+        expect(card.getVictoryPoints()).to.eq(1);
     });
 });

--- a/tests/cards/BlackPolarDust.spec.ts
+++ b/tests/cards/BlackPolarDust.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BlackPolarDust } from "../../src/cards/BlackPolarDust";
 import { Color } from "../../src/Color";
@@ -6,30 +5,36 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { maxOutOceans } from "../TestingUtils";
 import { Resources } from '../../src/Resources';
+import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("BlackPolarDust", function () {
+    let card : BlackPolarDust, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new BlackPolarDust();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new BlackPolarDust();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.MEGACREDITS,-4);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new BlackPolarDust();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-2);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
-    });
-    it("Does not provide ocean tile placement option", function () {
-        const card = new BlackPolarDust();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
 
+        expect(game.interrupts.length).to.eq(1);
+        const selectSpace = game.interrupts[0].playerInput as SelectSpace;
+        selectSpace.cb(selectSpace.availableSpaces[0]);
+        expect(player.getTerraformRating()).to.eq(21);
+    });
+
+    it("Cannot place ocean if no oceans left", function () {
         maxOutOceans(player, game);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
     })
 });

--- a/tests/cards/BreathingFilters.spec.ts
+++ b/tests/cards/BreathingFilters.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BreathingFilters } from "../../src/cards/BreathingFilters";
 import { Color } from "../../src/Color";
@@ -6,15 +5,22 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("BreathingFilters", function () {
+    let card : BreathingFilters, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new BreathingFilters();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new BreathingFilters();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foo", [player,player], player); 
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new BreathingFilters();
-        const player = new Player("test", Color.BLUE, false);
+        (game as any).oxygenLevel = 7;
+        expect(card.canPlay(player, game)).to.eq(true);
+
         card.play();
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);

--- a/tests/cards/BuildingIndustries.spec.ts
+++ b/tests/cards/BuildingIndustries.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BuildingIndustries } from "../../src/cards/BuildingIndustries";
 import { Color } from "../../src/Color";
@@ -6,15 +5,21 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("BuildingIndustries", function () {
+    let card : BuildingIndustries, player : Player;
+
+    beforeEach(function() {
+        card = new BuildingIndustries();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new BuildingIndustries();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new BuildingIndustries();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player)).to.eq(true);
+
         card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.STEEL)).to.eq(2);

--- a/tests/cards/Bushes.spec.ts
+++ b/tests/cards/Bushes.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Bushes } from "../../src/cards/Bushes";
 import { Color } from "../../src/Color";
@@ -7,15 +6,22 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Bushes", function () {
+    let card : Bushes, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Bushes();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Bushes();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Bushes();
-        const player = new Player("test", Color.BLUE, false);
+        (game as any).temperature = -10;
+        expect(card.canPlay(player, game)).to.eq(true);
+
         card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
         expect(player.plants).to.eq(2);

--- a/tests/cards/BusinessNetwork.spec.ts
+++ b/tests/cards/BusinessNetwork.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { BusinessNetwork } from "../../src/cards/BusinessNetwork";
 import { Color } from "../../src/Color";
@@ -10,65 +9,68 @@ import { Resources } from '../../src/Resources';
 import { IProjectCard } from '../../src/cards/IProjectCard';
 
 describe("BusinessNetwork", function () {
+    let card : BusinessNetwork, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new BusinessNetwork();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new BusinessNetwork();
-        const player = new Player("test", Color.BLUE, false);
+        expect(card.canPlay(player)).to.eq(true);
         card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
     });
-    it("Can't play", function () {
-        const card = new BusinessNetwork();
-        const player = new Player("test", Color.BLUE, false);
-        expect(card.canPlay(player)).to.eq(true);
+
+    it("Can't play", function () {  
         player.setProduction(Resources.MEGACREDITS,-5);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Can act", function () {
-        const card = new BusinessNetwork();
         expect(card.canAct()).to.eq(true);
     });
+
     it("Cannot buy card if cannot pay", function () {
-        const card = new BusinessNetwork();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 2;
         const action = card.action(player, game);
         expect(action instanceof SelectCard).to.eq(true);
+
         (action! as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
         expect(game.dealer.discarded.length).to.eq(1);
         expect(player.cardsInHand.length).to.eq(0);
         expect(player.megaCredits).to.eq(2);
     });
+
     it("Should action as not helion", function () {
-        const card = new BusinessNetwork();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 3;
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
+
         (action! as SelectCard<IProjectCard>).cb([]);
         expect(game.dealer.discarded.length).to.eq(1);
         expect(player.megaCredits).to.eq(3);
+
         player.megaCredits = 3;
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });
+
     it("Should action as helion", function () {
-        const card = new BusinessNetwork();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.canUseHeatAsMegaCredits = true;
         player.heat = 1;
         player.megaCredits = 3;
+
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
+
         const subAction: SelectHowToPay = (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]) as SelectHowToPay;
         expect(subAction).not.to.eq(undefined);
         expect(subAction.canUseHeat).to.eq(true);
         expect(function () { subAction.cb({heat: 0, megaCredits: 0, steel: 0, titanium: 0, microbes: 0 , floaters: 0}); }).to.throw();
+        
         subAction.cb({heat: 1, megaCredits: 2, steel: 0, titanium: 0, microbes: 0 , floaters: 0});
         expect(player.cardsInHand.length).to.eq(1);
         expect(player.heat).to.eq(0);

--- a/tests/cards/CEOsFavoriteProject.spec.ts
+++ b/tests/cards/CEOsFavoriteProject.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CEOsFavoriteProject } from "../../src/cards/CEOsFavoriteProject";
 import { Color } from "../../src/Color";
@@ -11,29 +10,33 @@ import { SecurityFleet } from "../../src/cards/SecurityFleet";
 import { Game } from "../../src/Game";
 
 describe("CEOsFavoriteProject", function () {
+    let card : CEOsFavoriteProject, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new CEOsFavoriteProject();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new CEOsFavoriteProject();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new CEOsFavoriteProject();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        
         const searchForLife = new SearchForLife();
         const securityFleet = new SecurityFleet();
-        player.playedCards.push(searchForLife, securityFleet);
-        player.addResourceTo(securityFleet);
         const decomposers = new Decomposers();
+        const birds = new Birds();
+
+        player.playedCards.push(searchForLife, securityFleet, decomposers, birds);
+        player.addResourceTo(securityFleet);
         player.addResourceTo(decomposers);
         player.addResourceTo(searchForLife);
-        const birds = new Birds();
-        player.playedCards.push(decomposers, birds);
         player.addResourceTo(birds);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
+
         action.cb([searchForLife]);
         expect(player.getResourcesOnCard(searchForLife)).to.eq(2);
         action.cb([birds]);

--- a/tests/cards/CarbonateProcessing.spec.ts
+++ b/tests/cards/CarbonateProcessing.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CarbonateProcessing } from "../../src/cards/CarbonateProcessing";
 import { Color } from "../../src/Color";
@@ -6,17 +5,22 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("CarbonateProcessing", function () {
+    let card : CarbonateProcessing, player : Player;
+
+    beforeEach(function() {
+        card = new CarbonateProcessing();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new CarbonateProcessing();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () { 
-        const card = new CarbonateProcessing();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
     });

--- a/tests/cards/CaretakerContract.spec.ts
+++ b/tests/cards/CaretakerContract.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CaretakerContract } from "../../src/cards/CaretakerContract";
 import { Color } from "../../src/Color";
@@ -6,22 +5,25 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("CaretakerContract", function () {
+    let card : CaretakerContract, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new CaretakerContract();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play or act", function () {
-        const card = new CaretakerContract();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () { 
-        const card = new CaretakerContract();
-        const action = card.play();
-        expect(action).to.eq(undefined);
+
+    it("Should play", function () {
+        (game as any).temperature = 0;
+        expect(card.canPlay(player, game)).to.eq(true);
     });
+
     it("Should act", function () {
-        const card = new CaretakerContract();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.heat = 8;
         card.action(player, game);
         expect(player.heat).to.eq(0);

--- a/tests/cards/Cartel.spec.ts
+++ b/tests/cards/Cartel.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Cartel } from "../../src/cards/Cartel";
 import { Color } from "../../src/Color";
@@ -9,30 +8,31 @@ import { LunarBeam } from "../../src/cards/LunarBeam";
 import { Resources } from '../../src/Resources';
 
 describe("Cartel", function () {
+    let card : Cartel, player : Player;
+
+    beforeEach(function() {
+        card = new Cartel();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Should play", function () { 
-        const card = new Cartel();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         player.playedCards.push(card);
+
         card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
     });
 
     it("Correctly counts tags", function () {
-        const card = new Cartel();
         const cards = [
             new ImportedHydrogen(), // event with earth tag
             new InterstellarColonyShip(), // event with earth tag
-            new LunarBeam() // Another card with earch tag
+            new LunarBeam() // another card with earth tag
         ]
-        const player = new Player("test", Color.BLUE, false);
 
         player.playedCards = player.playedCards.concat(cards);
-        
         card.play(player);
-
-        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2); // Only for LunarBeam and Cartel itself
+        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2); // exclude events
     });
 });

--- a/tests/cards/CloudSeeding.spec.ts
+++ b/tests/cards/CloudSeeding.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CloudSeeding } from "../../src/cards/CloudSeeding";
 import { Color } from "../../src/Color";
@@ -6,44 +5,48 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { maxOutOceans } from "../TestingUtils"
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("CloudSeeding", function () {
-    it("Can't play", function () { 
-        const card = new CloudSeeding();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        
-        maxOutOceans(player, game, 3);
+    let card : CloudSeeding, player : Player, player2 : Player, game : Game;
 
-        player.setProduction(Resources.MEGACREDITS,-5);
-        expect(card.canPlay(player, game)).to.eq(false);
-
+    beforeEach(function() {
+        card = new CloudSeeding();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
     });
 
-    it("Can't be played without heat production", function () {
-        const card = new CloudSeeding();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-
+    it("Can't play if cannot reduce MC production", function () { 
         maxOutOceans(player, game, 3);
+        player.setProduction(Resources.MEGACREDITS, -5);
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
 
+    it("Can't play if ocean requirements not met", function () { 
+        maxOutOceans(player, game, 2);
+        player.setProduction(Resources.HEAT);
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Can't play if no one has heat production", function () {
+        maxOutOceans(player, game, 3);
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
-        const card = new CloudSeeding();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-
-        // Satisfy requirements
-        player.setProduction(Resources.HEAT,3);
+        // Meet requirements
         player2.setProduction(Resources.HEAT);
-
         maxOutOceans(player, game, 3);
-
         expect(card.canPlay(player, game)).to.eq(true);
+        
+        card.play(player, game);
+        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
+        expect(player.getProduction(Resources.PLANTS)).to.eq(2);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.HEAT)).to.eq(0);
     });
 });

--- a/tests/cards/ColonizerTrainingCamp.spec.ts
+++ b/tests/cards/ColonizerTrainingCamp.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ColonizerTrainingCamp } from "../../src/cards/ColonizerTrainingCamp";
 import { Color } from "../../src/Color";
@@ -6,21 +5,23 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("ColonizerTrainingCamp", function () {
+    let card : ColonizerTrainingCamp, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ColonizerTrainingCamp();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new ColonizerTrainingCamp();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        expect(game.getOxygenLevel()).to.eq(6);
+        (game as any).oxygenLevel = 6;
         expect(card.canPlay(player, game)).to.eq(false);
     });
     it("Should play", function () {
-        const card = new ColonizerTrainingCamp();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 5;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play();
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2); 
     });

--- a/tests/cards/Comet.spec.ts
+++ b/tests/cards/Comet.spec.ts
@@ -1,44 +1,53 @@
-
 import { expect } from "chai";
 import { Comet } from "../../src/cards/Comet";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { maxOutOceans } from "../TestingUtils"
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
+import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("Comet", function () {
-    it("Should play", function () {
-        const card = new Comet();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("victim", Color.GREEN, false);
-        const player3 = new Player("notarget", Color.YELLOW, false);
-        const game = new Game("foobar", [player, player2, player3], player);
+    let card : Comet, player : Player, player2 : Player, player3: Player, game : Game;
 
+    beforeEach(function() {
+        card = new Comet();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        player3 = new Player("test3", Color.YELLOW, false);
+        game = new Game("foobar", [player, player2, player3], player);
+    });
+
+    it("Should play", function () {
+        player2.plants = 2;
+        player3.plants = 4;
+        
         card.play(player, game);
         expect(game.getTemperature()).to.eq(-28);
+        expect(game.interrupts.length).to.eq(2);
+
+        const selectSpace = game.interrupts[0].playerInput as SelectSpace;
+        selectSpace.cb(selectSpace.availableSpaces[0]);
+        expect(player.getTerraformRating()).to.eq(22);
+
+        const selectPlayer = game.interrupts[1].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.plants).to.eq(0);
     });
 
     it("Provides no options if there is nothing to confirm", function () {
-        const card = new Comet();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.RED, false);
-        const game = new Game("no_options_game", [player,player2], player);
-        
         maxOutOceans(player, game);
         player.plants = 8;
 
         const action = card.play(player, game);
-
         expect(action).to.eq(undefined);
+
         expect(player.plants).to.eq(8); // self plants are not removed
         expect(game.getTemperature()).to.eq(-28);
     });
 
     it("Works fine in solo mode", function() {
-        const card = new Comet();
-        const player = new Player("test", Color.BLUE, false);
         const game = new Game("solo_game", [player], player);
-
         player.plants = 8;
 
         var action = card.play(player, game);

--- a/tests/cards/CommercialDistrict.spec.ts
+++ b/tests/cards/CommercialDistrict.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CommercialDistrict } from "../../src/cards/CommercialDistrict";
 import { Color } from "../../src/Color";
@@ -9,23 +8,29 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("CommercialDistrict", function () {
+    let card : CommercialDistrict, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new CommercialDistrict();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new CommercialDistrict();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new CommercialDistrict();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace);
         action.cb(action.availableSpaces[0]);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(4);
+        
         const adjacent = game.board.getAdjacentSpaces(action.availableSpaces[0]);
         adjacent[0].tile = { tileType: TileType.CITY, card: card.name };
         adjacent[0].player = player;

--- a/tests/cards/CorporateStronghold.spec.ts
+++ b/tests/cards/CorporateStronghold.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CorporateStronghold } from "../../src/cards/CorporateStronghold";
 import { Color } from "../../src/Color";
@@ -9,24 +8,30 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("CorporateStronghold", function () {
+    let card : CorporateStronghold, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new CorporateStronghold();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new CorporateStronghold();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player,game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new CorporateStronghold();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player,game)).to.eq(true);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
         action.cb(action.availableSpaces[0]);
+
         expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-2);
     });

--- a/tests/cards/CupolaCity.spec.ts
+++ b/tests/cards/CupolaCity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { CupolaCity } from "../../src/cards/CupolaCity";
 import { Color } from "../../src/Color";
@@ -9,26 +8,31 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("CupolaCity", function () {
-    it("Can't play", function () {
-        const card = new CupolaCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        game.increaseOxygenLevel(player, 2); // 8
-        game.increaseOxygenLevel(player, 2); // 10
+    let card : CupolaCity, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new CupolaCity();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new CupolaCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+
+    it("Can't play if oxygen level too high", function () {
         player.setProduction(Resources.ENERGY);
+        (game as any).oxygenLevel = 10;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Should play", function () {
+        player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+        
         action.cb(action.availableSpaces[0]);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);

--- a/tests/cards/Decomposers.spec.ts
+++ b/tests/cards/Decomposers.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Decomposers } from "../../src/cards/Decomposers";
 import { Color } from "../../src/Color";
@@ -8,24 +7,29 @@ import { Algae } from "../../src/cards/Algae";
 import { Birds } from "../../src/cards/Birds";
 
 describe("Decomposers", function () {
+    let card : Decomposers, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Decomposers();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Decomposers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Decomposers();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 3;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play();
+
         card.onCardPlayed(player, game, new Birds());
         expect(card.resourceCount).to.eq(1);
         card.onCardPlayed(player, game, card);
         expect(card.resourceCount).to.eq(2);
         card.onCardPlayed(player, game, new Algae());
+        
         expect(card.resourceCount).to.eq(3);
         expect(card.getVictoryPoints()).to.eq(1);
     });

--- a/tests/cards/DeimosDown.spec.ts
+++ b/tests/cards/DeimosDown.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { DeimosDown } from "../../src/cards/DeimosDown";
 import { Color } from "../../src/Color";
@@ -6,26 +5,29 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("DeimosDown", function () {
-    it("Should play", function () {
-        const card = new DeimosDown();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
+    let card : DeimosDown, player : Player, player2 : Player, game : Game;
 
+    beforeEach(function() {
+        card = new DeimosDown();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Should play", function () {
+        player2.plants = 8;
         card.play(player, game);
+
         expect(game.getTemperature()).to.eq(-24);
         expect(player.steel).to.eq(4);
+        expect(player2.plants).to.eq(0);
     });
 
     it("Works fine in solo mode", function() {
-        const card = new DeimosDown();
-        const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player], player);
 
         player.plants = 15;
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
 
         expect(game.getTemperature()).to.eq(-24);
         expect(player.steel).to.eq(4);

--- a/tests/cards/DesignedMicroOrganisms.spec.ts
+++ b/tests/cards/DesignedMicroOrganisms.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { DesignedMicroOrganisms } from "../../src/cards/DesignedMicroOrganisms";
 import { Color } from "../../src/Color";
@@ -7,20 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("DesignedMicroOrganisms", function () {
+    let card : DesignedMicroOrganisms, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new DesignedMicroOrganisms();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new DesignedMicroOrganisms();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseTemperature(player, 3); // -24
-        game.increaseTemperature(player, 3); // -18
-        game.increaseTemperature(player, 3); // -12
+        (game as any).temperature = -12;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new DesignedMicroOrganisms();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -14;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
     });
 });

--- a/tests/cards/DevelopmentCenter.spec.ts
+++ b/tests/cards/DevelopmentCenter.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { DevelopmentCenter } from "../../src/cards/DevelopmentCenter";
 import { Color } from "../../src/Color";
@@ -6,23 +5,23 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("DevelopmentCenter", function () {
+    let card : DevelopmentCenter, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new DevelopmentCenter();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't act", function () {
-        const card = new DevelopmentCenter();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new DevelopmentCenter();
-        const action = card.play();
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new DevelopmentCenter();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 1;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player, game);
         expect(player.energy).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });

--- a/tests/cards/DomedCrater.spec.ts
+++ b/tests/cards/DomedCrater.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { DomedCrater } from "../../src/cards/DomedCrater";
 import { Color } from "../../src/Color";
@@ -9,30 +8,37 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("DomedCrater", function () {
-    it("Can't play", function () {
-        const card = new DomedCrater();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        game.increaseOxygenLevel(player, 2); // 8
+    let card : DomedCrater, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new DomedCrater();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
+        expect(card.canPlay(player,game)).to.eq(false);
+    });
+
+    it("Can't play if oxygen level too high", function () {
+        player.setProduction(Resources.ENERGY);
+        (game as any).oxygenLevel = 8;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new DomedCrater();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+
         action.cb(action.availableSpaces[0]);
         expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);
         expect(player.plants).to.eq(3);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/DustSeals.spec.ts
+++ b/tests/cards/DustSeals.spec.ts
@@ -1,27 +1,27 @@
-
 import { expect } from "chai";
 import { DustSeals } from "../../src/cards/DustSeals";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
-import { TileType } from "../../src/TileType";
+import { maxOutOceans } from "../TestingUtils"
 
 describe("DustSeals", function () {
+    let card : DustSeals, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new DustSeals();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new DustSeals();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const oceanSpaces = game.board.getAvailableSpacesForOcean(player);
-        for (let i = 0; i < 4; i++) {
-            oceanSpaces[i].tile = { tileType: TileType.OCEAN };
-        }
+        maxOutOceans(player, game, 4);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new DustSeals();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play();
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/EOSChasmaNationalPark.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { EosChasmaNationalPark } from "../../src/cards/EOSChasmaNationalPark";
 import { Color } from "../../src/Color";
@@ -10,62 +9,52 @@ import { Fish } from "../../src/cards/Fish";
 import { Resources } from '../../src/Resources';
 
 describe("EosChasmaNationalPark", function () {
+    let card : EosChasmaNationalPark, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new EosChasmaNationalPark();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new EosChasmaNationalPark();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new EosChasmaNationalPark();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player, player2], player);
-
-        // Fit minimal requirements
         (game as any).temperature = -12;
-
-        // Add cards to choose from
         const birds = new Birds();
         const fish = new Fish();
-        player.playedCards.push(birds);
-        player.playedCards.push(fish);
+        player.playedCards.push(birds, fish);
 
         expect(card.canPlay(player, game)).to.eq(true);
         const action = card.play(player, game);
         expect(action instanceof SelectCard).to.eq(true);
-        if (action === undefined) return;
         player.playedCards.push(card);
-
-        action.cb([birds]);
-        player.getVictoryPoints(game);
-
+        action!.cb([birds]);
+        
         expect(player.getResourcesOnCard(birds)).to.eq(1);
         expect(player.plants).to.eq(3);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
+
+        player.getVictoryPoints(game);
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });
+    
     it("Should play - single target", function () {
-        const card = new EosChasmaNationalPark();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player, player2], player);
-
-        // Fit minimal requirements
         (game as any).temperature = -12;
-
-        // Single target
         const birds = new Birds();
         player.playedCards.push(birds);
 
         expect(card.canPlay(player, game)).to.eq(true);
         card.play(player, game);
         player.playedCards.push(card);
-        player.getVictoryPoints(game);
 
         expect(player.getResourcesOnCard(birds)).to.eq(1);
         expect(player.plants).to.eq(3);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
+
+        player.getVictoryPoints(game);
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });
 });

--- a/tests/cards/EcologicalZone.spec.ts
+++ b/tests/cards/EcologicalZone.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { EcologicalZone } from "../../src/cards/EcologicalZone";
 import { Color } from "../../src/Color";
@@ -6,33 +5,35 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { SelectSpace } from "../../src/inputs/SelectSpace";
 import { TileType } from "../../src/TileType";
-import { Virus } from "../../src/cards/Virus";
 
 describe("EcologicalZone", function () {
+    let card : EcologicalZone, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new EcologicalZone();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new EcologicalZone();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new EcologicalZone();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
         const landSpace = game.board.getAvailableSpacesOnLand(player)[0];
         game.addGreenery(player, landSpace.id);
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+
         const adjacentSpace = action.availableSpaces[0];
         action.cb(adjacentSpace);
         expect(adjacentSpace.tile && adjacentSpace.tile.tileType).to.eq(TileType.ECOLOGICAL_ZONE); 
+
         card.onCardPlayed(player, game, card);
         expect(card.resourceCount).to.eq(2);
         expect(card.getVictoryPoints()).to.eq(1);
-        card.onCardPlayed(player, game, new Virus());
-        expect(card.resourceCount).to.eq(2);
     });
 });
 

--- a/tests/cards/ElectroCatapult.spec.ts
+++ b/tests/cards/ElectroCatapult.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ElectroCatapult } from "../../src/cards/ElectroCatapult";
 import { Color } from "../../src/Color";
@@ -8,42 +7,44 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Resources } from '../../src/Resources';
 
 describe("ElectroCatapult", function () {
-    it("Can't play", function () {
-        const card = new ElectroCatapult();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        game.increaseOxygenLevel(player, 2); // 8
-        game.increaseOxygenLevel(player, 1); // 9
-        expect(game.getOxygenLevel()).to.eq(9);
+    let card : ElectroCatapult, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ElectroCatapult();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
+        expect(card.canPlay(player,game)).to.eq(false);
+    });
+
+    it("Can't play if oxygen level too high", function () {
+        player.setProduction(Resources.ENERGY);
+        (game as any).oxygenLevel = 9;
         expect(card.canPlay(player, game)).to.eq(false); 
     });
+
     it("Should play", function () {
-        const card = new ElectroCatapult();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        card.play(player);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });
     it("Should act", function () {
-        const card = new ElectroCatapult();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.plants = 1;
         player.steel = 1;
+
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);
+
         action!.options[0].cb();
         expect(player.plants).to.eq(0);
         expect(player.megaCredits).to.eq(7);
+        
         action!.options[1].cb();
         expect(player.steel).to.eq(0);
         expect(player.megaCredits).to.eq(14);

--- a/tests/cards/EnergyTapping.spec.ts
+++ b/tests/cards/EnergyTapping.spec.ts
@@ -1,40 +1,42 @@
-
 import { expect } from "chai";
 import { EnergyTapping } from "../../src/cards/EnergyTapping";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("EnergyTapping", function () {
-    it("Can't be played", function () {
-        const card = new EnergyTapping();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.BLUE, false);
+    let card : EnergyTapping, player : Player, player2 : Player, game : Game;
 
-        const game = new Game("foobar", [player, player2], player);
+    beforeEach(function() {
+        card = new EnergyTapping();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new EnergyTapping();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.BLUE, false);
-        const player3 = new Player("test", Color.BLUE, false);
 
-        const game = new Game("foobar", [player,player2,player3], player);
+    it("Should play", function () {
         player2.setProduction(Resources.ENERGY,3);
-        player3.setProduction(Resources.ENERGY,5);
         expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
+        
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
     });
 
     it("Playable in solo mode", function () {
-        const card = new EnergyTapping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("energy_reducting", [player], player);
-
+        const game = new Game("foobar", [player], player);
         expect(card.canPlay(player, game)).to.eq(true);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
         
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);

--- a/tests/cards/EquatorialMagnetizer.spec.ts
+++ b/tests/cards/EquatorialMagnetizer.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { EquatorialMagnetizer } from "../../src/cards/EquatorialMagnetizer";
 import { Color } from "../../src/Color";
@@ -7,23 +6,23 @@ import { Resources } from '../../src/Resources';
 import { Game } from '../../src/Game';
 
 describe("EquatorialMagnetizer", function () {
+    let card : EquatorialMagnetizer, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new EquatorialMagnetizer();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't act", function () {
-        const card = new EquatorialMagnetizer();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new EquatorialMagnetizer();
-        const action = card.play();
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new EquatorialMagnetizer();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getTerraformRating()).to.eq(21);
     });

--- a/tests/cards/ExtremeColdFungus.spec.ts
+++ b/tests/cards/ExtremeColdFungus.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ExtremeColdFungus } from "../../src/cards/ExtremeColdFungus";
 import { Color } from "../../src/Color";
@@ -9,55 +8,53 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Ants } from "../../src/cards/Ants";
 
 describe("ExtremeColdFungus", function () {
+    let card : ExtremeColdFungus, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ExtremeColdFungus();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Can't play", function () {
-        const card = new ExtremeColdFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseTemperature(player, 3); // -24
-        game.increaseTemperature(player, 3); // -18
-        game.increaseTemperature(player, 3); // -12
-        game.increaseTemperature(player, 2); // -8 
+        (game as any).temperature = -8;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new ExtremeColdFungus();
         const action = card.play();
         expect(action).to.eq(undefined);
     });
-    it("Should act - single target", function () {
-        const card = new ExtremeColdFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
 
+    it("Should act - single target", function () {
         const tardigrades = new Tardigrades();
         player.playedCards.push(tardigrades);
         
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);
         
         action!.options[0].cb();
         expect(player.getResourcesOnCard(tardigrades)).to.eq(2);
+
         action!.options[1].cb();
         expect(player.plants).to.eq(1);
     });
+
     it("Should act - multiple targets", function () {
-        const card = new ExtremeColdFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        
-        player.playedCards.push(new Ants());
         const tardigrades = new Tardigrades();
-        player.playedCards.push(tardigrades);
-        player.addResourceTo(tardigrades, 4);
+        const ants = new Ants();
+        player.playedCards.push(tardigrades, ants);
+
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof OrOptions).to.eq(true);
         expect(action!.options.length).to.eq(2);
+
         action!.options[0].cb([tardigrades]);
-        expect(player.getResourcesOnCard(tardigrades)).to.eq(6);
-        action!.options[1].cb();
-        expect(player.plants).to.eq(1);
+        expect(player.getResourcesOnCard(tardigrades)).to.eq(2);
+
+        action!.options[0].cb([ants]);
+        expect(player.getResourcesOnCard(ants)).to.eq(2);
     });
 });

--- a/tests/cards/Farming.spec.ts
+++ b/tests/cards/Farming.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Farming } from "../../src/cards/Farming";
 import { Color } from "../../src/Color";
@@ -7,20 +6,27 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Farming", function () {
+    let card : Farming, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Farming();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Farming();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Farming();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = 4;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
         expect(player.plants).to.eq(2);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });

--- a/tests/cards/Fish.spec.ts
+++ b/tests/cards/Fish.spec.ts
@@ -1,39 +1,41 @@
-
 import { expect } from "chai";
 import { Fish } from "../../src/cards/Fish";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("Fish", function () {
+    let card : Fish, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Fish();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Can't play", function () {
-        const card = new Fish();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should act", function () {
-        const card = new Fish();
         card.action();
         expect(card.resourceCount).to.eq(1);
     });
+
     it("Should play", function () {
-        const card = new Fish();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2, player3], player);
-
-        // Fit minimal requirements
         (game as any).temperature = 2;
-
-        player2.setProduction(Resources.PLANTS,2);
-        player3.setProduction(Resources.PLANTS,7);
+        player2.setProduction(Resources.PLANTS);
 
         expect(card.canPlay(player, game)).to.eq(true);
-
         card.play(player, game);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
 
         player.addResourceTo(card, 5);
         expect(card.getVictoryPoints()).to.eq(card.resourceCount);

--- a/tests/cards/Flooding.spec.ts
+++ b/tests/cards/Flooding.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Flooding } from "../../src/cards/Flooding";
 import { Color } from "../../src/Color";
@@ -10,17 +9,21 @@ import { SpaceType } from "../../src/SpaceType";
 import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("Flooding", function () {
+    let card : Flooding, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Flooding();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Should play", function () {
-        const card = new Flooding();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         const oceans = game.board.getAvailableSpacesForOcean(player);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
         expect(action instanceof SelectSpace).to.eq(true);
-        expect(action.cb(oceans[0])).to.eq(undefined);
+
+        expect(action!.cb(oceans[0])).to.eq(undefined);
         const adjacentSpaces = game.board.getAdjacentSpaces(oceans[0]);
         oceans[0].tile = undefined;
         for (let i = 0; i < adjacentSpaces.length; i++) {
@@ -29,57 +32,36 @@ describe("Flooding", function () {
                 break;
             }
         }
-        const subAction: OrOptions = action.cb(oceans[0]) as OrOptions;
-        expect(subAction).not.to.eq(undefined);
+
+        const subAction: OrOptions = action!.cb(oceans[0]) as OrOptions;
         expect(subAction instanceof OrOptions).to.eq(true);
-        expect(subAction.options.length).to.eq(2);
-        expect(subAction.options[1].cb()).to.eq(undefined);
-        const subActionSelectPlayer: SelectPlayer = subAction.options[0] as SelectPlayer;
+        expect(subAction!.options.length).to.eq(2);
+        expect(subAction!.options[1].cb()).to.eq(undefined);
+        const subActionSelectPlayer: SelectPlayer = subAction!.options[0] as SelectPlayer;
         expect(subActionSelectPlayer.players.length).to.eq(1);
         expect(subActionSelectPlayer.players[0]).to.eq(player2);
+
         player2.megaCredits = 4;
         subActionSelectPlayer.cb(player2);
         expect(player2.megaCredits).to.eq(0);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
     });
 
     it("Does not suggest to remove money from yourself", function() {
-        const card = new Flooding();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         const oceanSpaces = game.board.getAvailableSpacesForOcean(player);
-
         const action = card.play(player, game);
 
         game.addGreenery(player, "03");
         game.addGreenery(player2, "05");
 
-        expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
         expect(action instanceof SelectSpace).to.eq(true);
-        const subActions: OrOptions = action.cb(oceanSpaces[0]) as OrOptions;
+        const subActions: OrOptions = action!.cb(oceanSpaces[0]) as OrOptions;
         expect(subActions.options.length).to.eq(2);
 
         const subActionSelectPlayer: SelectPlayer = subActions.options[0] as SelectPlayer;
         expect(subActionSelectPlayer.players.length).to.eq(1);
         expect(subActionSelectPlayer.players[0]).to.eq(player2);
-    });
-
-    it("Does not remove money for adjanced ocean tile", function() {
-        const card = new Flooding();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-
-        const action = card.play(player, game);
-
-        game.addOceanTile(player2, "34");
-
-        expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
-        expect(action instanceof SelectSpace).to.eq(true);
-        expect(action.cb(game.getSpace("33"))).to.eq(undefined);
     });
 });

--- a/tests/cards/FoodFactory.spec.ts
+++ b/tests/cards/FoodFactory.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { FoodFactory } from "../../src/cards/FoodFactory";
 import { Color } from "../../src/Color";
@@ -6,18 +5,25 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("FoodFactory", function () {
+    let card : FoodFactory, player : Player;
+
+    beforeEach(function() {
+        card = new FoodFactory();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new FoodFactory();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new FoodFactory();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.PLANTS);
+        expect(card.canPlay(player)).to.eq(true);
+
         card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(4);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/FuelFactory.spec.ts
+++ b/tests/cards/FuelFactory.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { FuelFactory } from "../../src/cards/FuelFactory";
 import { Color } from "../../src/Color";
@@ -6,17 +5,22 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("FuelFactory", function () {
-    it("Should throw", function () {
-        const card = new FuelFactory();
-        const player = new Player("test", Color.BLUE, false);
+    let card : FuelFactory, player : Player;
+
+    beforeEach(function() {
+        card = new FuelFactory();
+        player = new Player("test", Color.BLUE, false);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new FuelFactory();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player);
+        
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/FusionPower.spec.ts
+++ b/tests/cards/FusionPower.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { FusionPower } from "../../src/cards/FusionPower";
 import { Color } from "../../src/Color";
@@ -6,17 +5,22 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("FusionPower", function () {
+    let card : FusionPower, player : Player;
+
+    beforeEach(function() {
+        card = new FusionPower();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new FusionPower();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new FusionPower();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card, card);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(3);
     });
 });

--- a/tests/cards/GHGFactories.spec.ts
+++ b/tests/cards/GHGFactories.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { GHGFactories } from "../../src/cards/GHGFactories";
 import { Color } from "../../src/Color";
@@ -6,17 +5,22 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("GHGFactories", function () {
-    it("Should throw", function () {
-        const card = new GHGFactories();
-        const player = new Player("test", Color.BLUE, false);
+    let card : GHGFactories, player : Player;
+
+    beforeEach(function() {
+        card = new GHGFactories();
+        player = new Player("test", Color.BLUE, false);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new GHGFactories();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player);
+        
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(4);
     });

--- a/tests/cards/GHGProducingBacteria.spec.ts
+++ b/tests/cards/GHGProducingBacteria.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { GHGProducingBacteria } from "../../src/cards/GHGProducingBacteria";
 import { Color } from "../../src/Color";
@@ -7,37 +6,40 @@ import { Game } from "../../src/Game";
 import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("GHGProducingBacteria", function () {
+    let card : GHGProducingBacteria, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new GHGProducingBacteria();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new GHGProducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new GHGProducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
+        (game as any).oxygenLevel = 4;
         const action = card.play();
         expect(action).to.eq(undefined);
     });
+
     it("Should act", function () {
-        const card = new GHGProducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
-        let action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        
+        card.action(player, game);
         expect(card.resourceCount).to.eq(1);
-        action = card.action(player, game);
+        
+        card.action(player, game);
         expect(card.resourceCount).to.eq(2);
+
         const orAction = card.action(player, game) as OrOptions;
-        expect(orAction).not.to.eq(undefined);
         expect(orAction instanceof OrOptions).to.eq(true);
-        orAction.options[1].cb();
+
+        orAction!.options[1].cb();
         expect(card.resourceCount).to.eq(3);
-        orAction.options[0].cb();
+        
+        orAction!.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(game.getTemperature()).to.eq(-28);
     });

--- a/tests/cards/GeneRepair.spec.ts
+++ b/tests/cards/GeneRepair.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { GeneRepair } from "../../src/cards/GeneRepair";
 import { Color } from "../../src/Color";
@@ -7,19 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("GeneRepair", function () {
-    it("Should throw", function () {
-        const card = new GeneRepair();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(function () { card.play(player, game); }).to.throw("Requires 3 science tags.");
+    let card : GeneRepair, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new GeneRepair();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new GeneRepair();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card, card, card);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player, game);
+        
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);

--- a/tests/cards/Grass.spec.ts
+++ b/tests/cards/Grass.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Grass } from "../../src/cards/Grass";
 import { Color } from "../../src/Color";
@@ -7,17 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Grass", function () {
+    let card : Grass, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Grass();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Grass();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Grass();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -16;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+        
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.plants).to.eq(3);
     });

--- a/tests/cards/GreatDam.spec.ts
+++ b/tests/cards/GreatDam.spec.ts
@@ -1,23 +1,29 @@
-
 import { expect } from "chai";
 import { GreatDam } from "../../src/cards/GreatDam";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { maxOutOceans } from "../TestingUtils"
 
 describe("GreatDam", function () {
+    let card : GreatDam, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new GreatDam();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new GreatDam();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new GreatDam();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        maxOutOceans(player, game, 4);
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+        
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/GreatEscarpmentConsortium.spec.ts
+++ b/tests/cards/GreatEscarpmentConsortium.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { GreatEscarpmentConsortium } from "../../src/cards/GreatEscarpmentConsortium";
 import { Color } from "../../src/Color";
@@ -7,15 +6,19 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("GreatEscarpmentConsortium", function () {
-    it("Should throw, player doesn't have production", function () {
-        const card = new GreatEscarpmentConsortium();
-        const player = new Player("test", Color.BLUE, false);
+    let card : GreatEscarpmentConsortium, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new GreatEscarpmentConsortium();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player], player);
+    });
+
+    it("Cannot play without steel production", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+    
     it("Should play", function () {
-        const card = new GreatEscarpmentConsortium();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
         player.setProduction(Resources.STEEL);
         expect(card.canPlay(player)).to.eq(true);
         card.play(player, game);

--- a/tests/cards/Hackers.spec.ts
+++ b/tests/cards/Hackers.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Hackers } from "../../src/cards/Hackers";
 import { Color } from "../../src/Color";
@@ -6,14 +5,18 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("Hackers", function () {
+    let card : Hackers, player : Player;
+
+    beforeEach(function() {
+        card = new Hackers();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't play", function () {
-        const card = new Hackers();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Hackers();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
         expect(card.canPlay(player)).to.eq(true);
     });

--- a/tests/cards/HeatTrappers.spec.ts
+++ b/tests/cards/HeatTrappers.spec.ts
@@ -1,24 +1,27 @@
-
 import { expect } from "chai";
 import { HeatTrappers } from "../../src/cards/HeatTrappers";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("HeatTrappers", function () {
-    it("Should be playable in solo mode", function () {
-        const card = new HeatTrappers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
+    let card : HeatTrappers, player : Player, player2: Player, game: Game;
 
-        // Not enough according to card requirements
-        // but it's not important in solo mode
+    beforeEach(function() {
+        card = new HeatTrappers();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Should be playable in solo mode", function () {
+        game = new Game("foobar", [player], player);
         player.setProduction(Resources.HEAT);
 
         expect(card.canPlay(player, game)).to.eq(true);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
 
         expect(player.getProduction(Resources.HEAT)).to.eq(1); // Not changed
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
@@ -26,32 +29,22 @@ describe("HeatTrappers", function () {
         expect(player.getProduction(Resources.ENERGY)).to.eq(1); // Incremented
     });
 
-    it("Should be fast-playable with one default target", function () {
-        const card = new HeatTrappers();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar2", [player, player2], player);
-
+    it("Should play", function () {
         player2.setProduction(Resources.HEAT,7);
-
         expect(card.canPlay(player, game)).to.eq(true);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
 
-        expect(player.getProduction(Resources.HEAT)).to.eq(0); // Not changed
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.HEAT)).to.eq(5);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
-        expect(player.getProduction(Resources.ENERGY)).to.eq(1); // Incremented
     });
 
-    it("Can't play", function () {
-        const card = new HeatTrappers();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-
-        const game = new Game("foobar3", [player, player2], player);
-
+    it("Can't play if nobody has heat production", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
-
 });

--- a/tests/cards/Heather.spec.ts
+++ b/tests/cards/Heather.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Heather } from "../../src/cards/Heather";
 import { Color } from "../../src/Color";
@@ -7,17 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Heather", function () {
+    let card : Heather, player : Player, game: Game;
+
+    beforeEach(function() {
+        card = new Heather();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player,player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Heather();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Heather();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -14;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.plants).to.eq(1);
     });

--- a/tests/cards/Herbivores.spec.ts
+++ b/tests/cards/Herbivores.spec.ts
@@ -1,71 +1,53 @@
-
 import { expect } from "chai";
 import { Herbivores } from "../../src/cards/Herbivores";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("Herbivores", function () {
-    it("Should be fast-playable with one default target", function () {
-        const card = new Herbivores();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar2", [player, player2], player);
+    let card : Herbivores, player : Player, player2: Player, game: Game;
 
-        (game as any).oxygenLevel = 8;
-        player2.setProduction(Resources.PLANTS);
-
-        expect(card.canPlay(player, game)).to.eq(true);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
-
-        expect(card.resourceCount).to.eq(1);
-
+    beforeEach(function() {
+        card = new Herbivores();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
     });
 
-    it("Should ask for target", function () {
-        const card = new Herbivores();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar3", [player, player2, player3], player);
-
-        (game as any).oxygenLevel = 8;
-        player2.setProduction(Resources.PLANTS);
-        player3.setProduction(Resources.PLANTS,7);
-
-        expect(card.canPlay(player, game)).to.eq(true, "Cant play");
-        card.play(player, game);
-
-        expect(card.resourceCount).to.eq(1);
-    });
-
-    it("Can't play", function () {
-        const card = new Herbivores();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar3", [player, player2], player);
-
+    it("Can't play if nobody has plant production", function () {
         (game as any).oxygenLevel = 8;
         expect(card.canPlay(player, game)).to.eq(false);
+    });
 
+    it("Can't play if oxygen level too low", function () {
         (game as any).oxygenLevel = 7;
-        player2.setProduction(Resources.PLANTS,2);
+        player2.setProduction(Resources.PLANTS);
         expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Should play", function () {
+        (game as any).oxygenLevel = 8;
+        player2.setProduction(Resources.PLANTS);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
+        expect(card.resourceCount).to.eq(1);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });
 
     it("Should add resources", function () {
-        const card = new Herbivores();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-
         player.playedCards.push(card);
         expect(card.resourceCount).to.eq(0);
 
         game.addGreenery(player, game.board.getAvailableSpacesOnLand(player)[0].id);
         game.addGreenery(player, game.board.getAvailableSpacesOnLand(player)[0].id);
+        expect(card.resourceCount).to.eq(2);
 
         game.addGreenery(player2, game.board.getAvailableSpacesOnLand(player2)[0].id);
         expect(card.resourceCount).to.eq(2); // i.e. not changed
@@ -74,29 +56,8 @@ describe("Herbivores", function () {
     });
 
     it("Should be playable in solo mode", function () {
-        const card = new Herbivores();
-        const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar_solo", [player], player);
-
-        expect(card.canPlay(player, game)).to.eq(false, "Unexpetedely can play card without oxygen");
-
         (game as any).oxygenLevel = 8;
-
-        expect(card.canPlay(player, game)).to.eq(true, "Can't play for some reason");
-
-        player.setProduction(Resources.PLANTS);
-
-        card.play(player, game);
-            
-        player.playedCards.push(card);
-
-        expect(player.getProduction(Resources.PLANTS)).to.eq(1, "Somehow plantProduction is changed"); // Not changed
-
-        game.addGreenery(player, game.board.getAvailableSpacesOnLand(player)[0].id);
-        game.addGreenery(player, game.board.getAvailableSpacesOnLand(player)[0].id);
-
-        expect(card.resourceCount).to.eq(3);
-
-        expect(card.getVictoryPoints()).to.eq(1);
+        expect(card.canPlay(player, game)).to.eq(true);
     });
 });

--- a/tests/cards/IceCapMelting.spec.ts
+++ b/tests/cards/IceCapMelting.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { IceCapMelting } from "../../src/cards/IceCapMelting";
 import { Color } from "../../src/Color";
@@ -6,18 +5,23 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("IceCapMelting", function () {
+    let card : IceCapMelting, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new IceCapMelting();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new IceCapMelting();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new IceCapMelting();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = 2;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
     });
 });

--- a/tests/cards/ImmigrantCity.spec.ts
+++ b/tests/cards/ImmigrantCity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ImmigrantCity } from "../../src/cards/ImmigrantCity";
 import { Color } from "../../src/Color";
@@ -8,36 +7,40 @@ import { Resources } from '../../src/Resources';
 import { TharsisRepublic } from "../../src/cards/corporation/TharsisRepublic";
 
 describe("ImmigrantCity", function () {
-    it("Can't play", function () {
-        const card = new ImmigrantCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player,game)).to.eq(false);
+    let card : ImmigrantCity, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ImmigrantCity();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
     });
+    
+    it("Can't play without energy production", function () {
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+    
     it("Should play", function () {
-        const card = new ImmigrantCity();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         player.setProduction(Resources.ENERGY);
         const action = card.play(player, game);
         action.cb(action.availableSpaces[0]);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-2);
         player.playedCards.push(card);
+
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
     });
+
     it("Can play at -4 MC production", function () {
-        const card = new ImmigrantCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
         player.setProduction(Resources.ENERGY);
         player.setProduction(Resources.MEGACREDITS, -4);
-    
         expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
         action.cb(action.availableSpaces[0]);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-5);
         player.playedCards.push(card);
@@ -46,19 +49,16 @@ describe("ImmigrantCity", function () {
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-4);
     });
+    
     it("Tharsis can play at -5 MC production", function () {
-        const card = new ImmigrantCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
-        const tharsis = new TharsisRepublic();
-        player.corporationCard = tharsis;
-        
+        player.corporationCard = new TharsisRepublic();
         player.setProduction(Resources.ENERGY);
         player.setProduction(Resources.MEGACREDITS, -5);
-    
         expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
         action.cb(action.availableSpaces[0]);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-5); // should not increase
         player.playedCards.push(card);

--- a/tests/cards/ImportedHydrogen.spec.ts
+++ b/tests/cards/ImportedHydrogen.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ImportedHydrogen } from "../../src/cards/ImportedHydrogen";
 import { Color } from "../../src/Color";
@@ -12,22 +11,22 @@ import { Decomposers } from "../../src/cards/Decomposers";
 import { SelectOption } from "../../src/inputs/SelectOption";
 
 describe("ImportedHydrogen", function () {
-    it("Should play", function () {
-        const card = new ImportedHydrogen();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
+    let card : ImportedHydrogen, player : Player, game : Game;
 
+    beforeEach(function() {
+        card = new ImportedHydrogen();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Should play", function () {
         const pets = new Pets();
         const tardigrades = new Tardigrades();
         const decomposers = new Decomposers();
         player.playedCards.push(pets, tardigrades, decomposers);
 
-        var action = card.play(player, game);
-
+        const action = card.play(player, game);
         expect(action instanceof OrOptions).to.eq(true);
-        if (action === undefined) return;
-
         expect((action as OrOptions).options.length).to.eq(3);
 
         (action as OrOptions).options[0].cb();
@@ -39,17 +38,13 @@ describe("ImportedHydrogen", function () {
         expect(selectMicrobe.cards.length).to.eq(2);
         expect(selectMicrobe.cards[0]).to.eq(tardigrades);
         selectMicrobe.cb([tardigrades]);
+        
         expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
         selectAnimal.cb();
         expect(player.getResourcesOnCard(pets)).to.eq(2);
     });
 
     it("Should add plants directly if no microbe or animal cards available", function () {
-        const card = new ImportedHydrogen();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-
         expect(player.plants).to.eq(0);
         card.play(player, game);
         expect(player.plants).to.eq(3);

--- a/tests/cards/ImportedNitrogen.spec.ts
+++ b/tests/cards/ImportedNitrogen.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ImportedNitrogen } from "../../src/cards/ImportedNitrogen";
 import { Color } from "../../src/Color";
@@ -11,59 +10,58 @@ import { ICard } from '../../src/cards/ICard';
 import { Game } from '../../src/Game';
 
 describe("ImportedNitrogen", function () {
+    let card : ImportedNitrogen, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ImportedNitrogen();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play without animals and microbes", function () {
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const card = new ImportedNitrogen();
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
         expect(player.getTerraformRating()).to.eq(21);
         expect(player.plants).to.eq(4);
     });
+
     it("Should play with only animals", function () {
-        const card = new ImportedNitrogen();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const pets = new Pets();
         player.playedCards.push(pets);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
+
         const andAction = action as SelectCard<ICard>;
         andAction.cb([pets]);
         expect(player.getTerraformRating()).to.eq(21);
         expect(player.plants).to.eq(4);
         expect(player.getResourcesOnCard(pets)).to.eq(2);
     });
+
     it("Should play with only microbes", function () {
-        const card = new ImportedNitrogen();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const tardigrades = new Tardigrades();
         player.playedCards.push(tardigrades);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
+
         const andAction = action as SelectCard<ICard>;
         andAction.cb([tardigrades]);
         expect(player.getTerraformRating()).to.eq(21);
         expect(player.plants).to.eq(4);
         expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
     });
+    
     it("Should play with animals and microbes", function () {
-        const card = new ImportedNitrogen();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const pets = new Pets();
         const tardigrades = new Tardigrades();
         player.playedCards.push(pets, tardigrades);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof AndOptions).to.eq(true);
+
         const andAction = action as AndOptions;
         andAction.cb();
         expect(player.getTerraformRating()).to.eq(21);
         expect(player.plants).to.eq(4);
+
         andAction.options[0].cb([tardigrades]);
         expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
         andAction.options[1].cb([pets]);

--- a/tests/cards/IndustrialCenter.spec.ts
+++ b/tests/cards/IndustrialCenter.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { IndustrialCenter } from "../../src/cards/IndustrialCenter";
 import { Color } from "../../src/Color";
@@ -8,33 +7,33 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("IndustrialCenter", function () {
+    let card : IndustrialCenter, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new IndustrialCenter();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play or act", function () {
-        const card = new IndustrialCenter();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canAct(player)).to.eq(false);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should action", function () {
-        const card = new IndustrialCenter();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 7;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        card.action(player, game);
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.STEEL)).to.eq(1);
     });
+
     it("Should play", function () {
-        const card = new IndustrialCenter();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
         expect(game.getCitiesInPlayOnMars()).to.eq(1);
+        
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
-        action.cb(action.availableSpaces[0]);
-        expect(action.availableSpaces[0].tile).not.to.eq(undefined);
-        expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
+        action!.cb(action!.availableSpaces[0]);
+        expect(action!.availableSpaces[0].tile).not.to.eq(undefined);
+        expect(action!.availableSpaces[0].tile && action!.availableSpaces[0].tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
     });
 });

--- a/tests/cards/Insects.spec.ts
+++ b/tests/cards/Insects.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Insects } from "../../src/cards/Insects";
 import { Color } from "../../src/Color";
@@ -8,22 +7,25 @@ import { Trees } from "../../src/cards/Trees";
 import { Resources } from '../../src/Resources';
 
 describe("Insects", function () {
+    let card : Insects, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Insects();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Insects();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Insects();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 6;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(0);
+        
         player.playedCards.push(new Trees());
         card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);

--- a/tests/cards/InterstellarColonyShip.spec.ts
+++ b/tests/cards/InterstellarColonyShip.spec.ts
@@ -1,25 +1,29 @@
-
 import { expect } from "chai";
 import { InterstellarColonyShip } from "../../src/cards/InterstellarColonyShip";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { GeneRepair } from "../../src/cards/GeneRepair";
+import { Research } from "../../src/cards/Research";
 
 describe("InterstellarColonyShip", function () {
-    it("Should throw", function () {
-        const card = new InterstellarColonyShip();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(function () { card.play(player, game); }).to.throw("Requires 5 science tags.");
+    let card : InterstellarColonyShip, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new InterstellarColonyShip();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player)).to.eq(false);
+    });
+    
     it("Should play", function () {
-        const card = new InterstellarColonyShip();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.playedCards.push(new GeneRepair(), new GeneRepair(), new GeneRepair(), new GeneRepair(), new GeneRepair());
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        player.playedCards.push(new Research(), new Research(), new GeneRepair());
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(4);
     });

--- a/tests/cards/InventorsGuild.spec.ts
+++ b/tests/cards/InventorsGuild.spec.ts
@@ -7,36 +7,39 @@ import { SelectCard } from "../../src/inputs/SelectCard";
 import { IProjectCard } from "../../src/cards/IProjectCard";
 
 describe("InventorsGuild", function () {
+    let card : InventorsGuild, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new InventorsGuild();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new InventorsGuild();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
         expect(action).to.eq(undefined);
     });
+
     it("Should act", function () {
-        const card = new InventorsGuild();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 3;
         const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectCard).to.eq(true);
         (action! as SelectCard<IProjectCard>).cb([]);
+
         expect(game.dealer.discarded.length).to.eq(1);
         expect(player.megaCredits).to.eq(3);
         player.megaCredits = 3;
+
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });
+
     it("Cannot buy card if cannot pay", function () {
-        const card = new InventorsGuild();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 2;
         const action = card.action(player, game);
         expect(action instanceof SelectCard).to.eq(true);
+        
         (action! as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
         expect(game.dealer.discarded.length).to.eq(1);
         expect(player.cardsInHand.length).to.eq(0);

--- a/tests/cards/Ironworks.spec.ts
+++ b/tests/cards/Ironworks.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Ironworks } from "../../src/cards/Ironworks";
 import { Color } from "../../src/Color";
@@ -6,25 +5,24 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("Ironworks", function () {
-    it("Should throw", function () {
-        const card = new Ironworks();
-        const player = new Player("test", Color.BLUE, false);
+    let card : Ironworks, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Ironworks();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act without enough energy", function () {
+        player.energy = 3;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new Ironworks();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new Ironworks();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 4;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player, game);
         expect(player.energy).to.eq(0);
         expect(player.steel).to.eq(1);
         expect(game.getOxygenLevel()).to.eq(1);

--- a/tests/cards/KelpFarming.spec.ts
+++ b/tests/cards/KelpFarming.spec.ts
@@ -1,26 +1,34 @@
-
 import { expect } from "chai";
 import { KelpFarming } from "../../src/cards/KelpFarming";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { maxOutOceans } from "../TestingUtils";
 
 describe("KelpFarming", function () {
+    let card : KelpFarming, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new KelpFarming();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new KelpFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new KelpFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        maxOutOceans(player, game, 6);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        const plantsCount = player.plants;
+        card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
         expect(player.getProduction(Resources.PLANTS)).to.eq(3);
-        expect(player.plants).to.eq(2);
+        expect(player.plants).to.eq(plantsCount + 2);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/LakeMarineris.spec.ts
+++ b/tests/cards/LakeMarineris.spec.ts
@@ -1,23 +1,35 @@
-
 import { expect } from "chai";
 import { LakeMarineris } from "../../src/cards/LakeMarineris";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("LakeMarineris", function () {
+    let card : LakeMarineris, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new LakeMarineris();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new LakeMarineris();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new LakeMarineris();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -0;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player, game);
+
+        expect(game.interrupts.length).to.eq(2);
+        const firstOcean = game.interrupts[0].playerInput as SelectSpace;
+        firstOcean.cb(firstOcean.availableSpaces[0]);
+        const secondOcean = game.interrupts[1].playerInput as SelectSpace;
+        secondOcean.cb(secondOcean.availableSpaces[1]);
+        expect(player.getTerraformRating()).to.eq(22);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });

--- a/tests/cards/LargeConvoy.spec.ts
+++ b/tests/cards/LargeConvoy.spec.ts
@@ -1,22 +1,24 @@
-
 import { expect } from "chai";
 import { LargeConvoy } from "../../src/cards/LargeConvoy";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
-
 import { Pets } from "../../src/cards/Pets";
 import { OrOptions } from "../../src/inputs/OrOptions";
 import { maxOutOceans } from "../TestingUtils";
 import { Fish } from "../../src/cards/Fish";
 
 describe("LargeConvoy", function () {
+    let card : LargeConvoy, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new LargeConvoy();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play without animal cards", function () {
-        const card = new LargeConvoy();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
 
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
@@ -25,10 +27,6 @@ describe("LargeConvoy", function () {
     });
 
     it("Should play with single animal target", function () {
-        const card = new LargeConvoy();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-
         const pets = new Pets();
         player.playedCards.push(pets);
 
@@ -44,17 +42,12 @@ describe("LargeConvoy", function () {
     });
 
     it("Should play with multiple animal targets", function () {
-        const card = new LargeConvoy();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-
         const pets = new Pets();
         const fish = new Fish();
         player.playedCards.push(pets, fish);
 
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
 
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
@@ -63,30 +56,23 @@ describe("LargeConvoy", function () {
 
         (action as OrOptions).options[1].cb([pets])
         expect(player.getResourcesOnCard(pets)).to.eq(4);
-
     });
 
     it("Should play without oceans", function () {
-        const card = new LargeConvoy();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar2", [player,player2], player);
-
         const pets = new Pets();
         player.playedCards.push(pets);
-        maxOutOceans(player2, game);
+        maxOutOceans(player, game);
+        const plantsCount = player.plants;
+        const cardsInHand = player.cardsInHand.length;
 
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
 
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
-        expect(player.cardsInHand.length).to.eq(2);
-        expect(player.plants).to.eq(0);
+        expect(player.cardsInHand.length).to.eq(cardsInHand + 2);
 
-        expect(player.plants).to.eq(0);
         (action as OrOptions).options[0].cb()
-        expect(player.plants).to.eq(5);
+        expect(player.plants).to.eq(plantsCount + 5);
     });
 });

--- a/tests/cards/LavaFlows.spec.ts
+++ b/tests/cards/LavaFlows.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { LavaFlows } from "../../src/cards/LavaFlows";
 import { Color } from "../../src/Color";
@@ -9,23 +8,28 @@ import { SpaceName } from "../../src/SpaceName";
 import { SpaceType } from "../../src/SpaceType";
 
 describe("LavaFlows", function () {
-    it("Can't play", function () {
-        const card = new LavaFlows();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : LavaFlows, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new LavaFlows();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play if no available spaces", function () {
         game.addTile(player, SpaceType.LAND, game.getSpace(SpaceName.THARSIS_THOLUS), { tileType: TileType.LAVA_FLOWS }); 
-        const anotherPlayer = new Player("test", Color.RED, false);
-        game.getSpace(SpaceName.ASCRAEUS_MONS).player = anotherPlayer; // land claim
         game.addTile(player, SpaceType.LAND, game.getSpace(SpaceName.ARSIA_MONS), { tileType: TileType.LAVA_FLOWS });
         game.addTile(player, SpaceType.LAND, game.getSpace(SpaceName.PAVONIS_MONS), { tileType: TileType.LAVA_FLOWS });
+
+        const anotherPlayer = new Player("test", Color.RED, false);
+        game.getSpace(SpaceName.ASCRAEUS_MONS).player = anotherPlayer; // land claim
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new LavaFlows();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
+        
         action.cb(action.availableSpaces[0]);
         expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.LAVA_FLOWS);
         expect(action.availableSpaces[0].player).to.eq(player);

--- a/tests/cards/Lichen.spec.ts
+++ b/tests/cards/Lichen.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Lichen } from "../../src/cards/Lichen";
 import { Color } from "../../src/Color";
@@ -7,17 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Lichen", function () {
+    let card : Lichen, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Lichen();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Lichen();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Lichen();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -24;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });
 });

--- a/tests/cards/LightningHarvest.spec.ts
+++ b/tests/cards/LightningHarvest.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { LightningHarvest } from "../../src/cards/LightningHarvest";
 import { Color } from "../../src/Color";
@@ -8,21 +7,26 @@ import { GeneRepair } from "../../src/cards/GeneRepair";
 import { Resources } from '../../src/Resources';
 
 describe("LightningHarvest", function () {
-    it("Should throw", function () {
-        const card = new LightningHarvest();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(function () { card.play(player, game); }).to.throw("Requires 3 science tags");
+    let card : LightningHarvest, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new LightningHarvest();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new LightningHarvest();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new GeneRepair(), new GeneRepair(), new GeneRepair());
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/Livestock.spec.ts
+++ b/tests/cards/Livestock.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Livestock } from "../../src/cards/Livestock";
 import { Color } from "../../src/Color";
@@ -7,33 +6,40 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Livestock", function () {
-    it("Can't play", function () {
-        const card = new Livestock();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
-        game.increaseOxygenLevel(player, 2); // 8
-        game.increaseOxygenLevel(player, 1); // 9
+    let card : Livestock, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Livestock();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without plant production", function () {
+        (game as any).oxygenLevel = 9;
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new Livestock();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
+
+    it("Can't play if oxygen level too low", function () {
+        (game as any).oxygenLevel = 8;
         player.setProduction(Resources.PLANTS);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Should play", function () {
+        player.setProduction(Resources.PLANTS);
+        (game as any).oxygenLevel = 9;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
+        player.playedCards.push(card);
         expect(player.getProduction(Resources.PLANTS)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
+
         player.addResourceTo(card, 4);
         expect(card.getVictoryPoints()).to.eq(4);
     });
+    
     it("Should act", function () {
-        const card = new Livestock();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
         card.action();
         expect(card.resourceCount).to.eq(1);

--- a/tests/cards/LocalHeatTrapping.spec.ts
+++ b/tests/cards/LocalHeatTrapping.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { LocalHeatTrapping } from "../../src/cards/LocalHeatTrapping";
 import { Color } from "../../src/Color";
@@ -10,28 +9,29 @@ import { Game } from "../../src/Game";
 import { Fish } from "../../src/cards/Fish";
 
 describe("LocalHeatTrapping", function () {
-    it("Can't play", function () {
-        const card = new LocalHeatTrapping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
+    let card : LocalHeatTrapping, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new LocalHeatTrapping();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without 5 heat", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play - no animal targets", function () {
-        const card = new LocalHeatTrapping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
-        player.heat = 5;
-        player.playedCards.push(card);
 
+    it("Should play - no animal targets", function () {
+        player.heat = 5;
+        expect(card.canPlay(player, game)).to.eq(true);
+        
         card.play(player, game);
+        player.playedCards.push(card);
         expect(player.plants).to.eq(4);
         expect(player.heat).to.eq(0);
     });
+
     it("Should play - single animal target", function () {
-        const card = new LocalHeatTrapping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        
         player.heat = 5;
         const pets = new Pets();
         player.playedCards.push(card, pets);
@@ -47,11 +47,8 @@ describe("LocalHeatTrapping", function () {
         orOptions.options[1].cb();
         expect(player.getResourcesOnCard(pets)).to.eq(2);
     });
-    it("Should play - multiple animal targets", function () {
-        const card = new LocalHeatTrapping();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
 
+    it("Should play - multiple animal targets", function () {
         player.heat = 5;
         const pets = new Pets();
         const fish = new Fish();
@@ -62,17 +59,14 @@ describe("LocalHeatTrapping", function () {
         orOptions.options[1].cb([fish]);
         expect(player.getResourcesOnCard(fish)).to.eq(2);
     });
-    it("Can't play as Helion if not enough heat left after paying for card", function () {
-        const card = new LocalHeatTrapping();
-        const corp = new Helion();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
 
+    it("Can't play as Helion if not enough heat left after paying for card", function () {
+        const corp = new Helion();
         corp.play(player);
         player.corporationCard = corp;
+
         player.megaCredits = 0;
         player.heat = 5; // have to pay for card with 1 heat
-
         expect(card.canPlay(player, game)).to.eq(false);
     });
 });

--- a/tests/cards/LunarBeam.spec.ts
+++ b/tests/cards/LunarBeam.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { LunarBeam } from "../../src/cards/LunarBeam";
 import { Color } from "../../src/Color";
@@ -6,19 +5,23 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("LunarBeam", function () {
+    let card : LunarBeam, player : Player;
+
+    beforeEach(function() {
+        card = new LunarBeam();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can play", function () {
-        const card = new LunarBeam();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.MEGACREDITS,-4);
         expect(card.canPlay(player)).to.eq(false);
+
         player.setProduction(Resources.MEGACREDITS);
         expect(card.canPlay(player)).to.eq(true);
     });
+
     it("Should play", function () {
-        const card = new LunarBeam();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-2);
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);

--- a/tests/cards/MagneticFieldDome.spec.ts
+++ b/tests/cards/MagneticFieldDome.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MagneticFieldDome } from "../../src/cards/MagneticFieldDome";
 import { Color } from "../../src/Color";
@@ -7,18 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("MagneticFieldDome", function () {
-    it("Should throw", function () {
-        const card = new MagneticFieldDome();
-        const player = new Player("test", Color.BLUE, false);
+    let card : MagneticFieldDome, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MagneticFieldDome();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+    
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new MagneticFieldDome();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.ENERGY,2);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        player.setProduction(Resources.ENERGY, 2);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/MagneticFieldGenerators.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MagneticFieldGenerators } from "../../src/cards/MagneticFieldGenerators";
 import { Color } from "../../src/Color";
@@ -7,18 +6,23 @@ import { Resources } from '../../src/Resources';
 import { Game } from '../../src/Game';
 
 describe("MagneticFieldGenerators", function () {
-    it("Should throw", function () {
-        const card = new MagneticFieldGenerators();
-        const player = new Player("test", Color.BLUE, false);
+    let card : MagneticFieldGenerators, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MagneticFieldGenerators();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new MagneticFieldGenerators();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.ENERGY,4);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        player.setProduction(Resources.ENERGY, 4);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
         expect(player.getTerraformRating()).to.eq(23);

--- a/tests/cards/Mangrove.spec.ts
+++ b/tests/cards/Mangrove.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Mangrove } from "../../src/cards/Mangrove";
 import { Color } from "../../src/Color";
@@ -7,22 +6,27 @@ import { Game } from "../../src/Game";
 import { TileType } from "../../src/TileType";
 
 describe("Mangrove", function () {
+    let card : Mangrove, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Mangrove();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Mangrove();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Mangrove();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
-        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
-        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+
         action.cb(action.availableSpaces[0]);
         expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.GREENERY);
         expect(action.availableSpaces[0].player).to.eq(player);
+
+        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });
 });

--- a/tests/cards/MarsUniversity.spec.ts
+++ b/tests/cards/MarsUniversity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MarsUniversity } from "../../src/cards/MarsUniversity";
 import { Color } from "../../src/Color";
@@ -9,21 +8,28 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Research } from "../../src/cards/Research";
 
 describe("MarsUniversity", function () {
+    let card : MarsUniversity, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MarsUniversity();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new MarsUniversity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play();
         expect(action).to.eq(undefined);
-        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
-        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+
         expect(card.onCardPlayed(player, game, new Pets())).to.eq(undefined);
         expect(game.interrupts.length).to.eq(0);
+
         player.cardsInHand.push(card);
         card.onCardPlayed(player, game, card);
         expect(game.interrupts.length).to.eq(1);
+
         let orOptions = game.interrupts[0].playerInput as OrOptions;
         game.interrupts.splice(0, 1);
+
         orOptions.options[0].cb([card]);
         expect(player.cardsInHand.length).to.eq(1);
         expect(player.cardsInHand[0]).not.to.eq(card);
@@ -31,15 +37,21 @@ describe("MarsUniversity", function () {
         expect(game.dealer.discarded[0]).to.eq(card);
         expect(game.interrupts.length).to.eq(0);
     });
+
+    it("Gives victory point", function () {
+        card.play();
+        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+    });
+
     it("Runs twice for multiple science tags", function () {
-        const card = new MarsUniversity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
         player.cardsInHand.push(card, card);
         card.onCardPlayed(player, game, new Research());
         expect(game.interrupts.length).to.eq(1);
+
         let orOptions = game.interrupts[0].playerInput as OrOptions;
         game.interrupts.splice(0, 1);
+        
         orOptions.options[1].cb();
         expect(game.interrupts.length).to.eq(1);
         orOptions = game.interrupts[0].playerInput as OrOptions;

--- a/tests/cards/MartianRails.spec.ts
+++ b/tests/cards/MartianRails.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MartianRails } from "../../src/cards/MartianRails";
 import { Color } from "../../src/Color";
@@ -6,25 +5,25 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("MartianRails", function () {
-    it("Can't act", function () {
-        const card = new MartianRails();
-        const player = new Player("test", Color.BLUE, false);
+    let card : MartianRails, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MartianRails();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act without energy", function () {
+        expect(card.play(player, game)).to.eq(undefined);
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new MartianRails();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.play(player, game)).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new MartianRails();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 1;
+        expect(card.canAct(player)).to.eq(true);
         game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        
+        card.action(player, game);
         expect(player.energy).to.eq(0);
         expect(player.megaCredits).to.eq(1);
     });

--- a/tests/cards/MassConverter.spec.ts
+++ b/tests/cards/MassConverter.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MassConverter } from "../../src/cards/MassConverter";
 import { Color } from "../../src/Color";
@@ -8,17 +7,23 @@ import { TollStation } from "../../src/cards/TollStation";
 import { Resources } from '../../src/Resources';
 
 describe("MassConverter", function () {
+    let card : MassConverter, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MassConverter();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new MassConverter();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new MassConverter();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card, card, card, card, card);
-        expect(card.play(player)).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(6);
         expect(card.getCardDiscount(player, game, card)).to.eq(0);
         expect(card.getCardDiscount(player, game, new TollStation())).to.eq(2);

--- a/tests/cards/MethaneFromTitan.spec.ts
+++ b/tests/cards/MethaneFromTitan.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MethaneFromTitan } from "../../src/cards/MethaneFromTitan";
 import { Color } from "../../src/Color";
@@ -7,19 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("MethaneFromTitan", function () {
-    it("Should throw", function () {
-        const card = new MethaneFromTitan();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : MethaneFromTitan, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MethaneFromTitan();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
+    
     it("Should play", function () {
-        const card = new MethaneFromTitan();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 2;
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player);
+        
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/MiningArea.spec.ts
+++ b/tests/cards/MiningArea.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MiningArea } from "../../src/cards/MiningArea";
 import { Color } from "../../src/Color";
@@ -10,16 +9,19 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("MiningArea", function () {
+    let card : MiningArea, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MiningArea();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new MiningArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new MiningArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const lands = game.board.getAvailableSpacesOnLand(player);
         for (let land of lands) {
             if (land.bonus.indexOf(SpaceBonus.STEEL) !== -1 || land.bonus.indexOf(SpaceBonus.TITANIUM) !== -1) {
@@ -31,15 +33,17 @@ describe("MiningArea", function () {
                 }
             }
         }
+
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+        
         const titaniumSpace = action.availableSpaces.find((space) => space.bonus.indexOf(SpaceBonus.TITANIUM) !== -1 && space.bonus.indexOf(SpaceBonus.STEEL) === -1);
         expect(titaniumSpace).not.to.eq(undefined);
         action.cb(titaniumSpace!);
         expect(titaniumSpace!.player).to.eq(player);
         expect(titaniumSpace!.tile && titaniumSpace!.tile!.tileType).to.eq(TileType.MINING_AREA);
-        expect(player.getProduction(Resources.TITANIUM)).to.eq(1); 
+        expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
+        
         const steelSpace = action.availableSpaces.find((space) => space.bonus.indexOf(SpaceBonus.TITANIUM) === -1 && space.bonus.indexOf(SpaceBonus.STEEL) !== -1);
         expect(steelSpace).not.to.eq(undefined);
         action.cb(steelSpace!);

--- a/tests/cards/MiningRights.spec.ts
+++ b/tests/cards/MiningRights.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { MiningRights } from "../../src/cards/MiningRights";
 import { Color } from "../../src/Color";
@@ -10,10 +9,15 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("MiningRights", function () {
-    it("Should throw", function () {
-        const card = new MiningRights();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : MiningRights, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MiningRights();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play if no available spaces", function () {
         for (let land of game.board.getAvailableSpacesOnLand(player)) {
             if (land.bonus.indexOf(SpaceBonus.STEEL) !== -1 || land.bonus.indexOf(SpaceBonus.TITANIUM) !== -1) {
                 game.addTile(player, land.spaceType, land, { tileType: TileType.MINING_RIGHTS });
@@ -21,19 +25,18 @@ describe("MiningRights", function () {
         }
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new MiningRights();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
-        expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+
         const titaniumSpace = action.availableSpaces.find((space) => space.bonus.indexOf(SpaceBonus.TITANIUM) !== -1 && space.bonus.indexOf(SpaceBonus.STEEL) === -1);
         expect(titaniumSpace).not.to.eq(undefined);
         action.cb(titaniumSpace!);
         expect(titaniumSpace!.player).to.eq(player);
         expect(titaniumSpace!.tile && titaniumSpace!.tile!.tileType).to.eq(TileType.MINING_RIGHTS);
-        expect(player.getProduction(Resources.TITANIUM)).to.eq(1); 
+        expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
+
         const steelSpace = action.availableSpaces.find((space) => space.bonus.indexOf(SpaceBonus.TITANIUM) === -1 && space.bonus.indexOf(SpaceBonus.STEEL) !== -1);
         expect(steelSpace).not.to.eq(undefined);
         action.cb(steelSpace!);

--- a/tests/cards/Moss.spec.ts
+++ b/tests/cards/Moss.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Moss } from "../../src/cards/Moss";
 import { Color } from "../../src/Color";
@@ -6,41 +5,45 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 import { ViralEnhancers } from "../../src/cards/ViralEnhancers";
+import { maxOutOceans } from "../TestingUtils";
 
 describe("Moss", function () {
-    it("Can't play", function () {
-        const card = new Moss();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        while (game.board.getOceansOnBoard() < 3) {
-            game.addOceanTile(player, game.board.getAvailableSpacesForOcean(player)[0].id);
-        }
+    let card : Moss, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Moss();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without enough oceans", function () {
+        maxOutOceans(player, game, 2);
+        player.plants = 1;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
+    it("Can't play if have no plants", function () {
+        maxOutOceans(player, game, 3);
+        player.plants = 0;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new Moss();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
-        expect(player.plants).to.eq(-1);
+        maxOutOceans(player, game, 3);
+        player.plants = 1;
+        expect(card.canPlay(player, game)).to.eq(true);
+        
+        card.play(player);
+        expect(player.plants).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });
+
     it("Can play with 0 plants if have Viral Enhancers", function () {
-        const card = new Moss();
+        maxOutOceans(player, game, 3);
         const viralEnhancers = new ViralEnhancers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-
-        // meet min. requirements
-        game.addOceanTile(player, "06");
-        game.addOceanTile(player, "07");
-        game.addOceanTile(player, "34");
-
-        // setup player with viral enhancers in play and no plants
-        player.plants = 0;
         player.playedCards.push(viralEnhancers);
-        
+        player.plants = 0;
+
         expect(card.canPlay(player, game)).to.eq(true);
         card.play(player);
         

--- a/tests/cards/NaturalPreserve.spec.ts
+++ b/tests/cards/NaturalPreserve.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NaturalPreserve } from "../../src/cards/NaturalPreserve";
 import { Color } from "../../src/Color";
@@ -9,31 +8,39 @@ import { SelectSpace } from "../../src/inputs/SelectSpace";
 import { Resources } from '../../src/Resources';
 
 describe("NaturalPreserve", function () {
-    it("Can't play", function () {
-        const card = new NaturalPreserve();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : NaturalPreserve, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NaturalPreserve();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play if no spaces available", function () {
         const lands = game.board.getAvailableSpacesOnLand(player);
         for (let land of lands) {
             game.addTile(player, land.spaceType, land, { tileType: TileType.NATURAL_PRESERVE });
         }
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 1); // 5
+
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
+    it("Can't play if oxygen level too high", function () {
+        (game as any).oxygenLevel = 5;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new NaturalPreserve();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        expect(card.canPlay(player, game)).to.eq(true);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         expect(action instanceof SelectSpace).to.eq(true);
+
         action.cb(action.availableSpaces[0]);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
+        expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.NATURAL_PRESERVE);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
-        expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.NATURAL_PRESERVE);
     }); 
 });

--- a/tests/cards/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/NitriteReducingBacteria.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NitriteReducingBacteria } from "../../src/cards/NitriteReducingBacteria";
 import { Color } from "../../src/Color";
@@ -7,29 +6,33 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Game } from '../../src/Game';
 
 describe("NitriteReducingBacteria", function () {
+    let card : NitriteReducingBacteria, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NitriteReducingBacteria();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new NitriteReducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
         expect(card.resourceCount).to.eq(3);
     });
+
     it("Should act", function () {
-        const card = new NitriteReducingBacteria();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card);
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        card.action(player, game);
         expect(card.resourceCount).to.eq(1);
+
         player.addResourceTo(card, 3);
         let orOptions = card.action(player, game) as OrOptions;
-        expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+
+        orOptions!.options[1].cb();
         expect(card.resourceCount).to.eq(5);
-        orOptions.options[0].cb();
+        
+        orOptions!.options[0].cb();
         expect(card.resourceCount).to.eq(2);
         expect(player.getTerraformRating()).to.eq(21);
     });

--- a/tests/cards/NitrophilicMoss.spec.ts
+++ b/tests/cards/NitrophilicMoss.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NitrophilicMoss } from "../../src/cards/NitrophilicMoss";
 import { Color } from "../../src/Color";
@@ -6,41 +5,45 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 import { ViralEnhancers } from "../../src/cards/ViralEnhancers";
+import { maxOutOceans } from "../TestingUtils";
 
 describe("NitrophilicMoss", function () {
-    it("Can't play", function () {
-        const card = new NitrophilicMoss();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        const oceans = game.board.getAvailableSpacesForOcean(player);
-        for (let i = 0; i < 3; i++) {
-            game.addOceanTile(player, oceans[i].id);
-        }
+    let card : NitrophilicMoss, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NitrophilicMoss();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without enough oceans", function () {
+        maxOutOceans(player, game, 2);
+        player.plants = 2;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
+    it("Can't play if not enough plants", function () {
+        maxOutOceans(player, game, 3);
+        player.plants = 1;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new NitrophilicMoss();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
-        expect(player.plants).to.eq(-2);
+        maxOutOceans(player, game, 3);
+        player.plants = 2;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
+        expect(player.plants).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
     });
+
     it("Can play with 1 plant if have Viral Enhancers", function () {
-        const card = new NitrophilicMoss();
-        const viralEnhancers = new ViralEnhancers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-
-        // meet min. requirements
-        game.addOceanTile(player, "06");
-        game.addOceanTile(player, "07");
-        game.addOceanTile(player, "34");
-
         // setup player with viral enhancers in play and 1 plant
-        player.plants = 1;
+        const viralEnhancers = new ViralEnhancers();
         player.playedCards.push(viralEnhancers);
+        maxOutOceans(player, game, 3);
+        player.plants = 1;
         
         expect(card.canPlay(player, game)).to.eq(true);
         card.play(player);

--- a/tests/cards/NoctisCity.spec.ts
+++ b/tests/cards/NoctisCity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NoctisCity } from "../../src/cards/NoctisCity";
 import { Color } from "../../src/Color";
@@ -9,21 +8,26 @@ import { TileType } from "../../src/TileType";
 import { Resources } from '../../src/Resources';
 
 describe("NoctisCity", function () {
-    it("Should throw", function () {
-        const card = new NoctisCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : NoctisCity, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NoctisCity();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new NoctisCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
+        
         const noctis = game.getSpace(SpaceName.NOCTIS_CITY);
         expect(noctis.tile && noctis.tile.tileType).to.eq(TileType.CITY);
     });

--- a/tests/cards/NoctisFarming.spec.ts
+++ b/tests/cards/NoctisFarming.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NoctisFarming } from "../../src/cards/NoctisFarming";
 import { Color } from "../../src/Color";
@@ -7,19 +6,26 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("NoctisFarming", function () {
+    let card : NoctisFarming, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NoctisFarming();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new NoctisFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new NoctisFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -20;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         expect(player.plants).to.eq(2);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/NuclearPower.spec.ts
+++ b/tests/cards/NuclearPower.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { NuclearPower } from "../../src/cards/NuclearPower";
 import { Color } from "../../src/Color";
@@ -7,19 +6,22 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("NuclearPower", function () {
-    it("Should throw", function () {
-        const card = new NuclearPower();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.MEGACREDITS,-4);
-        expect(function () { card.play(player, game); }).to.throw("Not enough mega credit production");
+    let card : NuclearPower, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NuclearPower();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't play", function () {
+        player.setProduction(Resources.MEGACREDITS,-4);
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new NuclearPower();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player, game);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-2);
         expect(player.getProduction(Resources.ENERGY)).to.eq(3);
     });

--- a/tests/cards/OlympusConference.spec.ts
+++ b/tests/cards/OlympusConference.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { OlympusConference } from "../../src/cards/OlympusConference";
 import { Color } from "../../src/Color";
@@ -9,36 +8,44 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Research } from "../../src/cards/Research";
 
 describe("OlympusConference", function () {
+    let card : OlympusConference, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new OlympusConference();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new OlympusConference();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+
         expect(card.onCardPlayed(player, game, new Bushes())).to.eq(undefined) 
         card.onCardPlayed(player, game, card);
         expect(card.resourceCount).to.eq(1);
+
         card.onCardPlayed(player, game, card);
         expect(game.interrupts.length).to.eq(1);
+
         const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
         orOptions.options[1].cb();
         expect(card.resourceCount).to.eq(2);
+
         orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(player.cardsInHand.length).to.eq(1);
         expect(game.interrupts.length).to.eq(1);
     });
+
     it("Plays twice for Research", function () {
-        const card = new OlympusConference();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const game = new Game("foobar", [player], player);
         card.onCardPlayed(player, game, new Research());
         expect(game.interrupts.length).to.eq(1);
         expect(card.resourceCount).to.eq(1);
+        
         const orOptions: OrOptions = game.interrupts[0].playerInput as OrOptions;
         game.interrupts.splice(0, 1);
         orOptions.options[1].cb();

--- a/tests/cards/OpenCity.spec.ts
+++ b/tests/cards/OpenCity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { OpenCity } from "../../src/cards/OpenCity";
 import { Color } from "../../src/Color";
@@ -7,32 +6,39 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("OpenCity", function () {
-    it("Can play", function () {
-        const card = new OpenCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        for (let i = 0; i < 6; i++) {
-            game.increaseOxygenLevel(player, 2);
-        }
+    let card : OpenCity, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new OpenCity();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
+        expect(card.canPlay(player,game)).to.eq(false);
+    });
+
+    it("Can't play if oxygen level too low", function () {
+        player.setProduction(Resources.ENERGY);
+        (game as any).oxygenLevel = 11;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new OpenCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        for (let i = 0; i < 6; i++) {
-            game.increaseOxygenLevel(player, 2);
-        }
         player.setProduction(Resources.ENERGY);
+        (game as any).oxygenLevel = 12;
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         action.cb(action.availableSpaces[0]);
+        expect(game.getCitiesInPlayOnMars()).to.eq(1); 
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(4);
         expect(player.plants).to.eq(2);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
-        expect(game.getCitiesInPlayOnMars()).to.eq(1); 
     });
  });

--- a/tests/cards/OreProcessor.spec.ts
+++ b/tests/cards/OreProcessor.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { OreProcessor } from "../../src/cards/OreProcessor";
 import { Color } from "../../src/Color";
@@ -6,25 +5,24 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("OreProcessor", function () {
+    let card : OreProcessor, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new OreProcessor();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't act", function () {
-        const card = new OreProcessor();
-        const player = new Player("test", Color.BLUE, false);
+        player.energy = 3;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new OreProcessor();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new OreProcessor();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 4;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        card.action(player, game);
+
         expect(player.energy).to.eq(0);
         expect(player.titanium).to.eq(1);
         expect(game.getOxygenLevel()).to.eq(1);

--- a/tests/cards/PermafrostExtraction.spec.ts
+++ b/tests/cards/PermafrostExtraction.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { PermafrostExtraction } from "../../src/cards/PermafrostExtraction";
 import { Color } from "../../src/Color";
@@ -6,20 +5,24 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("PermafrostExtraction", function () {
+    let card : PermafrostExtraction, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new PermafrostExtraction();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new PermafrostExtraction();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new PermafrostExtraction();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        if (action !== undefined) {
-          action.cb(action.availableSpaces[0]);
-          expect(game.board.getOceansOnBoard()).to.eq(1);
-        }
+        (game as any).temperature = -8;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        const action = card.play(player, game);        
+        action!.cb(action!.availableSpaces[0]);
+        expect(game.board.getOceansOnBoard()).to.eq(1);
     });
 });

--- a/tests/cards/PhysicsComplex.spec.ts
+++ b/tests/cards/PhysicsComplex.spec.ts
@@ -1,32 +1,29 @@
-
 import { expect } from "chai";
 import { PhysicsComplex } from "../../src/cards/PhysicsComplex";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 
 describe("PhysicsComplex", function () {
+    let card : PhysicsComplex, player : Player;
+
+    beforeEach(function() {
+        card = new PhysicsComplex();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't act", function () {
-        const card = new PhysicsComplex();
-        const player = new Player("test", Color.BLUE, false);
+        card.play();
+        player.energy = 5;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new PhysicsComplex();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
-        player.addResourceTo(card, 4);
-        expect(card.getVictoryPoints()).to.eq(8);
-    });
+
     it("Should act", function () {
-        const card = new PhysicsComplex();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
         player.energy = 6;
-        const action = card.action(player);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player);
         expect(player.energy).to.eq(0);
         expect(card.resourceCount).to.eq(1);
-        expect(action).to.eq(undefined);
     });
 });

--- a/tests/cards/Plantation.spec.ts
+++ b/tests/cards/Plantation.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Plantation } from "../../src/cards/Plantation";
 import { Color } from "../../src/Color";
@@ -7,17 +6,22 @@ import { Game } from "../../src/Game";
 import { InventorsGuild } from "../../src/cards/InventorsGuild";
 
 describe("Plantation", function () {
+    let card : Plantation, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Plantation();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Plantation();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Plantation();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new InventorsGuild(), new InventorsGuild());
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         action.cb(action.availableSpaces[0]);

--- a/tests/cards/PowerInfrastructure.spec.ts
+++ b/tests/cards/PowerInfrastructure.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { PowerInfrastructure } from "../../src/cards/PowerInfrastructure";
 import { Color } from "../../src/Color";
@@ -6,19 +5,25 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("PowerInfrastructure", function () {
-    it("Should play", function () {
-        const card = new PowerInfrastructure();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.play(player, game)).to.eq(undefined);
+    let card : PowerInfrastructure, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new PowerInfrastructure();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't act", function () {
+        card.play(player, game);
+        expect(card.canAct(player)).to.eq(false);
+    });
+
     it("Should act", function () {
-        const card = new PowerInfrastructure();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 1;
+        expect(card.canAct(player)).to.eq(true);
         const action = card.action(player, game);
         action.cb(1);
+
         expect(player.energy).to.eq(0);
         expect(player.megaCredits).to.eq(1);
     });

--- a/tests/cards/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/PowerSupplyConsortium.spec.ts
@@ -1,47 +1,46 @@
-
 import { expect } from "chai";
 import { PowerSupplyConsortium } from "../../src/cards/PowerSupplyConsortium";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("PowerSupplyConsortium", function () {
-    it("Can't play: no tag ", function () {
-        const card = new PowerSupplyConsortium();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar2", [player], player);
+    let card : PowerSupplyConsortium, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new PowerSupplyConsortium();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Can't play without power tags", function () {
         player.setProduction(Resources.ENERGY,3);
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
-    it("Should play: other have energy production", function () {
-        const card = new PowerSupplyConsortium();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar2", [player, player2, player3], player);
-
+    it("Can play", function () {
         player2.setProduction(Resources.ENERGY,3);
-        player3.setProduction(Resources.ENERGY,7);
-        player.playedCards.push(card, card); // we need energy tag
-
+        player.playedCards.push(card, card);
         expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
-        expect(player.getProduction(Resources.ENERGY)).to.eq(1); // incremented
+        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
     });
 
-    it("Should be playable in solo mode: has tag", function () {
-        const card = new PowerSupplyConsortium();
-        const player = new Player("test", Color.BLUE, false);
+    it("Can play in solo mode if have enough power tags", function () {
         const game = new Game("foobar2", [player], player);
-        player.playedCards.push(card, card); // we need 2 energy tags
+        player.playedCards.push(card, card);
         expect(card.canPlay(player, game)).to.eq(true);
-        expect(player.getProduction(Resources.ENERGY)).to.eq(0);
 
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1); // incremented
     });
 });

--- a/tests/cards/Predators.spec.ts
+++ b/tests/cards/Predators.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Predators } from "../../src/cards/Predators";
 import { Color } from "../../src/Color";
@@ -10,52 +9,51 @@ import { ProtectedHabitats } from "../../src/cards/ProtectedHabitats";
 import { SmallAnimals } from "../../src/cards/SmallAnimals";
 
 describe("Predators", function () {
-    it("Can not play", function () {
-        const card = new Predators();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : Predators, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Predators();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canAct(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Predators();
-        const player = new Player("test", Color.BLUE, false);
+        (game as any).oxygenLevel = 11;
+        expect(card.canPlay(player, game)).to.eq(true);
         player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
+        
         player.addResourceTo(card, 5);
         expect(card.getVictoryPoints()).to.eq(5);
     });
+
     it("Should act", function () {
-        const card = new Predators();
         const fish = new Fish();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.playedCards.push(card);
-        player.playedCards.push(fish);
+        const smallAnimals = new SmallAnimals();
+        player.playedCards.push(card, fish, smallAnimals);
         player.addResourceTo(fish);
+        player.addResourceTo(smallAnimals);
         const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
-        if (action === undefined) return;
-        action.cb(action.cards);
+
+        action!.cb(action!.cards);
         expect(card.resourceCount).to.eq(1);
         expect(player.getResourcesOnCard(fish)).to.eq(0);
     });
+
     it("Respects pets", function () {
-        const card = new Predators();
-        const fish = new Fish();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
-
         player.playedCards.push(card);
-
+        const fish = new Fish();
         const pets = new Pets();
-        player2.playedCards.push(pets);
-        player2.addResourceTo(pets);
 
-        player3.playedCards.push(fish);
-        player3.addResourceTo(fish);
+        player2.playedCards.push(pets, fish);
+        player2.addResourceTo(pets);
+        player2.addResourceTo(fish);
 
         expect(card.canAct(player, game)).to.eq(true);
         
@@ -63,37 +61,19 @@ describe("Predators", function () {
         expect(action).to.eq(undefined); // No option to choose Pets card provided
 
         expect(card.resourceCount).to.eq(1);
-        expect(player3.getResourcesOnCard(fish)).to.eq(0);
+        expect(player2.getResourcesOnCard(fish)).to.eq(0);
         expect(player2.getResourcesOnCard(pets)).to.eq(1);
     });
 
     it("Respects protected habitats", function () {
-        const card = new Predators();
+        player.playedCards.push(card);
         const fish = new Fish();
         const animals = new SmallAnimals();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
 
-        player.playedCards.push(card);
-
-        player2.playedCards.push(new ProtectedHabitats());
-        player2.playedCards.push(animals);
+        player2.playedCards.push(animals, fish, new ProtectedHabitats());
         player2.addResourceTo(animals);
+        player2.addResourceTo(fish);
 
-        player3.playedCards.push(fish);
-        player3.addResourceTo(fish);
-
-        expect(card.canAct(player, game)).to.eq(true);
-        
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined); // No option to choose SmallAnimals card provided
-
-        expect(card.resourceCount).to.eq(1);
-        expect(player3.getResourcesOnCard(fish)).to.eq(0);
-        expect(player2.getResourcesOnCard(animals)).to.eq(1);
+        expect(card.canAct(player, game)).to.eq(false);
     });
-
-
 });

--- a/tests/cards/QuantumExtractor.spec.ts
+++ b/tests/cards/QuantumExtractor.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { QuantumExtractor } from "../../src/cards/QuantumExtractor";
 import { Color } from "../../src/Color";
@@ -8,18 +7,21 @@ import { Bushes } from "../../src/cards/Bushes";
 import { TollStation } from '../../src/cards/TollStation';
 
 describe("QuantumExtractor", function () {
+    let card : QuantumExtractor, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new QuantumExtractor();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new QuantumExtractor();
-        const player = new Player("test", Color.BLUE, false);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new QuantumExtractor();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(card, card, card, card);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        card.play(player);
         expect(card.getCardDiscount(player, game, new TollStation())).to.eq(2);
         expect(card.getCardDiscount(player, game, new Bushes())).to.eq(0);
     });

--- a/tests/cards/RadChemFactory.spec.ts
+++ b/tests/cards/RadChemFactory.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { RadChemFactory } from "../../src/cards/RadChemFactory";
 import { Color } from "../../src/Color";
@@ -7,18 +6,23 @@ import { Resources } from '../../src/Resources';
 import { Game } from '../../src/Game';
 
 describe("RadChemFactory", function () {
-    it("Should throw", function () {
-        const card = new RadChemFactory();
-        const player = new Player("test", Color.BLUE, false);
+    let card : RadChemFactory, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new RadChemFactory();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new RadChemFactory();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getTerraformRating()).to.eq(22);
     });

--- a/tests/cards/RadSuits.spec.ts
+++ b/tests/cards/RadSuits.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { RadSuits } from "../../src/cards/RadSuits";
 import { Color } from "../../src/Color";
@@ -7,21 +6,26 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("RadSuits", function () {
-    it("Should throw", function () {
-        const card = new RadSuits();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(function () { card.play(player, game); }).to.throw("Must have 2 cities in play");
+    let card : RadSuits, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new RadSuits();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new RadSuits();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const lands = game.board.getAvailableSpacesOnLand(player);
         game.addCityTile(player, lands[0].id);
         game.addCityTile(player, lands[1].id);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player, game);
+        
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/RegolithEaters.spec.ts
+++ b/tests/cards/RegolithEaters.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { RegolithEaters } from "../../src/cards/RegolithEaters";
 import { Color } from "../../src/Color";
@@ -7,29 +6,29 @@ import { Game } from "../../src/Game";
 import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("RegolithEaters", function () {
-    it("Should act", function () {
-        const card = new RegolithEaters();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+    let card : RegolithEaters, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new RegolithEaters();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
+
     it("Should act", function () {
-        const card = new RegolithEaters();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
         const action = card.action(player, game);
         expect(action).to.eq(undefined);
         expect(card.resourceCount).to.eq(1);
+
         card.action(player, game);
         expect(card.resourceCount).to.eq(2);
         const orOptions = card.action(player, game) as OrOptions;
-        expect(orOptions).not.to.eq(undefined);
         expect(orOptions instanceof OrOptions).to.eq(true);
-        orOptions.options[1].cb();
+
+        orOptions!.options[1].cb();
         expect(card.resourceCount).to.eq(3);
-        orOptions.options[0].cb();
+        
+        orOptions!.options[0].cb();
         expect(card.resourceCount).to.eq(1);
         expect(game.getOxygenLevel()).to.eq(1);
     });

--- a/tests/cards/ResearchOutpost.spec.ts
+++ b/tests/cards/ResearchOutpost.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ResearchOutpost } from "../../src/cards/ResearchOutpost";
 import { Color } from "../../src/Color";
@@ -7,24 +6,29 @@ import { Game } from "../../src/Game";
 import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("ResearchOutpost", function () {
+    let card : ResearchOutpost, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ResearchOutpost();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new ResearchOutpost();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game) as SelectSpace;
         expect(action).not.to.eq(undefined);
+
         action.cb(action.availableSpaces[0]);
         expect(game.getCitiesInPlay()).to.eq(1);
         expect(card.getCardDiscount()).to.eq(1);
     });
-    it("Can't play", function () {
-        const card = new ResearchOutpost();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+
+    it("Can't play if no spaces available", function () {
         const lands = game.board.getAvailableSpacesOnLand(player);
         for (let i = 0; i < lands.length; i++) {
             game.addGreenery(player, lands[i].id);
         }
+        
         expect(card.canPlay(player, game)).to.eq(false);
     });
 });

--- a/tests/cards/RestrictedArea.spec.ts
+++ b/tests/cards/RestrictedArea.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { RestrictedArea } from "../../src/cards/RestrictedArea";
 import { Color } from "../../src/Color";
@@ -7,27 +6,31 @@ import { Game } from "../../src/Game";
 import { TileType } from "../../src/TileType";
 
 describe("RestrictedArea", function () {
-    it("Can't act", function () {
-        const card = new RestrictedArea();
-        const player = new Player("test", Color.BLUE, false);
+    let card : RestrictedArea, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new RestrictedArea();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act if not enough MC", function () {
+        player.megaCredits = 1;
         expect(card.canAct(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new RestrictedArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         action.cb(action.availableSpaces[0]);
         expect(action.availableSpaces[0].tile && action.availableSpaces[0].tile.tileType).to.eq(TileType.RESTRICTED_AREA);
     });
+
     it("Should act", function () {
-        const card = new RestrictedArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 2;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        card.action(player, game);
+        
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand.length).to.eq(1);
     });

--- a/tests/cards/RoboticWorkforce.spec.ts
+++ b/tests/cards/RoboticWorkforce.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { RoboticWorkforce } from "../../src/cards/RoboticWorkforce";
 import { Color } from "../../src/Color";
@@ -12,11 +11,19 @@ import { Resources } from '../../src/Resources';
 import { UtopiaInvest } from "../../src/cards/turmoil/UtopiaInvest";
 
 describe("RoboticWorkforce", function () {
+    let card : RoboticWorkforce, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new RoboticWorkforce();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play if no building cards to copy", function () {
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should throw", function () {
-        const card = new RoboticWorkforce();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.play(player, game)).to.eq(undefined);
         player.playedCards.push(new FoodFactory(), new BiomassCombustors(), card);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
@@ -24,21 +31,16 @@ describe("RoboticWorkforce", function () {
         expect(function () { action!.cb([new FuelFactory()]); }).to.throw("not enough energy production");
         expect(function () { action!.cb([new FoodFactory()]); }).to.throw("not enough plant production");
     });
+
     it("Should play", function () {
-        const card = new RoboticWorkforce();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new NoctisFarming());
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         action!.cb([new NoctisFarming()]);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
     });
+
     it("Should play with corporation cards", function () {
-        const card = new RoboticWorkforce();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
         const corporationCard = new UtopiaInvest();
         player.corporationCard = corporationCard;
 

--- a/tests/cards/SearchForLife.spec.ts
+++ b/tests/cards/SearchForLife.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SearchForLife } from "../../src/cards/SearchForLife";
 import { Color } from "../../src/Color";
@@ -7,33 +6,44 @@ import { Game } from "../../src/Game";
 import { Tags } from "../../src/cards/Tags";
 
 describe("SearchForLife", function () {
-    it("Can't act", function () {
-        const card = new SearchForLife();
-        const player = new Player("test", Color.BLUE, false);
+    let card : SearchForLife, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new SearchForLife();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act if no MC", function () {
         expect(card.canAct(player)).to.eq(false);
     });
+
+    it("Can't play if oxygen level too high", function () {
+        (game as any).oxygenLevel = 7;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new SearchForLife();
-        const player = new Player("test", Color.BLUE, false);
+        (game as any).oxygenLevel = 6;
+        expect(card.canPlay(player, game)).to.eq(true);
         player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
+        
         expect(card.getVictoryPoints()).to.eq(0);
         player.addResourceTo(card);
         expect(card.getVictoryPoints()).to.eq(3);
     });
+
     it("Should act", function () {
-        const card = new SearchForLife();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const game = new Game("foobar", [player,player], player);
+
         while (game.dealer.discarded.find((c) => c.tags.length === 1 && c.tags[0] === Tags.MICROBES) === undefined ||
                game.dealer.discarded.find((c) => c.tags.length === 1 && c.tags[0] !== Tags.MICROBES) === undefined) {
             player.megaCredits = 1;
-            const action = card.action(player, game);
-            expect(action).to.eq(undefined);
+            card.action(player, game);
             expect(player.megaCredits).to.eq(0);
         }
+        
         expect(card.resourceCount >= 1).to.eq(true);    
     });
 });

--- a/tests/cards/SecurityFleet.spec.ts
+++ b/tests/cards/SecurityFleet.spec.ts
@@ -1,31 +1,26 @@
-
 import { expect } from "chai";
 import { SecurityFleet } from "../../src/cards/SecurityFleet";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 
 describe("SecurityFleet", function () {
-    it("Can't act", function () {
-        const card = new SecurityFleet();
-        const player = new Player("test", Color.BLUE, false);
+    let card : SecurityFleet, player : Player;
+
+    beforeEach(function() {
+        card = new SecurityFleet();
+        player = new Player("test", Color.BLUE, false);
+    });
+
+    it("Can't act if no titanium", function () {
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new SecurityFleet();
-        const player = new Player("test", Color.BLUE, false);
-        player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
-        player.addResourceTo(card, 5);
-        expect(card.getVictoryPoints()).to.eq(5);
-    });
+
     it("Should act", function () {
-        const card = new SecurityFleet();
-        const player = new Player("test", Color.BLUE, false);
-        player.titanium = 1;
         player.playedCards.push(card);
-        const action = card.action(player);
-        expect(action).to.eq(undefined);
+        player.titanium = 1;
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player);
         expect(player.titanium).to.eq(0);
         expect(card.resourceCount).to.eq(1);
     });

--- a/tests/cards/Shuttles.spec.ts
+++ b/tests/cards/Shuttles.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Shuttles } from "../../src/cards/Shuttles";
 import { Color } from "../../src/Color";
@@ -9,30 +8,37 @@ import { TollStation } from "../../src/cards/TollStation";
 import { Resources } from '../../src/Resources';
 
 describe("Shuttles", function () {
-    it("Can't play", function () {
-        const card = new Shuttles();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 1); // 5
+    let card : Shuttles, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Shuttles();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play without energy production", function () {
+        (game as any).oxygenLevel = 5;
         expect(card.canPlay(player, game)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new Shuttles();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 1); // 5
+
+    it("Can't play if oxygen level too low", function () {
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 4;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Should play", function () {
+        (game as any).oxygenLevel = 5;
+        player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
+        
         expect(card.getCardDiscount(player, game, new Bushes())).to.eq(0);
         expect(card.getCardDiscount(player, game, new TollStation())).to.eq(2);
     });

--- a/tests/cards/SmallAnimals.spec.ts
+++ b/tests/cards/SmallAnimals.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SmallAnimals } from "../../src/cards/SmallAnimals";
 import { Color } from "../../src/Color";
@@ -7,28 +6,37 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("SmallAnimals", function () {
-    it("Can't play", function () {
-        const card = new SmallAnimals();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player, game)).to.eq(false);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 2); // 6
+    let card : SmallAnimals, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new SmallAnimals();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Can't play if oxygen level too low", function () {
+        player2.setProduction(Resources.PLANTS);
+        (game as any).oxygenLevel = 5;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
+    it("Can't play if no one has plant production", function () {
+        (game as any).oxygenLevel = 6;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should act", function () {
-        const card = new SmallAnimals();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
         card.action();
         expect(card.resourceCount).to.eq(1);
     });
+
     it("Should play", function () {
-        const card = new SmallAnimals();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.PLANTS);
+        (game as any).oxygenLevel = 6;
+        player2.setProduction(Resources.PLANTS);
+        expect(card.canPlay(player, game)).to.eq(true);
+        
         player.playedCards.push(card);
         card.play(player, game);
 

--- a/tests/cards/SoilFactory.spec.ts
+++ b/tests/cards/SoilFactory.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SoilFactory } from "../../src/cards/SoilFactory";
 import { Color } from "../../src/Color";
@@ -6,19 +5,25 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("SoilFactory", function () {
-    it("Should throw", function () {
-        const card = new SoilFactory();
-        const player = new Player("test", Color.BLUE, false);
+    let card : SoilFactory, player : Player;
+
+    beforeEach(function() {
+        card = new SoilFactory();
+        player = new Player("test", Color.BLUE, false);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new SoilFactory();
-        const player = new Player("test", Color.BLUE, false);
         player.setProduction(Resources.ENERGY);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
+        
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/SpaceElevator.spec.ts
+++ b/tests/cards/SpaceElevator.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SpaceElevator } from "../../src/cards/SpaceElevator";
 import { Color } from "../../src/Color";
@@ -7,28 +6,30 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("SpaceElevator", function () {
-    it("Can't act", function () {
-        const card = new SpaceElevator();
-        const player = new Player("test", Color.BLUE, false);
+    let card : SpaceElevator, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new SpaceElevator();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act if no steel", function () {
         expect(card.canAct(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new SpaceElevator();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });
+
     it("Should act", function () {
-        const card = new SpaceElevator();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.steel = 1;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        
+        card.action(player, game);
         expect(player.steel).to.eq(0);
         expect(player.megaCredits).to.eq(5);
     });

--- a/tests/cards/SpaceMirrors.spec.ts
+++ b/tests/cards/SpaceMirrors.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SpaceMirrors } from "../../src/cards/SpaceMirrors";
 import { Color } from "../../src/Color";
@@ -6,22 +5,23 @@ import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
 
 describe("SpaceMirrors", function () {
+    let card : SpaceMirrors, player : Player;
+
+    beforeEach(function() {
+        card = new SpaceMirrors();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Can't act", function () {
-        const card = new SpaceMirrors();
-        const player = new Player("test", Color.BLUE, false);
+        player.megaCredits = 6;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new SpaceMirrors();
-        const action = card.play();
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new SpaceMirrors();
-        const player = new Player("test", Color.BLUE, false);
         player.megaCredits = 7;
-        const action = card.action(player);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player);
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     });

--- a/tests/cards/Steelworks.spec.ts
+++ b/tests/cards/Steelworks.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Steelworks } from "../../src/cards/Steelworks";
 import { Color } from "../../src/Color";
@@ -6,23 +5,24 @@ import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 
 describe("Steelworks", function () {
+    let card : Steelworks, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Steelworks();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't act", function () {
-        const card = new Steelworks();
-        const player = new Player("test", Color.BLUE, false);
+        player.energy = 3;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new Steelworks();
-        const action = card.play();
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new Steelworks();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 4;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+
+        card.action(player, game);
         expect(player.energy).to.eq(0);
         expect(player.steel).to.eq(2);
         expect(game.getOxygenLevel()).to.eq(1);

--- a/tests/cards/StripMine.spec.ts
+++ b/tests/cards/StripMine.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { StripMine } from "../../src/cards/StripMine";
 import { Color } from "../../src/Color";
@@ -7,18 +6,24 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("StripMine", function () {
-    it("Should throw", function () {
-        const card = new StripMine();
-        const player = new Player("test", Color.BLUE, false);
+    let card : StripMine, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new StripMine();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
+        player.setProduction(Resources.ENERGY, 1);
         expect(card.canPlay(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new StripMine();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.ENERGY,2);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        player.setProduction(Resources.ENERGY, 2);
+        expect(card.canPlay(player)).to.eq(true);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
         expect(player.getProduction(Resources.STEEL)).to.eq(2);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/SymbioticFungus.spec.ts
+++ b/tests/cards/SymbioticFungus.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { SymbioticFungus } from "../../src/cards/SymbioticFungus";
 import { Color } from "../../src/Color";
@@ -8,34 +7,34 @@ import { Ants } from "../../src/cards/Ants";
 import { Decomposers } from "../../src/cards/Decomposers";
 
 describe("SymbioticFungus", function () {
-    it("Can't act or play", function () {
-        const card = new SymbioticFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : SymbioticFungus, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new SymbioticFungus();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
         expect(card.canPlay(player, game)).to.eq(false);
-        expect(card.canAct(player)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new SymbioticFungus();
-        expect(card.play()).to.eq(undefined);
+        (game as any).temperature = -14;
+        expect(card.canPlay(player, game)).to.eq(true);
     });
+
     it("Should act - single target", function () {
-        const card = new SymbioticFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.playedCards.push(new Ants());
         card.action(player, game);
         expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);
     });
+
     it("Should act - multiple targets", function () {
-        const card = new SymbioticFungus();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.playedCards.push(new Ants());
-        player.playedCards.push(new Decomposers());
-        
+        player.playedCards.push(new Ants(), new Decomposers());
         const action = card.action(player, game);
         expect(action).not.to.eq(undefined);
+        
         action!.cb([player.playedCards[0]]);
         expect(player.getResourcesOnCard(player.playedCards[0])).to.eq(1);
     });

--- a/tests/cards/Tardigrades.spec.ts
+++ b/tests/cards/Tardigrades.spec.ts
@@ -1,25 +1,26 @@
-
 import { expect } from "chai";
 import { Tardigrades } from "../../src/cards/Tardigrades";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 
 describe("Tardigrades", function () {
+    let card : Tardigrades, player : Player;
+
+    beforeEach(function() {
+        card = new Tardigrades();
+        player = new Player("test", Color.BLUE, false);
+    });
+
     it("Should play", function () {
-        const card = new Tardigrades();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
         player.addResourceTo(card, 7);
         expect(card.getVictoryPoints()).to.eq(1);
     });
+
     it("Should act", function () {
-        const card = new Tardigrades();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(card);
-        const action = card.action();
-        expect(action).to.eq(undefined);
+        card.action();
         expect(card.resourceCount).to.eq(1);
     });
 });

--- a/tests/cards/TectonicStressPower.spec.ts
+++ b/tests/cards/TectonicStressPower.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { TectonicStressPower } from "../../src/cards/TectonicStressPower";
 import { Color } from "../../src/Color";
@@ -7,17 +6,22 @@ import { SearchForLife } from "../../src/cards/SearchForLife";
 import { Resources } from '../../src/Resources';
 
 describe("TectonicStressPower", function () {
-    it("Should throw", function () {
-        const card = new TectonicStressPower();
-        const player = new Player("test", Color.BLUE, false);
-        expect(function () { card.play(player); }).to.throw("Requires 2 science tags");
+    let card : TectonicStressPower, player : Player;
+
+    beforeEach(function() {
+        card = new TectonicStressPower();
+        player = new Player("test", Color.BLUE, false);
     });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new TectonicStressPower();
-        const player = new Player("test", Color.BLUE, false);
         player.playedCards.push(new SearchForLife(), new SearchForLife());
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        expect(card.canPlay(player)).to.eq(true);
+        card.play(player);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(3);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/Trees.spec.ts
+++ b/tests/cards/Trees.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Trees } from "../../src/cards/Trees";
 import { Color } from "../../src/Color";
@@ -7,19 +6,26 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Trees", function () {
+    let card : Trees, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Trees();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Trees();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Trees();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -4;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(3);
         expect(player.plants).to.eq(1);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/TundraFarming.spec.ts
+++ b/tests/cards/TundraFarming.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { TundraFarming } from "../../src/cards/TundraFarming";
 import { Color } from "../../src/Color";
@@ -7,20 +6,27 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("TundraFarming", function () {
+    let card : TundraFarming, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new TundraFarming();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new TundraFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new TundraFarming();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).temperature = -6;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
         expect(player.plants).to.eq(1);
+
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(2);
     });

--- a/tests/cards/UndergroundCity.spec.ts
+++ b/tests/cards/UndergroundCity.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { UndergroundCity } from "../../src/cards/UndergroundCity";
 import { Color } from "../../src/Color";
@@ -7,19 +6,25 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("UndergroundCity", function () {
+    let card : UndergroundCity, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new UndergroundCity();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new UndergroundCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        player.setProduction(Resources.ENERGY);
         expect(card.canPlay(player,game)).to.eq(false);
     });
+    
     it("Should play", function () {
-        const card = new UndergroundCity();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        player.setProduction(Resources.ENERGY,2);
+        player.setProduction(Resources.ENERGY, 2);
+        expect(card.canPlay(player,game)).to.eq(true);
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
+
         action.cb(action.availableSpaces[0]);
         expect(game.getCitiesInPlay()).to.eq(1);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/UndergroundDetonations.spec.ts
+++ b/tests/cards/UndergroundDetonations.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { UndergroundDetonations } from "../../src/cards/UndergroundDetonations";
 import { Color } from "../../src/Color";
@@ -7,25 +6,24 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("UndergroundDetonations", function () {
-    it("Should throw", function () {
-        const card = new UndergroundDetonations();
-        const player = new Player("test", Color.BLUE, false);
+    let card : UndergroundDetonations, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new UndergroundDetonations();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't act", function () {
+        player.megaCredits = 9;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new UndergroundDetonations();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new UndergroundDetonations();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.megaCredits = 10;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        
+        card.action(player, game);
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
     });

--- a/tests/cards/UrbanizedArea.spec.ts
+++ b/tests/cards/UrbanizedArea.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { UrbanizedArea } from "../../src/cards/UrbanizedArea";
 import { Color } from "../../src/Color";
@@ -7,26 +6,41 @@ import { Game } from "../../src/Game";
 import { SpaceName } from "../../src/SpaceName";
 import { SpaceType } from "../../src/SpaceType";
 import { Resources } from '../../src/Resources';
+import { ISpace } from "../../src/ISpace";
 
 describe("UrbanizedArea", function () {
-    it("Can't play", function () {
-        const card = new UrbanizedArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : UrbanizedArea, player : Player, game : Game, lands: ISpace[];
+
+    beforeEach(function() {
+        card = new UrbanizedArea();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+
+        const tharsisTholus = game.getSpace(SpaceName.THARSIS_THOLUS);
+        lands = game.board.getAdjacentSpaces(tharsisTholus).filter((space) => space.spaceType === SpaceType.LAND);
+    });
+
+    it("Can't play without energy production", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
+    it("Can't play without available space between two cities", function () {
+        game.addCityTile(player, lands[0].id);
+        player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
     it("Should play", function () {
-        const card = new UrbanizedArea();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        const tharsis = game.getSpace(SpaceName.THARSIS_THOLUS);
-        const lands = game.board.getAdjacentSpaces(tharsis).filter((space) => space.spaceType === SpaceType.LAND);
         game.addCityTile(player, lands[0].id);
         game.addCityTile(player, lands[1].id);
+
         player.setProduction(Resources.ENERGY);
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const action = card.play(player, game);
         expect(action).not.to.eq(undefined);
         expect(action.availableSpaces.length).to.eq(1);
+
         action.cb(action.availableSpaces[0]);
         expect(game.getCitiesInPlay()).to.eq(3);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/VestaShipyard.spec.ts
+++ b/tests/cards/VestaShipyard.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { VestaShipyard } from "../../src/cards/VestaShipyard";
 import { Color } from "../../src/Color";
@@ -11,12 +10,9 @@ describe("VestaShipyard", function () {
         const card = new VestaShipyard();
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player,player], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+
+        card.play(player, game);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
-    });
-    it("Should have victory point", function () {
-        const card = new VestaShipyard();
         expect(card.getVictoryPoints()).to.eq(1);
     });
 });

--- a/tests/cards/ViralEnhancers.spec.ts
+++ b/tests/cards/ViralEnhancers.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { ViralEnhancers } from "../../src/cards/ViralEnhancers";
 import { Color } from "../../src/Color";
@@ -11,47 +10,56 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { EcologicalZone } from "../../src/cards/EcologicalZone";
 
 describe("ViralEnhancers", function () {
+    let card : ViralEnhancers, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ViralEnhancers();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Should play", function () {
-        const card = new ViralEnhancers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
+        
         const ants = new Ants();
         const birds = new Birds();
         const moss = new Moss();
         player.playedCards.push(ants, birds, moss);
+
         card.onCardPlayed(player, game, birds);
         expect(game.interrupts.length).to.eq(1);
+
         let orOptions = game.interrupts[0].playerInput as OrOptions;
         orOptions.options[0].cb();
         expect(player.getResourcesOnCard(birds)).to.eq(1);
         orOptions.options[1].cb();
         expect(player.plants).to.eq(1);
+
         card.onCardPlayed(player, game, ants);
         expect(game.interrupts.length).to.eq(2);
+
         orOptions = game.interrupts[1].playerInput as OrOptions;
         orOptions.options[0].cb();
         expect(player.getResourcesOnCard(ants)).to.eq(1);
         orOptions.options[1].cb();
         expect(player.plants).to.eq(2);
     });
+
     it("Should play for each tag", function () {
-        const card = new ViralEnhancers();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player], player);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
+
         const ecologicalZone = new EcologicalZone();
         card.onCardPlayed(player, game, ecologicalZone);
         expect(game.interrupts.length).to.eq(1);
+
         let orOptions = game.interrupts[0].playerInput as OrOptions;
-        game.interrupts = [];
+        game.interrupts.pop();
         orOptions.options[0].cb();
         expect(player.getResourcesOnCard(ecologicalZone)).to.eq(1);
         expect(game.interrupts.length).to.eq(1);
+        
         orOptions = game.interrupts[0].playerInput as OrOptions;
-        game.interrupts = [];
+        game.interrupts.pop();
         orOptions.options[1].cb();
         expect(player.plants).to.eq(1);
         expect(game.interrupts.length).to.eq(0);

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Virus } from "../../src/cards/Virus";
 import { Color } from "../../src/Color";
@@ -9,44 +8,36 @@ import { OrOptions } from "../../src/inputs/OrOptions";
 import { Predators } from "../../src/cards/Predators";
 
 describe("Virus", function () {
+    let card : Virus, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Virus();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Should play", function () {
-        const card = new Virus();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
-        player2.plants = 5;
-        player3.plants = 7;
         const birds = new Birds();
         const predators = new Predators();
-        player.playedCards.push(birds);
-        player.playedCards.push(predators);
+        player.playedCards.push(birds, predators);
         player.addResourceTo(birds);
         player.addResourceTo(predators);
+        player.plants = 5;
+
         const orOptions = card.play(player2, game) as OrOptions;
         expect(orOptions instanceof OrOptions).to.eq(true);
-        player.plants = 5;
+        
         orOptions.options[0].cb([player.playedCards[0]]);
-        expect(player.plants).to.eq(5);
         expect(player.getResourcesOnCard(birds)).to.eq(0);
+
+        orOptions.options[1].cb();
+        expect(player.plants).to.eq(0);
     });
-    it("Should play when no other plays has resources", function () {
-        const card = new Virus();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
-        player.plants = 1;
-        player2.plants = 0;
-        player3.plants = 0;
-        const birds = new Birds();
-        const predators = new Predators();
-        player.playedCards.push(birds);
-        player.playedCards.push(predators);
-        player.addResourceTo(birds);
-        player.addResourceTo(predators);
-        const orOptions = card.play(player, game) as OrOptions;
-        expect(orOptions instanceof OrOptions).to.eq(true);
+
+    it("Can play when no other player has resources", function () {
+        player.plants = 5;
+        expect(card.play(player, game)).to.eq(undefined)
         expect(game.interrupts.length).to.eq(0);
     });
 });

--- a/tests/cards/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/WaterImportFromEuropa.spec.ts
@@ -1,37 +1,45 @@
-
 import { expect } from "chai";
 import { WaterImportFromEuropa } from "../../src/cards/WaterImportFromEuropa";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { AndOptions } from "../../src/inputs/AndOptions";
+import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("WaterImportFromEuropa", function () {
+    let card : WaterImportFromEuropa, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new WaterImportFromEuropa();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't act", function () {
-        const card = new WaterImportFromEuropa();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         expect(card.canAct(player,game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new WaterImportFromEuropa();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play();
-        expect(action).to.eq(undefined);
+        card.play();
         player.playedCards.push(card);
         expect(card.getVictoryPoints(player)).to.eq(1);
     });
+
     it("Should act", function () {
-        const card = new WaterImportFromEuropa();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.titanium = 1;
         player.megaCredits = 11;
+
         const action = card.action(player, game) as AndOptions;
         expect(action).not.to.eq(undefined);
         action.options[0].cb({ steel: 0, heat: 0, titanium: 1, megaCredits: 9 });
         action.cb();
+
         expect(player.titanium).to.eq(0);
         expect(player.megaCredits).to.eq(2);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectOcean = game.interrupts[0].playerInput as SelectSpace;
+        selectOcean.cb(selectOcean.availableSpaces[0]);
+        expect(player.getTerraformRating()).to.eq(21);
     });
 });

--- a/tests/cards/WaterSplittingPlant.spec.ts
+++ b/tests/cards/WaterSplittingPlant.spec.ts
@@ -1,28 +1,38 @@
-
 import { expect } from "chai";
 import { WaterSplittingPlant } from "../../src/cards/WaterSplittingPlant";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { maxOutOceans } from "../TestingUtils";
 
 describe("WaterSplittingPlant", function () {
+    let card : WaterSplittingPlant, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new WaterSplittingPlant();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can't play", function () {
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Can play", function () {
+        maxOutOceans(player, game, 2);
+        expect(card.canPlay(player, game)).to.eq(true);
+    });
+
     it("Can't act", function () {
-        const card = new WaterSplittingPlant();
-        const player = new Player("test", Color.BLUE, false);
+        player.energy = 2;
         expect(card.canAct(player)).to.eq(false);
     });
-    it("Should play", function () {
-        const card = new WaterSplittingPlant();
-        const action = card.play();
-        expect(action).to.eq(undefined);
-    });
+
     it("Should act", function () {
-        const card = new WaterSplittingPlant();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
         player.energy = 3;
-        const action = card.action(player, game);
-        expect(action).to.eq(undefined);
+        expect(card.canAct(player)).to.eq(true);
+        
+        card.action(player, game);
         expect(player.energy).to.eq(0);
         expect(game.getOxygenLevel()).to.eq(1);
     });

--- a/tests/cards/WavePower.spec.ts
+++ b/tests/cards/WavePower.spec.ts
@@ -1,23 +1,30 @@
-
 import { expect } from "chai";
 import { WavePower } from "../../src/cards/WavePower";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { maxOutOceans } from "../TestingUtils";
 
 describe("WavePower", function () {
+    let card : WavePower, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new WavePower();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new WavePower();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        maxOutOceans(player, game, 2);
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new WavePower();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        maxOutOceans(player, game, 3);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/Windmills.spec.ts
+++ b/tests/cards/Windmills.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Windmills } from "../../src/cards/Windmills";
 import { Color } from "../../src/Color";
@@ -7,17 +6,23 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Windmills", function () {
+    let card : Windmills, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Windmills();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Windmills();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        (game as any).oxygenLevel = 6;
         expect(card.canPlay(player, game)).to.eq(false);
     });
     it("Should play", function () {
-        const card = new Windmills();
-        const player = new Player("test", Color.BLUE, false);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+        (game as any).oxygenLevel = 7;
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/Worms.spec.ts
+++ b/tests/cards/Worms.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Worms } from "../../src/cards/Worms";
 import { Color } from "../../src/Color";
@@ -7,21 +6,25 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Worms", function () {
+    let card : Worms, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Worms();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Worms();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        (game as any).oxygenLevel = 3;
         expect(card.canPlay(player, game)).to.eq(false);
     });
+
     it("Should play", function () {
-        const card = new Worms();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
+        (game as any).oxygenLevel = 4;
+        expect(card.canPlay(player, game)).to.eq(true);
         player.playedCards.push(card);
-        const action = card.play(player);
-        expect(action).to.eq(undefined);
+
+        card.play(player);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     });
 });

--- a/tests/cards/Zeppelins.spec.ts
+++ b/tests/cards/Zeppelins.spec.ts
@@ -6,23 +6,26 @@ import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
 
 describe("Zeppelins", function () {
+    let card : Zeppelins, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Zeppelins();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
     it("Can't play", function () {
-        const card = new Zeppelins();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        (game as any).oxygenLevel = 4;
         expect(card.canPlay(player, game)).to.eq(false);
     });
     it("Should play", function () {
-        const card = new Zeppelins();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
-        game.increaseOxygenLevel(player, 2); // 2
-        game.increaseOxygenLevel(player, 2); // 4
-        game.increaseOxygenLevel(player, 1); // 5
+        (game as any).oxygenLevel = 5;
+        expect(card.canPlay(player, game)).to.eq(true);
+
         const lands = game.board.getAvailableSpacesOnLand(player);
         game.addCityTile(player, lands[0].id);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        
+        card.play(player, game);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);


### PR DESCRIPTION
**Ref:** https://mochajs.org/#hooks

We can DRY quite a bit of repeated code in each test by using `beforeEach()` hook. It will make tests cleaner and easier to read.

**Scope:**
- DRY base game tests
- Rewrite some tests for correctness and increase coverage
- Improve code readability