### PR TITLE
Reds' ruling bonus  for solo

### DIFF
--- a/src/turmoil/globalEvents/SnowCover.ts
+++ b/src/turmoil/globalEvents/SnowCover.ts
@@ -6,7 +6,7 @@ import { Turmoil } from '../Turmoil';
 import { MAX_TEMPERATURE } from '../../constants';
 
 export class SnowCover implements IGlobalEvent {
-    public name = GlobalEventName.SPONSORED_PROJECTS;
+    public name = GlobalEventName.SNOW_COVER;
     public description = "Decrease temperature 2 steps. Draw 1 card per influence.";
     public revealedDelegate = PartyName.KELVINISTS;
     public currentDelegate = PartyName.KELVINISTS;

--- a/src/turmoil/parties/Reds.ts
+++ b/src/turmoil/parties/Reds.ts
@@ -23,7 +23,7 @@ export class Reds extends Party implements IParty {
         // Different ruling if we only have on player
         else {
             const player = game.getPlayers()[0];
-            if(player.getTerraformRating() < 20) {
+            if(player.getTerraformRating() <= 20) {
                 player.increaseTerraformRating(game);
             }
         }


### PR DESCRIPTION
RULING BONUS: The player with lowest TR gains 1 TR. Ties are friendly. In solo, you receive 1 TR if you **have TR 20 or below**. 