### PR TITLE
Update resource production decrease

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -548,10 +548,23 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public addResourceProductionDecreaseInterrupt(player: Player, resource: Resources, count: number = 1, title?: string): void {
-      if (this.soloMode) {
-        return;
+      if (this.soloMode) return;
+
+      let candidates: Array<Player> = [];
+      if (resource === Resources.MEGACREDITS) {
+        candidates = this.getPlayers().filter((p) => p.getProduction(resource) >= count - 5);
+      } else {
+        candidates = this.getPlayers().filter((p) => p.getProduction(resource) >= count);
       }
-      this.addInterrupt(new SelectResourceProductionDecrease(player, this, resource, count, title));
+
+      if (candidates.length === 0) {
+        return;
+      } else if (candidates.length === 1) {
+        candidates[0].setProduction(resource, -count, this, player);
+        return undefined;
+      } else {
+        this.addInterrupt(new SelectResourceProductionDecrease(player, candidates, this, resource, count, title));
+      }
     }
 
     public addResourceDecreaseInterrupt(player: Player, resource: Resources, count: number = 1, title?: string): void {

--- a/src/interrupts/SelectResourceProductionDecrease.ts
+++ b/src/interrupts/SelectResourceProductionDecrease.ts
@@ -10,20 +10,14 @@ export class SelectResourceProductionDecrease implements PlayerInterrupt {
     public playerInput: PlayerInput;
     constructor(
         public player: Player,
+        public candidates: Array<Player>,
         public game: Game,
         public resource: Resources,
         public count: number = 1,
         public title: string = "Select player to decrease " + resource  + " production by " + count + " step(s)"
-    ){
-        var players;
-        if (this.resource === Resources.MEGACREDITS) {
-            players = game.getPlayers().filter((p) => p.getProduction(this.resource) >= count - 5);
-        } else {
-            players = game.getPlayers().filter((p) => p.getProduction(this.resource) >= count);
-        }
-
+    ) {
         this.playerInput = new SelectPlayer(
-            players,
+            candidates,
             this.title,
             (found: Player) => {
               found.setProduction(this.resource, -this.count, game, player);

--- a/tests/cards/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/AsteroidMiningConsortium.spec.ts
@@ -4,6 +4,7 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("AsteroidMiningConsortium", function () {
     let card : AsteroidMiningConsortium, player : Player, player2 : Player, game : Game;
@@ -22,8 +23,28 @@ describe("AsteroidMiningConsortium", function () {
     it("Can play if player has titanium production", function () {
         player.setProduction(Resources.TITANIUM);
         expect(card.canPlay(player)).to.eq(true);
+    });
 
+    it("Should play - auto select if single target", function () {
+        player.setProduction(Resources.TITANIUM);
+        card.play(player, game); // can decrease own production
+        expect(game.interrupts.length).to.eq(0);
+        expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.TITANIUM);
+        player2.setProduction(Resources.TITANIUM);
         card.play(player, game);
+        expect(player.getProduction(Resources.TITANIUM)).to.eq(2);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.TITANIUM)).to.eq(0);
+    });
+
+    it("Gives victory points", function () {
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);
     });

--- a/tests/cards/BiomassCombustors.spec.ts
+++ b/tests/cards/BiomassCombustors.spec.ts
@@ -34,9 +34,12 @@ describe("BiomassCombustors", function () {
     it("Should play", function () {
         (game as any).oxygenLevel = 6;
         player2.setProduction(Resources.PLANTS, 1);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
 
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);

--- a/tests/cards/CloudSeeding.spec.ts
+++ b/tests/cards/CloudSeeding.spec.ts
@@ -34,11 +34,23 @@ describe("CloudSeeding", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
-    it("Should play", function () {
+    it("Should play - auto select if single target", function () {
         // Meet requirements
         player2.setProduction(Resources.HEAT);
         maxOutOceans(player, game, 3);
         expect(card.canPlay(player, game)).to.eq(true);
+        
+        card.play(player, game);
+        expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
+        expect(player.getProduction(Resources.PLANTS)).to.eq(2);
+
+        expect(game.interrupts.length).to.eq(0);
+        expect(player2.getProduction(Resources.HEAT)).to.eq(0);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.HEAT);
+        player2.setProduction(Resources.HEAT);
         
         card.play(player, game);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);

--- a/tests/cards/EnergyTapping.spec.ts
+++ b/tests/cards/EnergyTapping.spec.ts
@@ -20,14 +20,25 @@ describe("EnergyTapping", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
-    it("Should play", function () {
-        player2.setProduction(Resources.ENERGY,3);
+    it("Should play - auto select if single target", function () {
+        player2.setProduction(Resources.ENERGY, 3);
         expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
-        
+        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.ENERGY, 3);
+        player2.setProduction(Resources.ENERGY, 3);
+        expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(4);
         expect(game.interrupts.length).to.eq(1);
+        
         const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.ENERGY)).to.eq(2);

--- a/tests/cards/Fish.spec.ts
+++ b/tests/cards/Fish.spec.ts
@@ -25,8 +25,20 @@ describe("Fish", function () {
         expect(card.resourceCount).to.eq(1);
     });
 
-    it("Should play", function () {
+    it("Should play - auto select if single target", function () {
         (game as any).temperature = 2;
+        player2.setProduction(Resources.PLANTS);
+
+        expect(card.canPlay(player, game)).to.eq(true);
+        card.play(player, game);
+
+        expect(game.interrupts.length).to.eq(0);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
+    });
+
+    it("Should play - multiple targets", function () {
+        (game as any).temperature = 2;
+        player.setProduction(Resources.PLANTS);
         player2.setProduction(Resources.PLANTS);
 
         expect(card.canPlay(player, game)).to.eq(true);
@@ -36,7 +48,9 @@ describe("Fish", function () {
         const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
+    });
 
+    it("Should give victory points", function () {
         player.addResourceTo(card, 5);
         expect(card.getVictoryPoints()).to.eq(card.resourceCount);
     });

--- a/tests/cards/GreatEscarpmentConsortium.spec.ts
+++ b/tests/cards/GreatEscarpmentConsortium.spec.ts
@@ -4,24 +4,43 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Resources } from '../../src/Resources';
+import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("GreatEscarpmentConsortium", function () {
-    let card : GreatEscarpmentConsortium, player : Player, game : Game;
+    let card : GreatEscarpmentConsortium, player : Player, player2 : Player, game : Game;
 
     beforeEach(function() {
         card = new GreatEscarpmentConsortium();
         player = new Player("test", Color.BLUE, false);
-        game = new Game("foobar", [player], player);
+        player2 = new Player("test2", Color.RED, false);
+        game = new Game("foobar", [player, player2], player);
     });
 
     it("Cannot play without steel production", function () {
         expect(card.canPlay(player)).to.eq(false);
     });
-    
-    it("Should play", function () {
+
+    it("Can play if player has steel production", function () {
         player.setProduction(Resources.STEEL);
         expect(card.canPlay(player)).to.eq(true);
+    });
+    
+    it("Should play - auto select if single target", function () {
+        player.setProduction(Resources.STEEL);
+        card.play(player, game); // can decrease own production
+        expect(game.interrupts.length).to.eq(0);
+        expect(player.getProduction(Resources.STEEL)).to.eq(1);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.STEEL);
+        player2.setProduction(Resources.STEEL);
         card.play(player, game);
         expect(player.getProduction(Resources.STEEL)).to.eq(2);
+
+        expect(game.interrupts.length).to.eq(1);
+        const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
+        selectPlayer.cb(player2);
+        expect(player2.getProduction(Resources.STEEL)).to.eq(0);
     });
 });

--- a/tests/cards/HeatTrappers.spec.ts
+++ b/tests/cards/HeatTrappers.spec.ts
@@ -29,22 +29,35 @@ describe("HeatTrappers", function () {
         expect(player.getProduction(Resources.ENERGY)).to.eq(1); // Incremented
     });
 
-    it("Should play", function () {
-        player2.setProduction(Resources.HEAT,7);
+    it("Should play - auto select if single target", function () {
+        player2.setProduction(Resources.HEAT, 7);
         expect(card.canPlay(player, game)).to.eq(true);
         card.play(player, game);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
+
+        expect(game.interrupts.length).to.eq(0);
+        expect(player2.getProduction(Resources.HEAT)).to.eq(5);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.HEAT, 3);
+        player2.setProduction(Resources.HEAT, 7);
+        card.play(player, game);
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
 
         expect(game.interrupts.length).to.eq(1);
         const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.HEAT)).to.eq(5);
-
-        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
-        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
     });
 
     it("Can't play if nobody has heat production", function () {
         expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Gives victory points", function () {
+        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
     });
 });

--- a/tests/cards/Herbivores.spec.ts
+++ b/tests/cards/Herbivores.spec.ts
@@ -27,10 +27,21 @@ describe("Herbivores", function () {
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
-    it("Should play", function () {
+    it("Should play - auto select if single target", function () {
         (game as any).oxygenLevel = 8;
         player2.setProduction(Resources.PLANTS);
         expect(card.canPlay(player, game)).to.eq(true);
+
+        card.play(player, game);
+        expect(card.resourceCount).to.eq(1);
+
+        expect(game.interrupts.length).to.eq(0);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
+    });
+
+    it("Should play - multiple targets", function () {
+        player.setProduction(Resources.PLANTS);
+        player2.setProduction(Resources.PLANTS);
 
         card.play(player, game);
         expect(card.resourceCount).to.eq(1);

--- a/tests/cards/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/PowerSupplyConsortium.spec.ts
@@ -17,17 +17,27 @@ describe("PowerSupplyConsortium", function () {
     });
 
     it("Can't play without power tags", function () {
-        player.setProduction(Resources.ENERGY,3);
+        player.setProduction(Resources.ENERGY, 3);
         expect(card.canPlay(player, game)).to.eq(false);
     });
 
-    it("Can play", function () {
-        player2.setProduction(Resources.ENERGY,3);
+    it("Can play - single target", function () {
+        player2.setProduction(Resources.ENERGY, 3);
         player.playedCards.push(card, card);
         expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
+        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
+    });
+
+    it("Can play - multiple targets", function () {
+        player.setProduction(Resources.ENERGY);
+        player2.setProduction(Resources.ENERGY, 3);
+
+        card.play(player, game);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(2);
 
         expect(game.interrupts.length).to.eq(1);
         const selectPlayer = game.interrupts[0].playerInput as SelectPlayer;

--- a/tests/cards/SmallAnimals.spec.ts
+++ b/tests/cards/SmallAnimals.spec.ts
@@ -39,9 +39,15 @@ describe("SmallAnimals", function () {
         
         player.playedCards.push(card);
         card.play(player, game);
+        expect(game.interrupts.length).to.eq(0);
+        expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
+    });
 
-        expect(card.getVictoryPoints()).to.eq(0);
+    it("Gives victory points", function () {
         player.addResourceTo(card, 3);
         expect(card.getVictoryPoints()).to.eq(1);
+
+        player.addResourceTo(card);
+        expect(card.getVictoryPoints()).to.eq(2);
     });
 });


### PR DESCRIPTION
**Scope:**
- Make `addResourceProductionDecreaseInterrupt` behaviour consistent with `addResourceDecreaseInterrupt`; there is no need to select a player if only one choice is possible.
- Update tests to cover the new logic