### PR TITLE
Always set hasIncreasedTerraformRatingThisGeneration when raising TR

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -149,7 +149,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             return;
           }; 
       }
+
       this.terraformRating++;
+      this.hasIncreasedTerraformRatingThisGeneration = true;
     }
 
     public increaseTerraformRatingSteps(value: number, game: Game) {


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/946

This issue happened because `hasIncreasedTerraformRatingThisGeneration` was not being set for Turmoil games