### PR TITLE
Fix discount for Earth Office and Teractor

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -1662,7 +1662,7 @@ export const HTML_DATA: Map<string, string> =
         <div class="content ">
             <div class="resource-tag tag-earth"></div> : <div class="money resource ">-3</div>
             <div class="description ">
-                (Effect: When you play an Earth card, you pay 3 MC less for it.)
+                (Effect: When you play an Earth tag, you pay 3 MC less for it.)
             </div>
         </div>
 `],
@@ -5337,7 +5337,7 @@ export const HTML_DATA: Map<string, string> =
         <div class="resource-tag tag-earth"></div> :
         <div class="resource money">-3</div>
         <div class="description" style="text-align:center;margin-top:0px;">
-          (Effect: When playing an Earth card, you pay 3 MC less for it.)
+          (Effect: When you play an Earth tag, you pay 3 MC less for it.)
         </div>
       </div>
       <span style="font-size:34px;

--- a/src/cards/EarthOffice.ts
+++ b/src/cards/EarthOffice.ts
@@ -1,10 +1,9 @@
-
-import {IProjectCard} from './IProjectCard';
-import {Tags} from './Tags';
-import {CardType} from './CardType';
-import {Player} from '../Player';
-import {Game} from '../Game';
-import { CardName } from '../CardName';
+import {IProjectCard} from "./IProjectCard";
+import {Tags} from "./Tags";
+import {CardType} from "./CardType";
+import {Player} from "../Player";
+import {Game} from "../Game";
+import { CardName } from "../CardName";
 
 export class EarthOffice implements IProjectCard {
     public cost: number = 1;
@@ -13,11 +12,9 @@ export class EarthOffice implements IProjectCard {
     public cardType: CardType = CardType.ACTIVE;
 
     public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-      if (card.tags.indexOf(Tags.EARTH) !== -1) {
-        return 3;
-      }
-      return 0;
+      return card.tags.filter(tag => tag === Tags.EARTH).length * 3;
     }
+
     public play() {
       return undefined;
     }

--- a/src/cards/corporation/Teractor.ts
+++ b/src/cards/corporation/Teractor.ts
@@ -1,20 +1,16 @@
-
 import { Tags } from "../Tags";
 import { CorporationCard } from "./CorporationCard";
 import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { IProjectCard } from "../IProjectCard";
-import { CardName } from '../../CardName';
+import { CardName } from "../../CardName";
 
 export class Teractor implements CorporationCard {
     public name: CardName = CardName.TERACTOR;
     public tags: Array<Tags> = [Tags.EARTH];
     public startingMegaCredits: number = 60;
     public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-        if (card.tags.indexOf(Tags.EARTH) !== -1) {
-            return 3;
-        }
-        return 0;
+        return card.tags.filter(tag => tag === Tags.EARTH).length * 3;
     }
     public play() {
         return undefined;

--- a/src/locales/cn/cards.json
+++ b/src/locales/cn/cards.json
@@ -333,7 +333,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "行动: 花费4个电力资源,获得1个钛合金资源和提升氧气浓度1格",
 
     "Earth Office": "地球办公室",
-    "Effect: When you play an Earth card, you pay 3 MC less for it.": "效果: 每当你要打出一张带有地球标志的卡,你可以少花费3MC",
+    "Effect: When you play an Earth tag, you pay 3 MC less for it.": "效果: 每当你打出一张地球标志卡,你可以少花费3MC",
 
     "Acquired Company": "并购公司",
 

--- a/src/locales/de/cards.json
+++ b/src/locales/de/cards.json
@@ -329,7 +329,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "AKTION: Verbrauche 4 Energie, um 1 Titan zu erhalten und den Sauerstoffgehalt um 1% zu erhöhen.",
 
     "Earth Office": "Verbindungsbüro Erde",
-    "Effect: When you play an Earth card, you pay 3 MC less for it.": "EFFEKT: Wenn du ein Erdesymbol ausspielst, bezahlst du 3 M€ weniger.",
+    "Effect: When you play an Earth tag, you pay 3 MC less for it.": "EFFEKT: Wenn du ein Erdesymbol ausspielst, bezahlst du 3 M€ weniger.",
 
     "Acquired Company": "Übernommenes Unternehmen",
 

--- a/src/locales/ru/cards.json
+++ b/src/locales/ru/cards.json
@@ -333,7 +333,7 @@
     "Action: Spend 4 energy to gain 1 titanium and increase oxygen 1 step.": "Действие: потратьте 4 энергии, чтобы получить 1 титан и повысить уровень кислорода на 1.",
 
     "Earth Office": "Офис на Земле",
-    "Effect: When you play an Earth card, you pay 3 MC less for it.": "Свойство: когда вы играете карту с символом Земли, вы платите на 3 MC меньше.",
+    "Effect: When you play an Earth tag, you pay 3 MC less for it.": "Свойство: когда вы играете карту с символом Земли, вы платите на 3 MC меньше.",
 
     "Acquired Company": "Приобретённая компания",
 

--- a/tests/cards/EarthOffice.spec.ts
+++ b/tests/cards/EarthOffice.spec.ts
@@ -1,20 +1,30 @@
-
 import { expect } from "chai";
 import { EarthOffice } from "../../src/cards/EarthOffice";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { Birds } from "../../src/cards/Birds";
+import { LunaGovernor } from "../../src/cards/colonies/LunaGovernor";
 
 describe("EarthOffice", function () {
-    it("Should play", function () {
-        const card = new EarthOffice();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : EarthOffice, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new EarthOffice();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+        
         const action = card.play();
         expect(action).to.eq(undefined);
+    });
+
+    it("Should play", function () {
         expect(card.getCardDiscount(player, game, card)).to.eq(3);
         expect(card.getCardDiscount(player, game, new Birds())).to.eq(0);
+    });
+
+    it("Discounts Luna Governor correctly", function () {
+        expect(card.getCardDiscount(player, game, new LunaGovernor())).to.eq(6);
     });
 });
 

--- a/tests/cards/corporation/Teractor.spec.ts
+++ b/tests/cards/corporation/Teractor.spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from "chai";
 import { Teractor } from "../../../src/cards/corporation/Teractor";
 import { Color } from "../../../src/Color";
@@ -6,15 +5,27 @@ import { Player } from "../../../src/Player";
 import { Game } from "../../../src/Game";
 import { Cartel } from "../../../src/cards/Cartel";
 import { Birds } from "../../../src/cards/Birds";
+import { LunaGovernor } from "../../../src/cards/colonies/LunaGovernor";
 
 describe("Teractor", function () {
-    it("Should play", function () {
-        const card = new Teractor();
-        const player = new Player("test", Color.BLUE, false);
-        const game = new Game("foobar", [player,player], player);
+    let card : Teractor, player : Player, game : Game;
+
+    beforeEach(function() {
+        card = new Teractor();
+        player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
+        
         const action = card.play();
         expect(action).to.eq(undefined);
+    });
+
+
+    it("Should play", function () {
         expect(card.getCardDiscount(player, game, new Cartel())).to.eq(3);
         expect(card.getCardDiscount(player, game, new Birds())).to.eq(0);
+    });
+
+    it("Discounts Luna Governor correctly", function () {
+        expect(card.getCardDiscount(player, game, new LunaGovernor())).to.eq(6);
     });
 });


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1161

Luna Governor should be discounted by 6 MC as confirmed by the game designer.

We could also consider to reword the effect text on Earth Office and Teractor to state the correct effect clearly, since this is not possible on the physical print version.