### PR TITLE
Display dynamic target score at game end

### DIFF
--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -47,7 +47,7 @@ export const GameEnd = Vue.component("game-end", {
                             <ul class="game_end_list">
                                 <li v-i18n>Try to win with expansions enabled</li>
                                 <li v-i18n>Try to win before the last generation comes</li>
-                                <li v-i18n>Can you get 90+ Victory Points?</li>
+                                <li><span v-i18n>Can you get</span> {{ player.victoryPointsBreakdown.total + 10 }}<span v-i18n>+ Victory Points?</span></li>
                             </ul>
                         </div>
                     </div>

--- a/src/locales/de/game_end.json
+++ b/src/locales/de/game_end.json
@@ -11,7 +11,8 @@
     "But it isn't the reason to stop making Mars better.": "Aber das ist kein Grund den Mars nicht noch besser zu machen.",
     "Try to win with expansions enabled": "Versuche mit aktivierten Erweiterungen zu gewinnen.",
     "Try to win before the last generation comes": "Versuche vor der letzten Generation zu gewinnen.",
-    "Can you get 90+ Victory Points?": "Schaffst du es 90 oder mehr Siegpunkte zu erreichen?",
+    "Can you get": "Schaffst du es",
+    "+ Victory Points?": " oder mehr Siegpunkte zu erreichen?",
 
     "Victory points breakdown after": "Siegpunkteaufschlüsselung nach",
     "generations": "Generationen",

--- a/src/locales/ru/game_end.json
+++ b/src/locales/ru/game_end.json
@@ -11,7 +11,8 @@
     "But it isn't the reason to stop making Mars better.": "Но это не повод останавливаться на достигнутом.",
     "Try to win with expansions enabled": "Попробуйте победить с дополнениями",
     "Try to win before the last generation comes": "Попробуйте победить до наступления последнего поколения",
-    "Can you get 90+ Victory Points?": "Сможете набрать 90+ победных очков?",
+    "Can you get": "Сможете набрать",
+    "+ Victory Points?": "+ победных очков?",
 
     "Victory points breakdown after": "Победные очки после",
     "generations": "поколений",


### PR DESCRIPTION
Some users pointed out that the displayed target is always a static value of 90+. Minor improvement to show a dynamic target based on the player's actual score (arbitrary value of player's score + 10)

<img width="750" alt="Screenshot 2020-07-31 at 7 56 02 PM" src="https://user-images.githubusercontent.com/2408094/89033248-f3e2ad80-d368-11ea-8045-e44049d14f0c.png">
<img width="542" alt="Screenshot 2020-07-31 at 7 56 15 PM" src="https://user-images.githubusercontent.com/2408094/89033251-f47b4400-d368-11ea-8be2-9d5608b1378b.png">
<img width="686" alt="Screenshot 2020-07-31 at 7 55 47 PM" src="https://user-images.githubusercontent.com/2408094/89033229-f04f2680-d368-11ea-8e5d-12da34b77e3e.png">
