### PR TITLE
issue_1195

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -141,7 +141,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         if (this.canAfford(REDS_RULING_POLICY_COST)) {
           game.addSelectHowToPayInterrupt(this, REDS_RULING_POLICY_COST, false, false, "Select how to pay for TR increase");
         } else {
-          this.megaCredits -= REDS_RULING_POLICY_COST;
+          // Cannot pay Reds, will not increase TR
+          return;
         }
         
         this.terraformRating++;
@@ -1874,16 +1875,28 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       return playableCards;
     }
 
-    public canAfford(cost: number, game?: Game, canUseSteel: boolean = false, canUseTitanium: boolean = false): boolean {
+    public canAfford(cost: number, game?: Game, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false): boolean {
+      
+      let extraResource: number = 0;
+      if (canUseFloaters !== undefined && canUseFloaters) {
+        extraResource += this.getFloatersCanSpend() * 3;
+      }
+
+      if (canUseMicrobes !== undefined && canUseMicrobes) {
+        extraResource += this.getMicrobesCanSpend() * 2;
+      }
+      
       if (game !== undefined && canUseTitanium) {
         return (this.canUseHeatAsMegaCredits ? this.heat : 0) +
         (canUseSteel ? this.steel * this.steelValue : 0) +
         (canUseTitanium ? this.titanium * this.getTitaniumValue(game) : 0) +
+        extraResource +
           this.megaCredits >= cost;        
       }
       
       return (this.canUseHeatAsMegaCredits ? this.heat : 0) +
               (canUseSteel ? this.steel * this.steelValue : 0) +
+              extraResource +
                 this.megaCredits >= cost;
     }
 

--- a/src/cards/Mangrove.ts
+++ b/src/cards/Mangrove.ts
@@ -22,7 +22,7 @@ export class Mangrove implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, false, true) && meetsTemperatureRequirements;
         }
     
         return meetsTemperatureRequirements;

--- a/src/cards/Plantation.ts
+++ b/src/cards/Plantation.ts
@@ -22,7 +22,7 @@ export class Plantation implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST) && meetsTagRequirements && canPlaceTile;
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, false, true) && meetsTagRequirements && canPlaceTile;
         }
     
         return meetsTagRequirements && canPlaceTile;

--- a/src/cards/ProtectedValley.ts
+++ b/src/cards/ProtectedValley.ts
@@ -23,7 +23,7 @@ export class ProtectedValley implements IProjectCard {
         const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
     
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true, false, false, true);
         }
     
         return true;

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -23,7 +23,7 @@ export class WildlifeDome implements IProjectCard {
             const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
             if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {
-                return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true) && meetsPartyRequirements && canPlaceTile;
+                return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true, false, false, true) && meetsPartyRequirements && canPlaceTile;
             }
 
             return meetsPartyRequirements && canPlaceTile;

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -21,7 +21,7 @@ export class AirScrappingExpedition implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true);
         }
   
         return true;

--- a/src/cards/venusNext/GHGImportFromVenus.ts
+++ b/src/cards/venusNext/GHGImportFromVenus.ts
@@ -19,7 +19,7 @@ export class GHGImportFromVenus implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true, true);
         }
   
         return true;

--- a/src/cards/venusNext/GiantSolarShade.ts
+++ b/src/cards/venusNext/GiantSolarShade.ts
@@ -20,7 +20,7 @@ export class GiantSolarShade implements IProjectCard {
         const stepsRaised = Math.min(remainingVenusSteps, 3);
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true, true);
         }
   
         return true;

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -17,7 +17,7 @@ export class NeutralizerFactory  implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const venusRequirementMet = game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST) && venusRequirementMet;
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true) && venusRequirementMet;
         }
   
         return venusRequirementMet;

--- a/src/cards/venusNext/OrbitalReflectors.ts
+++ b/src/cards/venusNext/OrbitalReflectors.ts
@@ -21,7 +21,7 @@ export class OrbitalReflectors  implements IProjectCard {
         const stepsRaised = Math.min(remainingVenusSteps, 2);
         
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true, true);
         }
   
         return true;

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -19,7 +19,7 @@ export class SulphurExports implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true, true);
         }
   
         return true;

--- a/src/cards/venusNext/VenusSoils.ts
+++ b/src/cards/venusNext/VenusSoils.ts
@@ -23,7 +23,7 @@ export class VenusSoils implements IProjectCard {
     public canPlay(player: Player, game: Game): boolean {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST);
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true, true);
         }
   
         return true;

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -23,7 +23,7 @@ export class VenusianPlants implements IProjectCard {
         const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
 
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST) && meetsVenusRequirements;
+          return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true, true) && meetsVenusRequirements;
         }
   
         return meetsVenusRequirements;

--- a/tests/cards/venusNext/GiantSolarShade.spec.ts
+++ b/tests/cards/venusNext/GiantSolarShade.spec.ts
@@ -3,7 +3,10 @@ import { expect } from "chai";
 import { GiantSolarShade } from "../../../src/cards/venusNext/GiantSolarShade";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
-import { Game } from "../../../src/Game";
+import { Game, GameOptions } from "../../../src/Game";
+import { setCustomGameOptions } from "../../TestingUtils";
+import { Reds } from "../../../src/turmoil/parties/Reds";
+import { Dirigibles } from "../../../src/cards/venusNext/Dirigibles";
 
 describe("GiantSolarShade", function () {
     it("Should play", function () {
@@ -15,4 +18,18 @@ describe("GiantSolarShade", function () {
         expect(game.getVenusScaleLevel()).to.eq(6);
         expect(player.getTerraformRating()).to.eq(23);
     });
+
+    it("Should play with Reds and Dirigibles", function () {
+        const player = new Player("test", Color.BLUE, false);
+        const gameOptions = setCustomGameOptions() as GameOptions;
+        const game = new Game("foobar", [player], player, gameOptions);
+        game.turmoil!.rulingParty = new Reds();
+        const card = new GiantSolarShade();
+        player.megaCredits = 27;
+        expect(card.canPlay(player, game)).to.eq(false);
+        player.playedCards.push(new Dirigibles());
+        player.addResourceTo(player.playedCards[0], 3);
+        expect(card.canPlay(player, game)).to.eq(true);
+    });   
+
 });


### PR DESCRIPTION
- Add Floaters and Microbes to CanAfford method (fix Reds policy bug)
- Fix a bug where MC could go negative

Edge case : If I'm able to play a card because of microbes or floaters (with dirigibles) with Reds ruling but I did not spend them and therefore I lack MC after to pay Red, TR will not be increased and MC will not be spent.