### PR TITLE
Update LocalHeatTrapping.ts

### DIFF
--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -91,6 +91,8 @@ export class LocalHeatTrapping implements IProjectCard {
             );
           }
         
+        player.heat -= 5
+        
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;
     }

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -91,7 +91,7 @@ export class LocalHeatTrapping implements IProjectCard {
             );
           }
         
-        player.heat -= 5
+        player.heat -= 5;
         
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;

--- a/src/cards/LocalHeatTrapping.ts
+++ b/src/cards/LocalHeatTrapping.ts
@@ -26,7 +26,7 @@ export class LocalHeatTrapping implements IProjectCard {
 
         // Helion must be able to pay for both the card and its effect
         if (player.canUseHeatAsMegaCredits) {
-          return player.heat + player.megaCredits >= requiredHeatAmt + player.getCardCost(game, this)
+          return (player.heat >= requiredHeatAmt) && (player.heat + player.megaCredits >= requiredHeatAmt + player.getCardCost(game, this))
         };
 
         return player.heat >= requiredHeatAmt || (player.isCorporation(CardName.STORMCRAFT_INCORPORATED) && (player.getResourcesOnCorporation() * 2) + player.heat >= 5 );
@@ -90,15 +90,6 @@ export class LocalHeatTrapping implements IProjectCard {
 
             );
           }
-
-        // Handle edge case for Helion
-        if (player.heat >= 5) {
-          player.heat -= 5;
-        } else {
-          const shortfall = 5 - player.heat;
-          player.heat = 0;
-          player.megaCredits -= shortfall;
-        }
         
         if (availableActions.options.length === 1) return availableActions.options[0].cb();
         return availableActions;


### PR DESCRIPTION
You cannot use megaCredits as heat. To play this card you MUST have 5 heat.
The tricky part is if the player can use heat as megaCredits then they not only need 5 heat but ALSO heat + megaCredits >= 5 + cardCost
I fixed the return value and removed the spurious code that deducted MC if there was not enough heat.