### PR TITLE
Fix available actions for Astrodrill

### DIFF
--- a/src/cards/promo/Astrodrill.ts
+++ b/src/cards/promo/Astrodrill.ts
@@ -26,54 +26,56 @@ export class Astrodrill implements IActionCard, CorporationCard {
         const asteroidCards = player.getResourceCards(ResourceType.ASTEROID);
         var opts: Array<SelectOption | SelectCard<ICard>> = [];
 
-        const gainStandardResource = new OrOptions(
-            new SelectOption("Gain 1 titanium", () => {
-                player.titanium += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.TITANIUM);
-                return undefined;
-            }),
-            new SelectOption("Gain 1 steel", () => {
-                player.steel += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.STEEL);
-                return undefined;
-            }),
-            new SelectOption("Gain 1 plant", () => {
-                player.plants += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.PLANTS);
-                return undefined;
-            }),
-            new SelectOption("Gain 1 energy", () => {
-                player.energy += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.ENERGY);
-                return undefined;
-            }),
-            new SelectOption("Gain 1 heat", () => {
-                player.heat += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.HEAT);
-                return undefined;
-            }),
-            new SelectOption("Gain 1 MC", () => {
-                player.megaCredits += 1;
-                LogHelper.logGainStandardResource(game, player, Resources.MEGACREDITS);
-                return undefined;
-            })
-        );
+        const gainStandardResource = new SelectOption("Gain a standard resource", () => {
+            return new OrOptions(
+                new SelectOption("Gain 1 titanium", () => {
+                    player.titanium += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.TITANIUM);
+                    return undefined;
+                }),
+                new SelectOption("Gain 1 steel", () => {
+                    player.steel += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.STEEL);
+                    return undefined;
+                }),
+                new SelectOption("Gain 1 plant", () => {
+                    player.plants += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.PLANTS);
+                    return undefined;
+                }),
+                new SelectOption("Gain 1 energy", () => {
+                    player.energy += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.ENERGY);
+                    return undefined;
+                }),
+                new SelectOption("Gain 1 heat", () => {
+                    player.heat += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.HEAT);
+                    return undefined;
+                }),
+                new SelectOption("Gain 1 MC", () => {
+                    player.megaCredits += 1;
+                    LogHelper.logGainStandardResource(game, player, Resources.MEGACREDITS);
+                    return undefined;
+                })
+            );
+        });
 
-        const addResourceToSelf = new SelectOption("Add 1 asteroid to this card and gain a standard resource", () => {
+        const addResourceToSelf = new SelectOption("Add 1 asteroid to this card", () => {
             player.addResourceTo(this);
             LogHelper.logAddResource(game, player, this);
 
-            return gainStandardResource;
+            return undefined;
         });
 
         const addResource = new SelectCard(
-            'Select card to add 1 asteroid and gain a standard resource',
+            "Select card to add 1 asteroid",
             asteroidCards,
             (foundCards: Array<ICard>) => {
                 player.addResourceTo(foundCards[0], 1);
                 LogHelper.logAddResource(game, player, foundCards[0]);
 
-                return gainStandardResource;
+                return undefined;
             }
         );
 
@@ -87,11 +89,7 @@ export class Astrodrill implements IActionCard, CorporationCard {
 
         if (this.resourceCount > 0) opts.push(spendResource);
         asteroidCards.length === 1 ? opts.push(addResourceToSelf) : opts.push(addResource);
-
-        if (opts.length === 1) {
-            if (opts[0] instanceof SelectOption) return (opts[0] as SelectOption).cb() as OrOptions;
-            return opts[0] as SelectCard<ICard>;
-        }
+        opts.push(gainStandardResource);
 
         return new OrOptions(...opts);
     }

--- a/tests/cards/promo/Astrodrill.spec.ts
+++ b/tests/cards/promo/Astrodrill.spec.ts
@@ -27,7 +27,7 @@ describe("Astrodrill", function () {
     it("Should play - can spend asteroid resource", function () {
         const action = card.action(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);
-        expect(action.options.length).to.eq(2);
+        expect(action.options.length).to.eq(3);
 
         // spend asteroid resource
         const spendAsteroidOption = action.options[0];
@@ -36,21 +36,19 @@ describe("Astrodrill", function () {
         expect(game.interrupts.length).to.eq(0);
     });
 
-    it("Should play - can add asteroid resource to self and gain a standard resource", function () {
+    it("Should play - can add asteroid resource to self", function () {
         const action = card.action(player, game) as OrOptions;
         expect(action instanceof OrOptions).to.eq(true);
-        expect(action.options.length).to.eq(2);
+        expect(action.options.length).to.eq(3);
 
         // add asteroid resource and gain standard resource
         const addAsteroidOption = action.options[1] as OrOptions;
-        const resourceChoices = addAsteroidOption.cb()! as OrOptions;
-        resourceChoices.options[2].cb()
-
+        const result = addAsteroidOption.cb();
         expect(card.resourceCount).to.eq(4);
-        expect(player.plants).to.eq(1);
+        expect(result).to.eq(undefined);
     });
 
-    it("Should play - can add asteroid resource to other card and gain a standard resource", function () {
+    it("Should play - can add asteroid resource to other card", function () {
         const cometAiming = new CometAiming();
         player.playedCards.push(cometAiming);
         
@@ -58,20 +56,24 @@ describe("Astrodrill", function () {
         expect(action instanceof OrOptions).to.eq(true);
         const addAsteroidOption = action.options[1] as SelectCard<ICard>;
 
-        const resourceChoices = addAsteroidOption.cb([cometAiming]) as OrOptions;
-        resourceChoices.options[3].cb();
+        const result = addAsteroidOption.cb([cometAiming]);
         expect(cometAiming.resourceCount).to.eq(1);
-        expect(player.energy).to.eq(1);
+        expect(result).to.eq(undefined);
     });
 
-    it("No resources on card - auto select add asteroid option", function () {
-        card.resourceCount = 0;
-        const resourceChoices = card.action(player, game) as OrOptions;
+    it("Should play - can gain a standard resource", function () {
+        const action = card.action(player, game) as OrOptions;
+        expect(action instanceof OrOptions).to.eq(true);
+        expect(action.options.length).to.eq(3);
+
+        const resourceChoices = action.options[2].cb() as OrOptions;
         expect(resourceChoices instanceof OrOptions).to.eq(true);
         expect(resourceChoices.options.length).to.eq(6);
 
         resourceChoices.options[1].cb();
-        expect(card.resourceCount).to.eq(1);
         expect(player.steel).to.eq(1);
+
+        resourceChoices.options[4].cb();
+        expect(player.heat).to.eq(1);
     });
 });


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1026

Astrodrill always has at least two action choices available: Add an asteroid resource to a card, or gain a standard resource.