### PR TITLE
Fix: Restrict no. of cards player can purchase during Research phase

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1030,8 +1030,12 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         );
         game.playerIsFinishedWithResearchPhase(this);
       };
+      
+      let maxPurchaseQty = 4;
 
       if (this.canUseHeatAsMegaCredits) {
+        maxPurchaseQty = Math.min(maxPurchaseQty, Math.floor((this.megaCredits + this.heat) / this.cardCost));
+        
         this.setWaitingFor(
             new AndOptions(() => {
               return undefined;
@@ -1053,11 +1057,13 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
                 (foundCards: Array<IProjectCard>) => {
                   selectedCards = foundCards;
                   return undefined;
-                }, 4, 0
+                }, maxPurchaseQty, 0
             )
             ), () => { payForCards(); }
         );
       } else {
+        maxPurchaseQty = Math.min(maxPurchaseQty, Math.floor(this.megaCredits / this.cardCost));
+
         this.setWaitingFor(
             new SelectCard(
                 "Select which cards to take into hand",
@@ -1066,7 +1072,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
                   htp.megaCredits = foundCards.length * this.cardCost;
                   selectedCards = foundCards;
                   return undefined;
-                }, 4, 0
+                }, maxPurchaseQty, 0
             ), () => { payForCards(); }
         );
       }


### PR DESCRIPTION
<img width="803" alt="Screenshot 2020-07-19 at 10 36 35 AM" src="https://user-images.githubusercontent.com/2408094/87865814-2f19cf80-c9ac-11ea-8e70-549bc1f3d89a.png">

Players should not be able to go into negative MC when purchasing cards during research phase. The max number of cards that can be selected for purchase should be restricted based on the player's available MC (+heat if Helion).