### PR TITLE
add support for AndOptions as child of OrOptions

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -672,10 +672,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       } else if (pi instanceof OrOptions) {
         const waiting: OrOptions = pi;
         const optionIndex = parseInt(input[0][0]);
-        const remainingInput = input[0].slice();
-        // Remove option index to process option
-        remainingInput.shift();
-        this.runInput(game, [remainingInput], waiting.options[optionIndex]);
+        const remainingInput = [];
+        for (let i = 1; i < input.length; i++) {
+            remainingInput.push(input[i].slice());
+        }
+        this.runInput(game, remainingInput, waiting.options[optionIndex]);
       } else if (pi instanceof SelectHowToPayForCard) {
         if (input.length !== 1 || input[0].length !== 2) {
           throw new Error("Incorrect options provided");

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -51,9 +51,11 @@ export const OrOptions = Vue.component("or-options", {
                 createElement("span", $t(option.title))
             ]));
             this.$data.childComponents.push(new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, option, (out: Array<Array<string>>) => {
-                const copy = out[0].slice();
-                copy.unshift(String(idx));
-                this.onsave([copy]);
+                const copy = [[String(idx)]];
+                for (let i = 0; i < out.length; i++) {
+                    copy.push(out[i].slice());
+                }
+                this.onsave(copy);
             }, false, false));
             subchildren.push(createElement("div", { style: { display: displayStyle, marginLeft: "30px" } }, [this.$data.childComponents[this.$data.childComponents.length - 1]]));
             optionElements.push(subchildren[subchildren.length - 1]);


### PR DESCRIPTION
@vincentneko I believe this will fix the issue of an `AndOptions` not being supported as a child of `OrOptions`. There was no real reason I used to limit this to one option other than there was never a need for this complexity. I believe this change will work. I gave this a try through a few `OrOptions` and it didn't seem to break anything.