### PR TITLE
Add sound for active player notification

### DIFF
--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -1,0 +1,66 @@
+const frequencies = [
+    196.00,
+    220.00,
+    246.94,
+    261.63,
+    293.66,
+    329.63,
+    349.23,
+    392.00,
+    440.00,
+    493.88,
+    523.25,
+    587.33,
+    659.25,
+    698.46,
+    783.99,
+    880.00,
+    987.77,
+    1046.50
+];
+
+function setupGainNode(audioCtx: AudioContext, time: number) {
+    time += audioCtx.currentTime;
+
+    const gainNode = audioCtx.createGain();
+    gainNode.connect(audioCtx.destination);
+    gainNode.gain.setValueAtTime(0, time);
+    gainNode.gain.linearRampToValueAtTime(1, time + 0.01);
+
+    return gainNode;
+}
+
+function setupOscillator(audioCtx: AudioContext, frequency: number, gainNode: GainNode) {
+    const oscillator = audioCtx.createOscillator();
+    oscillator.type = "sine";
+    oscillator.frequency.value = frequency;
+    oscillator.connect(gainNode);
+    
+    return oscillator;
+}
+
+function createAudioContext() {
+    const audioCtx = window.AudioContext || (window as any).webkitAudioContext ?  new AudioContext() : undefined;
+
+    if (audioCtx === undefined) console.log("This web browser doesn't support Web Audio API");
+    return audioCtx;
+}
+
+function playSound(audioCtx: AudioContext, frequency: number, time: number , len: number) {
+    const gainNode = setupGainNode(audioCtx, time);
+    const oscillator = setupOscillator(audioCtx, frequency, gainNode);
+
+    oscillator.start(time);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, time + len);
+    oscillator.stop(time + len);    
+}
+
+export function playActivePlayerSound() {
+    const audioCtx = createAudioContext();
+    if (audioCtx === undefined) return;
+
+    audioCtx.resume().then(() => {
+        playSound(audioCtx, frequencies[10], 0, 0.4);
+        playSound(audioCtx, frequencies[8], 0.2, 0.4);
+    });
+}

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -26,6 +26,7 @@ export const Preferences = Vue.component("preferences", {
             "hide_log": false,
             "lang": "en",
             "langs": LANGUAGES,
+            "enable_sounds": false
         };
     },
     methods: {
@@ -204,7 +205,13 @@ export const Preferences = Vue.component("preferences", {
                             <input type="checkbox" v-on:change="updatePreferences" v-model="hide_ma_scores" />
                             <i class="form-icon"></i> <span v-i18n>Hide Milestones / Awards scores</span>
                         </label>
-                    </div>                                       
+                    </div>   
+                    <div class="preferences_panel_item">
+                        <label class="form-switch">
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="enable_sounds" />
+                            <i class="form-icon"></i> <span v-i18n>Enable sounds</span>
+                        </label>
+                    </div>                                     
                     <div class="preferences_panel_item form-group">
                         <label class="form-label"><span v-i18n>Language</span> (<a href="javascript:document.location.reload(true);" v-i18n>refresh page</a> <span v-i18n>to see changes</span>)</label>
                         <div class="preferences_panel_langs">

--- a/src/components/PreferencesManager.ts
+++ b/src/components/PreferencesManager.ts
@@ -15,7 +15,10 @@ export class PreferencesManager {
         "hide_ma_scores",
         "hide_non_blue_cards",
         "hide_log",
-        "lang"];
+        "lang",
+        "enable_sounds"
+    ];
+
     static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();
     static localStorageSupported: boolean = typeof window["localStorage"] !== undefined && window["localStorage"] !== null;
 

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -1,4 +1,3 @@
-
 import Vue from "vue";
 
 import { AndOptions } from "./AndOptions";
@@ -13,6 +12,8 @@ import { SelectPlayer } from "./SelectPlayer";
 import { SelectSpace } from "./SelectSpace";
 import { $t } from "../directives/i18n";
 import { SelectPartyPlayer } from "./SelectPartyPlayer";
+import { PreferencesManager } from "./PreferencesManager";
+import { playActivePlayerSound } from "../SoundManager";
 
 var ui_update_timeout_id: number | undefined = undefined;
 
@@ -49,15 +50,17 @@ export const WaitingFor = Vue.component("waiting-for", {
                         if (result["result"] === "GO") {
                             (vueApp as any).$root.updatePlayer();
 
-                            if (Notification.permission !== 'granted') {
+                            if (Notification.permission !== "granted") {
                                 Notification.requestPermission();
                             }
                             if (Notification.permission === "granted") {
-                                new Notification('Terraforming Mars Online', {
+                                new Notification("Terraforming Mars Online", {
                                     icon: "/favicon.ico",
                                     body: "It's your turn!",
                                 });
                             }
+                            const soundsEnabled = PreferencesManager.loadValue("enable_sounds") === "1";
+                            if (soundsEnabled) playActivePlayerSound();
 
                             // We don't need to wait anymore - it's our turn
                             return;
@@ -97,7 +100,7 @@ export const WaitingFor = Vue.component("waiting-for", {
                         (window as any).location = (window as any).location;
                     }
 
-                } else if (xhr.status === 400 && xhr.responseType === 'json') {
+                } else if (xhr.status === 400 && xhr.responseType === "json") {
                     const element: HTMLElement | null = document.getElementById("dialog-default");
                     const message: HTMLElement | null = document.getElementById("dialog-default-message");
                     if (message !== null && element !== null && (element as HTMLDialogElement).showModal !== undefined) {


### PR DESCRIPTION
First-cut attempt at cleaning up and fixing an issue in the previous PR by @jijiqw in https://github.com/bafolts/terraforming-mars/pull/1219.

This is a POC for adding a sound when it is the active player's turn. If this approach is viable we can gradually introduce more sounds that can be customised and exported as individual functions.