### PR TITLE
ma css rework

### DIFF
--- a/src/components/Award.ts
+++ b/src/components/Award.ts
@@ -16,6 +16,10 @@ export const Award = Vue.component("award", {
         },
         getNameCss: function(awardName: string): string {
             return "ma-name ma-name--" +  awardName.replace(/ /g, "-").toLowerCase();
+        },
+        toggleMADescription: function(awardName: string) {
+            //TODO - rework this with v-show?
+            document.querySelector(`#${awardName} > .ma-description`)?.classList.toggle("ma-description-hidden");
         }
     },
     template: `
@@ -30,7 +34,7 @@ export const Award = Vue.component("award", {
             </div>
             
             <div v-show="isVisible()">
-                <div v-for="award in awards_list" :class="award.player_name ? 'ma-block pwned-item': 'ma-block'">
+                <div :id="award.award.name" title="press to show or hide the description" v-on:click.prevent="toggleMADescription(award.award.name)" v-for="award in awards_list" :class="award.player_name ? 'ma-block pwned-item': 'ma-block'">
                     <div class="ma-player" v-if="award.player_name"><i :title="award.player_name" :class="'board-cube board-cube--'+award.player_color" /></div>
                     <div class="ma-name--awards" :class="getNameCss(award.award.name)" v-i18n>
                         {{award.award.name}}
@@ -40,7 +44,7 @@ export const Award = Vue.component("award", {
                             )" :class="'ma-score player_bg_color_'+score.playerColor">{{ score.playerScore }}</p>
                         </div>
                     </div>
-                    <div class="ma-description" v-i18n>{{award.award.description}}</div>
+                    <div class="ma-description ma-description-hidden" v-i18n>{{award.award.description}}</div>
                 </div>
             </div>
         </div>

--- a/src/components/Milestone.ts
+++ b/src/components/Milestone.ts
@@ -16,6 +16,10 @@ export const Milestone = Vue.component("milestone", {
         },
         getNameCss: function(milestoneName: string): string {
             return "ma-name ma-name--" +  milestoneName.replace(/ /g, "-").toLowerCase();
+        },
+        toggleMADescription: function(milestoneName: string) {
+            //TODO - rework this with v-show?
+            document.querySelector(`#${milestoneName} > .ma-description`)?.classList.toggle("ma-description-hidden");
         }
     },
     template: `
@@ -29,7 +33,7 @@ export const Milestone = Vue.component("milestone", {
                 </span>
             </div>
             <div v-show="isVisible()">
-                <div v-for="milestone in milestones_list" :class="milestone.player_name ? 'ma-block pwned-item': 'ma-block'">
+                <div :id="milestone.milestone.name" title="press to show or hide the description" v-on:click.prevent="toggleMADescription(milestone.milestone.name)" v-for="milestone in milestones_list" :class="milestone.player_name ? 'ma-block pwned-item': 'ma-block'">
                     <div class="ma-player" v-if="milestone.player_name"><i :title="milestone.player_name" :class="'board-cube board-cube--'+milestone.player_color" /></div>
                     <div class="ma-name--milestones" :class="getNameCss(milestone.milestone.name)" v-i18n>
                         {{milestone.milestone.name}}
@@ -39,7 +43,7 @@ export const Milestone = Vue.component("milestone", {
                             )" :class="'ma-score player_bg_color_'+score.playerColor">{{ score.playerScore }}</p>
                         </div>
                     </div>
-                    <div class="ma-description" v-i18n>{{milestone.milestone.description}}</div>
+                    <div class="ma-description ma-description-hidden" v-i18n>{{milestone.milestone.description}}</div>
                 </div>
             </div>
         </div>

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -209,6 +209,7 @@
         font-family: Ubuntu, Sans;
         letter-spacing: 1px;
         font-size: 16px;
+        font-weight: bold;
         color: #303030;
         text-transform: uppercase;
         background: lightblue;
@@ -222,11 +223,19 @@
         display: inline-block;
         vertical-align: top;
         width: 156px;
+        cursor: pointer;
 
         .ma-score {
-            width: 25px;
             display: inline-block;
             color: white;
+            width: 20px;
+            height: 20px;
+            line-height: 20px;
+            border-radius: 50%;
+            margin: 6px 2px 0 2px;
+            display: inline-block;
+            color: white;
+            font-weight: normal;
         }
     
         .ma-scores {
@@ -242,7 +251,7 @@
         .ma-name {
             display: inline-block;
             width: 156px;
-            height: 97px;
+            height: 99px;
 
             color: #000000b0;
             padding-top: 62px;
@@ -398,6 +407,10 @@
             font-size: 14px;
             line-height: 15px;
             text-align: center;
+        }
+
+        .ma-description-hidden {
+            display: none;
         }
     }
 


### PR DESCRIPTION
## Changes
![Untitled](https://user-images.githubusercontent.com/6917565/88475083-fdb17e80-cf2c-11ea-8993-26401f6cfc2c.png)

- css tweaks
- MA descriptions are hidden
- clicking a MA toggles its description (show/hide)
- added a tooltip to mention that

### TODO
The ma-description divs are targeted with css selectors. 
Implement a proper way to toggle their show/hide states.
