### PR TITLE
allow for extra query params to /api/player route

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -323,7 +323,15 @@ function apiGetPlayer(
     req: http.IncomingMessage,
     res: http.ServerResponse
 ): void {
-  const playerId: string = req.url!.substring('/api/player?id='.length);
+  const qs = req.url!.substring('/api/player?'.length);
+  const queryParams = querystring.parse(qs);
+  let playerId = queryParams['id'] as string | Array<string> | undefined;
+  if (Array.isArray(playerId)) {
+    playerId = playerId[0];
+  }
+  if (playerId === undefined) {
+    playerId = "";
+  }
   const game = playersToGame.get(playerId);
   if (game === undefined) {
     notFound(req, res);


### PR DESCRIPTION
If you happen to append extra query string arguments to the player link the `/api/player` route ends up with the parameters. This change allows for the extra values to be passed to the route. The extra arguments are ignored. Internally the game does not append these query string arguments. These will get appended by third party applications but we should support them.