### PR TITLE
Fix: CuttingEdgeTechnology should not discount cards that raise TR when played

### DIFF
--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -14,6 +14,7 @@ export class Asteroid implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.ASTEROID;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -14,6 +14,7 @@ export class BigAsteroid implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.BIG_ASTEROID;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;

--- a/src/cards/BribedCommitte.ts
+++ b/src/cards/BribedCommitte.ts
@@ -13,6 +13,7 @@ export class BribedCommitte implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.BRIBED_COMMITTEE;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {

--- a/src/cards/Comet.ts
+++ b/src/cards/Comet.ts
@@ -14,6 +14,7 @@ export class Comet implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.COMET;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const temperatureStep = game.getTemperature() < MAX_TEMPERATURE ? 1 : 0;

--- a/src/cards/ConvoyFromEuropa.ts
+++ b/src/cards/ConvoyFromEuropa.ts
@@ -13,6 +13,7 @@ export class ConvoyFromEuropa implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.CONVOY_FROM_EUROPA;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/DeepWellHeating.ts
+++ b/src/cards/DeepWellHeating.ts
@@ -14,6 +14,7 @@ export class DeepWellHeating implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY, Tags.STEEL];
     public name: CardName = CardName.DEEP_WELL_HEATING;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;

--- a/src/cards/DeimosDown.ts
+++ b/src/cards/DeimosDown.ts
@@ -14,6 +14,7 @@ export class DeimosDown implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.DEIMOS_DOWN;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;

--- a/src/cards/EquatorialMagnetizer.ts
+++ b/src/cards/EquatorialMagnetizer.ts
@@ -15,6 +15,7 @@ export class EquatorialMagnetizer implements IActionCard, IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.EQUATORIAL_MAGNETIZER;
     public cardType: CardType = CardType.ACTIVE;
+    public hasRequirements = false;
 
     public play() {
       return undefined;

--- a/src/cards/Flooding.ts
+++ b/src/cards/Flooding.ts
@@ -19,6 +19,7 @@ export class Flooding implements IProjectCard {
   public cost: number = 7;
   public name: CardName = CardName.FLOODING;
   public tags: Array<Tags> = [];
+  public hasRequirements = false;
 
   public canPlay(player: Player, game: Game): boolean {
     const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -14,6 +14,7 @@ export class GiantIceAsteroid implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.GIANT_ICE_ASTEROID;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();

--- a/src/cards/IceAsteroid.ts
+++ b/src/cards/IceAsteroid.ts
@@ -13,6 +13,7 @@ export class IceAsteroid implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.ICE_ASTEROID;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();

--- a/src/cards/ImportedHydrogen.ts
+++ b/src/cards/ImportedHydrogen.ts
@@ -21,6 +21,7 @@ export class ImportedHydrogen implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.IMPORTED_HYDROGEN;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -18,6 +18,7 @@ export class ImportedNitrogen implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.IMPORTED_NITROGEN;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {

--- a/src/cards/LargeConvoy.ts
+++ b/src/cards/LargeConvoy.ts
@@ -21,6 +21,7 @@ export class LargeConvoy implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];
     public name: CardName = CardName.LARGE_CONVOY;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/MiningExpedition.ts
+++ b/src/cards/MiningExpedition.ts
@@ -14,6 +14,7 @@ export class MiningExpedition implements IProjectCard {
     public tags: Array<Tags> = [];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.MINING_EXPEDITION;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;

--- a/src/cards/NitrogenRichAsteroid.ts
+++ b/src/cards/NitrogenRichAsteroid.ts
@@ -14,6 +14,7 @@ export class NitrogenRichAsteroid implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.NITROGEN_RICH_ASTEROID;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         let steps = 2;

--- a/src/cards/ProtectedValley.ts
+++ b/src/cards/ProtectedValley.ts
@@ -17,6 +17,7 @@ export class ProtectedValley implements IProjectCard {
     public cardType: CardType = CardType.AUTOMATED;
     public tags: Array<Tags> = [Tags.PLANT, Tags.STEEL];
     public name: CardName = CardName.PROTECTED_VALLEY;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;

--- a/src/cards/ReleaseOfInertGases.ts
+++ b/src/cards/ReleaseOfInertGases.ts
@@ -13,6 +13,7 @@ export class ReleaseOfInertGases implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.RELEASE_OF_INERT_GASES;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {

--- a/src/cards/SubterraneanReservoir.ts
+++ b/src/cards/SubterraneanReservoir.ts
@@ -13,6 +13,7 @@ export class SubterraneanReservoir implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
     public tags: Array<Tags> = [];
     public name: CardName = CardName.SUBTERRANEAN_RESERVOIR;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
         const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/TerraformingGanymede.ts
+++ b/src/cards/TerraformingGanymede.ts
@@ -16,6 +16,7 @@ export class TerraformingGanymede implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.SPACE];
     public name: CardName = CardName.TERRAFORMING_GANYMEDE;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const steps = 1 + player.getTagCount(Tags.JOVIAN);

--- a/src/cards/TowingAComet.ts
+++ b/src/cards/TowingAComet.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
@@ -14,6 +13,7 @@ export class TowingAComet implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.TOWING_A_COMET;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const oxygenStep = game.getOxygenLevel() < MAX_OXYGEN_LEVEL ? 1 : 0;

--- a/src/cards/colonies/NitrogenFromTitan.ts
+++ b/src/cards/colonies/NitrogenFromTitan.ts
@@ -14,6 +14,7 @@ export class NitrogenFromTitan implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.SPACE];
     public name: CardName = CardName.NITROGEN_FROM_TITAN;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {

--- a/src/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/cards/promo/AsteroidDeflectionSystem.ts
@@ -18,6 +18,7 @@ export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IRes
     public resourceType: ResourceType = ResourceType.ASTEROID;
     public resourceCount: number = 0;
     public cardType: CardType = CardType.ACTIVE;
+    public hasRequirements = false;
 
     public canPlay(player: Player): boolean {
         return player.getProduction(Resources.ENERGY) >= 1;

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -17,10 +17,6 @@ export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCa
     public resourceCount: number = 0;
     public cardType: CardType = CardType.ACTIVE;
 
-    public canPlay(): boolean {
-        return true;
-    }
-
     public play() {
         return undefined;
     }

--- a/src/cards/promo/CometAiming.ts
+++ b/src/cards/promo/CometAiming.ts
@@ -22,10 +22,6 @@ export class CometAiming implements IActionCard, IProjectCard, IResourceCard {
     public resourceCount: number = 0;
     public cardType: CardType = CardType.ACTIVE;
 
-    public canPlay(): boolean {
-        return true;
-    }
-
     public play() {
         return undefined;
     }

--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -17,6 +17,7 @@ export class DeimosDownPromo implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.DEIMOS_DOWN_PROMO;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const canPlaceTile = game.board.getAvailableSpacesForCity(player).length > 0;

--- a/src/cards/promo/DirectedImpactors.ts
+++ b/src/cards/promo/DirectedImpactors.ts
@@ -22,10 +22,6 @@ export class DirectedImpactors implements IActionCard, IProjectCard, IResourceCa
     public resourceCount: number = 0;
     public cardType: CardType = CardType.ACTIVE;
 
-    public canPlay(): boolean {
-        return true;
-    }
-
     public play() {
         return undefined;
     }

--- a/src/cards/promo/DuskLaserMining.ts
+++ b/src/cards/promo/DuskLaserMining.ts
@@ -6,7 +6,6 @@ import { Player } from '../../Player';
 import { Resources } from '../../Resources';
 
 export class DuskLaserMining implements IProjectCard {
-
     public name: CardName = CardName.DUSK_LASER_MINING;
     public cost: number = 8;
     public tags: Array<Tags> = [Tags.SPACE];

--- a/src/cards/promo/EnergyMarket.ts
+++ b/src/cards/promo/EnergyMarket.ts
@@ -10,7 +10,6 @@ import { OrOptions } from "../../inputs/OrOptions";
 import { SelectAmount } from "../../inputs/SelectAmount";
 
 export class EnergyMarket implements IProjectCard {
-
     public name: CardName = CardName.ENERGY_MARKET;
     public cost: number = 3;
     public tags: Array<Tags> = [Tags.ENERGY];

--- a/src/cards/promo/FieldCappedCity.ts
+++ b/src/cards/promo/FieldCappedCity.ts
@@ -13,6 +13,7 @@ export class FieldCappedCity implements IProjectCard {
     public tags: Array<Tags> = [Tags.CITY, Tags.STEEL, Tags.ENERGY];
     public name: CardName = CardName.FIELD_CAPPED_CITY;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       return game.board.getAvailableSpacesForCity(player).length > 0;

--- a/src/cards/promo/InterplanetaryTrade.ts
+++ b/src/cards/promo/InterplanetaryTrade.ts
@@ -6,7 +6,6 @@ import { Player } from "../../Player";
 import { Resources } from "../../Resources";
 
 export class InterplanetaryTrade implements IProjectCard {
-
     public name: CardName = CardName.INTERPLANETARY_TRADE;
     public cost: number = 27;
     public tags: Array<Tags> = [Tags.SPACE];

--- a/src/cards/promo/JovianEmbassy.ts
+++ b/src/cards/promo/JovianEmbassy.ts
@@ -13,6 +13,7 @@ export class JovianEmbassy implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.STEEL];
     public name: CardName = CardName.JOVIAN_EMBASSY;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {

--- a/src/cards/promo/LawSuit.ts
+++ b/src/cards/promo/LawSuit.ts
@@ -7,13 +7,13 @@ import { SelectPlayer } from "../../inputs/SelectPlayer";
 import { Resources } from "../../Resources";
 import { CardName } from "../../CardName";
 
-export class LawSuit implements IProjectCard {
-    
+export class LawSuit implements IProjectCard {    
     public cost: number = 2;
     public tags: Array<Tags> = [Tags.EARTH];
     public cardType: CardType = CardType.EVENT;
     public name: CardName = CardName.LAW_SUIT;
     public hasRequirements = false;
+    
     public canPlay(player: Player) {
         return player.removingPlayers.length > 0;
     }

--- a/src/cards/promo/MagneticShield.ts
+++ b/src/cards/promo/MagneticShield.ts
@@ -13,6 +13,7 @@ export class MagneticShield implements IProjectCard {
     public cost: number = 26;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const hasEnergyTags = player.getTagCount(Tags.ENERGY) >= 2;

--- a/src/cards/promo/MercurianAlloys.ts
+++ b/src/cards/promo/MercurianAlloys.ts
@@ -5,7 +5,6 @@ import { Tags } from "../Tags";
 import { Player } from "../../Player";
 
 export class MercurianAlloys implements IProjectCard {
-
     public name: CardName = CardName.MERCURIAN_ALLOYS;
     public cost: number = 3;
     public tags: Array<Tags> = [Tags.SPACE];

--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -17,6 +17,7 @@ export class MoholeLake implements IActionCard, IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.MOHOLE_LAKE;
     public cardType: CardType = CardType.ACTIVE;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
       const temperatureStep = game.getTemperature() < MAX_TEMPERATURE ? 1 : 0;

--- a/src/cards/promo/OrbitalCleanup.ts
+++ b/src/cards/promo/OrbitalCleanup.ts
@@ -6,7 +6,6 @@ import { Player } from "../../Player";
 import { Resources } from "../../Resources";
 
 export class OrbitalCleanup implements IProjectCard {
-
     public name: CardName = CardName.ORBITAL_CLEANUP;
     public cost: number = 14;
     public tags: Array<Tags> = [Tags.EARTH, Tags.SPACE];

--- a/src/cards/promo/RegoPlastics.ts
+++ b/src/cards/promo/RegoPlastics.ts
@@ -5,7 +5,6 @@ import { Tags } from "../Tags";
 import { Player } from "../../Player";
 
 export class RegoPlastics implements IProjectCard {
-
     public name: CardName = CardName.REGO_PLASTICS;
     public cost: number = 10;
     public tags: Array<Tags> = [Tags.STEEL];

--- a/src/cards/promo/SaturnSurfing.ts
+++ b/src/cards/promo/SaturnSurfing.ts
@@ -8,7 +8,6 @@ import { CardName } from '../../CardName';
 import { Resources } from "../../Resources";
 
 export class SaturnSurfing implements IActionCard, IProjectCard, IResourceCard {
-
     public name: CardName = CardName.SATURN_SURFING;
     public cost: number = 13;
     public tags: Array<Tags> = [Tags.JOVIAN, Tags.EARTH];

--- a/src/cards/promo/SmallAsteroid.ts
+++ b/src/cards/promo/SmallAsteroid.ts
@@ -14,6 +14,7 @@ export class SmallAsteroid implements IProjectCard {
     public name: CardName = CardName.SMALL_ASTEROID;
     public tags: Array<Tags> = [Tags.SPACE];
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const canRaiseTemperature = game.getTemperature() < MAX_TEMPERATURE;

--- a/src/cards/promo/SnowAlgae.ts
+++ b/src/cards/promo/SnowAlgae.ts
@@ -7,7 +7,6 @@ import { Game } from '../../Game';
 import { Resources } from '../../Resources';
 
 export class SnowAlgae implements IProjectCard {
-
     public name: CardName = CardName.SNOW_ALGAE;
     public cost: number = 12;
     public tags: Array<Tags> = [Tags.PLANT];

--- a/src/cards/promo/StanfordTorus.ts
+++ b/src/cards/promo/StanfordTorus.ts
@@ -9,7 +9,6 @@ import { SpaceType } from "../../SpaceType";
 import { CardName } from '../../CardName';
 
 export class StanfordTorus implements IProjectCard {
-    
     public name: CardName = CardName.STANFORD_TORUS;
     public cost: number = 12;
     public tags: Array<Tags> = [Tags.SPACE, Tags.CITY];

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -16,6 +16,7 @@ export class AirScrappingExpedition implements IProjectCard {
     public tags: Array<Tags> = [Tags.VENUS];
     public name: CardName = CardName.AIR_SCRAPPING_EXPEDITION;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -15,6 +15,7 @@ export class CometForVenus implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.COMET_FOR_VENUS;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/src/cards/venusNext/GHGImportFromVenus.ts
+++ b/src/cards/venusNext/GHGImportFromVenus.ts
@@ -14,6 +14,7 @@ export class GHGImportFromVenus implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE, Tags.VENUS];
     public name: CardName = CardName.GHG_IMPORT_FROM_VENUS;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/src/cards/venusNext/GiantSolarShade.ts
+++ b/src/cards/venusNext/GiantSolarShade.ts
@@ -13,6 +13,7 @@ export class GiantSolarShade implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE, Tags.VENUS];
     public name: CardName = CardName.GIANT_SOLAR_SHADE;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const remainingVenusSteps = (MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;

--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -17,6 +17,7 @@ export class HydrogenToVenus implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.HYDROGEN_TO_VENUS;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
     private static readonly venusCardsWithFloaters: Set<CardName> = new Set<CardName>([
         CardName.AERIAL_MAPPERS,
         CardName.CELESTIC,

--- a/src/cards/venusNext/OrbitalReflectors.ts
+++ b/src/cards/venusNext/OrbitalReflectors.ts
@@ -14,6 +14,7 @@ export class OrbitalReflectors  implements IProjectCard {
     public tags: Array<Tags> = [Tags.VENUS, Tags.SPACE];
     public name: CardName = CardName.ORBITAL_REFLECTORS;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const remainingVenusSteps = (MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -14,6 +14,7 @@ export class SulphurExports implements IProjectCard {
     public tags: Array<Tags> = [Tags.VENUS, Tags.SPACE];
     public name: CardName = CardName.SULPHUR_EXPORTS;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -15,6 +15,8 @@ export class VenusMagnetizer implements IActionCard,IProjectCard {
     public tags: Array<Tags> = [Tags.VENUS];
     public name: CardName = CardName.VENUS_MAGNETIZER;
     public cardType: CardType = CardType.ACTIVE;
+    public hasRequirements = false;
+    
     public canPlay(player: Player, game: Game): boolean {
         return game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
     }

--- a/src/cards/venusNext/VenusSoils.ts
+++ b/src/cards/venusNext/VenusSoils.ts
@@ -18,6 +18,7 @@ export class VenusSoils implements IProjectCard {
     public tags: Array<Tags> = [Tags.VENUS, Tags.PLANT];
     public name: CardName = CardName.VENUS_SOILS;
     public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/src/cards/venusNext/WaterToVenus.ts
+++ b/src/cards/venusNext/WaterToVenus.ts
@@ -13,6 +13,7 @@ export class WaterToVenus implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.WATER_TO_VENUS;
     public cardType: CardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game) {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;

--- a/tests/cards/promo/AsteroidHollowing.spec.ts
+++ b/tests/cards/promo/AsteroidHollowing.spec.ts
@@ -15,7 +15,6 @@ describe("AsteroidHollowing", function () {
     });
 
     it("Should play", function () {
-        expect(card.canPlay()).to.eq(true);
         expect(card.play()).to.eq(undefined);
     });
 

--- a/tests/cards/promo/CometAiming.spec.ts
+++ b/tests/cards/promo/CometAiming.spec.ts
@@ -17,7 +17,6 @@ describe("CometAiming", function () {
     });
 
     it("Should play", function () {
-        expect(card.canPlay()).to.eq(true);
         expect(card.play()).to.eq(undefined);
     });
 

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -18,7 +18,6 @@ describe("DirectedImpactors", function () {
     });
     
     it("Should play", function () {
-        expect(card.canPlay()).to.eq(true);
         expect(card.play()).to.eq(undefined);
     });
 


### PR DESCRIPTION
Related to https://github.com/bafolts/terraforming-mars/pull/987

Cards that have `canPlay()` requirement due to Reds ruling policy effect should have `hasRequirements` set to `false`, so that they are not given 2 MC discount by Cutting Edge Technology promo card.