### PR TITLE
Make colony track increase from card effects optional for Europa

### DIFF
--- a/src/colonies/Callisto.ts
+++ b/src/colonies/Callisto.ts
@@ -9,7 +9,7 @@ export class Callisto extends Colony implements IColony {
     public name = ColonyName.CALLISTO;
     public description: string = "Energy";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         const qty = Math.max(2, (2 * this.trackPosition) -1 + Math.max(this.trackPosition - 4, 0));
         player.energy += qty;
         LogHelper.logGainStandardResource(game, player, Resources.ENERGY, qty);

--- a/src/colonies/Ceres.ts
+++ b/src/colonies/Ceres.ts
@@ -9,7 +9,7 @@ export class Ceres extends Colony implements IColony {
     public name = ColonyName.CERES;
     public description: string = "Steel";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         let qty : number;
         if (this.trackPosition === 2) {
             qty = 3;

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -9,6 +9,7 @@ import { LogMessageType } from "../LogMessageType";
 import { LogMessageData } from "../LogMessageData";
 import { LogMessageDataType } from "../LogMessageDataType";
 import { LogHelper } from "../components/LogHelper";
+import { MAX_COLONY_TRACK_POSITION } from "../constants";
 
 export interface IColony {
     name: ColonyName;
@@ -44,7 +45,7 @@ export abstract class Colony  {
         } else {
             this.trackPosition += value;
         }    
-        if (this.trackPosition > 6) this.trackPosition = 6;
+        if (this.trackPosition > MAX_COLONY_TRACK_POSITION) this.trackPosition = MAX_COLONY_TRACK_POSITION;
     }
 
     public decreaseTrack(value?: number): void {

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -8,6 +8,7 @@ import { Resources } from '../Resources';
 import { LogMessageType } from "../LogMessageType";
 import { LogMessageData } from "../LogMessageData";
 import { LogMessageDataType } from "../LogMessageDataType";
+import { LogHelper } from "../components/LogHelper";
 
 export interface IColony {
     name: ColonyName;
@@ -59,8 +60,9 @@ export abstract class Colony  {
         return this.colonies.length >= 3;
     }
 
-    public beforeTrade(colony: IColony, player: Player): void {
+    public beforeTrade(colony: IColony, player: Player, game: Game): void {
         if (player.colonyTradeOffset > 0) {
+            LogHelper.logColonyTrackIncrease(game, player, colony);
             colony.increaseTrack(player.colonyTradeOffset);
         }
     }    

--- a/src/colonies/Enceladus.ts
+++ b/src/colonies/Enceladus.ts
@@ -10,7 +10,7 @@ export class Enceladus extends Colony implements IColony {
     public isActive = false;
     public resourceType = ResourceType.MICROBE;
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         let microbes: number = 0;
         if (this.trackPosition > 4) {
             microbes = this.trackPosition - 1;

--- a/src/colonies/Europa.ts
+++ b/src/colonies/Europa.ts
@@ -4,12 +4,27 @@ import { Resources } from '../Resources';
 import { Game } from '../Game';
 import { ColonyName } from './ColonyName';
 import { LogHelper } from '../components/LogHelper';
+import { OrOptions } from '../inputs/OrOptions';
+import { SelectOption } from '../inputs/SelectOption';
 
 export class Europa extends Colony implements IColony {
     public name = ColonyName.EUROPA;
     public description: string = "Production";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        game.addInterrupt({ player, playerInput: new OrOptions(
+            new SelectOption("Increase colony track", "Confirm", () => {
+                this.beforeTrade(this, player);
+                this.handleTrade(game, player);
+                return undefined;
+            }),
+            new SelectOption("Do nothing", "Confirm", () => {
+                this.handleTrade(game, player);
+                return undefined;
+            })
+        )});
+    }
+
+    private handleTrade(game: Game, player: Player) {
         if (this.trackPosition < 2) {
             player.setProduction(Resources.MEGACREDITS);
             LogHelper.logGainProduction(game, player, Resources.MEGACREDITS);
@@ -22,6 +37,8 @@ export class Europa extends Colony implements IColony {
         }
         this.afterTrade(this, player, game);
     }
+
+
     public onColonyPlaced(player: Player, game: Game): undefined {
         super.addColony(this, player, game);
         game.addOceanInterrupt(player, 'Select ocean for Europa colony')

--- a/src/colonies/Europa.ts
+++ b/src/colonies/Europa.ts
@@ -13,7 +13,7 @@ export class Europa extends Colony implements IColony {
     public trade(player: Player, game: Game): void {
         game.addInterrupt({ player, playerInput: new OrOptions(
             new SelectOption("Increase colony track", "Confirm", () => {
-                this.beforeTrade(this, player);
+                this.beforeTrade(this, player, game);
                 this.handleTrade(game, player);
                 return undefined;
             }),

--- a/src/colonies/Ganymede.ts
+++ b/src/colonies/Ganymede.ts
@@ -9,7 +9,7 @@ export class Ganymede extends Colony implements IColony {
     public name = ColonyName.GANYMEDE;
     public description: string = "Plants";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         const qty = this.trackPosition;
         player.plants += qty;
         LogHelper.logGainStandardResource(game, player, Resources.PLANTS, qty);

--- a/src/colonies/Io.ts
+++ b/src/colonies/Io.ts
@@ -9,7 +9,7 @@ export class Io extends Colony implements IColony {
     public name = ColonyName.IO;
     public description: string = "Heat";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         let qty : number;
         if (this.trackPosition === 1 || this.trackPosition === 6) {
             qty = (this.trackPosition * 2) + 1;

--- a/src/colonies/Luna.ts
+++ b/src/colonies/Luna.ts
@@ -9,7 +9,7 @@ export class Luna extends Colony implements IColony {
     public name = ColonyName.LUNA;
     public description: string = "MegaCredits";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         const qty = this.trackPosition * 2 + Math.max(this.trackPosition - 2, 0) + Math.max(this.trackPosition - 5, 0);
         player.megaCredits += qty;
         LogHelper.logGainStandardResource(game, player, Resources.MEGACREDITS, qty);

--- a/src/colonies/Miranda.ts
+++ b/src/colonies/Miranda.ts
@@ -10,7 +10,7 @@ export class Miranda extends Colony implements IColony {
     public isActive = false;
     public resourceType = ResourceType.ANIMAL;
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         let animals: number = 0;
         if (this.trackPosition < 3) {
             animals = 1;

--- a/src/colonies/Pluto.ts
+++ b/src/colonies/Pluto.ts
@@ -10,7 +10,7 @@ export class Pluto extends Colony implements IColony {
     public description: string = "Cards";
     public trade(player: Player, game: Game): void {
         let extraCards: number = 0;
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         if (this.trackPosition === 2) {
             extraCards = 2;
         } else if (this.trackPosition < 5) {

--- a/src/colonies/Titan.ts
+++ b/src/colonies/Titan.ts
@@ -10,7 +10,7 @@ export class Titan extends Colony implements IColony {
     public isActive = false;
     public resourceType: ResourceType = ResourceType.FLOATER;
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         let floaters: number = 0;
         if (this.trackPosition < 5) {
             floaters = Math.max(this.trackPosition - 1, 1);

--- a/src/colonies/Triton.ts
+++ b/src/colonies/Triton.ts
@@ -9,7 +9,7 @@ export class Triton extends Colony implements IColony {
     public name = ColonyName.TRITON;
     public description: string = "Titanium";
     public trade(player: Player, game: Game): void {
-        this.beforeTrade(this, player);
+        this.beforeTrade(this, player, game);
         const qty = Math.max(this.trackPosition - 1, 1);
         player.titanium += qty;
         LogHelper.logGainStandardResource(game, player, Resources.TITANIUM, qty);

--- a/src/components/LogHelper.ts
+++ b/src/components/LogHelper.ts
@@ -7,6 +7,7 @@ import { LogMessageDataType } from "../LogMessageDataType";
 import { Resources } from "../Resources";
 import { ISpace } from "../ISpace";
 import { TileType } from "../TileType";
+import { IColony } from "../colonies/Colony";
 
 export class LogHelper {
     static logAddResource(game: Game, player: Player, card: ICard, qty: number = 1): void {
@@ -102,6 +103,16 @@ export class LogHelper {
             new LogMessageData(LogMessageDataType.STRING, type),
             new LogMessageData(LogMessageDataType.STRING, space.x.toString()),
             new LogMessageData(LogMessageDataType.STRING, space.y.toString())
+        );
+    }
+
+    static logColonyTrackIncrease(game: Game, player: Player, colony: IColony) {
+        game.log(
+            LogMessageType.DEFAULT,
+            "${0} increased ${1} colony track ${2} step(s)",
+            new LogMessageData(LogMessageDataType.PLAYER, player.id),
+            new LogMessageData(LogMessageDataType.STRING, colony.name),
+            new LogMessageData(LogMessageDataType.STRING, player.colonyTradeOffset.toString())
         );
     }
 }

--- a/src/components/LogHelper.ts
+++ b/src/components/LogHelper.ts
@@ -8,6 +8,7 @@ import { Resources } from "../Resources";
 import { ISpace } from "../ISpace";
 import { TileType } from "../TileType";
 import { IColony } from "../colonies/Colony";
+import { MAX_COLONY_TRACK_POSITION } from "../constants";
 
 export class LogHelper {
     static logAddResource(game: Game, player: Player, card: ICard, qty: number = 1): void {
@@ -107,12 +108,14 @@ export class LogHelper {
     }
 
     static logColonyTrackIncrease(game: Game, player: Player, colony: IColony) {
+        const stepsIncreased = Math.min(player.colonyTradeOffset, MAX_COLONY_TRACK_POSITION - colony.trackPosition);
+        
         game.log(
             LogMessageType.DEFAULT,
             "${0} increased ${1} colony track ${2} step(s)",
             new LogMessageData(LogMessageDataType.PLAYER, player.id),
             new LogMessageData(LogMessageDataType.STRING, colony.name),
-            new LogMessageData(LogMessageDataType.STRING, player.colonyTradeOffset.toString())
+            new LogMessageData(LogMessageDataType.STRING, stepsIncreased.toString())
         );
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const AIR_SCRAPPING_COST: number = 15;
 export const BUFFER_GAS_COST: number = 16;
 export const OCEAN_BONUS: number = 2;
 export const BUILD_COLONY_COST: number = 17;
+export const MAX_COLONY_TRACK_POSITION: number = 6;
 export const PLAYER_DELEGATES_COUNT: number = 7;
 export const REDS_RULING_POLICY_COST: number = 3;
 export const HELLAS_BONUS_OCEAN_COST: number = 6;


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1211

- Add option to increase colony track for Europa or do nothing
- Add log to show actual number of increased steps (1 or 2)

<img width="336" alt="Screenshot 2020-08-26 at 11 50 24 PM" src="https://user-images.githubusercontent.com/2408094/91326920-7b4fff00-e7f7-11ea-8b26-de3b9c6a5278.png">
<img width="452" alt="Screenshot 2020-08-26 at 11 50 44 PM" src="https://user-images.githubusercontent.com/2408094/91326926-7d19c280-e7f7-11ea-9609-fdf647390840.png">
