### PR TITLE
return 500 response on server error

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -49,10 +49,7 @@ const styles = fs.readFileSync("styles.css");
 const games: Map<string, Game> = new Map<string, Game>();
 const playersToGame: Map<string, Game> = new Map<string, Game>();
 
-function requestHandler(
-    req: http.IncomingMessage,
-    res: http.ServerResponse
-): void {
+function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.url !== undefined) {
         if (req.method === "GET") {
             if (req.url.replace(/\?.*$/, "").startsWith("/games-overview")) {
@@ -125,6 +122,17 @@ function requestHandler(
         }
     } else {
         notFound(req, res);
+    }
+}
+
+function requestHandler(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+): void {
+    try {
+        processRequest(req, res);
+    } catch (error) {
+        internalServerError(res, error);
     }
 }
 
@@ -259,12 +267,10 @@ function loadGame(req: http.IncomingMessage, res: http.ServerResponse): void {
             );
             res.setHeader("Content-Type", "application/json");
             res.write(getGame(gameToRebuild));
-        } catch (err) {
-            console.warn("error loading game", err);
-            res.writeHead(500);
-            res.write("Unable to load game");
+            res.end();
+        } catch (error) {
+            internalServerError(res, error);
         }
-        res.end();
     });
 }
 
@@ -455,12 +461,10 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
             });
             res.setHeader("Content-Type", "application/json");
             res.write(getGame(game));
-        } catch (err) {
-            console.warn("error creating game", err);
-            res.writeHead(500);
-            res.write("Unable to create game");
+            res.end();
+        } catch (error) {
+            internalServerError(res, error);
         }
-        res.end();
     });
 }
 
@@ -958,6 +962,13 @@ function getGame(game: Game): string {
         players: game.getPlayers(),
     };
     return JSON.stringify(output);
+}
+
+function internalServerError(res: http.ServerResponse, err: unknown): void {
+    console.warn("internal server error", err);
+    res.writeHead(500);
+    res.write("Internal server error " + err);
+    res.end();
 }
 
 function notFound(req: http.IncomingMessage, res: http.ServerResponse): void {


### PR DESCRIPTION
As this repository gains game options and contributors we have had short term errors show up which crash the node process. Since every game runs on one node process if there is any uncaught exception the node process has to be manually restarted. This change wraps all external requests and returns a 500 response if there is an error processing the exception.