### PR TITLE
Fix: Unpurchased cards in initial research phase should enter discard pile

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -722,10 +722,14 @@ export class Game implements ILoadable<SerializedGame, Game> {
             for (const dealt of foundCards) {
               if (foundCards.find((foundCard) => foundCard.name === dealt.name)) {
                 player.cardsInHand.push(dealt);
-              } else {
-                this.dealer.discard(dealt);
               }
             }
+
+            // discard all unpurchased cards
+            player.dealtProjectCards
+                .filter((card) => !foundCards.includes(card))
+                .forEach((card) => this.dealer.discard(card));
+
             return undefined;
           }, 10, 0
         )


### PR DESCRIPTION
Cards discarded during the initial research phase are not actually going into the discard pile.

This means that players do not have access to initially discarded cards even after the deck cycles through, and also causes unintended errors when the deck runs out of cards.

For testing:
- I replaced `src/Dealer.ts:996` with this line: `this.deck = [];`
- And set "Use promo cards" to true, "Corporate Era" to false.