### PR TITLE
Improve Atmoscoop: Don't show raise temp/Venus option if parameter is maxed

### DIFF
--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -10,6 +10,7 @@ import { SelectCard } from '../../inputs/SelectCard';
 import { ICard } from '../ICard';
 import { CardName } from '../../CardName';
 import { LogHelper } from '../../components/LogHelper';
+import * as constants from "./../../constants";
 
 export class Atmoscoop implements IProjectCard {
     public cost: number = 22;
@@ -19,58 +20,105 @@ export class Atmoscoop implements IProjectCard {
     public canPlay(player: Player): boolean {
         return player.getTagCount(Tags.SCIENCE) >= 3 ;
       }
+
     public play(player: Player, game: Game) {
+        let result = new OrOptions();
+        let options: Array<SelectCard<ICard> | SelectOption> = [];
+
         const floaterCards = player.getResourceCards(ResourceType.FLOATER);
-        
-        const raiseTemp = floaterCards.length === 1
-            ? new SelectOption(
-                "Raise temperature 2 steps and add 2 floaters to" + floaterCards[0].name,
-                () => {
-                    player.addResourceTo(floaterCards[0], 2);
-                    LogHelper.logAddResource(game, player, floaterCards[0], 2);
+
+        if (floaterCards.length === 0) {
+            if (!this.temperatureIsMaxed(game)) {
+                options.push(new SelectOption("Raise temperature 2 steps", () => {
                     return game.increaseTemperature(player,2);
-                })
-            : new SelectCard(
-                'Select card to add 2 floaters and raise temperature 2 steps',
-                floaterCards,
-                (foundCards: Array<ICard>) => {
-                player.addResourceTo(foundCards[0], 2);
-                LogHelper.logAddResource(game, player, foundCards[0], 2);
-                return game.increaseTemperature(player,2);
-                });
-
-        const raiseVenus = floaterCards.length === 1
-            ? new SelectOption(
-                "Raise Venus 2 steps and add 2 floaters to" + floaterCards[0].name,
-                () => {
-                    player.addResourceTo(floaterCards[0], 2);
-                    LogHelper.logAddResource(game, player, floaterCards[0], 2);
+                }));
+            }
+            
+            if (!this.venusIsMaxed(game)) {
+                options.push(new SelectOption("Raise Venus 2 steps", () => {
                     return game.increaseVenusScaleLevel(player,2);
-                })
-            : new SelectCard(
-                'Select card to add 2 floaters and raise Venus 2 steps',
-                floaterCards,
-                (foundCards: Array<ICard>) => {
-                player.addResourceTo(foundCards[0], 2);
-                LogHelper.logAddResource(game, player, foundCards[0], 2);
-                return game.increaseVenusScaleLevel(player,2);
-            });
+                }));
+            }
+        } else if (floaterCards.length === 1) {
+            if (!this.temperatureIsMaxed(game)) {
+                options.push(new SelectOption(
+                    "Raise temperature 2 steps and add 2 floaters to" + floaterCards[0].name,
+                    () => {
+                        player.addResourceTo(floaterCards[0], 2);
+                        LogHelper.logAddResource(game, player, floaterCards[0], 2);
+                        return game.increaseTemperature(player,2);
+                }));
+            }
 
-        const raiseTempOnly = new SelectOption("Raise temperature 2 steps", () => {
-            return game.increaseTemperature(player,2);
-        });
-        const raiseVenusOnly = new SelectOption("Raise Venus 2 steps", () => {
-            return game.increaseVenusScaleLevel(player,2);
-        });
+            if (!this.venusIsMaxed(game)) {
+                options.push(new SelectOption(
+                    "Raise Venus 2 steps and add 2 floaters to" + floaterCards[0].name,
+                    () => {
+                        player.addResourceTo(floaterCards[0], 2);
+                        LogHelper.logAddResource(game, player, floaterCards[0], 2);
+                        return game.increaseVenusScaleLevel(player,2);
+                }));
+            }
 
-        if (floaterCards.length >= 1) {
-            return new OrOptions(raiseTemp, raiseVenus);
+            if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
+                options.push(new SelectOption(
+                    "Add 2 floaters to" + floaterCards[0].name,
+                    () => {
+                        player.addResourceTo(floaterCards[0], 2);
+                        LogHelper.logAddResource(game, player, floaterCards[0], 2);
+                        return undefined;
+                }));
+            }
         } else {
-            return new OrOptions(raiseTempOnly, raiseVenusOnly);
+            if (!this.temperatureIsMaxed(game)) {
+                options.push(new SelectCard(
+                    'Select card to add 2 floaters and raise temperature 2 steps',
+                    floaterCards,
+                    (foundCards: Array<ICard>) => {
+                        player.addResourceTo(foundCards[0], 2);
+                        LogHelper.logAddResource(game, player, foundCards[0], 2);
+                        return game.increaseTemperature(player,2);
+                }));
+            }
+
+            if (!this.venusIsMaxed(game)) {
+                options.push(new SelectCard(
+                    'Select card to add 2 floaters and raise Venus 2 steps',
+                    floaterCards,
+                    (foundCards: Array<ICard>) => {
+                    player.addResourceTo(foundCards[0], 2);
+                    LogHelper.logAddResource(game, player, foundCards[0], 2);
+                    return game.increaseVenusScaleLevel(player,2);
+                }));
+            }
+
+            if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
+                options.push(new SelectCard(
+                    'Select card to add 2 floaters',
+                    floaterCards,
+                    (foundCards: Array<ICard>) => {
+                    player.addResourceTo(foundCards[0], 2);
+                    LogHelper.logAddResource(game, player, foundCards[0], 2);
+                    return undefined;
+                }));
+            }
         }
+
+        if (options.length === 1) return options[0];
+
+        result.options = options;
+        return result;
     }
     
     public getVictoryPoints() {
         return 1;
-    } 
+    }
+
+    private temperatureIsMaxed(game: Game) {
+        return game.getTemperature() === constants.MAX_TEMPERATURE;
+    }
+
+    private venusIsMaxed(game: Game) {
+        return game.getVenusScaleLevel() === constants.MAX_VENUS_SCALE;
+    }
 }

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -42,7 +42,7 @@ export class Atmoscoop implements IProjectCard {
         } else if (floaterCards.length === 1) {
             if (!this.temperatureIsMaxed(game)) {
                 options.push(new SelectOption(
-                    "Raise temperature 2 steps and add 2 floaters to" + floaterCards[0].name,
+                    "Raise temperature 2 steps and add 2 floaters to " + floaterCards[0].name,
                     () => {
                         player.addResourceTo(floaterCards[0], 2);
                         LogHelper.logAddResource(game, player, floaterCards[0], 2);
@@ -52,7 +52,7 @@ export class Atmoscoop implements IProjectCard {
 
             if (!this.venusIsMaxed(game)) {
                 options.push(new SelectOption(
-                    "Raise Venus 2 steps and add 2 floaters to" + floaterCards[0].name,
+                    "Raise Venus 2 steps and add 2 floaters to " + floaterCards[0].name,
                     () => {
                         player.addResourceTo(floaterCards[0], 2);
                         LogHelper.logAddResource(game, player, floaterCards[0], 2);
@@ -62,7 +62,7 @@ export class Atmoscoop implements IProjectCard {
 
             if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
                 options.push(new SelectOption(
-                    "Add 2 floaters to" + floaterCards[0].name,
+                    "Add 2 floaters to " + floaterCards[0].name,
                     () => {
                         player.addResourceTo(floaterCards[0], 2);
                         LogHelper.logAddResource(game, player, floaterCards[0], 2);
@@ -72,7 +72,7 @@ export class Atmoscoop implements IProjectCard {
         } else {
             if (!this.temperatureIsMaxed(game)) {
                 options.push(new SelectCard(
-                    'Select card to add 2 floaters and raise temperature 2 steps',
+                    "Select card to add 2 floaters and raise temperature 2 steps",
                     floaterCards,
                     (foundCards: Array<ICard>) => {
                         player.addResourceTo(foundCards[0], 2);
@@ -83,7 +83,7 @@ export class Atmoscoop implements IProjectCard {
 
             if (!this.venusIsMaxed(game)) {
                 options.push(new SelectCard(
-                    'Select card to add 2 floaters and raise Venus 2 steps',
+                    "Select card to add 2 floaters and raise Venus 2 steps",
                     floaterCards,
                     (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 2);
@@ -94,7 +94,7 @@ export class Atmoscoop implements IProjectCard {
 
             if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
                 options.push(new SelectCard(
-                    'Select card to add 2 floaters',
+                    "Select card to add 2 floaters",
                     floaterCards,
                     (foundCards: Array<ICard>) => {
                     player.addResourceTo(foundCards[0], 2);
@@ -104,7 +104,14 @@ export class Atmoscoop implements IProjectCard {
             }
         }
 
-        if (options.length === 1) return options[0];
+        if (options.length === 1) {
+            if (options instanceof SelectOption) return (options[0] as SelectOption).cb();
+
+            const selectCard = options[0] as SelectCard<ICard>;
+            if (floaterCards.length === 1) return selectCard.cb([floaterCards[0]]);
+            
+            return selectCard;
+        };
 
         result.options = options;
         return result;

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -29,7 +29,7 @@ describe("Atmoscoop", function () {
         player.playedCards.push(new Research(), new SearchForLife());
         expect(card.canPlay(player)).to.eq(true);
 
-        const action = card.play(player, game);
+        const action = card.play(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);
 
         expect(action.options.length).to.eq(2);
@@ -43,7 +43,7 @@ describe("Atmoscoop", function () {
         const card2 = new Dirigibles();
         player.playedCards.push(card2);
 
-        const action = card.play(player, game);
+        const action = card.play(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);
 
         const orOptions = action.options[1] as OrOptions;
@@ -57,7 +57,7 @@ describe("Atmoscoop", function () {
         const card3 = new FloatingHabs();
         player.playedCards.push(card2, card3);
 
-        const action = card.play(player, game);
+        const action = card.play(player, game) as OrOptions;
         const orOptions = action.options[0] as SelectCard<ICard>;
         
         orOptions.cb([card3]);

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -10,14 +10,17 @@ import { SelectCard } from "../../../src/inputs/SelectCard";
 import { ICard } from "../../../src/cards/ICard";
 import { Research } from "../../../src/cards/Research";
 import { SearchForLife } from "../../../src/cards/SearchForLife";
+import  * as constants from "../../../src/constants";
 
 describe("Atmoscoop", function () {
-    let card : Atmoscoop, player : Player, game : Game;
+    let card : Atmoscoop, player : Player, game : Game, dirigibles: Dirigibles, floatingHabs: FloatingHabs;
 
     beforeEach(function() {
         card = new Atmoscoop();
         player = new Player("test", Color.BLUE, false);
         game = new Game("foobar", [player, player], player);
+        dirigibles = new Dirigibles();
+        floatingHabs = new FloatingHabs();
     });
 
     it("Can't play", function () {
@@ -40,8 +43,7 @@ describe("Atmoscoop", function () {
     });
 
     it("Should play - single target", function () {
-        const card2 = new Dirigibles();
-        player.playedCards.push(card2);
+        player.playedCards.push(dirigibles);
 
         const action = card.play(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);
@@ -49,19 +51,60 @@ describe("Atmoscoop", function () {
         const orOptions = action.options[1] as OrOptions;
         orOptions.cb();
         expect(game.getVenusScaleLevel()).to.eq(4);
-        expect(card2.resourceCount).to.eq(2);
+        expect(dirigibles.resourceCount).to.eq(2);
     });
 
     it("Should play - multiple targets", function () {
-        const card2 = new Dirigibles();
-        const card3 = new FloatingHabs();
-        player.playedCards.push(card2, card3);
+        player.playedCards.push(dirigibles, floatingHabs);
 
         const action = card.play(player, game) as OrOptions;
         const orOptions = action.options[0] as SelectCard<ICard>;
         
-        orOptions.cb([card3]);
+        orOptions.cb([floatingHabs]);
         expect(game.getTemperature()).to.eq(-26);
-        expect(card3.resourceCount).to.eq(2);
+        expect(floatingHabs.resourceCount).to.eq(2);
+    });
+
+    it("Should play - single target, one global parameter maxed", function () {
+        player.playedCards.push(dirigibles);
+        (game as any).temperature = constants.MAX_TEMPERATURE;
+
+        const action = card.play(player, game);
+        expect(action).to.eq(undefined);
+        expect(game.getVenusScaleLevel()).to.eq(4);
+        expect(dirigibles.resourceCount).to.eq(2);
+    });
+
+    it("Should play - single target, both global parameters maxed", function () {
+        player.playedCards.push(dirigibles);
+        (game as any).venusScaleLevel = constants.MAX_VENUS_SCALE;
+        (game as any).temperature = constants.MAX_TEMPERATURE;
+
+        const action = card.play(player, game);
+        expect(action).to.eq(undefined);
+        expect(dirigibles.resourceCount).to.eq(2);
+    });
+
+    it("Should play - multiple targets, one global parameter maxed", function () {
+        player.playedCards.push(dirigibles, floatingHabs);
+        (game as any).temperature = constants.MAX_TEMPERATURE;
+
+        const action = card.play(player, game) as SelectCard<ICard>;
+        expect(action instanceof SelectCard).to.eq(true);
+
+        action.cb([dirigibles]);
+        expect(game.getVenusScaleLevel()).to.eq(4);
+        expect(dirigibles.resourceCount).to.eq(2);
+    });
+
+    it("Should play - multiple targets, both global parameters maxed", function () {
+        player.playedCards.push(dirigibles, floatingHabs);
+        (game as any).venusScaleLevel = constants.MAX_VENUS_SCALE;
+        (game as any).temperature = constants.MAX_TEMPERATURE;
+
+        const action = card.play(player, game) as SelectCard<ICard>;
+        expect(action instanceof SelectCard).to.eq(true);
+        action.cb([dirigibles]);
+        expect(dirigibles.resourceCount).to.eq(2);
     });
 });


### PR DESCRIPTION
- Player should not see raise Venus or raise temperature option if that parameter is already maxed out
- If there is only one parameter that can be raised, it should happen automatically, no need to click