### PR TITLE
Fix incorrect double assignment of milestones option title

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2119,7 +2119,6 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       if (this.canAfford(8) && !game.allMilestonesClaimed()) {
         const remainingMilestones = new OrOptions();
         remainingMilestones.title = "Claim a milestone";
-        remainingMilestones.title = "Confirm";
         remainingMilestones.options = game.milestones
             .filter(
                 (milestone: IMilestone) =>


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1170

`title` is incorrectly assigned twice on lines 2121 and 2122