### PR TITLE
Disable beginner corp if option selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Terraforming Mars Boardgame
 
 The board game is great, this repository highly recommends purchasing [it](https://www.amazon.com/Stronghold-Games-6005SG-Terraforming-Board/dp/B01GSYA4K2) for personal use. If you want to play with people online, you can use this tool.
 
+Join us on Discord [here](https://discord.gg/fWXE53K).
+
 ## Demo
 
 You can try online [here](https://terraforming-mars.herokuapp.com/). Please post any issues found. If you plan on playing long running games it is recommended to host the game locally. This demo site is currently not stable and gets restarted during each push to `master`. As this repository is gaining in popularity we attempt to make this demo page stable but it can't be guaranteed that your game will not be lost. Running the game locally will always be straight forward and it is highly recommended to host the game locally and provide the server ip to other players.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Thanks goes to these wonderful people:
     </td>
     <td align="center">
       <a href="https://github.com/ssimeonoff"><img src="https://avatars3.githubusercontent.com/u/6917565?s=460&v=4" width="100px;" alt=""/><br />
-        <sub><b>Simeon Simeonov</b></sub><br />Cards and Colonies design</a>
+        <sub><b>Simeon Simeonov</b></sub><br />UX, cards and Colonies design</a>
     </td>
     <td align="center">
       <a href="https://github.com/pierrehilbert"><img src="https://avatars0.githubusercontent.com/u/806950?v=3" width="100px;" alt=""/><br />

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -291,19 +291,13 @@ export class Game implements ILoadable<SerializedGame, Game> {
             }
           }
 
-          if (!this.corporateEra) {
-            player.setProduction(Resources.MEGACREDITS);
-            player.setProduction(Resources.STEEL);
-            player.setProduction(Resources.TITANIUM);
-            player.setProduction(Resources.PLANTS);
-            player.setProduction(Resources.ENERGY);
-            player.setProduction(Resources.HEAT);
-          }
+          this.setStartingProductions(player);
 
           if (!gameOptions.initialDraftVariant) {
             player.setWaitingFor(this.pickCorporationCard(player), () => {});
           }
         } else {
+          this.setStartingProductions(player);
           this.playCorporationCard(player, new BeginnerCorporation());
         }
       }
@@ -322,6 +316,17 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.initialDraft = true;
         this.runDraftRound(true);
         return;
+      }
+    }
+
+    private setStartingProductions(player: Player) {
+      if (!this.corporateEra) {
+        player.setProduction(Resources.MEGACREDITS);
+        player.setProduction(Resources.STEEL);
+        player.setProduction(Resources.TITANIUM);
+        player.setProduction(Resources.PLANTS);
+        player.setProduction(Resources.ENERGY);
+        player.setProduction(Resources.HEAT);
       }
     }
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -268,7 +268,13 @@ export class Game implements ILoadable<SerializedGame, Game> {
         const player = players[i];
         const remainingPlayers = this.players.length - i;
         
-        if (!player.beginner) {
+        if (!player.beginner ||
+          // Bypass beginner choice if any extension is choosen
+              gameOptions.preludeExtension || 
+              gameOptions.venusNextExtension || 
+              gameOptions.coloniesExtension || 
+              gameOptions.turmoilExtension ||
+              gameOptions.initialDraftVariant) {
           // Failsafe for exceding corporation pool
           if (this.startingCorporations * remainingPlayers > corporationCards.length) {
             this.startingCorporations = 2;
@@ -298,7 +304,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           }
         } else {
           this.setStartingProductions(player);
-          this.playCorporationCard(player, new BeginnerCorporation());
+          this.playerHasPickedCorporationCard(player, new BeginnerCorporation() );
         }
       }
 


### PR DESCRIPTION
Bypass beginner corp choice if any extension is selected (along with initial draft)
Fix a bug where game was struck if a beginner corp was selected
Update discord link with a non expiring invitation

Some work is still needed on the UI to disable beginner corp selector if any extension is selected (along with initial draft)