### PR TITLE
Fix:when a player with corp MiningGuild places an ocean act as the WG 

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -581,7 +581,7 @@ function getWaitingFor(
       result.canUseHeat = (waitingFor as SelectHowToPayForCard).canUseHeat;
       break;
     case PlayerInputTypes.SELECT_CARD:
-      result.cards = getCardsAsCardModel((waitingFor as SelectCard<ICard>).cards);
+      result.cards = getCardsAsCardModel((waitingFor as SelectCard<ICard>).cards, false);
       result.maxCardsToSelect = (waitingFor as SelectCard<ICard>)
           .maxCardsToSelect;
       result.minCardsToSelect = (waitingFor as SelectCard<ICard>)

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -253,6 +253,11 @@ export class Game implements ILoadable<SerializedGame, Game> {
         corporationCards.push(...ALL_TURMOIL_CORPORATIONS.map((cf) => new cf.factory()));
       }  
 
+      // Add Promo stuff
+      if (this.promoCardsOption) {
+        corporationCards.push(...ALL_PROMO_CORPORATIONS.map((cf) => new cf.factory()));
+      }  
+
       // Setup custom corporation list
       const minCorpsRequired = players.length * this.startingCorporations;
       if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length >= minCorpsRequired) {
@@ -1480,6 +1485,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
             player.megaCredits += player.oceanBonus;
           }
         });
+      }else{
+        space.player = undefined;
       }
       
       this.tilePlaced(space);


### PR DESCRIPTION
Fix:when a player with corp MiningGuild places an ocean act as the WG (when he is the first palyer), his STEEL prod increase one by mistake