### PR TITLE
Fix: Pharmacy Union should remove 4 MC from corp owner

### DIFF
--- a/src/cards/promo/PharmacyUnion.ts
+++ b/src/cards/promo/PharmacyUnion.ts
@@ -41,9 +41,10 @@ export class PharmacyUnion implements CorporationCard {
 
     public onCardPlayed(player: Player, game: Game, card: IProjectCard): void {
         if (this.isDisabled) return undefined;
-        
+
         if (card.tags.includes(Tags.MICROBES)) {
             const microbeTagCount = card.tags.filter((cardTag) => cardTag === Tags.MICROBES).length;
+            const player = game.getPlayers().find((p) => p.isCorporation(this.name))!;
             player.addResourceTo(this, microbeTagCount);
             player.megaCredits = Math.max(player.megaCredits - microbeTagCount * 4, 0)
         }

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -35,18 +35,23 @@ describe("PharmacyUnion", function () {
         expect(player.cardsInHand[0].tags.includes(Tags.SCIENCE)).to.eq(true);
     });
 
-    it("Gains diseases when ANY player plays microbe cards", function () {
+    it("Gains diseases and removes MC when ANY player plays microbe cards", function () {
+        player.megaCredits = 8;
+        player2.megaCredits = 8;
         card.play();
 
         const ants = new Ants();
         player.playedCards.push(ants);
         card.onCardPlayed(player, game, ants);
         expect(card.resourceCount).to.eq(3);
+        expect(player.megaCredits).to.eq(4);
 
         const viralEnhancers = new ViralEnhancers();
         player2.playedCards.push(viralEnhancers);
         card.onCardPlayed(player2, game, viralEnhancers);
+        expect(player2.megaCredits).to.eq(8); // should not change
         expect(card.resourceCount).to.eq(4);
+        expect(player.megaCredits).to.eq(0);
     });
     
     it("Removes diseases and gives TR only when corp owner plays science cards", function () {


### PR DESCRIPTION
This commit fixes a bug where Pharmacy Union's effect incorrectly removes 4 MC from the player who played the microbe tag.

The 4 MC should be removed from the player who has the Pharmacy Union corporation.