### PR TITLE
Improve tile coordinates log

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1564,9 +1564,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         return undefined;
       });
 
-      if (this.canAfford((9 - this.colonyTradeDiscount))) howToPayForTrade.options.push(payWithMC);
       if (this.energy >= (3 - this.colonyTradeDiscount)) howToPayForTrade.options.push(payWithEnergy);
       if (this.titanium >= (3 - this.colonyTradeDiscount)) howToPayForTrade.options.push(payWithTitanium);
+      if (this.canAfford((9 - this.colonyTradeDiscount))) howToPayForTrade.options.push(payWithMC);
 
       opts.push(howToPayForTrade);
       opts.push(selectColony);

--- a/src/components/LogHelper.ts
+++ b/src/components/LogHelper.ts
@@ -77,7 +77,14 @@ export class LogHelper {
     }
 
     static logTilePlacement(game: Game, player: Player, space: ISpace, tileType: TileType) {
+
+        // Skip off-grid tiles
+        if (space.x === -1 && space.y === -1) return;
+
         let type : string;
+        let offset: number = Math.abs(space.y - 4);
+        let row: number = space.y + 1;
+        let position: number = space.x - offset + 1;
 
         switch (tileType) {
             case TileType.GREENERY:
@@ -99,11 +106,11 @@ export class LogHelper {
 
         game.log(
             LogMessageType.DEFAULT,
-            "${0} placed ${1} tile on (${2}, ${3})",
+            "${0} placed ${1} tile on row ${2} position ${3}",
             new LogMessageData(LogMessageDataType.PLAYER, player.id),
             new LogMessageData(LogMessageDataType.STRING, type),
-            new LogMessageData(LogMessageDataType.STRING, space.x.toString()),
-            new LogMessageData(LogMessageDataType.STRING, space.y.toString())
+            new LogMessageData(LogMessageDataType.STRING, row.toString()),
+            new LogMessageData(LogMessageDataType.STRING, position.toString())            
         );
     }
 


### PR DESCRIPTION
- Human friendly tile coordinates : Green placed city tile on row 5 position 1
- Remove log lines for off-grid tiles (the one with -1, -1 coordinates, like Maxwell base for instance)
- Reorder colony trade payment options (energy then titanium then MC)