### PR TITLE
Selected card css

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -68,7 +68,7 @@
 
 input[type=checkbox]:checked + .filterDiv,
 input[type=radio]:checked + .filterDiv {
-  box-shadow: 0 0 0 2px #303030, 0 0 0px 5px #c97e23;
+  box-shadow: 0 0 0 2px #303030, 0 0 0px 6px #c97e23;
 }
 
 input[type=checkbox]:checked + .filterDiv::after,

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -68,9 +68,24 @@
 
 input[type=checkbox]:checked + .filterDiv,
 input[type=radio]:checked + .filterDiv {
-  box-shadow: 0 0 0 2px #303030, 0 0 8px 8px #e28c22;
-  transform: translate(0px, -5px);
-  transition: 0.1s;
+  box-shadow: 0 0 0 2px #303030, 0 0 0px 5px #c97e23;
+}
+
+input[type=checkbox]:checked + .filterDiv::after,
+input[type=radio]:checked + .filterDiv::after {
+  content: "✓";
+  position: absolute;
+  width: 252px;
+  height: 50px;
+  line-height: 50px;
+  top: 195px;
+  left: -6px;
+  text-align: center;
+  font-weight: bold;
+  font-size: 36px;
+  background: linear-gradient(to right, #c97e23, #e28c22, #c97e23);
+  color: black;
+  border-bottom: 1px solid #222;
 }
 
 .filterDiv3 {
@@ -1292,7 +1307,7 @@ input[type=radio]:checked + .filterDiv {
   font-size: 14px;
   background-color: rgb(255,204,100);
   background: linear-gradient(to right,#ddd,#666);
-  border-radius: 0px 20px 0px 16px;
+  border-radius: 0px 20px;
   border-top: 4px solid #dddddd;
   border-left: 4px solid #dddddd;
   border-bottom: 4px solid #898989;


### PR DESCRIPTION
The current blurry box-shadow selection is barely visible on mobile. 
A label is much better. 
Instead of using .js to add/remove the label, a pseudo ::after background is used for it.

Suggested design:
![Untitled](https://user-images.githubusercontent.com/6917565/93258424-8ff03900-f79e-11ea-92a6-f33189d7a080.png)

