### PR TITLE
remove eslint from start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "build": "node make_locales.js && eslint src/*.ts && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js",
-    "start": "node make_locales.js && eslint src/*.ts && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js && node dist/server.js",
+    "start": "node make_locales.js && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js && node dist/server.js",
     "pretest": "tsc --build tsconfig-test.json",
     "test": "mocha dist/tests/**.spec.js dist/tests/cards/**.spec.js dist/tests/cards/corporation/**.spec.js dist/tests/cards/prelude/**.spec.js dist/tests/cards/venusNext/**.spec.js dist/tests/cards/colonies/**.spec.js dist/tests/cards/turmoil/**.spec.js dist/tests/cards/promo/**.spec.js dist/tests/globalEvents/**.spec.js dist/tests/milestones/**.spec.js",
     "testgiven": "tsc --build tsconfig.json && webpack --config webpack.config.js && tsc --build tsconfig-test.json && mocha",


### PR DESCRIPTION
`eslint` was added to `npm start` but `eslint` is only a `devDependency`. If the `start` command is going to run `eslint` it will need to be a dependency as heroku doesn't install `devDependency`. Since `eslint` is a development tool it doesn't make sense to include with `start` which is the command heroku or anyone installing locally to run would use. Only someone developing needs `eslint`.