### PR TITLE
Fix: CrashSiteCleanup should be playable in solo mode

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -592,8 +592,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public addResourceDecreaseInterrupt(player: Player, resource: Resources, count: number = 1, title?: string): void {
       if (this.soloMode) {
+        // Crash site cleanup hook
+        if (resource === Resources.PLANTS) this.someoneHasRemovedOtherPlayersPlants = true;
         return;
       }
+
       let candidates: Array<Player> = [];
       if (resource === Resources.PLANTS) {
         candidates = this.getPlayers().filter((p) => p.id !== player.id && !p.plantsAreProtected() && p.getResource(resource) > 0);

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -225,7 +225,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         }
 
         // Crash site cleanup hook
-        if (fromPlayer !== this && resource === Resources.PLANTS) {
+        if (fromPlayer !== this && resource === Resources.PLANTS && amount < 0) {
           game.someoneHasRemovedOtherPlayersPlants = true;
         }
 

--- a/tests/cards/promo/CrashSiteCleanup.spec.ts
+++ b/tests/cards/promo/CrashSiteCleanup.spec.ts
@@ -38,4 +38,13 @@ describe("CrashSiteCleanup", function () {
         action.options[1].cb();
         expect(player.steel).to.eq(2);
     });
+
+    it("Can play if removed plants from neutral player in solo mode", function () {
+        game = new Game("foobar", [player], player);
+        const smallAsteroid = new SmallAsteroid();
+        smallAsteroid.play(player, game);
+
+        expect(card.canPlay(player, game)).to.eq(true);
+        expect(game.someoneHasRemovedOtherPlayersPlants).to.eq(true);
+    });
 });


### PR DESCRIPTION
The card should be playable after any card that removes plants is played, as you can always target neutral opponent in solo mode.