### PR TITLE
Add missing Turmoil card Political Alliance

### DIFF
--- a/src/CardName.ts
+++ b/src/CardName.ts
@@ -429,6 +429,7 @@ export enum CardName {
     GMO_CONTRACT = "GMO Contract",
     MARTIAN_MEDIA_CENTER = "Martian Media Center",
     PARLIAMENT_HALL = "Parliament Hall",
+    POLITICAL_ALLIANCE = "Political Alliance",
     PR_OFFICE = "PR Office",
     PUBLIC_CELEBRATIONS = "Public Celebrations",
     RECRUITMENT = "Recruitment",

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -458,6 +458,7 @@ import { AsteroidDeflectionSystem } from "./cards/promo/AsteroidDeflectionSystem
 import { SubCrustMeasurements } from "./cards/promo/SubCrustMeasurements";
 import { Potatoes } from "./cards/promo/Potatoes";
 import { MeatIndustry } from "./cards/promo/MeatIndustry";
+import { PoliticalAlliance } from "./cards/turmoil/PoliticalAlliance";
 
 
 export interface ICardFactory<T> {
@@ -654,6 +655,7 @@ export const ALL_TURMOIL_PROJECTS_CARDS: Array<ICardFactory<IProjectCard>> = [
     { cardName: CardName.MARTIAN_MEDIA_CENTER, factory: MartianMediaCenter },
     { cardName: CardName.PARLIAMENT_HALL, factory: ParliamentHall },
     { cardName: CardName.PR_OFFICE, factory: PROffice },
+    { cardName: CardName.POLITICAL_ALLIANCE, factory: PoliticalAlliance },
     { cardName: CardName.PUBLIC_CELEBRATIONS, factory: PublicCelebrations },
     { cardName: CardName.RECRUITMENT, factory: Recruitment },
     { cardName: CardName.RED_TOURISM_WAVE, factory: RedTourismWave },

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -7324,6 +7324,21 @@ export const HTML_DATA: Map<string, string> =
       </div>
   </div>
 `],
+[CardName.POLITICAL_ALLIANCE, `
+  <div class="title background-color-events">Political Alliance</div>
+  <div class="price">4</div>
+  <div class="turmoil-icon project-icon"></div>
+  <div class="tag tag1 tag-event"></div>
+  <div class="card-number">X09</div>
+  <div class="content">
+    <div class="requirements">2 Party Leaders</div>
+      <div class="tile rating"></div>
+      <br>
+      <div class="description">
+        (Requires that you have 2 party leaders. Gain 1 TR.)
+      </div>
+  </div>
+`],
 [CardName.PR_OFFICE, `
   <div class="title background-color-automated ">PR Office</div>
   <div class="price">7</div>

--- a/src/cards/turmoil/PoliticalAlliance.ts
+++ b/src/cards/turmoil/PoliticalAlliance.ts
@@ -4,6 +4,9 @@ import { CardName } from "../../CardName";
 import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
+import { REDS_RULING_POLICY_COST } from "../../constants";
 
 export class PoliticalAlliance implements IProjectCard {
     public cost: number = 4;
@@ -15,7 +18,12 @@ export class PoliticalAlliance implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
             const parties = game.turmoil.parties.filter(party => party.partyLeader === player.id);
-            return parties.length > 1;
+            const meetsPartyLeaderRequirements = parties.length > 1;
+
+            if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+                return player.canAfford(this.cost + REDS_RULING_POLICY_COST) && meetsPartyLeaderRequirements;
+            }
+            return meetsPartyLeaderRequirements;
         }
         return false;
     }

--- a/src/cards/turmoil/PoliticalAlliance.ts
+++ b/src/cards/turmoil/PoliticalAlliance.ts
@@ -1,0 +1,27 @@
+import { IProjectCard } from "../IProjectCard";
+import { Tags } from "../Tags";
+import { CardName } from "../../CardName";
+import { CardType } from "../CardType";
+import { Player } from "../../Player";
+import { Game } from "../../Game";
+
+export class PoliticalAlliance implements IProjectCard {
+    public cost: number = 4;
+    public tags: Array<Tags> = [];
+    public name: CardName = CardName.POLITICAL_ALLIANCE;
+    public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
+
+    public canPlay(player: Player, game: Game): boolean {
+        if (game.turmoil !== undefined) {
+            const parties = game.turmoil.parties.filter(party => party.partyLeader === player.id);
+            return parties.length > 1;
+        }
+        return false;
+    }
+
+    public play(player: Player, game: Game) {
+        player.increaseTerraformRating(game);
+        return undefined;
+    }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const BUFFER_GAS_COST: number = 16;
 export const OCEAN_BONUS: number = 2;
 export const BUILD_COLONY_COST: number = 17;
 export const PLAYER_DELEGATES_COUNT: number = 7;
+export const REDS_RULING_POLICY_COST: number = 3;
 export const LANGUAGES = [
     {"id": "en", "title": "English"},
     {"id": "de", "title": "German"},

--- a/tests/cards/turmoil/PoliticalAlliance.spec.ts
+++ b/tests/cards/turmoil/PoliticalAlliance.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+import { PoliticalAlliance } from "../../../src/cards/turmoil/PoliticalAlliance";
+import { Player } from "../../../src/Player";
+import { Color } from "../../../src/Color";
+import { BoardName } from '../../../src/BoardName';
+import { GameOptions, Game } from '../../../src/Game';
+import { PartyName } from "../../../src/turmoil/parties/PartyName";
+import { Turmoil } from "../../../src/turmoil/Turmoil";
+
+describe("PoliticalAlliance", function () {
+    let card : PoliticalAlliance, player : Player, game : Game, turmoil: Turmoil;
+
+    beforeEach(function() {
+        card = new PoliticalAlliance();
+        player = new Player("test", Color.BLUE, false);
+        
+        const gameOptions = {
+            draftVariant: false,
+            initialDraftVariant: false,
+            corporateEra: true,
+            randomMA: false,
+            preludeExtension: false,
+            venusNextExtension: true,
+            coloniesExtension: false,
+            turmoilExtension: true,
+            boardName: BoardName.ORIGINAL,
+            showOtherPlayersVP: false,
+            customCorporationsList: [],
+            solarPhaseOption: false,
+            promoCardsOption: false,
+            undoOption: false,
+            startingCorporations: 2,
+            soloTR: false,
+            clonedGamedId: undefined
+          } as GameOptions;
+        
+          game = new Game("foobar", [player, player], player, gameOptions);
+          turmoil = game.turmoil!
+    });
+
+    it("Can't play", function () {
+        let greens = turmoil.getPartyByName(PartyName.GREENS)!;
+        greens.partyLeader = player.id;
+        expect(card.canPlay(player, game)).to.eq(false);
+    });
+
+    it("Should play", function () {
+        let greens = turmoil.getPartyByName(PartyName.GREENS)!;
+        let reds = turmoil.getPartyByName(PartyName.REDS)!;
+        greens.partyLeader = player.id;
+        reds.partyLeader = player.id;
+        expect(card.canPlay(player, game)).to.eq(true); 
+
+        card.play(player, game);
+        expect(player.getTerraformRating()).to.eq(21);
+    });
+});


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/985

Add missing Political Alliance card from Turmoil expansion.

<img width="197" alt="Screenshot 2020-07-15 at 10 27 10 AM" src="https://user-images.githubusercontent.com/2408094/87496435-25c7f480-c686-11ea-94da-4c6ae59ebc6e.png">
