### PR TITLE
Add workaround for Reds tax avoidance

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -137,7 +137,12 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Turmoil Reds capacity
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && game.phase === Phase.ACTION) {
-        game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, true, true, "Select how to pay for TR increase");
+        if (this.canAfford(REDS_RULING_POLICY_COST)) {
+          game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, false, false, "Select how to pay for TR increase");
+        } else {
+          this.megaCredits -= REDS_RULING_POLICY_COST;
+        }
+        
         this.terraformRating++;
         this.hasIncreasedTerraformRatingThisGeneration = true;
         return;
@@ -1940,7 +1945,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         (canUseSteel ? this.steel * this.steelValue : 0) +
         (canUseTitanium ? this.titanium * this.getTitaniumValue(game) : 0) +
           this.megaCredits >= cost;        
-      } 
+      }
       
       return (this.canUseHeatAsMegaCredits ? this.heat : 0) +
               (canUseSteel ? this.steel * this.steelValue : 0) +

--- a/src/cards/AquiferPumping.ts
+++ b/src/cards/AquiferPumping.ts
@@ -28,7 +28,6 @@ export class AquiferPumping implements IActionCard, IProjectCard {
       let oceanCost = 8;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        oceanCost += REDS_RULING_POLICY_COST;
         return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, game, true, false);
       }
 


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1011

This change ensures that the Reds 3 MC tax is always removed from the player, but it can temporarily give rise to negative MC before the next production phase. Possible exploit is as follows:

<img width="548" alt="Screenshot 2020-07-18 at 12 39 31 PM" src="https://user-images.githubusercontent.com/2408094/87844930-abe97280-c8f4-11ea-9aac-b05e24631598.png">

Player can afford Aquifer pumping action (cost 11) when Reds are in play.

<img width="491" alt="Screenshot 2020-07-18 at 12 39 47 PM" src="https://user-images.githubusercontent.com/2408094/87844940-bb68bb80-c8f4-11ea-8708-7e50ee47adc0.png">

Pay for action using all available MC.

<img width="489" alt="Screenshot 2020-07-18 at 12 40 01 PM" src="https://user-images.githubusercontent.com/2408094/87844942-c3c0f680-c8f4-11ea-8325-a416c4da90bd.png">

The Reds tax will still deduct 3 MC from the player in this scenario to prevent tax avoidance.