### PR TITLE
Update tests for plant removal cards

### DIFF
--- a/tests/cards/Asteroid.spec.ts
+++ b/tests/cards/Asteroid.spec.ts
@@ -1,17 +1,34 @@
-
 import { expect } from "chai";
 import { Asteroid } from "../../src/cards/Asteroid";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { OrOptions } from "../../src/inputs/OrOptions";
+import { Resources } from "../../src/Resources";
 
 describe("Asteroid", function () {
+    let card : Asteroid, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Asteroid();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Should play", function () {
-        const card = new Asteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player,player2], player);
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        player2.plants = 2;
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[1].cb(); // do nothing
+        expect(player2.getResource(Resources.PLANTS)).to.eq(2);
+
+        orOptions.options[0].cb();
+        expect(player2.getResource(Resources.PLANTS)).to.eq(0);
+
+        expect(player.titanium).to.eq(2);
+        expect(game.getTemperature()).to.eq(-28);
     });
 });

--- a/tests/cards/BigAsteroid.spec.ts
+++ b/tests/cards/BigAsteroid.spec.ts
@@ -3,13 +3,40 @@ import { BigAsteroid } from "../../src/cards/BigAsteroid";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("BigAsteroid", function () {
+    let card : BigAsteroid, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new BigAsteroid();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Should play", function () {
-        const card = new BigAsteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+        player2.plants = 5;
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[1].cb(); // do nothing
+        expect(player2.plants).to.eq(5);
+
+        orOptions.options[0].cb();
+        expect(player2.plants).to.eq(1);
+        expect(game.getTemperature()).to.eq(-26);
+        expect(player.titanium).to.eq(4);
+    });
+
+    it("Works fine in solo", function () {
+        game = new Game("foobar", [player], player);
+        player.plants = 5;
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
+
+        expect(player.plants).to.eq(5);
         expect(game.getTemperature()).to.eq(-26);
         expect(player.titanium).to.eq(4);
     });

--- a/tests/cards/Comet.spec.ts
+++ b/tests/cards/Comet.spec.ts
@@ -39,8 +39,8 @@ describe("Comet", function () {
         maxOutOceans(player, game);
         player.plants = 8;
 
-        const action = card.play(player, game);
-        expect(action).to.eq(undefined);
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
 
         expect(player.plants).to.eq(8); // self plants are not removed
         expect(game.getTemperature()).to.eq(-28);
@@ -52,5 +52,6 @@ describe("Comet", function () {
 
         var action = card.play(player, game);
         expect(action).to.eq(undefined);
+        expect(player.plants).to.eq(8);
     });
 });

--- a/tests/cards/GiantIceAsteroid.spec.ts
+++ b/tests/cards/GiantIceAsteroid.spec.ts
@@ -1,21 +1,44 @@
-
 import { expect } from "chai";
 import { GiantIceAsteroid } from "../../src/cards/GiantIceAsteroid";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { SelectSpace } from "../../src/inputs/SelectSpace";
+import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("GiantIceAsteroid", function () {
-    it("Should play", function () {
-        const card = new GiantIceAsteroid();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const player3 = new Player("test3", Color.YELLOW, false);
-        const game = new Game("foobar", [player,player2,player3], player);
+    let card : GiantIceAsteroid, player : Player, player2 : Player, player3 : Player, game : Game;
 
-        const action = card.play(player, game);
-        expect(action).eq(undefined);
+    beforeEach(function() {
+        card = new GiantIceAsteroid();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        player3 = new Player("test3", Color.YELLOW, false);
+        game = new Game("foobar", [player, player2, player3], player);
+    });
+
+    it("Should play", function () {
+        player2.plants = 4;
+        player3.plants = 6;
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(3);
+
+        const firstOcean = game.interrupts[0].playerInput as SelectSpace;
+        firstOcean.cb(firstOcean.availableSpaces[0]);
+        const secondOcean = game.interrupts[1].playerInput as SelectSpace;
+        secondOcean.cb(secondOcean.availableSpaces[1]);
+
+        const orOptions = game.interrupts[2].playerInput as OrOptions;
+        expect(orOptions.options.length).to.eq(3);
+
+        orOptions.options[0].cb();
+        expect(player2.plants).to.eq(0);
+
+        orOptions.options[1].cb();
+        expect(player3.plants).to.eq(0);
+
         expect(game.getTemperature()).to.eq(-26);
+        expect(player.getTerraformRating()).to.eq(24);
     });
 });
 

--- a/tests/cards/MiningExpedition.spec.ts
+++ b/tests/cards/MiningExpedition.spec.ts
@@ -1,17 +1,29 @@
-
 import { expect } from "chai";
 import { MiningExpedition } from "../../src/cards/MiningExpedition";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { OrOptions } from "../../src/inputs/OrOptions";
 
 describe("MiningExpedition", function () {
+    let card : MiningExpedition, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new MiningExpedition();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
     it("Should play", function () {
-        const card = new MiningExpedition();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player, player2], player);
+        player2.plants = 8;
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[0].cb();
+        expect(player2.plants).to.eq(6);
+
         expect(player.steel).to.eq(2);
         expect(game.getOxygenLevel()).to.eq(1);
     });

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -43,5 +43,6 @@ describe("Virus", function () {
         player.plants = 5;
         expect(card.play(player, game)).to.eq(undefined)
         expect(game.interrupts.length).to.eq(0);
+        expect(player.plants).to.eq(5);
     });
 });

--- a/tests/cards/colonies/ImpactorSwarm.spec.ts
+++ b/tests/cards/colonies/ImpactorSwarm.spec.ts
@@ -3,14 +3,32 @@ import { ImpactorSwarm } from "../../../src/cards/colonies/ImpactorSwarm";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from '../../../src/Game';
+import { OrOptions } from "../../../src/inputs/OrOptions";
 
 describe("ImpactorSwarm", function () {
-    it("Should play", function () {
-        const card = new ImpactorSwarm();
-        const player = new Player("test", Color.BLUE, false);
-        const player2 = new Player("test2", Color.RED, false);
-        const game = new Game("foobar", [player, player2], player);
+    let card : ImpactorSwarm, player : Player, player2 : Player, game : Game;
+
+    beforeEach(function() {
+        card = new ImpactorSwarm();
+        player = new Player("test", Color.BLUE, false);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
+    });
+
+    it("Should play when no other player has plants", function () {
+        const action = card.play(player, game);
+        expect(action).to.eq(undefined);
+        expect(player.heat).to.eq(12);
+    });
+
+    it("Should be able to remove plants from other player", function () {
+        player2.plants = 2;
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as OrOptions;
+        orOptions.options[0].cb();
+        expect(player2.plants).to.eq(0);
         expect(player.heat).to.eq(12);
     });
 });

--- a/tests/cards/promo/SmallAsteroid.spec.ts
+++ b/tests/cards/promo/SmallAsteroid.spec.ts
@@ -23,10 +23,10 @@ describe("SmallAsteroid", function () {
 
         const orOptions = game.interrupts[0].playerInput as OrOptions;
         orOptions.options[1].cb(); // do nothing
-        expect(player2.getResource(Resources.PLANTS)).to.eq(3);
+        expect(player2.plants).to.eq(3);
 
         orOptions.options[0].cb();
-        expect(player2.getResource(Resources.PLANTS)).to.eq(1);
+        expect(player2.plants).to.eq(1);
         expect(game.getTemperature()).to.eq(-28);
     });
 
@@ -50,14 +50,14 @@ describe("SmallAsteroid", function () {
         expect(orOptions.options.length).to.eq(3);
 
         orOptions.options[2].cb(); // do nothing
-        expect(player2.getResource(Resources.PLANTS)).to.eq(3);
-        expect(player3.getResource(Resources.PLANTS)).to.eq(5);
+        expect(player2.plants).to.eq(3);
+        expect(player3.plants).to.eq(5);
 
         orOptions.options[0].cb();
-        expect(player2.getResource(Resources.PLANTS)).to.eq(1);
+        expect(player2.plants).to.eq(1);
 
         orOptions.options[1].cb();
-        expect(player3.getResource(Resources.PLANTS)).to.eq(3);
+        expect(player3.plants).to.eq(3);
         
         expect(game.getTemperature()).to.eq(-28);
     });


### PR DESCRIPTION
Update tests to properly cover scenarios:

- No plants available to remove
- One opponent has plants
- Multiple opponents have plants
- Player chooses not to remove any plants