### PR TITLE
Refactor some code into PartyHooks

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -52,7 +52,7 @@ import { SerializedGame } from "./SerializedGame";
 import { SerializedPlayer } from "./SerializedPlayer";
 import { CardName } from "./CardName";
 import { Turmoil } from "./turmoil/Turmoil";
-import { PartyName } from "./turmoil/parties/PartyName";
+import { PartyHooks } from "./turmoil/parties/PartyHooks";
 import { IParty } from "./turmoil/parties/IParty";
 import { OrOptions } from "./inputs/OrOptions";
 import { SelectOption } from "./inputs/SelectOption";
@@ -1342,15 +1342,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
 
       // Turmoil Mars First ruling policy
-      if (this.turmoilExtension 
-        && this.turmoil !== undefined 
-        && this.turmoil.rulingParty !== undefined 
-        && this.turmoil.rulingParty.name === PartyName.MARS
-        && spaceType !== SpaceType.COLONY
-        && this.phase === Phase.ACTION
-        && !isWorldGov) {
-          player.setResource(Resources.STEEL, 1);
-      }      
+      PartyHooks.applyMarsFirstRulingPolicy(this, player, spaceType, isWorldGov);
 
       // Hellas special requirements ocean tile
       if (space.id === SpaceName.HELLAS_OCEAN_TILE 
@@ -1428,13 +1420,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
         tileType: TileType.GREENERY
       });
       // Turmoil Greens ruling policy
-      if (this.turmoilExtension 
-        && this.turmoil !== undefined 
-        && this.turmoil.rulingParty !== undefined 
-        && this.turmoil.rulingParty.name === PartyName.GREENS
-        && this.phase ===  Phase.ACTION) {
-          player.setResource(Resources.MEGACREDITS, 4);
-      }
+      PartyHooks.applyGreensRulingPolicy(this, player);
+
       if (shouldRaiseOxygen) return this.increaseOxygenLevel(player, 1);
       return undefined;
     }

--- a/src/turmoil/parties/PartyHooks.ts
+++ b/src/turmoil/parties/PartyHooks.ts
@@ -1,0 +1,35 @@
+import { Player } from "../../Player";
+import { Game } from '../../Game';
+import { PartyName } from "./PartyName";
+import { SpaceType } from "../../SpaceType";
+import { Phase } from "../../Phase";
+import { Resources } from "../../Resources";
+
+export class PartyHooks {
+    static applyMarsFirstRulingPolicy(game: Game, player: Player, spaceType: SpaceType, isWorldGov: boolean) {
+        if (this.shouldApplyPolicy(game, PartyName.MARS)
+        && spaceType !== SpaceType.COLONY
+        && game.phase === Phase.ACTION
+        && !isWorldGov) {
+          player.setResource(Resources.STEEL, 1);
+        }
+    }
+
+    static applyGreensRulingPolicy(game: Game, player: Player) {
+        if (this.shouldApplyPolicy(game, PartyName.GREENS) && game.phase === Phase.ACTION) {
+            player.setResource(Resources.MEGACREDITS, 4);
+        }
+    }
+
+    static shouldApplyPolicy(game: Game, partyName: PartyName) {
+        if (!game.turmoilExtension) return false;
+
+        const turmoil = game.turmoil!;
+        if (!turmoil) return false;
+
+        const rulingParty = turmoil.rulingParty!;
+        if (!rulingParty) return false;
+
+        return rulingParty.name === partyName;
+    }
+}

--- a/tests/cards/turmoil/BannedDelegate.spec.ts
+++ b/tests/cards/turmoil/BannedDelegate.spec.ts
@@ -7,6 +7,7 @@ import { GameOptions, Game } from '../../../src/Game';
 import { PartyName } from "../../../src/turmoil/parties/PartyName";
 import { Turmoil } from "../../../src/turmoil/Turmoil";
 import { SelectDelegate } from "../../../src/inputs/SelectDelegate";
+import { OrOptions } from "../../../src/inputs/OrOptions";
 
 describe("Banned Delegate", function () {
     let card : BannedDelegate, player : Player, player2 : Player, game : Game, turmoil: Turmoil;
@@ -54,9 +55,16 @@ describe("Banned Delegate", function () {
         turmoil.sendDelegateToParty(player2.id, PartyName.GREENS, game);
         const initialDelegatesCount = greens.delegates.length;
 
-        const selectDelegate = card.play(player, game) as SelectDelegate;
-        const action = selectDelegate!.cb(selectDelegate.players[0]);
-        console.log(action);
+        const result = card.play(player, game);
+
+        if (result instanceof SelectDelegate) {
+            const selectDelegate = result as SelectDelegate;
+            selectDelegate.cb(result.players[0]);
+        } else {
+            const orOptions = result as OrOptions;
+            orOptions.options.forEach((option) => option.cb((option as SelectDelegate).players[0]));
+        }
+
         expect(greens.delegates.length).to.eq(initialDelegatesCount - 1);
     });
 });


### PR DESCRIPTION
Minor groundwork for future variants like https://boardgamegeek.com/thread/2411719/turmoil-20-political-agendas which the designer has already given permission to include here.

Also fixes a flaky BannedDelegate test caused by random factor during game setup. Sometimes `BannedDelegate.play()` returns `Array<SelectDelegate>` with multiple parties instead of just `SelectDelegate` with one party.