### PR TITLE
Fix: Player can't take actions that raise TR if can't pay tax while Reds are ruling

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1939,7 +1939,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
                 this.megaCredits >= cost;
     }
 
-    private getAvailableStandardProjects(game: Game): OrOptions {
+    public getAvailableStandardProjects(game: Game): OrOptions {
       const standardProjects = new OrOptions();
       standardProjects.title = "Pay for a Standard Project";
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1940,31 +1940,36 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       const standardProjects = new OrOptions();
       standardProjects.title = "Pay for a Standard Project";
 
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
+
       if (this.canAfford(this.powerPlantCost)) {
         standardProjects.options.push(
             this.buildPowerPlant(game)
         );
       }
 
-      if (
-        this.canAfford(constants.ASTEROID_COST) &&
-            game.getTemperature() < constants.MAX_TEMPERATURE) {
+      let asteroidCost = constants.ASTEROID_COST
+      if (redsAreRuling) asteroidCost += REDS_RULING_POLICY_COST;
+      
+      if (this.canAfford(asteroidCost) && game.getTemperature() < constants.MAX_TEMPERATURE) {
         standardProjects.options.push(
             this.asteroid(game)
         );
       }
 
-      if (
-        this.canAfford(constants.AQUIFER_COST) &&
-            game.board.getOceansOnBoard() < constants.MAX_OCEAN_TILES) {
+      let aquiferCost = constants.AQUIFER_COST
+      if (redsAreRuling) aquiferCost += REDS_RULING_POLICY_COST;
+
+      if (this.canAfford(aquiferCost) && game.board.getOceansOnBoard() < constants.MAX_OCEAN_TILES) {
         standardProjects.options.push(
             this.aquifer(game)
         );
       }
 
-      if (
-        this.canAfford(constants.GREENERY_COST) &&
-            game.board.getAvailableSpacesForGreenery(this).length > 0) {
+      let greeneryCost = constants.GREENERY_COST
+      if (redsAreRuling) greeneryCost += REDS_RULING_POLICY_COST;
+
+      if (this.canAfford(greeneryCost) && game.board.getAvailableSpacesForGreenery(this).length > 0) {
         standardProjects.options.push(
             this.addGreenery(game)
         );
@@ -1978,9 +1983,12 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         );
       }
 
-      if ( game.venusNextExtension &&
-        this.canAfford(constants.AIR_SCRAPPING_COST) &&
-            game.getVenusScaleLevel() < constants.MAX_VENUS_SCALE) {
+      let airScrappingCost = constants.AIR_SCRAPPING_COST
+      if (redsAreRuling) airScrappingCost += REDS_RULING_POLICY_COST;
+
+      if (game.venusNextExtension
+        && this.canAfford(airScrappingCost)
+        && game.getVenusScaleLevel() < constants.MAX_VENUS_SCALE) {
         standardProjects.options.push(
             this.airScrapping(game)
         );
@@ -1998,8 +2006,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           }
       }
 
-      if ( game.soloTR &&
-        this.canAfford(constants.BUFFER_GAS_COST)) {
+      let bufferGasCost = constants.BUFFER_GAS_COST
+      if (redsAreRuling) bufferGasCost += REDS_RULING_POLICY_COST;
+
+      if (game.soloTR && this.canAfford(bufferGasCost)) {
         standardProjects.options.push(
             this.bufferGas(game)
         );

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -50,6 +50,7 @@ import { MiningRights } from "./cards/MiningRights";
 import { PharmacyUnion } from "./cards/promo/PharmacyUnion";
 import { Board } from "./Board";
 import { PartyHooks } from "./turmoil/parties/PartyHooks";
+import { REDS_RULING_POLICY_COST } from "./constants";
 
 export type PlayerId = string;
 
@@ -134,14 +135,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Turmoil Reds capacity
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && game.phase === Phase.ACTION) {
-        if (this.canAfford(3)) {
-          game.addSelectHowToPayInterrupt(this, 3, false, false, "Select how to pay for TR increase");
-          this.terraformRating++;
-          this.hasIncreasedTerraformRatingThisGeneration = true;
-          return;
-        } else {
-            return;
-        }; 
+        game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, false, false, "Select how to pay for TR increase");
+        this.terraformRating++;
+        this.hasIncreasedTerraformRatingThisGeneration = true;
+        return;
       }
 
       this.terraformRating++;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -135,7 +135,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Turmoil Reds capacity
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && game.phase === Phase.ACTION) {
-        game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, false, false, "Select how to pay for TR increase");
+        game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, true, true, "Select how to pay for TR increase");
         this.terraformRating++;
         this.hasIncreasedTerraformRatingThisGeneration = true;
         return;

--- a/src/cards/AquiferPumping.ts
+++ b/src/cards/AquiferPumping.ts
@@ -9,7 +9,8 @@ import {AndOptions} from '../inputs/AndOptions';
 import {SelectHowToPay} from '../inputs/SelectHowToPay';
 import * as constants from '../constants';
 import { CardName } from '../CardName';
-
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class AquiferPumping implements IActionCard, IProjectCard {
     public cost: number = 18;
@@ -21,7 +22,16 @@ export class AquiferPumping implements IActionCard, IProjectCard {
       return undefined;
     }
     public canAct(player: Player, game: Game): boolean {
-      return player.canAfford(8, game, true, false) && game.board.getOceansOnBoard() < constants.MAX_OCEAN_TILES;
+      const oceansMaxed = game.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES;
+      if (oceansMaxed) return false;
+
+      const canAffordOcean = player.canAfford(8, game, true, false);
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(constants.REDS_RULING_POLICY_COST) && canAffordOcean;
+      }
+
+      return canAffordOcean;
     }
     public action(player: Player, game: Game) {
       let howToPay: HowToPay;

--- a/src/cards/AquiferPumping.ts
+++ b/src/cards/AquiferPumping.ts
@@ -7,10 +7,10 @@ import {Game} from '../Game';
 import {HowToPay} from '../inputs/HowToPay';
 import {AndOptions} from '../inputs/AndOptions';
 import {SelectHowToPay} from '../inputs/SelectHowToPay';
-import * as constants from '../constants';
 import { CardName } from '../CardName';
 import { PartyHooks } from '../turmoil/parties/PartyHooks';
 import { PartyName } from '../turmoil/parties/PartyName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
 
 export class AquiferPumping implements IActionCard, IProjectCard {
     public cost: number = 18;
@@ -22,16 +22,17 @@ export class AquiferPumping implements IActionCard, IProjectCard {
       return undefined;
     }
     public canAct(player: Player, game: Game): boolean {
-      const oceansMaxed = game.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES;
+      const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
       if (oceansMaxed) return false;
 
-      const canAffordOcean = player.canAfford(8, game, true, false);
+      let oceanCost = 8;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(constants.REDS_RULING_POLICY_COST) && canAffordOcean;
+        oceanCost += REDS_RULING_POLICY_COST;
+        return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, game, true, false);
       }
 
-      return canAffordOcean;
+      return player.canAfford(oceanCost, game, true, false);
     }
     public action(player: Player, game: Game) {
       let howToPay: HowToPay;

--- a/src/cards/ArtificialLake.ts
+++ b/src/cards/ArtificialLake.ts
@@ -6,10 +6,10 @@ import {Game} from '../Game';
 import {ISpace} from '../ISpace';
 import {SelectSpace} from '../inputs/SelectSpace';
 import {SpaceType} from '../SpaceType';
-import * as constants from '../constants';
 import { CardName } from '../CardName';
 import { PartyHooks } from '../turmoil/parties/PartyHooks';
 import { PartyName } from '../turmoil/parties/PartyName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
 
 export class ArtificialLake implements IProjectCard {
     public cost: number = 15;
@@ -18,16 +18,16 @@ export class ArtificialLake implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
       const meetsTemperatureRequirements = game.getTemperature() >= -6 - (player.getRequirementsBonus(game) * 2);
-      const oceansMaxed = game.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES;
+      const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-        return player.canAfford(constants.REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, true) && meetsTemperatureRequirements;
       }
 
       return meetsTemperatureRequirements;
     }
     public play(player: Player, game: Game) {
-      if (game.board.getOceansOnBoard() >= constants.MAX_OCEAN_TILES) return undefined;
+      if (game.board.getOceansOnBoard() >= MAX_OCEAN_TILES) return undefined;
 
       return new SelectSpace(
           'Select a land space to place an ocean',

--- a/src/cards/ArtificialLake.ts
+++ b/src/cards/ArtificialLake.ts
@@ -8,6 +8,8 @@ import {SelectSpace} from '../inputs/SelectSpace';
 import {SpaceType} from '../SpaceType';
 import * as constants from '../constants';
 import { CardName } from '../CardName';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class ArtificialLake implements IProjectCard {
     public cost: number = 15;
@@ -15,12 +17,16 @@ export class ArtificialLake implements IProjectCard {
     public name: CardName = CardName.ARTIFICIAL_LAKE;
     public cardType: CardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -6 - (
-        player.getRequirementsBonus(game) * 2
-      );
+      const meetsTemperatureRequirements = game.getTemperature() >= -6 - (player.getRequirementsBonus(game) * 2);
+      const oceansMaxed = game.board.getOceansOnBoard() === constants.MAX_OCEAN_TILES;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+        return player.canAfford(constants.REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+      }
+
+      return meetsTemperatureRequirements;
     }
     public play(player: Player, game: Game) {
-
       if (game.board.getOceansOnBoard() >= constants.MAX_OCEAN_TILES) return undefined;
 
       return new SelectSpace(

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -18,7 +18,7 @@ export class Asteroid implements IProjectCard {
     public canPlay(player: Player, game: Game) {
       const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
-        return player.canAfford(REDS_RULING_POLICY_COST);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
       }
 
       return true;

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -5,12 +5,24 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class Asteroid implements IProjectCard {
     public cost: number = 14;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.ASTEROID;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+      const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
+        return player.canAfford(REDS_RULING_POLICY_COST);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       game.increaseTemperature(player, 1);

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -5,12 +5,26 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { CardName } from '../CardName';
 import { Resources } from '../Resources';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class BigAsteroid implements IProjectCard {
     public cost: number = 27;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.BIG_ASTEROID;
+
+    public canPlay(player: Player, game: Game) {
+      const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+      const stepsRaised = Math.min(remainingTemperatureSteps, 2);
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+    }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       game.increaseTemperature(player, 2);

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -20,7 +20,7 @@ export class BigAsteroid implements IProjectCard {
       const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
     }
 
       return true;

--- a/src/cards/BlackPolarDust.ts
+++ b/src/cards/BlackPolarDust.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -6,6 +5,9 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { Resources } from "../Resources";
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class BlackPolarDust implements IProjectCard {
     public cost: number = 15;
@@ -13,8 +15,15 @@ export class BlackPolarDust implements IProjectCard {
     public name: CardName = CardName.BLACK_POLAR_DUST;
     public cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.MEGACREDITS) >= -3;
+    public canPlay(player: Player, game: Game): boolean {
+      const meetsMcProdRequirement = player.getProduction(Resources.MEGACREDITS) >= -3;
+      const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+        return player.canAfford(REDS_RULING_POLICY_COST) && meetsMcProdRequirement;
+      }
+
+      return meetsMcProdRequirement;
     }
     public play(player: Player, game: Game) {
       player.setProduction(Resources.MEGACREDITS,-2);

--- a/src/cards/BlackPolarDust.ts
+++ b/src/cards/BlackPolarDust.ts
@@ -20,7 +20,7 @@ export class BlackPolarDust implements IProjectCard {
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-        return player.canAfford(REDS_RULING_POLICY_COST) && meetsMcProdRequirement;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsMcProdRequirement;
       }
 
       return meetsMcProdRequirement;

--- a/src/cards/BribedCommitte.ts
+++ b/src/cards/BribedCommitte.ts
@@ -16,7 +16,7 @@ export class BribedCommitte implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2);
       }
 
       return true;

--- a/src/cards/BribedCommitte.ts
+++ b/src/cards/BribedCommitte.ts
@@ -1,16 +1,26 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../constants';
 
 export class BribedCommitte implements IProjectCard {
     public cost: number = 7;
     public tags: Array<Tags> = [Tags.EARTH];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.BRIBED_COMMITTEE;
+
+    public canPlay(player: Player, game: Game) {
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/CaretakerContract.ts
+++ b/src/cards/CaretakerContract.ts
@@ -28,7 +28,7 @@ export class CaretakerContract implements IActionCard, IProjectCard {
       const hasEnoughHeat = player.heat >= 8 || (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && (player.getResourcesOnCorporation() * 2) + player.heat >= 8);
       
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasEnoughHeat;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2) && hasEnoughHeat;
       }
 
       return hasEnoughHeat;

--- a/src/cards/CaretakerContract.ts
+++ b/src/cards/CaretakerContract.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard, ICard } from './ICard';
 import {IProjectCard} from './IProjectCard';
 import {CardType} from './CardType';
@@ -8,6 +7,9 @@ import {Game} from '../Game';
 import { AndOptions } from '../inputs/AndOptions';
 import { SelectAmount } from '../inputs/SelectAmount';
 import { CardName } from '../CardName';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../constants';
 
 export class CaretakerContract implements IActionCard, IProjectCard {
     public cost: number = 3;
@@ -22,8 +24,14 @@ export class CaretakerContract implements IActionCard, IProjectCard {
     public play() {
       return undefined;
     }
-    public canAct(player: Player): boolean {
-      return player.heat >= 8 || (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && (player.getResourcesOnCorporation() * 2) + player.heat >= 8 );
+    public canAct(player: Player, game: Game): boolean {
+      const hasEnoughHeat = player.heat >= 8 || (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && (player.getResourcesOnCorporation() * 2) + player.heat >= 8);
+      
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasEnoughHeat;
+      }
+
+      return hasEnoughHeat;
     }
     public action(player: Player, game: Game) {
       if (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && player.getResourcesOnCorporation() > 0 ) {

--- a/src/cards/Comet.ts
+++ b/src/cards/Comet.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -6,12 +5,27 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { CardName } from '../CardName';
 import { Resources } from '../Resources';
+import { MAX_TEMPERATURE, MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class Comet implements IProjectCard {
     public cost: number = 21;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.COMET;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+      const temperatureStep = game.getTemperature() < MAX_TEMPERATURE ? 1 : 0;
+      const oceanStep = game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
+      const totalSteps = temperatureStep + oceanStep;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       game.increaseTemperature(player, 1);

--- a/src/cards/Comet.ts
+++ b/src/cards/Comet.ts
@@ -21,7 +21,7 @@ export class Comet implements IProjectCard {
       const totalSteps = temperatureStep + oceanStep;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * totalSteps, game, false, true);
       }
 
       return true;

--- a/src/cards/ConvoyFromEuropa.ts
+++ b/src/cards/ConvoyFromEuropa.ts
@@ -1,16 +1,28 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class ConvoyFromEuropa implements IProjectCard {
     public cost: number = 15;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.CONVOY_FROM_EUROPA;
+
+    public canPlay(player: Player, game: Game): boolean {
+      const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+        return player.canAfford(REDS_RULING_POLICY_COST);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       player.cardsInHand.push(game.dealer.dealCard());

--- a/src/cards/ConvoyFromEuropa.ts
+++ b/src/cards/ConvoyFromEuropa.ts
@@ -18,7 +18,7 @@ export class ConvoyFromEuropa implements IProjectCard {
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-        return player.canAfford(REDS_RULING_POLICY_COST);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
       }
 
       return true;

--- a/src/cards/DeepWellHeating.ts
+++ b/src/cards/DeepWellHeating.ts
@@ -18,7 +18,7 @@ export class DeepWellHeating implements IProjectCard {
     public canPlay(player: Player, game: Game) {
       const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
-        return player.canAfford(REDS_RULING_POLICY_COST);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, true);
       }
 
       return true;

--- a/src/cards/DeepWellHeating.ts
+++ b/src/cards/DeepWellHeating.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -6,12 +5,24 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class DeepWellHeating implements IProjectCard {
     public cost: number = 13;
     public tags: Array<Tags> = [Tags.ENERGY, Tags.STEEL];
     public name: CardName = CardName.DEEP_WELL_HEATING;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+      const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
+        return player.canAfford(REDS_RULING_POLICY_COST);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       player.setProduction(Resources.ENERGY);

--- a/src/cards/DeimosDown.ts
+++ b/src/cards/DeimosDown.ts
@@ -20,7 +20,7 @@ export class DeimosDown implements IProjectCard {
       const stepsRaised = Math.min(remainingTemperatureSteps, 3);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
       }
 
       return true;

--- a/src/cards/DeimosDown.ts
+++ b/src/cards/DeimosDown.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -6,12 +5,26 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import { CardName } from '../CardName';
 import { Resources } from '../Resources';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class DeimosDown implements IProjectCard {
     public cost: number = 31;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.DEIMOS_DOWN;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+      const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+      const stepsRaised = Math.min(remainingTemperatureSteps, 3);
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       game.increaseTemperature(player, 3);

--- a/src/cards/EquatorialMagnetizer.ts
+++ b/src/cards/EquatorialMagnetizer.ts
@@ -23,7 +23,7 @@ export class EquatorialMagnetizer implements IActionCard, IProjectCard {
       const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && hasEnergyProduction;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && hasEnergyProduction;
       }
 
       return hasEnergyProduction;

--- a/src/cards/EquatorialMagnetizer.ts
+++ b/src/cards/EquatorialMagnetizer.ts
@@ -1,4 +1,3 @@
-
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
@@ -7,6 +6,9 @@ import {IProjectCard} from './IProjectCard';
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../constants';
 
 export class EquatorialMagnetizer implements IActionCard, IProjectCard {
     public cost: number = 11;
@@ -17,8 +19,14 @@ export class EquatorialMagnetizer implements IActionCard, IProjectCard {
     public play() {
       return undefined;
     }
-    public canAct(player: Player): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1;
+    public canAct(player: Player, game: Game): boolean {
+      const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && hasEnergyProduction;
+      }
+
+      return hasEnergyProduction;
     }
     public action(player: Player, game: Game) {
       player.setProduction(Resources.ENERGY,-1);

--- a/src/cards/Flooding.ts
+++ b/src/cards/Flooding.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {Player} from '../Player';
@@ -11,12 +10,26 @@ import {SelectSpace} from '../inputs/SelectSpace';
 import {ISpace} from '../ISpace';
 import { CardName } from '../CardName';
 import { Resources } from '../Resources';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class Flooding implements IProjectCard {
   public cardType: CardType = CardType.EVENT;
   public cost: number = 7;
   public name: CardName = CardName.FLOODING;
   public tags: Array<Tags> = [];
+
+  public canPlay(player: Player, game: Game): boolean {
+    const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+      return player.canAfford(REDS_RULING_POLICY_COST);
+    }
+
+    return true;
+  }
+
   public play(player: Player, game: Game) {
     if (game.soloMode) {
       game.addOceanInterrupt(player);

--- a/src/cards/Flooding.ts
+++ b/src/cards/Flooding.ts
@@ -24,7 +24,7 @@ export class Flooding implements IProjectCard {
     const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
     if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-      return player.canAfford(REDS_RULING_POLICY_COST);
+      return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
     }
 
     return true;

--- a/src/cards/GHGProducingBacteria.ts
+++ b/src/cards/GHGProducingBacteria.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard, IResourceCard } from './ICard';
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -10,6 +9,9 @@ import { ResourceType } from "../ResourceType";
 import { SelectOption } from "../inputs/SelectOption";
 import { CardName } from '../CardName';
 import { LogHelper } from '../components/LogHelper';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../constants';
 
 export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 8;
@@ -28,22 +30,30 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
         return true;
     }
     public action(player: Player, game: Game) {
-        if (this.resourceCount > 1) {
-            return new OrOptions(
-                new SelectOption("Remove 2 microbes to raise temperature 1 step", () => {
-                    player.removeResourceFrom(this,2);
-                    LogHelper.logRemoveResource(game, player, this, 2, "raise temperature 1 step");
-                    return game.increaseTemperature(player, 1);
-                }),
-                new SelectOption("Add 1 microbe to this card", () => {
-                    player.addResourceTo(this);
-                    LogHelper.logAddResource(game, player, this);
-                    return undefined;
-                })
-            );
+        if (this.resourceCount < 2) {
+            player.addResourceTo(this);
+            LogHelper.logAddResource(game, player, this);
+            return undefined;
         }
-        player.addResourceTo(this);
-        LogHelper.logAddResource(game, player, this);
-        return undefined;
+
+        let orOptions = new OrOptions();
+        const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
+
+        if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
+            orOptions.options.push(new SelectOption("Remove 2 microbes to raise temperature 1 step", () => {
+                player.removeResourceFrom(this,2);
+                LogHelper.logRemoveResource(game, player, this, 2, "raise temperature 1 step");
+                return game.increaseTemperature(player, 1);
+            }));
+        }
+
+        orOptions.options.push(new SelectOption("Add 1 microbe to this card", () => {
+            player.addResourceTo(this);
+            LogHelper.logAddResource(game, player, this);
+            return undefined;
+        }));
+
+        if (orOptions.options.length === 1) return orOptions.options[0].cb();
+        return orOptions;
     }
 }

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -21,7 +21,7 @@ export class GiantIceAsteroid implements IProjectCard {
         const stepsRaised = Math.min(remainingTemperatureSteps, 2) + Math.min(remainingOceans, 2);
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
         }
   
         return true;

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -5,12 +5,27 @@ import { Player } from "../Player";
 import { Game } from "../Game";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class GiantIceAsteroid implements IProjectCard {
     public cost: number = 36;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.GIANT_ICE_ASTEROID;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();
+        const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+        const stepsRaised = Math.min(remainingTemperatureSteps, 2) + Math.min(remainingOceans, 2);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.increaseTemperature(player, 2);

--- a/src/cards/IceAsteroid.ts
+++ b/src/cards/IceAsteroid.ts
@@ -1,16 +1,29 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class IceAsteroid implements IProjectCard {
     public cost: number = 23;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.ICE_ASTEROID;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();
+        const oceansPlaced = Math.min(remainingOceans, 2);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * oceansPlaced);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.addOceanInterrupt(player, "Select space for first ocean");

--- a/src/cards/IceAsteroid.ts
+++ b/src/cards/IceAsteroid.ts
@@ -19,7 +19,7 @@ export class IceAsteroid implements IProjectCard {
         const oceansPlaced = Math.min(remainingOceans, 2);
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * oceansPlaced);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * oceansPlaced);
         }
   
         return true;

--- a/src/cards/IceAsteroid.ts
+++ b/src/cards/IceAsteroid.ts
@@ -19,7 +19,7 @@ export class IceAsteroid implements IProjectCard {
         const oceansPlaced = Math.min(remainingOceans, 2);
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * oceansPlaced);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * oceansPlaced, game, false, true);
         }
   
         return true;

--- a/src/cards/IceCapMelting.ts
+++ b/src/cards/IceCapMelting.ts
@@ -18,7 +18,7 @@ export class IceCapMelting implements IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
         }
     
         return meetsTemperatureRequirements;

--- a/src/cards/IceCapMelting.ts
+++ b/src/cards/IceCapMelting.ts
@@ -1,10 +1,12 @@
-
 import { CardType } from "./CardType";
 import { IProjectCard } from "./IProjectCard";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { Tags } from "./Tags";
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class IceCapMelting implements IProjectCard {
     public cost: number = 5;
@@ -12,7 +14,14 @@ export class IceCapMelting implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.ICE_CAP_MELTING;
     public canPlay(player: Player, game: Game): boolean {
-        return game.getTemperature() >= 2 - (2 * player.getRequirementsBonus(game));
+        const meetsTemperatureRequirements = game.getTemperature() >= 2 - (2 * player.getRequirementsBonus(game));
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+        }
+    
+        return meetsTemperatureRequirements;
     }
     public play(player: Player, game: Game) {
         game.addOceanInterrupt(player);

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -1,5 +1,4 @@
 import {ICard} from './ICard';
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -13,12 +12,25 @@ import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { LogHelper } from '../components/LogHelper';
 import { Resources } from '../Resources';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class ImportedHydrogen implements IProjectCard {
     public cost: number = 16;
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.IMPORTED_HYDROGEN;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+    
+        return true;
+    }
 
     public play(player: Player, game: Game): undefined | PlayerInput {
         const availableMicrobeCards = player.getResourceCards(ResourceType.MICROBE);

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -26,7 +26,7 @@ export class ImportedHydrogen implements IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
     
         return true;

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -9,12 +9,23 @@ import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
 import { LogHelper } from '../components/LogHelper';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../constants';
 
 export class ImportedNitrogen implements IProjectCard {
     public cost: number = 23;
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.IMPORTED_NITROGEN;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     private giveResources(player: Player, game: Game): undefined {
         player.increaseTerraformRating(game);

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -21,7 +21,7 @@ export class ImportedNitrogen implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/Ironworks.ts
+++ b/src/cards/Ironworks.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -6,6 +5,9 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class Ironworks implements IActionCard, IProjectCard {
     public cost: number = 11;
@@ -16,8 +18,15 @@ export class Ironworks implements IActionCard, IProjectCard {
     public play(_player: Player, _game: Game) {
         return undefined;
     }
-    public canAct(player: Player): boolean {
-        return player.energy >= 4;
+    public canAct(player: Player, game: Game): boolean {
+        const hasEnoughEnergy = player.energy >= 4;
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
+        }
+
+        return hasEnoughEnergy;
     }
     public action(player: Player, game: Game) {
         player.energy -= 4;

--- a/src/cards/LakeMarineris.ts
+++ b/src/cards/LakeMarineris.ts
@@ -19,7 +19,7 @@ export class LakeMarineris implements IProjectCard {
         const oceansPlaced = Math.min(remainingOceans, 2);
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * oceansPlaced) && meetsTemperatureRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * oceansPlaced) && meetsTemperatureRequirements;
         }
   
         return meetsTemperatureRequirements;

--- a/src/cards/LakeMarineris.ts
+++ b/src/cards/LakeMarineris.ts
@@ -1,10 +1,12 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class LakeMarineris implements IProjectCard {
     public cost: number = 18;
@@ -12,8 +14,17 @@ export class LakeMarineris implements IProjectCard {
     public name: CardName = CardName.LAKE_MARINERIS;
     public cardType: CardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-        return game.getTemperature() >= 0 - (2 * player.getRequirementsBonus(game));
+        const meetsTemperatureRequirements = game.getTemperature() >= 0 - (2 * player.getRequirementsBonus(game));
+        const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();
+        const oceansPlaced = Math.min(remainingOceans, 2);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * oceansPlaced) && meetsTemperatureRequirements;
+        }
+  
+        return meetsTemperatureRequirements;
     }
+
     public play(player: Player, game: Game) {
         game.addOceanInterrupt(player, "Select space for first ocean");
         game.addOceanInterrupt(player, "Select space for second ocean");

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -26,7 +26,7 @@ export class LargeConvoy implements IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
     
         return true;

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -12,12 +12,25 @@ import { ResourceType } from '../ResourceType';
 import { CardName } from '../CardName';
 import { LogHelper } from '../components/LogHelper';
 import { Resources } from '../Resources';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
+import { PartyHooks } from '../turmoil/parties/PartyHooks';
+import { PartyName } from '../turmoil/parties/PartyName';
 
 export class LargeConvoy implements IProjectCard {
     public cost: number = 36;
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.LARGE_CONVOY;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+    
+        return true;
+      }
 
     public play(player: Player, game: Game): PlayerInput | undefined {
         player.cardsInHand.push(game.dealer.dealCard(), game.dealer.dealCard());

--- a/src/cards/LavaFlows.ts
+++ b/src/cards/LavaFlows.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { CardType } from "./CardType";
 import { SpaceType } from "../SpaceType";
@@ -11,6 +10,9 @@ import { ISpace } from "../ISpace";
 import { SelectSpace } from "../inputs/SelectSpace";
 import { BoardName } from '../BoardName';
 import { CardName } from '../CardName';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class LavaFlows implements IProjectCard {
     public cost: number = 18;
@@ -39,7 +41,15 @@ export class LavaFlows implements IProjectCard {
         }    
     }
     public canPlay(player: Player, game: Game): boolean {
-        return LavaFlows.getVolcanicSpaces(player, game).length > 0;
+        const canPlaceTile = LavaFlows.getVolcanicSpaces(player, game).length > 0;
+        const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+        const stepsRaised = Math.min(remainingTemperatureSteps, 2);
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
+        }
+
+      return canPlaceTile;
     }
     public play(player: Player, game: Game) {
         return new SelectSpace("Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons", LavaFlows.getVolcanicSpaces(player, game), (space: ISpace) => {

--- a/src/cards/LavaFlows.ts
+++ b/src/cards/LavaFlows.ts
@@ -46,7 +46,7 @@ export class LavaFlows implements IProjectCard {
         const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
         }
 
       return canPlaceTile;

--- a/src/cards/MagneticFieldDome.ts
+++ b/src/cards/MagneticFieldDome.ts
@@ -19,7 +19,7 @@ export class MagneticFieldDome implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 2;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, true) && hasEnergyProduction;
         }
   
         return hasEnergyProduction;

--- a/src/cards/MagneticFieldDome.ts
+++ b/src/cards/MagneticFieldDome.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { Game } from "../Game";
@@ -6,6 +5,9 @@ import { Player } from "../Player";
 import { CardType } from "./CardType";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../constants";
 
 export class MagneticFieldDome implements IProjectCard {
     public cost: number = 5;
@@ -13,9 +15,16 @@ export class MagneticFieldDome implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.MAGNETIC_FIELD_DOME;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.ENERGY) >= 2;
+
+    public canPlay(player: Player, game: Game) {
+        const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 2;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction;
+        }
+  
+        return hasEnergyProduction;
     }
+
     public play(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,-2);
         player.setProduction(Resources.PLANTS);

--- a/src/cards/MagneticFieldGenerators.ts
+++ b/src/cards/MagneticFieldGenerators.ts
@@ -20,7 +20,7 @@ export class MagneticFieldGenerators implements IProjectCard {
         const meetsEnergyRequirements = player.getProduction(Resources.ENERGY) >= 4;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * 3) && meetsEnergyRequirements;
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 3, game, true) && meetsEnergyRequirements;
         }
 
         return meetsEnergyRequirements;

--- a/src/cards/MagneticFieldGenerators.ts
+++ b/src/cards/MagneticFieldGenerators.ts
@@ -1,4 +1,3 @@
-
 import { Player } from "../Player";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -6,6 +5,9 @@ import { CardType } from "./CardType";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../constants";
 
 export class MagneticFieldGenerators implements IProjectCard {
     public cost: number = 20;
@@ -13,9 +15,17 @@ export class MagneticFieldGenerators implements IProjectCard {
     public name: CardName = CardName.MAGNETIC_FIELD_GENERATORS;
     public cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.ENERGY) >= 4;
+    
+    public canPlay(player: Player, game: Game): boolean {
+        const meetsEnergyRequirements = player.getProduction(Resources.ENERGY) >= 4;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * 3) && meetsEnergyRequirements;
+        }
+
+        return meetsEnergyRequirements;
     }
+
     public play(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,-4);
         player.setProduction(Resources.PLANTS,2);

--- a/src/cards/Mangrove.ts
+++ b/src/cards/Mangrove.ts
@@ -22,7 +22,7 @@ export class Mangrove implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
         }
     
         return meetsTemperatureRequirements;

--- a/src/cards/Mangrove.ts
+++ b/src/cards/Mangrove.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -8,15 +7,27 @@ import { SelectSpace } from "../inputs/SelectSpace";
 import { SpaceType } from "../SpaceType";
 import { ISpace } from "../ISpace";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class Mangrove implements IProjectCard {
     public cost: number = 12;
     public tags: Array<Tags> = [Tags.PLANT];
     public name: CardName = CardName.MANGROVE;
     public cardType: CardType = CardType.AUTOMATED;
+    
     public canPlay(player: Player, game: Game): boolean {
-        return game.getTemperature() >= 4 - (2 * player.getRequirementsBonus(game));
+        const meetsTemperatureRequirements = game.getTemperature() >= 4 - (2 * player.getRequirementsBonus(game));
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+        }
+    
+        return meetsTemperatureRequirements;
     }
+
     public play(player: Player, game: Game) {
         return new SelectSpace("Select ocean space for greenery tile", game.board.getAvailableSpacesForOcean(player), (foundSpace: ISpace) => {
             return game.addGreenery(player, foundSpace.id, SpaceType.OCEAN);

--- a/src/cards/MiningExpedition.ts
+++ b/src/cards/MiningExpedition.ts
@@ -19,7 +19,7 @@ export class MiningExpedition implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
     
         return true;

--- a/src/cards/MiningExpedition.ts
+++ b/src/cards/MiningExpedition.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { CardType } from "./CardType";
 import { Tags } from "./Tags";
@@ -6,12 +5,25 @@ import { Player } from "../Player";
 import { Game } from "../Game";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class MiningExpedition implements IProjectCard {
     public cost: number = 12;
     public tags: Array<Tags> = [];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.MINING_EXPEDITION;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+    
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.addResourceDecreaseInterrupt(player, Resources.PLANTS, 2);

--- a/src/cards/NitrogenRichAsteroid.ts
+++ b/src/cards/NitrogenRichAsteroid.ts
@@ -20,7 +20,7 @@ export class NitrogenRichAsteroid implements IProjectCard {
         if (game.getTemperature() < MAX_TEMPERATURE) steps++;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * steps);
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST * steps, game, false, true);
         }
       
         return true;

--- a/src/cards/NitrogenRichAsteroid.ts
+++ b/src/cards/NitrogenRichAsteroid.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -6,12 +5,26 @@ import { Player } from "../Player";
 import { Game } from "../Game";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class NitrogenRichAsteroid implements IProjectCard {
     public cost: number = 31;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.NITROGEN_RICH_ASTEROID;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        let steps = 2;
+        if (game.getTemperature() < MAX_TEMPERATURE) steps++;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * steps);
+        }
+      
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/NuclearZone.ts
+++ b/src/cards/NuclearZone.ts
@@ -23,7 +23,7 @@ export class NuclearZone implements IProjectCard {
         const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
         }
 
       return canPlaceTile;

--- a/src/cards/NuclearZone.ts
+++ b/src/cards/NuclearZone.ts
@@ -7,6 +7,9 @@ import { SelectSpace } from "../inputs/SelectSpace";
 import { TileType } from "../TileType";
 import { ISpace } from "../ISpace";
 import { CardName } from '../CardName';
+import { MAX_TEMPERATURE, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class NuclearZone implements IProjectCard {
     public cost: number = 10;
@@ -14,9 +17,16 @@ export class NuclearZone implements IProjectCard {
     public name: CardName = CardName.NUCLEAR_ZONE;
     public cardType: CardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player, game: Game) {
+    public canPlay(player: Player, game: Game): boolean {
         const canPlaceTile = game.board.getAvailableSpacesOnLand(player).length > 0;
-        return canPlaceTile;
+        const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+        const stepsRaised = Math.min(remainingTemperatureSteps, 2);
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
+        }
+
+      return canPlaceTile;
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/OreProcessor.ts
+++ b/src/cards/OreProcessor.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -6,6 +5,9 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class OreProcessor implements IActionCard, IProjectCard {
     public cost: number = 13;
@@ -16,8 +18,15 @@ export class OreProcessor implements IActionCard, IProjectCard {
     public play(_player: Player, _game: Game) {
         return undefined;
     }
-    public canAct(player: Player): boolean {
-        return player.energy >= 4;
+    public canAct(player: Player, game: Game): boolean {
+        const hasEnoughEnergy = player.energy >= 4;
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
+        }
+
+        return hasEnoughEnergy;
     }
     public action(player: Player, game: Game) {
         player.energy -= 4;

--- a/src/cards/PermafrostExtraction.ts
+++ b/src/cards/PermafrostExtraction.ts
@@ -1,4 +1,3 @@
-
 import { CardType } from "./CardType";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -6,17 +5,28 @@ import { Player } from "../Player";
 import { Game } from "../Game";
 import { SelectSpace } from "../inputs/SelectSpace";
 import { ISpace } from "../ISpace";
-import { MAX_OCEAN_TILES } from '../constants';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
 import { CardName } from '../CardName';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class PermafrostExtraction implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
     public tags: Array<Tags> = [];
     public cost: number = 8;
     public name: CardName = CardName.PERMAFROST_EXTRACTION;
+
     public canPlay(player: Player, game: Game): boolean {
-        return game.getTemperature() >= -8 - (2 * player.getRequirementsBonus(game));
+        const meetsTemperatureRequirements = game.getTemperature() >= -8 - (2 * player.getRequirementsBonus(game));
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+        }
+    
+        return meetsTemperatureRequirements;
     }
+
     public play(player: Player, game: Game) {
 
         if (game.board.getOceansOnBoard() === MAX_OCEAN_TILES) {

--- a/src/cards/PermafrostExtraction.ts
+++ b/src/cards/PermafrostExtraction.ts
@@ -21,7 +21,7 @@ export class PermafrostExtraction implements IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
         }
     
         return meetsTemperatureRequirements;

--- a/src/cards/Plantation.ts
+++ b/src/cards/Plantation.ts
@@ -22,7 +22,7 @@ export class Plantation implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTagRequirements && canPlaceTile;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsTagRequirements && canPlaceTile;
         }
     
         return meetsTagRequirements && canPlaceTile;

--- a/src/cards/Plantation.ts
+++ b/src/cards/Plantation.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { CardType } from "./CardType";
 import { Tags } from "./Tags";
@@ -7,15 +6,28 @@ import { Game } from "../Game";
 import { SelectSpace } from "../inputs/SelectSpace";
 import { ISpace } from "../ISpace";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class Plantation implements IProjectCard {
     public cost: number = 15;
     public cardType: CardType = CardType.AUTOMATED;
     public tags: Array<Tags> = [Tags.PLANT];
     public name: CardName = CardName.PLANTATION;
+
     public canPlay(player: Player, game: Game): boolean {
-        return player.getTagCount(Tags.SCIENCE) >= 2 && game.board.getAvailableSpacesOnLand(player).length > 0;
+        const meetsTagRequirements = player.getTagCount(Tags.SCIENCE) >= 2;
+        const canPlaceTile = game.board.getAvailableSpacesOnLand(player).length > 0;
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && meetsTagRequirements && canPlaceTile;
+        }
+    
+        return meetsTagRequirements && canPlaceTile;
     }
+
     public play(player: Player, game: Game) {
         return new SelectSpace("Select space for greenery tile", game.board.getAvailableSpacesForGreenery(player), (space: ISpace) => {
             return game.addGreenery(player, space.id);

--- a/src/cards/ProtectedValley.ts
+++ b/src/cards/ProtectedValley.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
@@ -9,12 +8,25 @@ import { SelectSpace } from "../inputs/SelectSpace";
 import { ISpace } from "../ISpace";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class ProtectedValley implements IProjectCard {
     public cost: number = 23;
     public cardType: CardType = CardType.AUTOMATED;
     public tags: Array<Tags> = [Tags.PLANT, Tags.STEEL];
     public name: CardName = CardName.PROTECTED_VALLEY;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+    
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         return new SelectSpace(

--- a/src/cards/ProtectedValley.ts
+++ b/src/cards/ProtectedValley.ts
@@ -22,7 +22,7 @@ export class ProtectedValley implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, true);
         }
     
         return true;

--- a/src/cards/ProtectedValley.ts
+++ b/src/cards/ProtectedValley.ts
@@ -22,7 +22,7 @@ export class ProtectedValley implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
     
         return true;

--- a/src/cards/RadChemFactory.ts
+++ b/src/cards/RadChemFactory.ts
@@ -19,7 +19,7 @@ export class RadChemFactory implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasEnergyProduction;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2, game, true) && hasEnergyProduction;
         }
   
         return hasEnergyProduction;

--- a/src/cards/RadChemFactory.ts
+++ b/src/cards/RadChemFactory.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -6,6 +5,9 @@ import { Player } from "../Player";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 import { Game } from '../Game';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../constants";
 
 export class RadChemFactory implements IProjectCard {
     public cost: number = 8;
@@ -13,9 +15,16 @@ export class RadChemFactory implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.RAD_CHEM_FACTORY;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.ENERGY) >= 1;
+
+    public canPlay(player: Player, game: Game) {
+        const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasEnergyProduction;
+        }
+  
+        return hasEnergyProduction;
     }
+
     public play(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,-1);
         player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/ReleaseOfInertGases.ts
+++ b/src/cards/ReleaseOfInertGases.ts
@@ -16,7 +16,7 @@ export class ReleaseOfInertGases implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * 2);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2);
         }
   
         return true;

--- a/src/cards/ReleaseOfInertGases.ts
+++ b/src/cards/ReleaseOfInertGases.ts
@@ -1,16 +1,26 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../constants";
 
 export class ReleaseOfInertGases implements IProjectCard {
     public cost: number = 14;
     public tags: Array<Tags> = [];
     public name: CardName = CardName.RELEASE_OF_INERT_GASES;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * 2);
+        }
+  
+        return true;
+      }
 
     public play(player: Player, game: Game) {
         player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/Steelworks.ts
+++ b/src/cards/Steelworks.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -6,6 +5,9 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class Steelworks implements IProjectCard, IActionCard {
     public cost: number = 15;
@@ -13,8 +15,15 @@ export class Steelworks implements IProjectCard, IActionCard {
     public name: CardName = CardName.STEELWORKS;
     public cardType: CardType = CardType.ACTIVE;
 
-    public canAct(player: Player): boolean {
-        return player.energy >= 4;
+    public canAct(player: Player, game: Game): boolean {
+        const hasEnoughEnergy = player.energy >= 4;
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
+        }
+
+        return hasEnoughEnergy;
     }
     public action(player: Player, game: Game) {
         player.energy -= 4;

--- a/src/cards/StripMine.ts
+++ b/src/cards/StripMine.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -6,6 +5,9 @@ import { Player } from "../Player";
 import { Game } from "../Game";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class StripMine implements IProjectCard {
     public cost: number = 25;
@@ -13,8 +15,16 @@ export class StripMine implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.STRIP_MINE;
     public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.ENERGY) >= 2;
+    public canPlay(player: Player, game: Game): boolean {
+        const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 2;
+        const remainingOxygenSteps = MAX_OXYGEN_LEVEL - game.getOxygenLevel();
+        const stepsRaised = Math.min(remainingOxygenSteps, 2);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && hasEnergyProduction;
+        }
+
+        return hasEnergyProduction;
     }
     public play(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,-2);

--- a/src/cards/StripMine.ts
+++ b/src/cards/StripMine.ts
@@ -21,7 +21,7 @@ export class StripMine implements IProjectCard {
         const stepsRaised = Math.min(remainingOxygenSteps, 2);
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && hasEnergyProduction;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, true) && hasEnergyProduction;
         }
 
         return hasEnergyProduction;

--- a/src/cards/SubterraneanReservoir.ts
+++ b/src/cards/SubterraneanReservoir.ts
@@ -1,16 +1,28 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { CardType } from "./CardType";
 import { Tags } from "./Tags";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class SubterraneanReservoir implements IProjectCard {
     public cost: number = 11;
     public cardType: CardType = CardType.EVENT;
     public tags: Array<Tags> = [];
     public name: CardName = CardName.SUBTERRANEAN_RESERVOIR;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.addOceanInterrupt(player);

--- a/src/cards/SubterraneanReservoir.ts
+++ b/src/cards/SubterraneanReservoir.ts
@@ -18,7 +18,7 @@ export class SubterraneanReservoir implements IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
   
         return true;

--- a/src/cards/TerraformingGanymede.ts
+++ b/src/cards/TerraformingGanymede.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -8,12 +7,25 @@ import { CardName } from '../CardName';
 import { LogMessageType } from "../LogMessageType";
 import { LogMessageData } from "../LogMessageData";
 import { LogMessageDataType } from "../LogMessageDataType";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../constants";
 
 export class TerraformingGanymede implements IProjectCard {
     public cost: number = 33;
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.SPACE];
     public name: CardName = CardName.TERRAFORMING_GANYMEDE;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+        const steps = 1 + player.getTagCount(Tags.JOVIAN);
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * steps);
+        }
+    
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         const steps = 1 + player.getTagCount(Tags.JOVIAN);

--- a/src/cards/TerraformingGanymede.ts
+++ b/src/cards/TerraformingGanymede.ts
@@ -21,7 +21,7 @@ export class TerraformingGanymede implements IProjectCard {
         const steps = 1 + player.getTagCount(Tags.JOVIAN);
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * steps);
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST * steps, game, false, true);
         }
     
         return true;

--- a/src/cards/TowingAComet.ts
+++ b/src/cards/TowingAComet.ts
@@ -5,12 +5,27 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class TowingAComet implements IProjectCard {
     public cost: number = 23;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.TOWING_A_COMET;
+
+    public canPlay(player: Player, game: Game) {
+        const oxygenStep = game.getOxygenLevel() < MAX_OXYGEN_LEVEL ? 1 : 0;
+        const oceanStep = game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
+        const totalSteps = oxygenStep + oceanStep;
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
+        }
+  
+        return true;
+      }
 
     public play(player: Player, game: Game) {
         game.addOceanInterrupt(player);

--- a/src/cards/TowingAComet.ts
+++ b/src/cards/TowingAComet.ts
@@ -21,7 +21,7 @@ export class TowingAComet implements IProjectCard {
         const totalSteps = oxygenStep + oceanStep;
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * totalSteps, game, false, true);
         }
   
         return true;

--- a/src/cards/WaterImportFromEuropa.ts
+++ b/src/cards/WaterImportFromEuropa.ts
@@ -29,13 +29,13 @@ export class WaterImportFromEuropa implements IActionCard, IProjectCard {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
         if (oceansMaxed) return false;
   
-        const canAffordOcean = player.canAfford(12, game, false, true);
+        let oceanCost = 12;
   
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && canAffordOcean;
+          return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
-        return canAffordOcean;
+        return player.canAfford(oceanCost, game, false, true);;
     }
     public action(player: Player, game: Game) {
         let htp: HowToPay;

--- a/src/cards/WaterImportFromEuropa.ts
+++ b/src/cards/WaterImportFromEuropa.ts
@@ -8,8 +8,10 @@ import { Game } from "../Game";
 import { AndOptions } from "../inputs/AndOptions";
 import { HowToPay } from "../inputs/HowToPay";
 import { SelectHowToPay } from "../inputs/SelectHowToPay";
-import { MAX_OCEAN_TILES } from '../constants';
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
 import { CardName } from '../CardName';
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class WaterImportFromEuropa implements IActionCard, IProjectCard {
     public cost: number = 25;
@@ -24,7 +26,16 @@ export class WaterImportFromEuropa implements IActionCard, IProjectCard {
         return undefined;
     }
     public canAct(player: Player, game: Game): boolean {
-        return (player.canAfford(12, game, false, true) && game.board.getOceansOnBoard() < MAX_OCEAN_TILES);
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+        if (oceansMaxed) return false;
+  
+        const canAffordOcean = player.canAfford(12, game, false, true);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && canAffordOcean;
+        }
+  
+        return canAffordOcean;
     }
     public action(player: Player, game: Game) {
         let htp: HowToPay;

--- a/src/cards/WaterSplittingPlant.ts
+++ b/src/cards/WaterSplittingPlant.ts
@@ -1,10 +1,12 @@
-
 import { CardType } from "./CardType";
 import { Tags } from "./Tags";
 import { IProjectCard } from "./IProjectCard";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { CardName } from '../CardName';
+import { MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST } from "../constants";
+import { PartyHooks } from "../turmoil/parties/PartyHooks";
+import { PartyName } from "../turmoil/parties/PartyName";
 
 export class WaterSplittingPlant implements IProjectCard {
     public cost: number = 12;
@@ -17,8 +19,15 @@ export class WaterSplittingPlant implements IProjectCard {
     public play() {
         return undefined;
     }
-    public canAct(player: Player): boolean {
-        return player.energy >= 3;
+    public canAct(player: Player, game: Game): boolean {
+        const hasEnoughEnergy = player.energy >= 3;
+        const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
+        }
+
+        return hasEnoughEnergy;
     }
     public action(player: Player, game: Game) {
         player.energy -= 3;

--- a/src/cards/colonies/JovianLanterns.ts
+++ b/src/cards/colonies/JovianLanterns.ts
@@ -6,6 +6,9 @@ import { CardName } from '../../CardName';
 import { ResourceType } from '../../ResourceType';
 import { Game } from '../../Game';
 import { IResourceCard } from '../ICard';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class JovianLanterns implements IProjectCard, IResourceCard {
     public cost: number = 20;
@@ -15,8 +18,14 @@ export class JovianLanterns implements IProjectCard, IResourceCard {
     public resourceType: ResourceType = ResourceType.FLOATER;
     public resourceCount: number = 0;
 
-    public canPlay(player: Player): boolean {
-        return player.getTagCount(Tags.JOVIAN) >= 1;
+    public canPlay(player: Player, game: Game): boolean {
+        const meetsTagRequirements = player.getTagCount(Tags.JOVIAN) >= 1;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST) && meetsTagRequirements;
+        }
+
+        return meetsTagRequirements;
     }
 
     public canAct(player: Player): boolean {

--- a/src/cards/colonies/JovianLanterns.ts
+++ b/src/cards/colonies/JovianLanterns.ts
@@ -22,7 +22,7 @@ export class JovianLanterns implements IProjectCard, IResourceCard {
         const meetsTagRequirements = player.getTagCount(Tags.JOVIAN) >= 1;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST) && meetsTagRequirements;
+            return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsTagRequirements;
         }
 
         return meetsTagRequirements;

--- a/src/cards/colonies/NitrogenFromTitan.ts
+++ b/src/cards/colonies/NitrogenFromTitan.ts
@@ -17,7 +17,7 @@ export class NitrogenFromTitan implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2, game, false, true);
       }
 
       return true;

--- a/src/cards/colonies/NitrogenFromTitan.ts
+++ b/src/cards/colonies/NitrogenFromTitan.ts
@@ -5,12 +5,23 @@ import { Player } from "../../Player";
 import { CardName } from '../../CardName';
 import { ResourceType } from '../../ResourceType';
 import { Game } from '../../Game';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class NitrogenFromTitan implements IProjectCard {
     public cost: number = 25;
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.SPACE];
     public name: CardName = CardName.NITROGEN_FROM_TITAN;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
       player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/colonies/TitanAirScrapping.ts
+++ b/src/cards/colonies/TitanAirScrapping.ts
@@ -39,7 +39,7 @@ export class TitanAirScrapping implements IProjectCard, IResourceCard {
 
         if (this.resourceCount >= 2 && player.titanium > 0) {
             const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
-            if (!redsAreRuling || redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST)) {
+            if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
                 opts.push(spendResource);
             } 
             opts.push(addResource);

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -17,12 +17,13 @@ export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard
     }
     public canAct(player: Player, game: Game): boolean {
         const hasIncreasedTR = player.hasIncreasedTerraformRatingThisGeneration;
+        const actionCost = 3;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + 3);
+            return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + actionCost);
         }
         
-        return hasIncreasedTR && player.canAfford(3); 
+        return hasIncreasedTR && player.canAfford(actionCost); 
     }
     public action(player: Player, game: Game) {
         player.megaCredits -= 3;

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -1,10 +1,12 @@
-
 import { IActionCard } from "../ICard";
 import { Tags } from "../Tags";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { CorporationCard } from "./CorporationCard";
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard {
     public name: CardName = CardName.UNITED_NATIONS_MARS_INITIATIVE;
@@ -13,8 +15,14 @@ export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard
     public play() {
         return undefined;
     }
-    public canAct(player: Player): boolean {
-        return player.hasIncreasedTerraformRatingThisGeneration && player.canAfford(3); 
+    public canAct(player: Player, game: Game): boolean {
+        const hasIncreasedTR = player.hasIncreasedTerraformRatingThisGeneration;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + 3);
+        }
+        
+        return hasIncreasedTR && player.canAfford(3); 
     }
     public action(player: Player, game: Game) {
         player.megaCredits -= 3;

--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -10,7 +10,7 @@ import { TileType } from '../../TileType';
 import { ISpace } from '../../ISpace';
 import { PartyHooks } from '../../turmoil/parties/PartyHooks';
 import { PartyName } from '../../turmoil/parties/PartyName';
-import { REDS_RULING_POLICY_COST } from '../../constants';
+import { REDS_RULING_POLICY_COST, MAX_TEMPERATURE } from '../../constants';
 
 export class DeimosDownPromo implements IProjectCard {
     public cost: number = 31;
@@ -20,9 +20,11 @@ export class DeimosDownPromo implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       const canPlaceTile = game.board.getAvailableSpacesForCity(player).length > 0;
+      const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+      const stepsRaised = Math.min(remainingTemperatureSteps, 3);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 3) && canPlaceTile;
+        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
     }
 
       return canPlaceTile;

--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -24,7 +24,7 @@ export class DeimosDownPromo implements IProjectCard {
       const stepsRaised = Math.min(remainingTemperatureSteps, 3);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true) && canPlaceTile;
     }
 
       return canPlaceTile;

--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -8,6 +8,9 @@ import { Resources } from '../../Resources';
 import { SelectSpace } from '../../inputs/SelectSpace';
 import { TileType } from '../../TileType';
 import { ISpace } from '../../ISpace';
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../../constants';
 
 export class DeimosDownPromo implements IProjectCard {
     public cost: number = 31;
@@ -17,6 +20,11 @@ export class DeimosDownPromo implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       const canPlaceTile = game.board.getAvailableSpacesForCity(player).length > 0;
+
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 3) && canPlaceTile;
+    }
+
       return canPlaceTile;
     }
 

--- a/src/cards/promo/JovianEmbassy.ts
+++ b/src/cards/promo/JovianEmbassy.ts
@@ -4,6 +4,9 @@ import {CardType} from './../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import { CardName } from '../../CardName';
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../../constants';
 
 export class JovianEmbassy implements IProjectCard {
     public cost: number = 14;
@@ -11,10 +14,19 @@ export class JovianEmbassy implements IProjectCard {
     public name: CardName = CardName.JOVIAN_EMBASSY;
     public cardType: CardType = CardType.AUTOMATED;
 
+    public canPlay(player: Player, game: Game) {
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST);
+      }
+
+      return true;
+    }
+
     public play(player: Player, game: Game) {
       player.increaseTerraformRating(game);
       return undefined;
     }
+    
     public getVictoryPoints() {
       return 1;
     }

--- a/src/cards/promo/JovianEmbassy.ts
+++ b/src/cards/promo/JovianEmbassy.ts
@@ -16,7 +16,7 @@ export class JovianEmbassy implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
       }
 
       return true;

--- a/src/cards/promo/JovianEmbassy.ts
+++ b/src/cards/promo/JovianEmbassy.ts
@@ -16,7 +16,7 @@ export class JovianEmbassy implements IProjectCard {
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, true);
       }
 
       return true;

--- a/src/cards/promo/MagneticFieldGeneratorsPromo.ts
+++ b/src/cards/promo/MagneticFieldGeneratorsPromo.ts
@@ -1,4 +1,3 @@
-
 import { Player } from "../../Player";
 import { IProjectCard } from "../IProjectCard";
 import { Tags } from "../Tags";
@@ -9,6 +8,9 @@ import { Game } from '../../Game';
 import { SelectSpace } from "../../inputs/SelectSpace";
 import { TileType } from "../../TileType";
 import { ISpace } from "../../ISpace";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class MagneticFieldGeneratorsPromo implements IProjectCard {
     public cost: number = 22;
@@ -19,6 +21,10 @@ export class MagneticFieldGeneratorsPromo implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const meetsEnergyRequirements = player.getProduction(Resources.ENERGY) >= 4;
         const canPlaceTile = game.board.getAvailableSpacesOnLand(player).length > 0;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST * 3) && meetsEnergyRequirements && canPlaceTile;
+          }
 
         return meetsEnergyRequirements && canPlaceTile;
     }

--- a/src/cards/promo/MagneticFieldGeneratorsPromo.ts
+++ b/src/cards/promo/MagneticFieldGeneratorsPromo.ts
@@ -23,7 +23,7 @@ export class MagneticFieldGeneratorsPromo implements IProjectCard {
         const canPlaceTile = game.board.getAvailableSpacesOnLand(player).length > 0;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST * 3) && meetsEnergyRequirements && canPlaceTile;
+            return player.canAfford(REDS_RULING_POLICY_COST * 3, game, true) && meetsEnergyRequirements && canPlaceTile;
           }
 
         return meetsEnergyRequirements && canPlaceTile;

--- a/src/cards/promo/MagneticShield.ts
+++ b/src/cards/promo/MagneticShield.ts
@@ -4,6 +4,9 @@ import { CardType } from '../CardType';
 import { Tags } from '../Tags';
 import { Player } from '../../Player';
 import { Game } from '../../Game';
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../../constants';
 
 export class MagneticShield implements IProjectCard {
     public name: CardName = CardName.MAGNETIC_SHIELD;
@@ -11,8 +14,13 @@ export class MagneticShield implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player): boolean {
-        return player.getTagCount(Tags.ENERGY) >= 2;
+    public canPlay(player: Player, game: Game) {
+        const hasEnergyTags = player.getTagCount(Tags.ENERGY) >= 2;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * 4) && hasEnergyTags;
+        }
+  
+        return hasEnergyTags;
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/promo/MagneticShield.ts
+++ b/src/cards/promo/MagneticShield.ts
@@ -17,7 +17,7 @@ export class MagneticShield implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const hasEnergyTags = player.getTagCount(Tags.ENERGY) >= 2;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * 4) && hasEnergyTags;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 4, game, false, true) && hasEnergyTags;
         }
   
         return hasEnergyTags;

--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -24,7 +24,7 @@ export class MoholeLake implements IActionCard, IProjectCard {
       const totalSteps = temperatureStep + oceanStep;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
+        return player.canAfford(REDS_RULING_POLICY_COST * totalSteps, game, true);
       }
 
       return true;

--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -8,12 +8,23 @@ import { CardName } from '../../CardName';
 import { ResourceType } from "../../ResourceType";
 import { SelectCard } from "../../inputs/SelectCard";
 import { LogHelper } from "../../components/LogHelper";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class MoholeLake implements IActionCard, IProjectCard {
     public cost: number = 31;
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.MOHOLE_LAKE;
     public cardType: CardType = CardType.ACTIVE;
+
+    public canPlay(player: Player, game: Game) {
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+      }
+
+      return true;
+    }
 
     public play(player: Player, game: Game) {
         game.increaseTemperature(player, 1);

--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -10,7 +10,7 @@ import { SelectCard } from "../../inputs/SelectCard";
 import { LogHelper } from "../../components/LogHelper";
 import { PartyHooks } from "../../turmoil/parties/PartyHooks";
 import { PartyName } from "../../turmoil/parties/PartyName";
-import { REDS_RULING_POLICY_COST } from "../../constants";
+import { REDS_RULING_POLICY_COST, MAX_TEMPERATURE, MAX_OCEAN_TILES } from "../../constants";
 
 export class MoholeLake implements IActionCard, IProjectCard {
     public cost: number = 31;
@@ -19,8 +19,12 @@ export class MoholeLake implements IActionCard, IProjectCard {
     public cardType: CardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game) {
+      const temperatureStep = game.getTemperature() < MAX_TEMPERATURE ? 1 : 0;
+      const oceanStep = game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
+      const totalSteps = temperatureStep + oceanStep;
+
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 2);
+        return player.canAfford(REDS_RULING_POLICY_COST * totalSteps);
       }
 
       return true;

--- a/src/cards/promo/PharmacyUnion.ts
+++ b/src/cards/promo/PharmacyUnion.ts
@@ -11,6 +11,9 @@ import { CorporationName } from "../../CorporationName";
 import { LogMessageType } from "../../LogMessageType";
 import { LogMessageData } from "../../LogMessageData";
 import { LogMessageDataType } from "../../LogMessageDataType";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class PharmacyUnion implements CorporationCard {
     public name: CardName = CardName.PHARMACY_UNION;
@@ -71,20 +74,24 @@ export class PharmacyUnion implements CorporationCard {
             return undefined;
         } else {
             const availableOptions: OrOptions = new OrOptions();
+            const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
 
-            availableOptions.options.push(
-                new SelectOption('Turn this card face down and gain 3 TR', () => {
-                    this.isDisabled = true;
-                    player.increaseTerraformRatingSteps(3, game);
-                    game.log(
-                        LogMessageType.DEFAULT,
-                        "${0} turned ${1} face down to gain 3 TR",
-                        new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                        new LogMessageData(LogMessageDataType.CARD, this.name)
-                    );
-                    return undefined;
-                })
-            );
+            if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST * 3))) {
+                availableOptions.options.push(
+                    new SelectOption('Turn this card face down and gain 3 TR', () => {
+                        this.isDisabled = true;
+                        player.increaseTerraformRatingSteps(3, game);
+                        game.log(
+                            LogMessageType.DEFAULT,
+                            "${0} turned ${1} face down to gain 3 TR",
+                            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                            new LogMessageData(LogMessageDataType.CARD, this.name)
+                        );
+                        return undefined;
+                    })
+                );
+            }
+
             availableOptions.options.push(
                 new SelectOption('Do nothing', () => {
                     this.runInterrupts(player, game, scienceTags - 1);

--- a/src/cards/promo/SmallAsteroid.ts
+++ b/src/cards/promo/SmallAsteroid.ts
@@ -7,7 +7,7 @@ import { Game } from "../../Game";
 import { Resources } from "../../Resources";
 import { PartyHooks } from "../../turmoil/parties/PartyHooks";
 import { PartyName } from "../../turmoil/parties/PartyName";
-import { REDS_RULING_POLICY_COST } from "../../constants";
+import { REDS_RULING_POLICY_COST, MAX_TEMPERATURE } from "../../constants";
 
 export class SmallAsteroid implements IProjectCard {
     public cost: number = 10;
@@ -16,7 +16,8 @@ export class SmallAsteroid implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
 
     public canPlay(player: Player, game: Game) {
-        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        const canRaiseTemperature = game.getTemperature() < MAX_TEMPERATURE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && canRaiseTemperature) {
           return player.canAfford(REDS_RULING_POLICY_COST);
         }
   

--- a/src/cards/promo/SmallAsteroid.ts
+++ b/src/cards/promo/SmallAsteroid.ts
@@ -18,7 +18,7 @@ export class SmallAsteroid implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const canRaiseTemperature = game.getTemperature() < MAX_TEMPERATURE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && canRaiseTemperature) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/promo/SmallAsteroid.ts
+++ b/src/cards/promo/SmallAsteroid.ts
@@ -5,13 +5,23 @@ import { Tags } from "../Tags";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { Resources } from "../../Resources";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class SmallAsteroid implements IProjectCard {
-
     public cost: number = 10;
     public name: CardName = CardName.SMALL_ASTEROID;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.increaseTemperature(player, 1);

--- a/src/cards/turmoil/PROffice.ts
+++ b/src/cards/turmoil/PROffice.ts
@@ -6,6 +6,8 @@ import { Player } from "../../Player";
 import { Game } from '../../Game';
 import { PartyName } from '../../turmoil/parties/PartyName';
 import { Resources } from "../../Resources";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class PROffice implements IProjectCard {
     public cost: number = 7;
@@ -15,7 +17,12 @@ export class PROffice implements IProjectCard {
 
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
-            return game.turmoil.canPlay(player, PartyName.UNITY);
+            const meetsPartyRequirements = game.turmoil.canPlay(player, PartyName.UNITY);
+            if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+                return player.canAfford(REDS_RULING_POLICY_COST) && meetsPartyRequirements;
+            }
+
+            return meetsPartyRequirements;
         }
         return false;
     }

--- a/src/cards/turmoil/PROffice.ts
+++ b/src/cards/turmoil/PROffice.ts
@@ -19,7 +19,7 @@ export class PROffice implements IProjectCard {
         if (game.turmoil !== undefined) {
             const meetsPartyRequirements = game.turmoil.canPlay(player, PartyName.UNITY);
             if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-                return player.canAfford(REDS_RULING_POLICY_COST) && meetsPartyRequirements;
+                return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsPartyRequirements;
             }
 
             return meetsPartyRequirements;

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -4,6 +4,9 @@ import { CardName } from "../../CardName";
 import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class VoteOfNoConfidence implements IProjectCard {
     public cost: number = 5;
@@ -13,11 +16,17 @@ export class VoteOfNoConfidence implements IProjectCard {
     public hasRequirements = false;
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
-            if (!game.turmoil!.hasAvailableDelegates(player.id)) {
-                return false;
-            }
+            if (!game.turmoil!.hasAvailableDelegates(player.id)) return false;
+            
             const parties = game.turmoil.parties.filter(party => party.partyLeader === player.id);
-            return game.turmoil.chairman === "NEUTRAL" && parties.length > 0;
+            const chairmanIsNeutral = game.turmoil.chairman === "NEUTRAL";
+            const hasPartyLeadership = parties.length > 0;
+
+            if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+                return player.canAfford(REDS_RULING_POLICY_COST) && chairmanIsNeutral && hasPartyLeadership;
+            }
+
+            return chairmanIsNeutral && hasPartyLeadership;
         }
         return false;
     }

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -23,7 +23,7 @@ export class VoteOfNoConfidence implements IProjectCard {
             const hasPartyLeadership = parties.length > 0;
 
             if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-                return player.canAfford(REDS_RULING_POLICY_COST) && chairmanIsNeutral && hasPartyLeadership;
+                return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && chairmanIsNeutral && hasPartyLeadership;
             }
 
             return chairmanIsNeutral && hasPartyLeadership;

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -7,6 +7,8 @@ import { Game } from '../../Game';
 import { PartyName } from '../../turmoil/parties/PartyName';
 import { SelectSpace } from "../../inputs/SelectSpace";
 import { ISpace } from "../../ISpace";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { REDS_RULING_POLICY_COST, MAX_OXYGEN_LEVEL } from "../../constants";
 
 export class WildlifeDome implements IProjectCard {
     public cost: number = 15;
@@ -17,7 +19,14 @@ export class WildlifeDome implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
             const canPlaceTile = game.board.getAvailableSpacesForGreenery(player).length > 0;
-            return game.turmoil.canPlay(player, PartyName.GREENS) && canPlaceTile;
+            const meetsPartyRequirements = game.turmoil.canPlay(player, PartyName.GREENS);
+            const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+
+            if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
+                return player.canAfford(REDS_RULING_POLICY_COST) && meetsPartyRequirements && canPlaceTile;
+            }
+
+            return meetsPartyRequirements && canPlaceTile;
         }
         return false;
     }

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -23,7 +23,7 @@ export class WildlifeDome implements IProjectCard {
             const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
             if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-                return player.canAfford(REDS_RULING_POLICY_COST) && meetsPartyRequirements && canPlaceTile;
+                return player.canAfford(REDS_RULING_POLICY_COST, game, true) && meetsPartyRequirements && canPlaceTile;
             }
 
             return meetsPartyRequirements && canPlaceTile;

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -20,7 +20,7 @@ export class AirScrappingExpedition implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
   
         return true;

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -7,12 +7,24 @@ import { ResourceType } from "../../ResourceType";
 import { SelectCard } from '../../inputs/SelectCard';
 import { CardName } from '../../CardName';
 import { Game } from "../../Game";
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST, MAX_VENUS_SCALE } from '../../constants';
 
 export class AirScrappingExpedition implements IProjectCard {
     public cost: number = 13;
     public tags: Array<Tags> = [Tags.VENUS];
     public name: CardName = CardName.AIR_SCRAPPING_EXPEDITION;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.increaseVenusScaleLevel(player,1);

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -27,7 +27,7 @@ export class Atmoscoop implements IProjectCard {
         const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
         
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(constants.REDS_RULING_POLICY_COST * stepsRaised) && meetsTagRequirements;
+          return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, game, false, true) && meetsTagRequirements;
         }
   
         return meetsTagRequirements;

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -11,15 +11,27 @@ import { ICard } from '../ICard';
 import { CardName } from '../../CardName';
 import { LogHelper } from '../../components/LogHelper';
 import * as constants from "./../../constants";
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
 
 export class Atmoscoop implements IProjectCard {
     public cost: number = 22;
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.SPACE];
     public name: CardName = CardName.ATMOSCOOP;
     public cardType: CardType = CardType.AUTOMATED;
-    public canPlay(player: Player): boolean {
-        return player.getTagCount(Tags.SCIENCE) >= 3 ;
-      }
+
+    public canPlay(player: Player, game: Game) {
+        const meetsTagRequirements = player.getTagCount(Tags.SCIENCE) >= 3;
+        const remainingTemperatureSteps = (constants.MAX_TEMPERATURE - game.getTemperature()) / 2;
+        const remainingVenusSteps = (constants.MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;
+        const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(constants.REDS_RULING_POLICY_COST * stepsRaised) && meetsTagRequirements;
+        }
+  
+        return meetsTagRequirements;
+    }
 
     public play(player: Player, game: Game) {
         let result = new OrOptions();

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -19,7 +19,7 @@ export class CometForVenus implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -6,12 +6,24 @@ import { SelectPlayer } from '../../inputs/SelectPlayer';
 import { Game } from '../../Game';
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class CometForVenus implements IProjectCard {
     public cost: number = 11;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.COMET_FOR_VENUS;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         const venusTagPlayers = game.getPlayers().filter((otherPlayer) => otherPlayer.id !== player.id && otherPlayer.getTagCount(Tags.VENUS, false, false) > 0);

--- a/src/cards/venusNext/ExtractorBalloons.ts
+++ b/src/cards/venusNext/ExtractorBalloons.ts
@@ -8,6 +8,9 @@ import { OrOptions } from "../../inputs/OrOptions";
 import { SelectOption } from "../../inputs/SelectOption";
 import { Game } from '../../Game';
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class ExtractorBalloons implements IActionCard,IProjectCard, IResourceCard {
     public cost: number = 21;
@@ -21,9 +24,14 @@ export class ExtractorBalloons implements IActionCard,IProjectCard, IResourceCar
         this.resourceCount += 3;
         return undefined;
     }
-    public canAct(): boolean {
+    public canAct(player: Player, game: Game): boolean {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
         return true;
-    }    
+    }   
     public action(player: Player, game: Game) {
         if (this.resourceCount < 2) {
             this.resourceCount++;

--- a/src/cards/venusNext/ExtractorBalloons.ts
+++ b/src/cards/venusNext/ExtractorBalloons.ts
@@ -27,7 +27,7 @@ export class ExtractorBalloons implements IActionCard,IProjectCard, IResourceCar
     public canAct(player: Player, game: Game): boolean {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
   
         return true;

--- a/src/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/cards/venusNext/ForcedPrecipitation.ts
@@ -8,8 +8,10 @@ import { SelectHowToPay } from '../../inputs/SelectHowToPay';
 import { OrOptions } from '../../inputs/OrOptions';
 import { SelectOption } from '../../inputs/SelectOption';
 import { Game } from '../../Game';
-import { MAX_VENUS_SCALE } from '../../constants';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class ForcedPrecipitation implements IActionCard,IProjectCard, IResourceCard {
     public cost: number = 8;
@@ -22,9 +24,16 @@ export class ForcedPrecipitation implements IActionCard,IProjectCard, IResourceC
     public play() {
         return undefined;
     }
+
     public canAct(player: Player, game: Game): boolean {
-        return player.canAfford(2) || 
-          (this.resourceCount > 1 &&  game.getVenusScaleLevel() < MAX_VENUS_SCALE);
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        const canSpendResource = this.resourceCount > 1 && !venusMaxed;
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(2) || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
+        }
+  
+        return player.canAfford(2) || canSpendResource;
     }  
     
     public action(player: Player, game: Game) {

--- a/src/cards/venusNext/GHGImportFromVenus.ts
+++ b/src/cards/venusNext/GHGImportFromVenus.ts
@@ -5,12 +5,24 @@ import { Player } from "../../Player";
 import { Game } from '../../Game';
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class GHGImportFromVenus implements IProjectCard {
     public cost: number = 23;
     public tags: Array<Tags> = [Tags.SPACE, Tags.VENUS];
     public name: CardName = CardName.GHG_IMPORT_FROM_VENUS;
     public cardType: CardType = CardType.EVENT;
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         player.setProduction(Resources.HEAT,3);

--- a/src/cards/venusNext/GHGImportFromVenus.ts
+++ b/src/cards/venusNext/GHGImportFromVenus.ts
@@ -18,7 +18,7 @@ export class GHGImportFromVenus implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/GiantSolarShade.ts
+++ b/src/cards/venusNext/GiantSolarShade.ts
@@ -19,7 +19,7 @@ export class GiantSolarShade implements IProjectCard {
         const stepsRaised = Math.min(remainingVenusSteps, 3);
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/GiantSolarShade.ts
+++ b/src/cards/venusNext/GiantSolarShade.ts
@@ -4,12 +4,26 @@ import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class GiantSolarShade implements IProjectCard {
     public cost: number = 27;
     public tags: Array<Tags> = [Tags.SPACE, Tags.VENUS];
     public name: CardName = CardName.GIANT_SOLAR_SHADE;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+        const remainingVenusSteps = (MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;
+        const stepsRaised = Math.min(remainingVenusSteps, 3);
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         return game.increaseVenusScaleLevel(player, 3);

--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -8,6 +8,9 @@ import { ResourceType } from '../../ResourceType';
 import { SelectCard } from '../../inputs/SelectCard';
 import { CardName } from '../../CardName';
 import { LogHelper } from '../../components/LogHelper';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
 
 export class HydrogenToVenus implements IProjectCard {
     public cost: number = 11;
@@ -26,6 +29,16 @@ export class HydrogenToVenus implements IProjectCard {
         CardName.LOCAL_SHADING,
         CardName.STRATOPOLIS
     ]);
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
+
     public play(player: Player, game: Game) {
         const jovianTags: number = player.getTagCount(Tags.JOVIAN);
         const floatersCards = player.getResourceCards(ResourceType.FLOATER).filter((card) => {

--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -33,7 +33,7 @@ export class HydrogenToVenus implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/JetStreamMicroscrappers.ts
+++ b/src/cards/venusNext/JetStreamMicroscrappers.ts
@@ -7,8 +7,10 @@ import { ResourceType } from "../../ResourceType";
 import { OrOptions } from "../../inputs/OrOptions";
 import { SelectOption } from '../../inputs/SelectOption';
 import { Game } from '../../Game';
-import { MAX_VENUS_SCALE } from '../../constants';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class JetStreamMicroscrappers implements IActionCard,IProjectCard, IResourceCard {
     public cost: number = 12;
@@ -21,10 +23,18 @@ export class JetStreamMicroscrappers implements IActionCard,IProjectCard, IResou
     public play() {
         return undefined;
     }
+
     public canAct(player: Player, game: Game): boolean {
-        return player.titanium > 0 || 
-          (this.resourceCount > 1 && game.getVenusScaleLevel() < MAX_VENUS_SCALE);
-    }    
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        const canSpendResource = this.resourceCount > 1 && !venusMaxed;
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.titanium > 0 || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
+        }
+  
+        return player.titanium > 0 || canSpendResource;
+    }
+
     public action(player: Player, game: Game) {
         var opts: Array<SelectOption> = [];
 

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -17,7 +17,7 @@ export class NeutralizerFactory  implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusRequirementMet = game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && venusRequirementMet;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && venusRequirementMet;
         }
   
         return venusRequirementMet;

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -1,10 +1,12 @@
-
 import { IProjectCard } from "../IProjectCard";
 import { Tags } from "../Tags";
 import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from '../../Game';
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class NeutralizerFactory  implements IProjectCard {
     public cost: number = 7;
@@ -12,8 +14,13 @@ export class NeutralizerFactory  implements IProjectCard {
     public name: CardName = CardName.NEUTRALIZER_FACTORY;
     public cardType: CardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player, game: Game): boolean {
-        return game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
+    public canPlay(player: Player, game: Game) {
+        const venusRequirementMet = game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && venusRequirementMet;
+        }
+  
+        return venusRequirementMet;
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/venusNext/Omnicourt.ts
+++ b/src/cards/venusNext/Omnicourt.ts
@@ -17,7 +17,7 @@ export class Omnicourt implements IProjectCard {
     public canPlay(player: Player, game: Game) {
       const hasRequiredTags = player.checkMultipleTagPresence([Tags.VENUS, Tags.EARTH, Tags.JOVIAN]);
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasRequiredTags;
+        return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2, game, true) && hasRequiredTags;
       }
 
       return hasRequiredTags;

--- a/src/cards/venusNext/Omnicourt.ts
+++ b/src/cards/venusNext/Omnicourt.ts
@@ -4,16 +4,24 @@ import { CardType } from '../CardType';
 import { Player } from '../../Player';
 import { CardName } from '../../CardName';
 import { Game } from '../../Game';
+import { PartyHooks } from '../../turmoil/parties/PartyHooks';
+import { PartyName } from '../../turmoil/parties/PartyName';
+import { REDS_RULING_POLICY_COST } from '../../constants';
 
 export class Omnicourt implements IProjectCard {
     public cost: number = 11;
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.OMNICOURT;
     public cardType: CardType = CardType.AUTOMATED;
+    
+    public canPlay(player: Player, game: Game) {
+      const hasRequiredTags = player.checkMultipleTagPresence([Tags.VENUS, Tags.EARTH, Tags.JOVIAN]);
+      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+        return player.canAfford(REDS_RULING_POLICY_COST * 2) && hasRequiredTags;
+      }
 
-    public canPlay(player: Player): boolean {
-      return player.checkMultipleTagPresence([Tags.VENUS, Tags.EARTH, Tags.JOVIAN]);
-    }
+      return hasRequiredTags;
+  }
     
     public play(player: Player, game: Game) {
       player.increaseTerraformRatingSteps(2, game);

--- a/src/cards/venusNext/OrbitalReflectors.ts
+++ b/src/cards/venusNext/OrbitalReflectors.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "../IProjectCard";
 import { Tags } from "../Tags";
 import { CardType } from "../CardType";
@@ -6,6 +5,9 @@ import { Player } from "../../Player";
 import { Game } from '../../Game';
 import { Resources } from '../../Resources';
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class OrbitalReflectors  implements IProjectCard {
     public cost: number = 26;
@@ -13,7 +15,16 @@ export class OrbitalReflectors  implements IProjectCard {
     public name: CardName = CardName.ORBITAL_REFLECTORS;
     public cardType: CardType = CardType.AUTOMATED;
 
-
+    public canPlay(player: Player, game: Game) {
+        const remainingVenusSteps = (MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;
+        const stepsRaised = Math.min(remainingVenusSteps, 2);
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         game.increaseVenusScaleLevel(player,2);

--- a/src/cards/venusNext/OrbitalReflectors.ts
+++ b/src/cards/venusNext/OrbitalReflectors.ts
@@ -20,7 +20,7 @@ export class OrbitalReflectors  implements IProjectCard {
         const stepsRaised = Math.min(remainingVenusSteps, 2);
         
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * stepsRaised);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -8,8 +8,10 @@ import { SelectHowToPay } from '../../inputs/SelectHowToPay';
 import { OrOptions } from '../../inputs/OrOptions';
 import { SelectOption } from '../../inputs/SelectOption';
 import { Game } from '../../Game';
-import { MAX_VENUS_SCALE } from '../../constants';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class RotatorImpacts implements IActionCard,IProjectCard, IResourceCard {
     public cost: number = 6;
@@ -25,8 +27,14 @@ export class RotatorImpacts implements IActionCard,IProjectCard, IResourceCard {
         return undefined;
     }
     public canAct(player: Player, game: Game): boolean {
-        return player.canAfford(6, game, false, true) || 
-          (this.resourceCount > 0 && game.getVenusScaleLevel() < MAX_VENUS_SCALE);
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        const canSpendResource = this.resourceCount > 0 && !venusMaxed;
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(6, game, false, true) || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
+        }
+  
+        return player.canAfford(6, game, false, true) || canSpendResource;
     }  
     
     public action(player: Player, game: Game) {

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -4,15 +4,26 @@ import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class SpinInducingAsteroid implements IProjectCard {
     public cost: number = 16;
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.SPIN_INDUCING_ASTEROID;
     public cardType: CardType = CardType.EVENT;
-    public canPlay(player: Player, game: Game): boolean {
-        return game.getVenusScaleLevel() - (2 * player.getRequirementsBonus(game, true)) <= 10;
+
+    public canPlay(player: Player, game: Game) {
+        const meetsVenusRequirements = game.getVenusScaleLevel() - (2 * player.getRequirementsBonus(game, true)) <= 10;
+        
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+          return player.canAfford(REDS_RULING_POLICY_COST * 2) && meetsVenusRequirements;
+        }
+  
+        return meetsVenusRequirements;
     }
+
     public play(player: Player, game: Game) {
         game.increaseVenusScaleLevel(player,2);
         return undefined;

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -18,7 +18,7 @@ export class SpinInducingAsteroid implements IProjectCard {
         const meetsVenusRequirements = game.getVenusScaleLevel() - (2 * player.getRequirementsBonus(game, true)) <= 10;
         
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(REDS_RULING_POLICY_COST * 2) && meetsVenusRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST * 2, game, false, true) && meetsVenusRequirements;
         }
   
         return meetsVenusRequirements;

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -5,12 +5,24 @@ import { Player } from "../../Player";
 import { Resources } from "../../Resources";
 import { Game } from '../../Game';
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class SulphurExports implements IProjectCard {
     public cost: number = 21;
     public tags: Array<Tags> = [Tags.VENUS, Tags.SPACE];
     public name: CardName = CardName.SULPHUR_EXPORTS;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         player.setProduction(Resources.MEGACREDITS,player.getTagCount(Tags.VENUS) + 1 );

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -18,7 +18,7 @@ export class SulphurExports implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/Thermophiles.ts
+++ b/src/cards/venusNext/Thermophiles.ts
@@ -7,10 +7,12 @@ import { ResourceType } from "../../ResourceType";
 import { OrOptions } from "../../inputs/OrOptions";
 import { SelectOption } from '../../inputs/SelectOption';
 import { Game } from '../../Game';
-import { MAX_VENUS_SCALE } from '../../constants';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
 import { SelectCard } from '../../inputs/SelectCard';
 import { CardName } from '../../CardName';
 import { LogHelper } from "../../components/LogHelper";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class Thermophiles implements IActionCard,IProjectCard, IResourceCard {
     public cost: number = 9;
@@ -63,8 +65,12 @@ export class Thermophiles implements IActionCard,IProjectCard, IResourceCard {
             return undefined;
         });
 
+        const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
+
         if (canRaiseVenus) {
-            opts.push(spendResource);
+            if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
+                opts.push(spendResource);
+            }
         } else {
             if (venusMicrobeCards.length === 1) return addResourceToSelf;
             return addResource;

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -5,8 +5,10 @@ import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from '../../Game';
 import { Resources } from "../../Resources";
-import { MAX_VENUS_SCALE } from '../../constants';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from '../../constants';
 import { CardName } from '../../CardName';
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class VenusMagnetizer implements IActionCard,IProjectCard {
     public cost: number = 7;
@@ -20,7 +22,14 @@ export class VenusMagnetizer implements IActionCard,IProjectCard {
         return undefined;
     }
     public canAct(player: Player, game: Game): boolean {
-        return player.getProduction(Resources.ENERGY) > 0 && game.getVenusScaleLevel() < MAX_VENUS_SCALE ;
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        const hasEnergyProduction = player.getProduction(Resources.ENERGY) > 0;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+            return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && !venusMaxed;;
+        }
+
+        return hasEnergyProduction && !venusMaxed;
     }   
     public action(player: Player, game: Game) {
         player.setProduction(Resources.ENERGY,-1);

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -26,7 +26,7 @@ export class VenusMagnetizer implements IActionCard,IProjectCard {
         const hasEnergyProduction = player.getProduction(Resources.ENERGY) > 0;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && !venusMaxed;;
+            return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && !venusMaxed;
         }
 
         return hasEnergyProduction && !venusMaxed;

--- a/src/cards/venusNext/VenusSoils.ts
+++ b/src/cards/venusNext/VenusSoils.ts
@@ -22,7 +22,7 @@ export class VenusSoils implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST);
         }
   
         return true;

--- a/src/cards/venusNext/VenusSoils.ts
+++ b/src/cards/venusNext/VenusSoils.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "../IProjectCard";
 import { Tags } from "../Tags";
 import { CardType } from "../CardType";
@@ -10,12 +9,24 @@ import { Game } from '../../Game';
 import { ICard } from '../ICard';
 import { CardName } from '../../CardName';
 import { LogHelper } from "../../components/LogHelper";
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class VenusSoils implements IProjectCard {
     public cost: number = 20;
     public tags: Array<Tags> = [Tags.VENUS, Tags.PLANT];
     public name: CardName = CardName.VENUS_SOILS;
     public cardType: CardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
 
     public play(player: Player, game: Game) {
         player.setProduction(Resources.PLANTS);

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -8,15 +8,27 @@ import { Game } from '../../Game';
 import { ICard } from '../ICard';
 import { CardName } from '../../CardName';
 import { LogHelper } from "../../components/LogHelper";
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class VenusianPlants implements IProjectCard {
     public cost: number = 13;
     public tags: Array<Tags> = [Tags.VENUS, Tags.PLANT];
     public name: CardName = CardName.VENUSIAN_PLANTS;
     public cardType: CardType = CardType.AUTOMATED;
-    public canPlay(player: Player, game: Game): boolean {
-        return game.getVenusScaleLevel() >= 16 - (2 * player.getRequirementsBonus(game, true));
+
+    public canPlay(player: Player, game: Game) {
+        const meetsVenusRequirements = game.getVenusScaleLevel() >= 16 - (2 * player.getRequirementsBonus(game, true));
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST) && meetsVenusRequirements;
+        }
+  
+        return meetsVenusRequirements;
     }
+    
     public play(player: Player, game: Game) {
         game.increaseVenusScaleLevel(player,1);
         const cards = this.getResCards(player);

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -23,7 +23,7 @@ export class VenusianPlants implements IProjectCard {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST) && meetsVenusRequirements;
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsVenusRequirements;
         }
   
         return meetsVenusRequirements;

--- a/src/cards/venusNext/WaterToVenus.ts
+++ b/src/cards/venusNext/WaterToVenus.ts
@@ -4,6 +4,9 @@ import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { CardName } from '../../CardName';
+import { MAX_VENUS_SCALE, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class WaterToVenus implements IProjectCard {
     public cost: number = 9;
@@ -11,9 +14,17 @@ export class WaterToVenus implements IProjectCard {
     public name: CardName = CardName.WATER_TO_VENUS;
     public cardType: CardType = CardType.EVENT;
 
+    public canPlay(player: Player, game: Game) {
+        const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+          return player.canAfford(REDS_RULING_POLICY_COST);
+        }
+  
+        return true;
+    }
+
     public play(player: Player, game: Game) {
         game.increaseVenusScaleLevel(player,1);
         return undefined;
     }
-
 }

--- a/src/cards/venusNext/WaterToVenus.ts
+++ b/src/cards/venusNext/WaterToVenus.ts
@@ -17,7 +17,7 @@ export class WaterToVenus implements IProjectCard {
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(REDS_RULING_POLICY_COST);
+          return player.canAfford(this.cost + REDS_RULING_POLICY_COST, game, false, true);
         }
   
         return true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const BUFFER_GAS_COST: number = 16;
 export const OCEAN_BONUS: number = 2;
 export const BUILD_COLONY_COST: number = 17;
 export const PLAYER_DELEGATES_COUNT: number = 7;
+export const REDS_RULING_POLICY_COST: number = 3;
 export const LANGUAGES = [
     {"id": "en", "title": "English"},
     {"id": "de", "title": "German"},

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -12,8 +12,12 @@ import { OrOptions } from "../src/inputs/OrOptions";
 import { SelectSpace } from "../src/inputs/SelectSpace";
 import { SpaceBonus } from "../src/SpaceBonus";
 import { Turmoil } from "../src/turmoil/Turmoil";
-import { resetBoard } from "./TestingUtils";
+import { resetBoard, maxOutOceans } from "./TestingUtils";
 import { Reds } from "../src/turmoil/parties/Reds";
+import { ReleaseOfInertGases } from "../src/cards/ReleaseOfInertGases";
+import { JovianEmbassy } from "../src/cards/promo/JovianEmbassy";
+import { IceAsteroid } from "../src/cards/IceAsteroid";
+import { ProtectedValley } from "../src/cards/ProtectedValley";
 
 describe("Turmoil", function () {
     let player : Player, game : Game, turmoil: Turmoil;
@@ -128,14 +132,37 @@ describe("Turmoil", function () {
         expect(player.steel).to.eq(0); // should not give ruling policy bonus
     });
 
-    it("Does not allow to raise TR if Reds are ruling and player cannot pay", function () {
+    it("Can't raise TR via Standard Projects if Reds are ruling and player cannot pay", function () {
         turmoil.rulingParty = new Reds();
-        game.phase = Phase.ACTION;
-    
         player.megaCredits = 14;
         const availableStandardProjects = player.getAvailableStandardProjects(game);
-    
+        
         // can only use Power Plant as cannot pay 3 for Reds ruling policy
         expect(availableStandardProjects.options.length).to.eq(1); 
+    });
+
+    it("Can't play cards to raise TR directly if Reds are ruling and player cannot pay", function () {
+        turmoil.rulingParty = new Reds();
+        player.megaCredits = 16;
+        const releaseOfInertGases = new ReleaseOfInertGases();
+        const jovianEmbassy = new JovianEmbassy();
+        
+        expect(releaseOfInertGases.canPlay(player, game)).to.eq(false); // needs 20 MC
+        expect(jovianEmbassy.canPlay(player, game)).to.eq(false); // needs 17 MC
+    });
+
+    it("Can't play cards to raise TR via global parameters if Reds are ruling and player cannot pay", function () {
+        turmoil.rulingParty = new Reds();
+        player.megaCredits = 25;
+        const iceAsteroid = new IceAsteroid();
+        const protectedValley = new ProtectedValley();
+        
+        expect(iceAsteroid.canPlay(player, game)).to.eq(false); // needs 29 MC
+        expect(protectedValley.canPlay(player, game)).to.eq(false); // needs 26 MC
+
+        // can play if won't gain TR from raising global parameter
+        maxOutOceans(player, game, 9);
+        expect(protectedValley.canPlay(player, game)).to.eq(true);
+        expect(iceAsteroid.canPlay(player, game)).to.eq(true);
     });
 });

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -13,6 +13,7 @@ import { SelectSpace } from "../src/inputs/SelectSpace";
 import { SpaceBonus } from "../src/SpaceBonus";
 import { Turmoil } from "../src/turmoil/Turmoil";
 import { resetBoard } from "./TestingUtils";
+import { Reds } from "../src/turmoil/parties/Reds";
 
 describe("Turmoil", function () {
     let player : Player, game : Game, turmoil: Turmoil;
@@ -125,5 +126,16 @@ describe("Turmoil", function () {
 
         placeOcean.cb(steelSpace!);
         expect(player.steel).to.eq(0); // should not give ruling policy bonus
+    });
+
+    it("Does not allow to raise TR if Reds are ruling and player cannot pay", function () {
+        turmoil.rulingParty = new Reds();
+        game.phase = Phase.ACTION;
+    
+        player.megaCredits = 14;
+        const availableStandardProjects = player.getAvailableStandardProjects(game);
+    
+        // can only use Power Plant as cannot pay 3 for Reds ruling policy
+        expect(availableStandardProjects.options.length).to.eq(1); 
     });
 });

--- a/tests/cards/BlackPolarDust.spec.ts
+++ b/tests/cards/BlackPolarDust.spec.ts
@@ -18,7 +18,7 @@ describe("BlackPolarDust", function () {
 
     it("Can't play", function () {
         player.setProduction(Resources.MEGACREDITS,-4);
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {

--- a/tests/cards/CaretakerContract.spec.ts
+++ b/tests/cards/CaretakerContract.spec.ts
@@ -15,7 +15,7 @@ describe("CaretakerContract", function () {
 
     it("Can't play or act", function () {
         expect(card.canPlay(player, game)).to.eq(false);
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should play", function () {

--- a/tests/cards/EquatorialMagnetizer.spec.ts
+++ b/tests/cards/EquatorialMagnetizer.spec.ts
@@ -15,12 +15,12 @@ describe("EquatorialMagnetizer", function () {
     });
 
     it("Can't act", function () {
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.setProduction(Resources.ENERGY);
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
 
         card.action(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/Ironworks.spec.ts
+++ b/tests/cards/Ironworks.spec.ts
@@ -15,12 +15,12 @@ describe("Ironworks", function () {
 
     it("Can't act without enough energy", function () {
         player.energy = 3;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.energy = 4;
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
 
         card.action(player, game);
         expect(player.energy).to.eq(0);

--- a/tests/cards/MagneticFieldDome.spec.ts
+++ b/tests/cards/MagneticFieldDome.spec.ts
@@ -15,12 +15,12 @@ describe("MagneticFieldDome", function () {
     });
     
     it("Can't play", function () {
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
         player.setProduction(Resources.ENERGY, 2);
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/MagneticFieldGenerators.spec.ts
@@ -15,12 +15,12 @@ describe("MagneticFieldGenerators", function () {
     });
 
     it("Can't play", function () {
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
         player.setProduction(Resources.ENERGY, 4);
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/OreProcessor.spec.ts
+++ b/tests/cards/OreProcessor.spec.ts
@@ -15,12 +15,12 @@ describe("OreProcessor", function () {
 
     it("Can't act", function () {
         player.energy = 3;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.energy = 4;
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
         card.action(player, game);
 
         expect(player.energy).to.eq(0);

--- a/tests/cards/RadChemFactory.spec.ts
+++ b/tests/cards/RadChemFactory.spec.ts
@@ -15,12 +15,12 @@ describe("RadChemFactory", function () {
     });
 
     it("Can't play", function () {
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
         player.setProduction(Resources.ENERGY);
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/Steelworks.spec.ts
+++ b/tests/cards/Steelworks.spec.ts
@@ -15,12 +15,12 @@ describe("Steelworks", function () {
 
     it("Can't act", function () {
         player.energy = 3;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.energy = 4;
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
 
         card.action(player, game);
         expect(player.energy).to.eq(0);

--- a/tests/cards/StripMine.spec.ts
+++ b/tests/cards/StripMine.spec.ts
@@ -16,12 +16,12 @@ describe("StripMine", function () {
 
     it("Can't play", function () {
         player.setProduction(Resources.ENERGY, 1);
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
         player.setProduction(Resources.ENERGY, 2);
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/cards/WaterSplittingPlant.spec.ts
+++ b/tests/cards/WaterSplittingPlant.spec.ts
@@ -25,12 +25,12 @@ describe("WaterSplittingPlant", function () {
 
     it("Can't act", function () {
         player.energy = 2;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.energy = 3;
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
         
         card.action(player, game);
         expect(player.energy).to.eq(0);

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { NitrogenFromTitan } from "../../../src/cards/colonies/NitrogenFromTitan";
+import { Color } from "../../../src/Color";
+import { Player } from "../../../src/Player";
+import { Game } from '../../../src/Game';
+import { JovianLanterns } from "../../../src/cards/colonies/JovianLanterns";
+import { TitanFloatingLaunchPad } from "../../../src/cards/colonies/TitanFloatingLaunchPad";
+import { SelectCard } from "../../../src/inputs/SelectCard";
+import { ICard } from "../../../src/cards/ICard";
+
+describe("NitrogenFromTitan", function () {
+    let card : NitrogenFromTitan, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new NitrogenFromTitan();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+    });
+
+    it("Can play without floaters", function () {
+        const tr = player.getTerraformRating();
+        card.play(player, game);
+        expect(player.getTerraformRating()).to.eq(tr + 2);
+        expect(game.interrupts.length).to.eq(0);
+    });
+
+    it("Can play with single Jovian floater card", function () {
+        const jovianLanterns = new JovianLanterns();
+        player.playedCards.push(jovianLanterns);
+
+        card.play(player, game);
+        expect(jovianLanterns.resourceCount).to.eq(2);
+    });
+
+    it("Can play with multiple Jovian floater cards", function () {
+        const jovianLanterns = new JovianLanterns();
+        player.playedCards.push(jovianLanterns, new TitanFloatingLaunchPad());
+
+        card.play(player, game);
+        expect(game.interrupts.length).to.eq(1);
+
+        const orOptions = game.interrupts[0].playerInput as SelectCard<ICard>;
+        orOptions.cb([jovianLanterns]);
+        expect(jovianLanterns.resourceCount).to.eq(2);
+    });
+});

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -29,6 +29,8 @@ describe("NitrogenFromTitan", function () {
         player.playedCards.push(jovianLanterns);
 
         card.play(player, game);
+        const orOptions = game.interrupts[0].playerInput as SelectCard<ICard>;
+        orOptions.cb([jovianLanterns]);
         expect(jovianLanterns.resourceCount).to.eq(2);
     });
 

--- a/tests/cards/colonies/TitanAirScrapping.spec.ts
+++ b/tests/cards/colonies/TitanAirScrapping.spec.ts
@@ -16,14 +16,14 @@ describe("TitanAirScrapping", function () {
 
     it("Can't act", function () {
         player.playedCards.push(card);
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act - both actions possible", function () {
         player.playedCards.push(card);
         player.titanium = 3;
         player.addResourceTo(card, 7);
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
 
         const orOptions = card.action(player, game) as OrOptions;
         expect(orOptions instanceof OrOptions).to.eq(true);
@@ -33,10 +33,11 @@ describe("TitanAirScrapping", function () {
         expect(player.getResourcesOnCard(card)).to.eq(5);
         expect(card.getVictoryPoints()).to.eq(2);
     });
+    
     it("Should act automatically when only one action possible", function () {
         player.playedCards.push(card);
         player.addResourceTo(card, 2);
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
         
         card.action(player, game)
         expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
+++ b/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
@@ -15,19 +15,19 @@ describe("UnitedNationsMarsInitiative", function () {
 
     it("Can't act if TR was not raised", function  () {
         player.megaCredits = 10;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Can't act if not enough MC", function  () {
         player.setTerraformRating(21);
         player.megaCredits = 2;
-        expect(card.canAct(player)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(false);
     });
 
     it("Should act", function () {
         player.increaseTerraformRating(game);
         player.megaCredits = 3;
-        expect(card.canAct(player)).to.eq(true);
+        expect(card.canAct(player, game)).to.eq(true);
 
         card.action(player, game);
         expect(player.megaCredits).to.eq(0);

--- a/tests/cards/promo/MagneticShield.spec.ts
+++ b/tests/cards/promo/MagneticShield.spec.ts
@@ -15,13 +15,13 @@ describe("MagneticShield", function () {
     });
 
     it("Can't play if not enough power tags available", function () {
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play", function () {
         player.playedCards.push(new PowerPlant());
         player.playedCards.push(new PowerPlant());
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
         
         card.play(player, game);
         expect(player.getTerraformRating()).to.eq(24);

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -36,6 +36,9 @@ describe("WildlifeDome", function () {
         
         let greens = game.turmoil!.getPartyByName(PartyName.GREENS)!;
         greens.delegates.push(player.id, player.id);
+        expect(card.canPlay(player, game)).to.eq(false); 
+
+        player.megaCredits = 3;
         expect(card.canPlay(player, game)).to.eq(true); 
 
         const action = card.play(player, game);

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -25,12 +25,12 @@ describe("Atmoscoop", function () {
 
     it("Can't play", function () {
         player.playedCards.push(new Research());
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
     });
 
     it("Should play - no targets", function () {
         player.playedCards.push(new Research(), new SearchForLife());
-        expect(card.canPlay(player)).to.eq(true);
+        expect(card.canPlay(player, game)).to.eq(true);
 
         const action = card.play(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);

--- a/tests/cards/venusNext/Omnicourt.spec.ts
+++ b/tests/cards/venusNext/Omnicourt.spec.ts
@@ -9,7 +9,7 @@ describe("Omnicourt", function () {
         const card = new Omnicourt();
         const player = new Player("test", Color.BLUE, false);
         const game = new Game("foobar", [player,player], player);
-        expect(card.canPlay(player)).to.eq(false);
+        expect(card.canPlay(player, game)).to.eq(false);
         const action = card.play(player, game);
         expect(action).to.eq(undefined);
         expect(player.getTerraformRating()).to.eq(22);


### PR DESCRIPTION
Fix for issue https://github.com/bafolts/terraforming-mars/issues/986.

**Note:**
1. This PR does not address extreme edge cases (e.g. greenery or ocean tiles placed give additional MC that allows the player to eventually pay the 3n MC Reds tax).
2. A workaround is added in https://github.com/bafolts/terraforming-mars/pull/987/commits/d407d7b63ff8f464bb618e02fda97a4b0eb19d12 to prevent the game from potentially entering a locked state if player tries to avoid paying Reds tax. This approach is similar to the one taken for Stratospheric Birds.