### PR TITLE
Select how to pay cleanup

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1019,19 +1019,21 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public playerIsFinishedWithResearchPhase(player: Player): void {
       this.researchedPlayers.add(player.id);
-      if (this.allPlayersHaveFinishedResearch() && this.interrupts.length === 0) {
-        this.gotoActionPhase();
-      } else if (this.allPlayersHaveFinishedResearch() && this.interrupts.length > 0 ) {
+      if (this.allPlayersHaveFinishedResearch()) {
+        if (this.interrupts.length === 0) {
+          this.gotoActionPhase();
+        } else {
         // Resolve research interrupt (Helion player)
-        let interrupt = this.interrupts.shift();
-        if (interrupt !== undefined && interrupt.playerInput !== undefined) {
-          if (interrupt.beforeAction !== undefined) {
-            interrupt.beforeAction();
-          }
-          interrupt.player.setWaitingFor(interrupt.playerInput, () => {
-            this.playerIsFinishedWithResearchPhase(player);
-            return;
-          });
+          let interrupt = this.interrupts.shift();
+          if (interrupt !== undefined && interrupt.playerInput !== undefined) {
+            if (interrupt.beforeAction !== undefined) {
+              interrupt.beforeAction();
+            }
+            interrupt.player.setWaitingFor(interrupt.playerInput, () => {
+              this.playerIsFinishedWithResearchPhase(player);
+              return;
+            });
+          }          
         }
       }
     }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1019,8 +1019,20 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public playerIsFinishedWithResearchPhase(player: Player): void {
       this.researchedPlayers.add(player.id);
-      if (this.allPlayersHaveFinishedResearch()) {
+      if (this.allPlayersHaveFinishedResearch() && this.interrupts.length === 0) {
         this.gotoActionPhase();
+      } else if (this.allPlayersHaveFinishedResearch() && this.interrupts.length > 0 ) {
+        // Resolve research interrupt (Helion player)
+        let interrupt = this.interrupts.shift();
+        if (interrupt !== undefined && interrupt.playerInput !== undefined) {
+          if (interrupt.beforeAction !== undefined) {
+            interrupt.beforeAction();
+          }
+          interrupt.player.setWaitingFor(interrupt.playerInput, () => {
+            this.playerIsFinishedWithResearchPhase(player);
+            return;
+          });
+        }
       }
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1000,7 +1000,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       const payForCards = () => {
         const purchasedCardsCost = this.cardCost * selectedCards.length;
-        game.addSelectHowToPayInterrupt(this, purchasedCardsCost, false, false, "Select how to pay " + purchasedCardsCost + " for purchasing " + selectedCards.length + " card(s)");
+        if (selectedCards.length > 0) {
+          game.addSelectHowToPayInterrupt(this, purchasedCardsCost, false, false, "Select how to pay " + purchasedCardsCost + " for purchasing " + selectedCards.length + " card(s)");
+        }
         selectedCards.forEach((card) => {
           this.cardsInHand.push(card);
         });

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1502,32 +1502,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       });      
       let howToPayForTrade = new OrOptions();
       howToPayForTrade.title = "Trade with a colony";
+
       const payWithMC = new SelectOption("Pay " + (9 - this.colonyTradeDiscount) +" MC", () => {
-        this.megaCredits -= (9 - this.colonyTradeDiscount);
+        game.addSelectHowToPayInterrupt(this, 9 - this.colonyTradeDiscount, false, false, "Select how to pay " + (9 - this.colonyTradeDiscount) + " for colony trade");
         return selectColony;
       });
-
-      if (this.canAfford(9, game) && this.canUseHeatAsMegaCredits && this.heat > 0) {
-        let htp: HowToPay;
-        let helionTrade = new SelectHowToPay(
-          "Select how to spend " + (9 - this.colonyTradeDiscount) +" MC",
-          false,
-          false,
-          true,
-          (9 - this.colonyTradeDiscount),
-          (stp) => {
-            htp = stp;
-            this.megaCredits -= htp.megaCredits;
-            this.heat -= htp.heat;
-            return selectColony;
-          }
-        )
-        howToPayForTrade.options.push(helionTrade);
-
-      } else if (this.canAfford((9 - this.colonyTradeDiscount))) {
-        howToPayForTrade.options.push(payWithMC);
-      }
-
       const payWithEnergy = new SelectOption("Pay " + (3 - this.colonyTradeDiscount) +" Energy", () => {
         this.energy -= (3 - this.colonyTradeDiscount);
         return selectColony;
@@ -1537,6 +1516,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         return selectColony;  
       });
 
+      if (this.canAfford((9 - this.colonyTradeDiscount))) howToPayForTrade.options.push(payWithMC);
       if (this.energy >= (3 - this.colonyTradeDiscount)) howToPayForTrade.options.push(payWithEnergy);
       if (this.titanium >= (3 - this.colonyTradeDiscount)) howToPayForTrade.options.push(payWithTitanium);
 

--- a/src/cards/AquiferPumping.ts
+++ b/src/cards/AquiferPumping.ts
@@ -4,9 +4,6 @@ import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
-import {HowToPay} from '../inputs/HowToPay';
-import {AndOptions} from '../inputs/AndOptions';
-import {SelectHowToPay} from '../inputs/SelectHowToPay';
 import { CardName } from '../CardName';
 import { PartyHooks } from '../turmoil/parties/PartyHooks';
 import { PartyName } from '../turmoil/parties/PartyName';
@@ -34,30 +31,8 @@ export class AquiferPumping implements IActionCard, IProjectCard {
       return player.canAfford(oceanCost, game, true, false);
     }
     public action(player: Player, game: Game) {
-      let howToPay: HowToPay;
-      return new AndOptions(
-          () => {
-            if (
-              (howToPay.steel * player.steelValue) +
-              howToPay.megaCredits +
-              howToPay.heat < 8
-            ) {
-              throw new Error('Need to pay 8');
-            }
-            player.steel -= howToPay.steel;
-            player.heat -= howToPay.heat;
-            player.megaCredits -= howToPay.megaCredits;
-            game.addOceanInterrupt(player);
-            return undefined;
-          },
-          new SelectHowToPay(
-              'Select how to pay for action', true, false,
-              player.canUseHeatAsMegaCredits, 8,
-              (htp: HowToPay) => {
-                howToPay = htp;
-                return undefined;
-              }
-          )
-      );
+      game.addOceanInterrupt(player);
+      game.addSelectHowToPayInterrupt(player, 8, true, false, "Select how to pay for action");
+      return undefined;
     }
 }

--- a/src/cards/BusinessNetwork.ts
+++ b/src/cards/BusinessNetwork.ts
@@ -3,7 +3,6 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {SelectCard} from '../inputs/SelectCard';
-import {SelectHowToPay} from '../inputs/SelectHowToPay';
 import {IActionCard} from './ICard';
 import {IProjectCard} from './IProjectCard';
 import { Resources } from '../Resources';
@@ -39,26 +38,9 @@ export class BusinessNetwork implements IActionCard, IProjectCard {
             game.dealer.discard(dealtCard);
             return undefined;
           }
-          if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay(
-              'Select how to pay and buy ' + dealtCard.name, false, false,
-              true, player.cardCost,
-              (htp) => {
-                if (htp.heat + htp.megaCredits < player.cardCost) {
-                  game.dealer.discard(dealtCard);
-                  throw new Error('Not enough spent to buy card');
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                LogHelper.logCardChange(game, player, "drew", 1);
-                player.cardsInHand.push(dealtCard);
-                return undefined;
-              }
-            );
-          }
           LogHelper.logCardChange(game, player, "drew", 1);
           player.cardsInHand.push(dealtCard);
-          player.megaCredits -= player.cardCost;
+          game.addSelectHowToPayInterrupt(player, player.cardCost, false, false, "Select how to pay for action");
           return undefined;
         }, canSelectCard ? 1 : 0 , 0
       );

--- a/src/cards/IndustrialCenter.ts
+++ b/src/cards/IndustrialCenter.ts
@@ -5,7 +5,6 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { TileType } from "../TileType";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { SelectSpace } from "../inputs/SelectSpace";
 import { ISpace } from "../ISpace";
 import { Resources } from '../Resources';
@@ -34,19 +33,8 @@ export class IndustrialCenter implements IActionCard, IProjectCard {
     public canAct(player: Player): boolean {
         return player.canAfford(7);
     }
-    public action(player: Player, _game: Game) {
-        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay("Select how to pay for action", false, false, true, 7, (htp) => {
-                if (htp.megaCredits + htp.heat < 7) {
-                    throw "Need to spend 7";
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                player.setProduction(Resources.STEEL);
-                return undefined;
-            });
-        }
-        player.megaCredits -= 7;
+    public action(player: Player, game: Game) {
+        game.addSelectHowToPayInterrupt(player, 7, false, false, "Select how to pay for action");
         player.setProduction(Resources.STEEL);
         return undefined;
     }

--- a/src/cards/InventorsGuild.ts
+++ b/src/cards/InventorsGuild.ts
@@ -2,7 +2,6 @@ import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import {SelectCard} from '../inputs/SelectCard';
 import { IProjectCard } from "./IProjectCard";
 import { IActionCard } from "./ICard";
@@ -33,26 +32,9 @@ export class InventorsGuild implements IActionCard, IProjectCard {
               game.dealer.discard(dealtCard);
               return undefined;
             }
-            if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-              return new SelectHowToPay(
-                'Select how to pay and buy ' + dealtCard.name, false, false,
-                true, player.cardCost,
-                (htp) => {
-                  if (htp.heat + htp.megaCredits < player.cardCost) {
-                    game.dealer.discard(dealtCard);
-                    throw new Error('Not enough spent to buy card');
-                  }
-                  player.megaCredits -= htp.megaCredits;
-                  player.heat -= htp.heat;
-                  LogHelper.logCardChange(game, player, "drew", 1);
-                  player.cardsInHand.push(dealtCard);
-                  return undefined;
-                }
-              );
-            }
             LogHelper.logCardChange(game, player, "drew", 1);
             player.cardsInHand.push(dealtCard);
-            player.megaCredits -= player.cardCost;
+            game.addSelectHowToPayInterrupt(player, player.cardCost, false, false, "Select how to pay for action");
             return undefined;
           }, canSelectCard ? 1 : 0 , 0
         );

--- a/src/cards/RestrictedArea.ts
+++ b/src/cards/RestrictedArea.ts
@@ -6,7 +6,6 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { TileType } from "../TileType";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { SelectSpace } from "../inputs/SelectSpace";
 import { ISpace } from "../ISpace";
 import { CardName } from "../CardName";
@@ -31,18 +30,7 @@ export class RestrictedArea implements IActionCard, IProjectCard {
         return player.canAfford(2);
     }
     public action(player: Player, game: Game) {
-        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay("Select how to pay for action", false, false, true, 2, (htp) => {
-                if (htp.heat + htp.megaCredits < 2) {
-                    throw "Not enough spent";
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                player.cardsInHand.push(game.dealer.dealCard());
-                return undefined;
-            });
-        }
-        player.megaCredits -= 2;
+        game.addSelectHowToPayInterrupt(player, 2, false, false, "Select how to pay for action");
         player.cardsInHand.push(game.dealer.dealCard());
         return undefined;
     }

--- a/src/cards/SearchForLife.ts
+++ b/src/cards/SearchForLife.ts
@@ -6,7 +6,6 @@ import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { ResourceType } from "../ResourceType";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { CardName } from '../CardName';
 import { LogMessageType } from "../LogMessageType";
 import { LogMessageData } from "../LogMessageData";
@@ -35,33 +34,20 @@ export class SearchForLife implements IActionCard, IProjectCard, IResourceCard {
         return player.canAfford(1);
     }
     public action(player: Player, game: Game) {
-        const doAction = () => {
-            const topCard = game.dealer.dealCard();
-            if (topCard.tags.indexOf(Tags.MICROBES) !== -1) {
-                this.resourceCount++;
-            }
-
-            game.log(
-                LogMessageType.DEFAULT,
-                "${0} revealed and discarded ${1}",
-                new LogMessageData(LogMessageDataType.PLAYER, player.id),
-                new LogMessageData(LogMessageDataType.CARD, topCard.name)
-            );
-            
-            game.dealer.discard(topCard);
-            return undefined;
-        };
-        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay("Select how to pay for action", false, false, true, 1,(htp) => {
-                if (htp.heat + htp.megaCredits < 1) {
-                    throw "Need to spend at least one";
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                return doAction();
-            });
+                const topCard = game.dealer.dealCard();
+        if (topCard.tags.indexOf(Tags.MICROBES) !== -1) {
+            this.resourceCount++;
         }
-        player.megaCredits--;
-        return doAction();
+
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} revealed and discarded ${1}",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.CARD, topCard.name)
+        );
+        
+        game.dealer.discard(topCard);
+        game.addSelectHowToPayInterrupt(player, 1, false, false, "Select how to pay for action");
+        return undefined;
     }
 }

--- a/src/cards/SpaceMirrors.ts
+++ b/src/cards/SpaceMirrors.ts
@@ -4,9 +4,9 @@ import { IActionCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
-import { Resources } from '../Resources';
-import { CardName } from '../CardName';
+import { Resources } from "../Resources";
+import { CardName } from "../CardName";
+import { Game } from "../Game";
 
 export class SpaceMirrors implements IActionCard, IProjectCard {
     public cost: number = 3;
@@ -20,19 +20,8 @@ export class SpaceMirrors implements IActionCard, IProjectCard {
     public canAct(player: Player): boolean {
         return player.canAfford(7);
     }
-    public action(player: Player) {
-        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay("Select how to pay for action", false, false, true, 7, (htp) => {
-                if (htp.megaCredits + htp.heat < 7) {
-                    throw "Not enough spent";
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                player.setProduction(Resources.ENERGY);
-                return undefined;
-            });
-        }
-        player.megaCredits -= 7;
+    public action(player: Player, game: Game) {
+        game.addSelectHowToPayInterrupt(player, 7, false, false, "Select how to pay for action");
         player.setProduction(Resources.ENERGY);
         return undefined;
     }

--- a/src/cards/UndergroundDetonations.ts
+++ b/src/cards/UndergroundDetonations.ts
@@ -5,7 +5,6 @@ import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { Resources } from '../Resources';
 import { CardName } from '../CardName';
 
@@ -18,23 +17,12 @@ export class UndergroundDetonations implements IActionCard, IProjectCard {
     public canAct(player: Player): boolean {
         return player.canAfford(10);
     }
-    public action(player: Player, _game: Game) {
-        if (player.canUseHeatAsMegaCredits && player.heat > 0) {
-            return new SelectHowToPay("Select how to pay for action", false, false, true, 10, (htp) => {
-                if (htp.heat + htp.megaCredits < 10) {
-                    throw "Need to spend 10";
-                }
-                player.heat -= htp.heat;
-                player.megaCredits -= htp.megaCredits;
-                player.setProduction(Resources.HEAT,2);
-                return undefined;
-            });
-        }
-        player.megaCredits -= 10;
+    public action(player: Player, game: Game) {
+        game.addSelectHowToPayInterrupt(player, 10, false, false, "Select how to pay for action");
         player.setProduction(Resources.HEAT,2);
         return undefined;
     }
-    public play(_player: Player, _game: Game) {
+    public play() {
         return undefined;
     }
 }

--- a/src/cards/WaterImportFromEuropa.ts
+++ b/src/cards/WaterImportFromEuropa.ts
@@ -5,9 +5,6 @@ import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
-import { AndOptions } from "../inputs/AndOptions";
-import { HowToPay } from "../inputs/HowToPay";
-import { SelectHowToPay } from "../inputs/SelectHowToPay";
 import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from '../constants';
 import { CardName } from '../CardName';
 import { PartyHooks } from "../turmoil/parties/PartyHooks";
@@ -38,22 +35,8 @@ export class WaterImportFromEuropa implements IActionCard, IProjectCard {
         return player.canAfford(oceanCost, game, false, true);;
     }
     public action(player: Player, game: Game) {
-        let htp: HowToPay;
-        return new AndOptions(
-            () => {
-                if ((player.canUseHeatAsMegaCredits ? htp.heat : 0) + htp.megaCredits + (htp.titanium * player.getTitaniumValue(game)) < 12) {
-                    throw "Need to spend at least 12";
-                }
-                game.addOceanInterrupt(player);
-                player.titanium -= htp.titanium;
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                return undefined;
-            },
-            new SelectHowToPay("Select how to pay for action", false, true, player.canUseHeatAsMegaCredits, 12, (howToPay: HowToPay) => {
-                htp = howToPay;
-                return undefined;
-            })
-        );
+        game.addOceanInterrupt(player);
+        game.addSelectHowToPayInterrupt(player, 12, false, true, "Select how to pay for action");
+        return undefined;        
     }
 }

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -4,7 +4,6 @@ import { Tags } from "../Tags";
 import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { ResourceType } from "../../ResourceType";
-import { SelectHowToPay } from '../../inputs/SelectHowToPay';
 import { OrOptions } from '../../inputs/OrOptions';
 import { SelectOption } from '../../inputs/SelectOption';
 import { Game } from '../../Game';
@@ -59,21 +58,9 @@ export class RotatorImpacts implements IActionCard,IProjectCard, IResourceCard {
     }
 
     private addResource(player: Player, game: Game) {
-        return new SelectHowToPay(
-            'Select how to pay ', false, true,
-            player.canUseHeatAsMegaCredits,
-            6,
-            (htp) => {
-                if (htp.heat + htp.megaCredits + htp.titanium * player.getTitaniumValue(game) < 6) {
-                    throw new Error('Not enough for action');
-                }
-                player.megaCredits -= htp.megaCredits;
-                player.heat -= htp.heat;
-                player.titanium -= htp.titanium;
-                this.resourceCount++;
-                return undefined;
-            }
-        );
+        game.addSelectHowToPayInterrupt(player, 6, false, true, "Select how to pay for action");
+        this.resourceCount++;
+        return undefined;
     }
 
     private spendResource(player: Player, game: Game) {

--- a/tests/cards/AquiferPumping.spec.ts
+++ b/tests/cards/AquiferPumping.spec.ts
@@ -18,39 +18,15 @@ describe("AquiferPumping", function () {
     });
 
     it("Should action", function () {
-        const action = card.action(player, game);
-        expect(action).not.to.eq(undefined);
         player.megaCredits = 8;
+        const action = card.action(player, game);
+        expect(action).to.eq(undefined);
 
-        action.options[0].cb({
-            heat: 0,
-            steel: 0,
-            titanium: 0,
-            megaCredits: 8
-        });
-
-        action.cb();
         expect(player.megaCredits).to.eq(0);
 
-        action.options[0].cb({
-            heat: 0,
-            steel: 0,
-            titanium: 0,
-            megaCredits: 7
-        });
-        expect(function () { action.cb(); }).to.throw("Need to pay 8");
     });
 
     it("Cannot action if not enough to pay", function () {
         expect(card.canAct(player, game)).to.eq(false);
-        const action = card.action(player, game);
-        
-        action.options[0].cb({
-            heat: 0,
-            steel: 0,
-            titanium: 0,
-            megaCredits: 7
-        });
-        expect(function () { action.cb(); }).to.throw("Need to pay 8");
     });
 });

--- a/tests/cards/BusinessNetwork.spec.ts
+++ b/tests/cards/BusinessNetwork.spec.ts
@@ -4,7 +4,6 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { SelectCard } from "../../src/inputs/SelectCard";
-import { SelectHowToPay } from "../../src/inputs/SelectHowToPay";
 import { Resources } from '../../src/Resources';
 import { IProjectCard } from '../../src/cards/IProjectCard';
 
@@ -58,22 +57,4 @@ describe("BusinessNetwork", function () {
         expect(player.cardsInHand.length).to.eq(1);
     });
 
-    it("Should action as helion", function () {
-        player.canUseHeatAsMegaCredits = true;
-        player.heat = 1;
-        player.megaCredits = 3;
-
-        const action = card.action(player, game);
-        expect(action instanceof SelectCard).to.eq(true);
-
-        const subAction: SelectHowToPay = (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]) as SelectHowToPay;
-        expect(subAction).not.to.eq(undefined);
-        expect(subAction.canUseHeat).to.eq(true);
-        expect(function () { subAction.cb({heat: 0, megaCredits: 0, steel: 0, titanium: 0, microbes: 0 , floaters: 0, isResearchPhase: false}); }).to.throw();
-        
-        subAction.cb({heat: 1, megaCredits: 2, steel: 0, titanium: 0, microbes: 0 , floaters: 0, isResearchPhase: false});
-        expect(player.cardsInHand.length).to.eq(1);
-        expect(player.heat).to.eq(0);
-        expect(player.megaCredits).to.eq(1);
-    });
 });

--- a/tests/cards/SpaceMirrors.spec.ts
+++ b/tests/cards/SpaceMirrors.spec.ts
@@ -3,13 +3,15 @@ import { SpaceMirrors } from "../../src/cards/SpaceMirrors";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Resources } from '../../src/Resources';
+import { Game } from '../../src/Game';
 
 describe("SpaceMirrors", function () {
-    let card : SpaceMirrors, player : Player;
+    let card : SpaceMirrors, player : Player, game : Game;
 
     beforeEach(function() {
         card = new SpaceMirrors();
         player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
 
     it("Can't act", function () {
@@ -21,7 +23,7 @@ describe("SpaceMirrors", function () {
         player.megaCredits = 7;
         expect(card.canAct(player)).to.eq(true);
 
-        card.action(player);
+        card.action(player, game);
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     });

--- a/tests/cards/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/WaterImportFromEuropa.spec.ts
@@ -3,7 +3,6 @@ import { WaterImportFromEuropa } from "../../src/cards/WaterImportFromEuropa";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
-import { AndOptions } from "../../src/inputs/AndOptions";
 import { SelectSpace } from "../../src/inputs/SelectSpace";
 
 describe("WaterImportFromEuropa", function () {
@@ -26,16 +25,12 @@ describe("WaterImportFromEuropa", function () {
     });
 
     it("Should act", function () {
-        player.titanium = 1;
-        player.megaCredits = 11;
+        player.megaCredits = 13;
 
-        const action = card.action(player, game) as AndOptions;
-        expect(action).not.to.eq(undefined);
-        action.options[0].cb({ steel: 0, heat: 0, titanium: 1, megaCredits: 9 });
-        action.cb();
+        const action = card.action(player, game);
+        expect(action).to.eq(undefined);
 
-        expect(player.titanium).to.eq(0);
-        expect(player.megaCredits).to.eq(2);
+        expect(player.megaCredits).to.eq(1);
 
         expect(game.interrupts.length).to.eq(1);
         const selectOcean = game.interrupts[0].playerInput as SelectSpace;

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -4,7 +4,6 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from '../../../src/Game';
 import { OrOptions } from '../../../src/inputs/OrOptions';
-import { SelectHowToPay } from '../../../src/inputs/SelectHowToPay';
 import { MAX_VENUS_SCALE } from "../../../src/constants";
 
 describe("RotatorImpacts", function () {
@@ -36,12 +35,8 @@ describe("RotatorImpacts", function () {
         expect(card.resourceCount).to.eq(0);
         expect(card.canAct(player, game)).to.eq(true);
 
-        const selectHowToPay = card.action(player,game) as SelectHowToPay;
-        expect(selectHowToPay instanceof SelectHowToPay).to.eq(true);
-        selectHowToPay.cb({ steel: 0, heat: 0, titanium: 1, megaCredits: 3, microbes: 0, floaters: 0, isResearchPhase: false });
+        card.action(player,game);
         expect(card.resourceCount).to.eq(1);
-        expect(player.megaCredits).to.eq(13);
-        expect(player.titanium).to.eq(1);
 
         // two possible actions: add resource or spend titanium
         const orOptions = card.action(player,game) as OrOptions;


### PR DESCRIPTION
This one is quite big and could have some impact on the game...
It also removes more than 300 lines of code !

All calls to `SelectHowToPay `have been removed and will now use the `addSelectHowToPayInterrupt `mechanism which is consistent with Helion pay with heat.
This is also true for the research phase.

Some extra testing would be appreciated along with the review !
