### PR TITLE
Minor visual improvements

### DIFF
--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -81,7 +81,7 @@ input[type=radio]:checked + label {
   color: #5755d9;
   cursor: pointer;
 }
-
+  
 @import "./language_switcher.less";
 @import "./cards.less";
 @import "./language_hacks.less";

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -65,7 +65,7 @@
 
 .tag-overview-cont {
     .accordion-body {
-        overflow-x: auto;
+        overflow-x: auto;    
     }
 }
 
@@ -241,6 +241,10 @@
 .player_home_block {
     margin-bottom: 20px;
 
+    .accordion-header{
+        display: inline-block;
+    }
+    
     .player_item {
         display: inline-block;
         vertical-align: middle;
@@ -254,15 +258,19 @@
         padding: 1px 5px;
         border-radius: 4px;
         font-weight: bold;
-   }
-
+    }
+    .tags_cont .player_name_cont {
+        text-align: left;
+    }
     .player_name_cont {
+        text-align: center;
         width: 150px;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
         display: inline-block;
         vertical-align: middle;
+         
 
         .player_number {
             margin-right: 5px;
@@ -275,7 +283,7 @@
             text-overflow: ellipsis;
 
             .corporation-name {
-                font-size: 11px;
+                font-size: 16px;
             }
         }
     }


### PR DESCRIPTION
@alrusdi @vincentneko @meussiebeaucoup
I took the liberty to make some minor changes on the new awesome tags-overview block. They are a bit opinionated and I'm ok to be rejected:
1. Corp name srift at 11px is very tiny (12px should be the minimal text size anyway). I feel 16 should be ok as there is enogh space and it is much balanced.
2. I'd prefer centered player names since the boxes are with fixed size.
3. I've kept the left alignment of names in the tags-overview container
4. The `>Tag overview` label had an invisible clickable length, never a good sign, so I fixed that too (It was the case with `>Board` as well)

![bit_improved](https://user-images.githubusercontent.com/836179/90876299-19cd0200-e3ab-11ea-8581-44dc50d91f28.png)
