### PR TITLE
throw error if infinite loops are blocking node process

### DIFF
--- a/src/Board.ts
+++ b/src/Board.ts
@@ -1,6 +1,7 @@
 import { ISpace } from "./ISpace";
 import { Player } from "./Player";
 import { SpaceType } from "./SpaceType";
+import { SpaceName } from "./SpaceName";
 import { SpaceBonus } from "./SpaceBonus";
 import { TileType } from "./TileType";
 
@@ -40,14 +41,14 @@ export abstract class Board {
 
     // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript
     // generate random float in [0,1) with seed
-    public mulberry32() {
+    protected mulberry32(): number {
         var t = this.seed += 0x6D2B79F5;
         t = Math.imul(t ^ t >>> 15, t | 1);
         t ^= t + Math.imul(t ^ t >>> 7, t | 61);
         return ((t ^ t >>> 14) >>> 0) / 4294967296;
     }
 
-    public shuffleArray(array: Array<Object>) {
+    public shuffleArray(array: Array<Object>): void {
         for (let i = array.length - 1; i > 0; i--) {
             const j = Math.floor(this.mulberry32() * (i + 1));
             [array[i], array[j]] = [array[j], array[i]];
@@ -60,7 +61,25 @@ export abstract class Board {
             return new Land(idx, pos_x, pos_y, bonus);
         }
     }
-
+    protected shuffleMap(oceans: Array<boolean>, bonuses: Array<Array<SpaceBonus>>, landList: Array<SpaceName>): void {
+        this.shuffleArray(oceans);
+        this.shuffleArray(bonuses);
+        let safety = 0;
+        while (safety < 1000) {
+            let satisfy = true;
+            for (const land of landList) {
+                const land_id = Number(land) - 3;
+                while (oceans[land_id]) {
+                    satisfy = false;
+                    let idx = Math.floor(this.mulberry32() * (oceans.length + 1));
+                    [oceans[land_id], oceans[idx]] = [oceans[idx], oceans[land_id]];
+                }
+            }
+            if (satisfy) return;
+            safety++;
+        }
+        throw new Error("infinite loop detected");
+    }
     public seed: number=0;
     public spaces: Array<ISpace> = [];
     public getAdjacentSpaces(space: ISpace): Array<ISpace> {
@@ -186,12 +205,16 @@ export abstract class Board {
     }
 
     public getRandomCitySpace(offset: number): Space {
-        while (true) {
+        let safety = 0;
+        // avoid bugs which would lock node process
+        while (safety < 1000) {
             let space = this.getRandomSpace(offset);
             if (this.canPlaceTile(space) && this.getAdjacentSpaces(space).find(sp => this.canPlaceTile(sp)) !== undefined) {
                 return space;
             }
+            safety++;
         }
+        throw new Error("space not found for getRandomCitySpace");
     }
 
     protected canPlaceTile(space: ISpace): boolean {

--- a/src/ElysiumBoard.ts
+++ b/src/ElysiumBoard.ts
@@ -9,8 +9,8 @@ export class ElysiumBoard extends Board {
         this.spaces.push(new BoardColony(SpaceName.GANYMEDE_COLONY));
         this.spaces.push(new BoardColony(SpaceName.PHOBOS_SPACE_HAVEN));
 
-        let is_ocean = [];
-        let bonus = [];
+        const is_ocean: Array<boolean> = [];
+        const bonus: Array<Array<SpaceBonus>> = [];
         // y=0
         is_ocean.push(true, true, true, true, false);
         bonus.push([],
@@ -80,23 +80,7 @@ export class ElysiumBoard extends Board {
         bonus.push([SpaceBonus.STEEL], [], [SpaceBonus.DRAW_CARD], [SpaceBonus.DRAW_CARD], [SpaceBonus.STEEL, SpaceBonus.STEEL]);
         
         if (shuffleMapOption) {
-            this.shuffleArray(is_ocean);
-            this.shuffleArray(bonus);
-            while (true) {
-                let satisfy = true;
-                let land_list: Array<SpaceName> = [
-                    SpaceName.HECATES_THOLUS, SpaceName.ELYSIUM_MONS, SpaceName.ARSIA_MONS_ELYSIUM, SpaceName.OLYMPUS_MONS
-                ];
-                for (let land of land_list) {
-                    let land_id = Number(land) - 3;
-                    while (is_ocean[land_id]) {
-                        satisfy = false;
-                        let idx = Math.floor(this.mulberry32() * (is_ocean.length + 1));
-                        [is_ocean[land_id], is_ocean[idx]] = [is_ocean[idx], is_ocean[land_id]];
-                    }
-                }
-                if (satisfy) break;
-            }
+            this.shuffleMap(is_ocean, bonus, [SpaceName.HECATES_THOLUS, SpaceName.ELYSIUM_MONS, SpaceName.ARSIA_MONS_ELYSIUM, SpaceName.OLYMPUS_MONS]);
         }
 
         let idx = 3, me_id = 0;

--- a/src/OriginalBoard.ts
+++ b/src/OriginalBoard.ts
@@ -1,6 +1,6 @@
 import { SpaceBonus } from "./SpaceBonus";
 import { SpaceName } from "./SpaceName";
-import { Board, Land, BoardColony, Space } from "./Board";
+import { Board, Land, BoardColony } from "./Board";
 import { Player } from "./Player";
 import { ISpace } from "./ISpace";
 
@@ -12,8 +12,8 @@ export class OriginalBoard extends Board {
         this.spaces.push(new BoardColony(SpaceName.GANYMEDE_COLONY));
         this.spaces.push(new BoardColony(SpaceName.PHOBOS_SPACE_HAVEN));
 
-        let is_ocean = [];
-        let bonus = [];
+        const is_ocean: Array<boolean> = [];
+        const bonus: Array<Array<SpaceBonus>> = [];
         // y=0
         is_ocean.push(false, true, false, true, true);
         bonus.push([SpaceBonus.STEEL, SpaceBonus.STEEL], [SpaceBonus.STEEL, SpaceBonus.STEEL], [], [SpaceBonus.DRAW_CARD], []);
@@ -73,21 +73,7 @@ export class OriginalBoard extends Board {
         bonus.push([SpaceBonus.STEEL], [SpaceBonus.STEEL, SpaceBonus.STEEL], [], [], [SpaceBonus.TITANIUM, SpaceBonus.TITANIUM]);
 
         if (shuffleMapOption) {
-            this.shuffleArray(is_ocean);
-            this.shuffleArray(bonus);
-            while (true) {
-                let satisfy = true;
-                let land_list = [SpaceName.NOCTIS_CITY, SpaceName.THARSIS_THOLUS, SpaceName.ASCRAEUS_MONS, SpaceName.ARSIA_MONS, SpaceName.PAVONIS_MONS];
-                for (let land of land_list) {
-                    let land_id = Number(land) - 3;
-                    while (is_ocean[land_id]) {
-                        satisfy = false;
-                        let idx = Math.floor(this.mulberry32() * (is_ocean.length + 1));
-                        [is_ocean[land_id], is_ocean[idx]] = [is_ocean[idx], is_ocean[land_id]];
-                    }
-                }
-                if (satisfy) break;
-            }
+            this.shuffleMap(is_ocean, bonus, [SpaceName.NOCTIS_CITY, SpaceName.THARSIS_THOLUS, SpaceName.ASCRAEUS_MONS, SpaceName.ARSIA_MONS, SpaceName.PAVONIS_MONS]);
         }
 
         let pos_x = 4, pos_y = 0;
@@ -153,19 +139,9 @@ export class OriginalBoard extends Board {
     public getAvailableSpacesOnLand(player: Player): Array<ISpace> {
         return super.getAvailableSpacesOnLand(player).filter((space) => space.id !== SpaceName.NOCTIS_CITY);
     }
-    public getRandomCitySpace(offset: number): Space {
-        while (true) {
-            let space = super.getRandomSpace(offset);
-            if (this.canPlaceTile(space) && this.getAdjacentSpaces(space).find(sp => this.canPlaceTile(sp)) !== undefined) {
-                return space;
-            }
-        }
-    }
-
     protected canPlaceTile(space: ISpace): boolean {
         return space !== undefined && space.tile === undefined && space instanceof Land && space.id !== SpaceName.NOCTIS_CITY;
     }
-
     public getForestSpace(spaces: Array<ISpace>): ISpace {
         const space = super.shuffle(spaces).find((s) => this.canPlaceTile(s));
         if (space === undefined) {

--- a/tests/Board.spec.ts
+++ b/tests/Board.spec.ts
@@ -36,4 +36,9 @@ describe("Board", function () {
         const availableSpaces = board.getAvailableSpacesForGreenery(player1);
         expect(availableSpaces.length).to.eq(1);
     });
+    it("doesnt block node process when bug with getRandomCitySpace", function () {
+        const board = new OriginalBoard();
+        (board as any).canPlaceTile = function () { return false; };
+        expect(function () { board.getRandomCitySpace(0); }).to.throw("space not found for getRandomCitySpace");
+    });
 });


### PR DESCRIPTION
We can not have `while (true)` loops running as they can potentially take over the node process. One of these I assume looped indefinitely yesterday and took down the heroku instance. I have put in guards around every usage of `while (true)` and consolidated some of the code which was using this pattern.