### PR TITLE
Fix hasRequirements for VoteOfNoConfidence

### DIFF
--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -13,7 +13,7 @@ export class VoteOfNoConfidence implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.VOTE_OF_NO_CONFIDENCE;
     public cardType: CardType = CardType.EVENT;
-    public hasRequirements = false;
+
     public canPlay(player: Player, game: Game): boolean {
         if (game.turmoil !== undefined) {
             if (!game.turmoil!.hasAvailableDelegates(player.id)) return false;

--- a/tests/cards/promo/CuttingEdgeTechnology.spec.ts
+++ b/tests/cards/promo/CuttingEdgeTechnology.spec.ts
@@ -5,6 +5,7 @@ import { Game } from "../../../src/Game";
 import { CuttingEdgeTechnology } from "../../../src/cards/promo/CuttingEdgeTechnology";
 import { DustSeals } from "../../../src/cards/DustSeals";
 import { HeatTrappers } from "../../../src/cards/HeatTrappers";
+import { VoteOfNoConfidence } from "../../../src/cards/turmoil/VoteOfNoConfidence";
 
 describe("CuttingEdgeTechnology", function () {
     it("Should play", function () {
@@ -14,9 +15,11 @@ describe("CuttingEdgeTechnology", function () {
         card.play();
 
         const discountedCard = new DustSeals();
+        const discountedCard2 = new VoteOfNoConfidence();
         const undiscountedCard = new HeatTrappers();
 
         expect(card.getCardDiscount(player, game, discountedCard)).to.eq(2);
+        expect(card.getCardDiscount(player, game, discountedCard2)).to.eq(2);
         expect(card.getCardDiscount(player, game, undiscountedCard)).to.eq(0);
         expect(card.getVictoryPoints()).to.eq(1);
     });


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1149

Card should be discounted 2 MC by CuttingEdgeTechnology as it has requirements.

![photo_2020-08-13_16-43-31](https://user-images.githubusercontent.com/2408094/90113969-a6146f00-dd84-11ea-81d2-4047eae7d876.jpg)
