### PR TITLE
Add missing log for Factorum's drawn building card

### DIFF
--- a/src/cards/promo/Factorum.ts
+++ b/src/cards/promo/Factorum.ts
@@ -7,6 +7,9 @@ import { Resources } from "../../Resources";
 import { SelectOption } from '../../inputs/SelectOption';
 import { OrOptions } from '../../inputs/OrOptions';
 import { CardName } from '../../CardName';
+import { LogMessageType } from "../../LogMessageType";
+import { LogMessageData } from "../../LogMessageData";
+import { LogMessageDataType } from "../../LogMessageDataType";
 
 export class Factorum implements IActionCard, CorporationCard {
     public name: CardName = CardName.FACTORUM;
@@ -34,6 +37,16 @@ export class Factorum implements IActionCard, CorporationCard {
         const drawBuildingCard = new SelectOption("Spend 3 MC to draw a building card", () => {
             player.megaCredits -= 3;
             player.cardsInHand.push(game.drawCardsByTag(Tags.STEEL, 1)[0]);
+
+            const drawnCard = game.getCardsInHandByTag(player, Tags.STEEL).slice(-1)[0];
+
+            game.log(
+                LogMessageType.DEFAULT,
+                "${0} drew ${1}",
+                new LogMessageData(LogMessageDataType.PLAYER, player.id),
+                new LogMessageData(LogMessageDataType.CARD, drawnCard.name)
+            );
+
             return undefined;
         });
 


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1114

Official clarification from the designer is here: https://boardgamegeek.com/thread/2351530/article/34083951#34083951

<img width="289" alt="Screenshot 2020-08-04 at 8 28 08 PM" src="https://user-images.githubusercontent.com/2408094/89293981-63baa600-d691-11ea-850a-936e8172eada.png">
