### PR TITLE
Make removing Plants optional

### DIFF
--- a/tests/cards/Comet.spec.ts
+++ b/tests/cards/Comet.spec.ts
@@ -4,8 +4,8 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { maxOutOceans } from "../TestingUtils"
-import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 import { SelectSpace } from "../../src/inputs/SelectSpace";
+import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("Comet", function () {
     let card : Comet, player : Player, player2 : Player, player3: Player, game : Game;
@@ -30,8 +30,8 @@ describe("Comet", function () {
         selectSpace.cb(selectSpace.availableSpaces[0]);
         expect(player.getTerraformRating()).to.eq(22);
 
-        const selectPlayer = game.interrupts[1].playerInput as SelectPlayer;
-        selectPlayer.cb(player2);
+        const orOptions = game.interrupts[1].playerInput as OrOptions;
+        orOptions.options[0].cb();
         expect(player2.plants).to.eq(0);
     });
 

--- a/tests/cards/DeimosDown.spec.ts
+++ b/tests/cards/DeimosDown.spec.ts
@@ -3,6 +3,7 @@ import { DeimosDown } from "../../src/cards/DeimosDown";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("DeimosDown", function () {
     let card : DeimosDown, player : Player, player2 : Player, game : Game;
@@ -17,6 +18,10 @@ describe("DeimosDown", function () {
     it("Should play", function () {
         player2.plants = 8;
         card.play(player, game);
+
+        expect(game.interrupts.length).to.eq(1);
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[0].cb();
 
         expect(game.getTemperature()).to.eq(-24);
         expect(player.steel).to.eq(4);

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -32,6 +32,10 @@ describe("Virus", function () {
         expect(player.getResourcesOnCard(birds)).to.eq(0);
 
         orOptions.options[1].cb();
+        expect(game.interrupts.length).to.eq(1);
+        
+        const action = game.interrupts[0].playerInput as OrOptions;
+        action.options[0].cb();
         expect(player.plants).to.eq(0);
     });
 

--- a/tests/cards/promo/SmallAsteroid.spec.ts
+++ b/tests/cards/promo/SmallAsteroid.spec.ts
@@ -4,6 +4,7 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from "../../../src/Game";
 import { Resources } from "../../../src/Resources";
+import { OrOptions } from "../../../src/inputs/OrOptions";
 
 describe("SmallAsteroid", function () {
     let card : SmallAsteroid, player : Player, player2 : Player, game : Game;
@@ -18,6 +19,13 @@ describe("SmallAsteroid", function () {
     it("Should play", function () {
         player2.setResource(Resources.PLANTS, 3);
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[1].cb(); // do nothing
+        expect(player2.getResource(Resources.PLANTS)).to.eq(3);
+
+        orOptions.options[0].cb();
         expect(player2.getResource(Resources.PLANTS)).to.eq(1);
         expect(game.getTemperature()).to.eq(-28);
     });
@@ -27,5 +35,30 @@ describe("SmallAsteroid", function () {
         const game = new Game("solo", [player], player);
         card.play(player, game);
         expect(player.getResource(Resources.PLANTS)).to.eq(3);
+    });
+
+    it("Works correctly with multiple targets", function() {
+        const player3 = new Player("test3", Color.YELLOW, false);
+        game = new Game("foobar", [player, player2, player3], player);
+        player2.setResource(Resources.PLANTS, 3);
+        player3.setResource(Resources.PLANTS, 5);
+
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        expect(orOptions.options.length).to.eq(3);
+
+        orOptions.options[2].cb(); // do nothing
+        expect(player2.getResource(Resources.PLANTS)).to.eq(3);
+        expect(player3.getResource(Resources.PLANTS)).to.eq(5);
+
+        orOptions.options[0].cb();
+        expect(player2.getResource(Resources.PLANTS)).to.eq(1);
+
+        orOptions.options[1].cb();
+        expect(player3.getResource(Resources.PLANTS)).to.eq(3);
+        
+        expect(game.getTemperature()).to.eq(-28);
     });
 });


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/930

This change introduces an additional option to "Do nothing", and also clearly shows how many plants will be removed from each player.

<img width="316" alt="Screenshot 2020-07-07 at 1 07 48 PM" src="https://user-images.githubusercontent.com/2408094/86717717-ffd29c80-c054-11ea-85df-893262cc1c3d.png">
<img width="311" alt="Screenshot 2020-07-07 at 12 31 07 PM" src="https://user-images.githubusercontent.com/2408094/86717723-019c6000-c055-11ea-9853-ba76571d07bb.png">
