### PR TITLE
1. Fix :  Mons Insurance

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -255,7 +255,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }      
 
       // Mons Insurance hook
-      if (game !== undefined && game.monsInsuranceOwner !== undefined && amount < 0 && fromPlayer !== undefined) {
+      if (game !== undefined && game.monsInsuranceOwner !== undefined && amount < 0 && fromPlayer !== undefined && fromPlayer !== this) {
         this.resolveMonsInsurance(game);
       }
     }
@@ -308,7 +308,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       // Mons Insurance hook  
-      if (game !== undefined && game.monsInsuranceOwner !== undefined && amount < 0 && fromPlayer !== undefined) {
+      if (game !== undefined && game.monsInsuranceOwner !== undefined && amount < 0 && fromPlayer !== undefined && fromPlayer !== this) {
         this.resolveMonsInsurance(game);
       }
 

--- a/src/cards/Flooding.ts
+++ b/src/cards/Flooding.ts
@@ -40,17 +40,17 @@ export class Flooding implements IProjectCard {
         "Select space for ocean tile",
         game.board.getAvailableSpacesForOcean(player),
         (space: ISpace) => {
-          const adjacentPlayers: Array<Player> = [];
+          const adjacentPlayers: Set<Player> = new Set<Player>();
           game.addOceanTile(player, space.id);
           game.board.getAdjacentSpaces(space).forEach((space) => {
             if (space.player && space.player !== player) {
-              adjacentPlayers.push(space.player);
+              adjacentPlayers.add(space.player);
             }
           });
-          if (adjacentPlayers.length > 0) {
+          if (adjacentPlayers.size > 0) {
             return new OrOptions(
                 new SelectPlayer(
-                    adjacentPlayers,
+                    Array.from(adjacentPlayers),
                     "Select adjacent player to remove 4 mega credits from",
                     "Remove credits",
                     (selectedPlayer: Player) => {


### PR DESCRIPTION
1. Fix :  monsInsuranceOwner  needn't  pay 3mc when someone removes his own resources (red-bordered resource icons cards ,such as  fish  )

2. Improvement: merge duplicate targets of  flooding