### PR TITLE
Fixed no color for initial draft on player turn order

### DIFF
--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -56,9 +56,8 @@ export const PlayerHome = Vue.component("player-home", {
                     (player.needsToDraft === undefined && player.isActive)
                 ) {
                     classes.push("player_is_active");
-                } else {
-                    classes.push(playerBgColorClass(player.color));
                 }
+                classes.push(playerBgColorClass(player.color));
             }
             return classes.join(" ");
         },


### PR DESCRIPTION
Resolving this:
![initial](https://user-images.githubusercontent.com/836179/93340645-bf05b980-f835-11ea-8afe-4f93b3b9b650.png)
