### PR TITLE
Fix: Don't add Reds tax for SP greenery if oxygen is maxed

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1919,7 +1919,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       let greeneryCost = constants.GREENERY_COST
-      if (redsAreRuling) greeneryCost += REDS_RULING_POLICY_COST;
+      const oxygenNotMaxed = game.getOxygenLevel() < constants.MAX_OXYGEN_LEVEL;
+      if (redsAreRuling && oxygenNotMaxed) greeneryCost += REDS_RULING_POLICY_COST;
 
       if (this.canAfford(greeneryCost) && game.board.getAvailableSpacesForGreenery(this).length > 0) {
         standardProjects.options.push(

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -23,6 +23,7 @@ import { NitrogenFromTitan } from "../src/cards/colonies/NitrogenFromTitan";
 import { SpaceStation } from "../src/cards/SpaceStation";
 import { EarthCatapult } from "../src/cards/EarthCatapult";
 import { QuantumExtractor } from "../src/cards/QuantumExtractor";
+import * as constants from "../src/constants";
 
 describe("Turmoil", function () {
     let player : Player, game : Game, turmoil: Turmoil;
@@ -126,6 +127,17 @@ describe("Turmoil", function () {
         
         // can only use Power Plant as cannot pay 3 for Reds ruling policy
         expect(availableStandardProjects.options.length).to.eq(1); 
+    });
+
+    it("Can do SP greenery at normal cost if Reds are ruling and oxygen is maxed", function () {
+        turmoil.rulingParty = new Reds();
+        player.megaCredits = 23;
+        let availableStandardProjects = player.getAvailableStandardProjects(game);
+        expect(availableStandardProjects.options.length).to.eq(4);
+
+        (game as any).oxygenLevel = constants.MAX_OXYGEN_LEVEL;
+        availableStandardProjects = player.getAvailableStandardProjects(game);
+        expect(availableStandardProjects.options.length).to.eq(5);
     });
 
     it("Can't play cards to raise TR directly if Reds are ruling and player cannot pay", function () {


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1190