### PR TITLE
Update IndustrialCenter.ts

### DIFF
--- a/src/cards/IndustrialCenter.ts
+++ b/src/cards/IndustrialCenter.ts
@@ -40,7 +40,8 @@ export class IndustrialCenter implements IActionCard, IProjectCard {
                 if (htp.megaCredits + htp.heat < 7) {
                     throw "Need to spend 7";
                 }
-                player.megaCredits -= 7;
+                player.megaCredits -= htp.megaCredits;
+                player.heat -= htp.heat;
                 player.setProduction(Resources.STEEL);
                 return undefined;
             });


### PR DESCRIPTION
This _may_ be related to #1036. If Helion payed for card action with heat, it would always deduct MC instead.