### PR TITLE
Show ressources on cards

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -467,8 +467,8 @@ function getCorporationCard(player: Player): CardModel | undefined {
 
 function getPlayer(player: Player, game: Game): string {
   const output = {
-    cardsInHand: getCards(player, player.cardsInHand, game),
-    draftedCards: getCards(player, player.draftedCards, game),
+    cardsInHand: getCards(player, player.cardsInHand, game, false),
+    draftedCards: getCards(player, player.draftedCards, game, false),
     milestones: getMilestones(game),
     awards: getAwards(game),
     cardCost: player.cardCost,
@@ -528,11 +528,11 @@ function getPlayer(player: Player, game: Game): string {
   return JSON.stringify(output);
 }
 
-function getCardsAsCardModel(cards: Array<ICard>): Array<CardModel> {
+function getCardsAsCardModel(cards: Array<ICard>, showResouces: boolean = true): Array<CardModel> {
   let result:Array<CardModel> = [];
 
   cards.forEach((card) => {
-    result.push({name: card.name, resources: (card.resourceCount !== undefined ? card.resourceCount : 0), calculatedCost : 0, cardType : CardType.AUTOMATED});
+    result.push({name: card.name, resources: (card.resourceCount !== undefined && showResouces ? card.resourceCount : undefined), calculatedCost : 0, cardType : CardType.AUTOMATED});
   });
 
   return result;
@@ -573,7 +573,7 @@ function getWaitingFor(
       }
       break;
     case PlayerInputTypes.SELECT_HOW_TO_PAY_FOR_CARD:
-      result.cards = getCardsAsCardModel((waitingFor as SelectHowToPayForCard).cards);
+      result.cards = getCardsAsCardModel((waitingFor as SelectHowToPayForCard).cards, false);
       result.microbes = (waitingFor as SelectHowToPayForCard).microbes;
       result.floaters = (waitingFor as SelectHowToPayForCard).floaters;
       result.canUseHeat = (waitingFor as SelectHowToPayForCard).canUseHeat;
@@ -620,10 +620,11 @@ function getWaitingFor(
 function getCards(
     player: Player,
     cards: Array<IProjectCard>,
-    game: Game
+    game: Game,
+    showResouces: boolean = true
 ): Array<CardModel> {
   return cards.map((card) => ({
-    resources: player.getResourcesOnCard(card),
+    resources: showResouces?player.getResourcesOnCard(card):undefined,
     name: card.name,
     calculatedCost: player.getCardCost(game, card),
     cardType: card.cardType

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -397,10 +397,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       return game.getSpaceCount(TileType.CITY, this) + game.getSpaceCount(TileType.CAPITAL, this);
     }
         
-    public getResourcesOnCard(card: ICard): number {
+    public getResourcesOnCard(card: ICard): number | undefined {
       if (card.resourceCount !== undefined) {
         return card.resourceCount;
-      } else return 0;
+      } else return undefined;
     }
 
     public getResourcesOnCorporation():number {
@@ -506,7 +506,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public getResourceCount(resource: ResourceType): number {
       let count: number = 0;
       this.getCardsWithResources().filter(card => card.resourceType === resource).forEach((card) => {
-        count += this.getResourcesOnCard(card);
+        count += this.getResourcesOnCard(card)!;
       });
       return count;
     }
@@ -1203,7 +1203,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public getMicrobesCanSpend(): number {
         for (const playedCard of this.playedCards) {
             if (playedCard.name === CardName.PSYCHROPHILES) {
-                return this.getResourcesOnCard(playedCard);
+                return this.getResourcesOnCard(playedCard)!;
             }
         }
         return 0;
@@ -1213,7 +1213,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       for (const playedCard of this.playedCards) {
 
           if (playedCard.name === CardName.DIRIGIBLES) {
-              return this.getResourcesOnCard(playedCard);
+              return this.getResourcesOnCard(playedCard)!;
           }
       }
       return 0;

--- a/src/awards/Excentric.ts
+++ b/src/awards/Excentric.ts
@@ -8,10 +8,10 @@ export class Excentric implements IAward {
     public getScore(player: Player, _game: Game): number {
         let score: number = 0;
         if (player.corporationCard !== undefined) {
-          score += player.getResourcesOnCard(player.corporationCard);
+          score += player.getResourcesOnCard(player.corporationCard)!;
         }  
         player.playedCards.forEach(card => {
-            score += player.getResourcesOnCard(card);
+            score += player.getResourcesOnCard(card)!;
         });
         return score;
     }   

--- a/src/components/Card.ts
+++ b/src/components/Card.ts
@@ -118,7 +118,7 @@ export const Card = Vue.component("card", {
     },
     template: `
     <div :class="getCardCssClass(card)">
-        <div class="card_resources_counter" v-if="card.resources">RES:<span class="card_resources_counter--number"> {{ card.resources }}</span></div>
+        <div class="card_resources_counter" v-if="card.resources !== undefined">RES:<span class="card_resources_counter--number"> {{ card.resources }}</span></div>
         <div class="card-content-wrapper" v-i18n v-html=this.getCardContent()></div>
     </div>
     `

--- a/src/components/Card.ts
+++ b/src/components/Card.ts
@@ -94,8 +94,7 @@ function getCardContent(cardName: string): string {
 export const Card = Vue.component("card", {
     props: [
         "card",
-        "resources",
-        "player"
+        "actionUsed"
     ],
     methods: {
         getCardContent: function() {
@@ -106,11 +105,7 @@ export const Card = Vue.component("card", {
         },
         getCardCssClass: function (card: CardModel): string {
             var cssClass = "filterDiv card-" + card.name.toLowerCase().replace(/ /g, "-");
-            const wasActivated = (this.player !== undefined
-                                    && this.player.actionsThisGeneration !== undefined
-                                    && this.player.actionsThisGeneration.indexOf(this.card.name) !== -1
-                                ) ? true : false;
-            if (wasActivated) {
+            if (this.actionUsed) {
                 cssClass += " cards-action-was-used"
             }
             return cssClass;

--- a/src/components/Colony.ts
+++ b/src/components/Colony.ts
@@ -5,7 +5,6 @@ import { ColonyName } from '../colonies/ColonyName';
 
 export const Colony = Vue.component("colony", {
     props: [
-        "player",
         "colony"
     ],
     data: function () {

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -6,6 +6,7 @@ import { PlayerResources } from "./PlayerResources";
 import { StackedCards } from './StackedCards';
 import { PlayerMixin } from "./PlayerMixin";
 import { TagCount } from './TagCount';
+import { CardModel } from "../models/CardModel";
 
 
 export const OtherPlayer = Vue.component("other-player", {
@@ -22,7 +23,12 @@ export const OtherPlayer = Vue.component("other-player", {
         },
         isVisible: function () {
             return (this.$root as any).getVisibilityState("other_player_"+this.player.id);
-        }
+        },
+        isCardActivated: function (card: CardModel): boolean {
+            return this.player !== undefined
+            && this.player.actionsThisGeneration !== undefined
+            && this.player.actionsThisGeneration.indexOf(card.name) !== -1;
+        }        
     },
     template: `
         <div> 
@@ -55,10 +61,10 @@ export const OtherPlayer = Vue.component("other-player", {
                     <span class="player_name" :class="'player_bg_color_' + player.color"> {{ player.name }} played cards </span>
                     <div>
                         <div v-if="player.corporationCard !== undefined" class="cardbox">
-                            <card :card="player.corporationCard" :player="player"></card>
+                            <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard)"></card>
                         </div>
                         <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                            <card :card="card" :player="player"></card>
+                            <card :card="card" :actionUsed="isCardActivated(card)"></card>
                         </div>
 
                         <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" :player="player"></stacked-cards>
@@ -70,7 +76,7 @@ export const OtherPlayer = Vue.component("other-player", {
                     <span> Self-Replicating Robots cards </span>
                     <div>
                         <div v-for="card in getCardsByType(player.selfReplicatingRobotsCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                            <card :card="card" :player="player"></card>
+                            <card :card="card"></card>
                         </div>
                     </div>
                 </div>                

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -6,7 +6,6 @@ import { PlayerResources } from "./PlayerResources";
 import { StackedCards } from './StackedCards';
 import { PlayerMixin } from "./PlayerMixin";
 import { TagCount } from './TagCount';
-import { CardModel } from "../models/CardModel";
 
 
 export const OtherPlayer = Vue.component("other-player", {
@@ -23,12 +22,7 @@ export const OtherPlayer = Vue.component("other-player", {
         },
         isVisible: function () {
             return (this.$root as any).getVisibilityState("other_player_"+this.player.id);
-        },
-        isCardActivated: function (card: CardModel): boolean {
-            return this.player !== undefined
-            && this.player.actionsThisGeneration !== undefined
-            && this.player.actionsThisGeneration.indexOf(card.name) !== -1;
-        }        
+        }     
     },
     template: `
         <div> 
@@ -61,10 +55,10 @@ export const OtherPlayer = Vue.component("other-player", {
                     <span class="player_name" :class="'player_bg_color_' + player.color"> {{ player.name }} played cards </span>
                     <div>
                         <div v-if="player.corporationCard !== undefined" class="cardbox">
-                            <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard)"></card>
+                            <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard, player)"></card>
                         </div>
                         <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                            <card :card="card" :actionUsed="isCardActivated(card)"></card>
+                            <card :card="card" :actionUsed="isCardActivated(card, player)"></card>
                         </div>
 
                         <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" :player="player"></stacked-cards>

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -14,7 +14,6 @@ import { LogPanel } from './LogPanel';
 import { PlayerMixin } from './PlayerMixin';
 import { TagCount } from './TagCount';
 import { Turmoil } from './Turmoil';
-import { CardModel } from "../models/CardModel";
 
 const dialogPolyfill = require("dialog-polyfill");
 
@@ -59,11 +58,6 @@ export const PlayerHome = Vue.component("player-home", {
                 fleetsRange.push(i);
             }
             return fleetsRange
-        },
-        isCardActivated: function (card: CardModel): boolean {
-            return this.player !== undefined
-            && this.player.actionsThisGeneration !== undefined
-            && this.player.actionsThisGeneration.indexOf(card.name) !== -1;
         }
     },
     mounted: function () {
@@ -182,10 +176,10 @@ export const PlayerHome = Vue.component("player-home", {
                     <h2 :class="'player_color_'+ player.color" v-i18n>Played Cards</h2>
 
                     <div v-if="player.corporationCard !== undefined" class="cardbox">
-                        <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard)"></card>
+                        <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard, player)"></card>
                     </div>
                     <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                        <card :card="card" :actionUsed="isCardActivated(card)"> </card>
+                        <card :card="card" :actionUsed="isCardActivated(card, player)"> </card>
                     </div>
 
                     <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" ></stacked-cards>

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -14,6 +14,7 @@ import { LogPanel } from './LogPanel';
 import { PlayerMixin } from './PlayerMixin';
 import { TagCount } from './TagCount';
 import { Turmoil } from './Turmoil';
+import { CardModel } from "../models/CardModel";
 
 const dialogPolyfill = require("dialog-polyfill");
 
@@ -58,6 +59,11 @@ export const PlayerHome = Vue.component("player-home", {
                 fleetsRange.push(i);
             }
             return fleetsRange
+        },
+        isCardActivated: function (card: CardModel): boolean {
+            return this.player !== undefined
+            && this.player.actionsThisGeneration !== undefined
+            && this.player.actionsThisGeneration.indexOf(card.name) !== -1;
         }
     },
     mounted: function () {
@@ -176,10 +182,10 @@ export const PlayerHome = Vue.component("player-home", {
                     <h2 :class="'player_color_'+ player.color" v-i18n>Played Cards</h2>
 
                     <div v-if="player.corporationCard !== undefined" class="cardbox">
-                        <card :card="player.corporationCard" :player="player"></card>
+                        <card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard)"></card>
                     </div>
                     <div v-for="card in getCardsByType(player.playedCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                        <card :card="card" :player="player"></card>
+                        <card :card="card" :actionUsed="isCardActivated(card)"> </card>
                     </div>
 
                     <stacked-cards :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" ></stacked-cards>
@@ -190,7 +196,7 @@ export const PlayerHome = Vue.component("player-home", {
                     <h2 :class="'player_color_'+ player.color" v-i18n>Self-Replicating Robots cards</h2>
                     <div>
                         <div v-for="card in getCardsByType(player.selfReplicatingRobotsCards, [getActiveCardType()])" :key="card.name" class="cardbox">
-                            <card :card="card" :player="player"></card>
+                            <card :card="card"></card>
                         </div>
                     </div>
                 </div>

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -266,7 +266,7 @@ export const PlayerHome = Vue.component("player-home", {
                 </div>
                 <div class="player_home_colony_cont">
                     <div class="player_home_colony" v-for="colony in player.colonies" :key="colony.name">
-                        <colony :colony="colony" :player="player"></colony>
+                        <colony :colony="colony"></colony>
                     </div>
                 </div>
             </div>

--- a/src/components/PlayerMixin.ts
+++ b/src/components/PlayerMixin.ts
@@ -1,5 +1,6 @@
 import { CardModel } from '../models/CardModel';
 import { CardType } from '../cards/CardType';
+import { PlayerModel } from "../models/PlayerModel";
 // Common code for player layouts
 
 export const PlayerMixin = {
@@ -24,6 +25,12 @@ export const PlayerMixin = {
         },
         getPreludeCardType: function() {
             return CardType.PRELUDE;
+        },
+        isCardActivated: function (card: CardModel, player: PlayerModel): boolean {
+            return player !== undefined
+            && player.actionsThisGeneration !== undefined
+            && player.actionsThisGeneration.indexOf(card.name) !== -1;
         }
+        
     }
 }

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -2,10 +2,11 @@
 import Vue from "vue";
 
 interface SelectCardModel {
-    cards: Array<string>;
+    cards: Array<CardModel>;
 }
 
 import { Card } from "./Card";
+import { CardModel } from "../models/CardModel";
 
 export const SelectCard = Vue.component("select-card", {
     props: ["playerinput", "onsave", "showsave", "showtitle"],

--- a/src/milestones/Hoverlord.ts
+++ b/src/milestones/Hoverlord.ts
@@ -8,7 +8,7 @@ export class Hoverlord implements IMilestone {
     public getScore(player: Player): number {
         let floaterResources: number = 0;
         player.getCardsWithResources().filter(card => card.resourceType === ResourceType.FLOATER).forEach((card) => {
-            floaterResources += player.getResourcesOnCard(card);
+            floaterResources += player.getResourcesOnCard(card)!;
         });
         return floaterResources;
     }

--- a/src/models/CardModel.ts
+++ b/src/models/CardModel.ts
@@ -2,7 +2,7 @@ import { CardType } from '../cards/CardType';
 
 export interface CardModel {
     name: string;
-    resources: number;
+    resources: number | undefined;
     calculatedCost: number;
     cardType: CardType;
 }


### PR DESCRIPTION
- Cards with 0 resources on it will show RES : 0 instead of nothing.
- Rework card component so there is no need to pass the full player object to it. This should save some server resources.
- Resources on cards will be displayed when prompting cards for selection, like this:

![Screenshot 2020-07-23 09 43 03](https://user-images.githubusercontent.com/56086992/88278790-47a72400-cce3-11ea-808e-4ea2a92b48de.png)


