### PR TITLE
Added variables.less and mixins.less and setup inital values

### DIFF
--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -2,11 +2,18 @@
 @import (inline) "../../node_modules/spectre.css/dist/spectre-exp.min.css";
 @import (inline) "../../node_modules//spectre.css/dist/spectre-icons.min.css";
 @import (inline) "../../node_modules/dialog-polyfill/dialog-polyfill.css";
+@import "./variables.less";
+@import "./mixins.less";
 
 html,
 body {
     height: 100%;
     margin: 0px;
+}
+.btn {
+    color: @text_action !important;
+    background: @bg_action !important;
+    border-color: @boder_action !important;
 }
 
 .capitalized {
@@ -43,15 +50,13 @@ a:active {
 }
 
 body {
-    background: #303030;
-    color: #dddddd;
-    font-family: Ubuntu, Sans;
-    font-size: 23px;
+    background: @bg_main;
+    color: @text_main;
+    font-family: @font_family_main;
+    font-size: @font_size_big;
 }
 
 h1 {
-    color: #ddd;
-    font-family: Ubuntu, Sans;
     filter: drop-shadow(4px 4px 4px black);
     text-shadow: -1px -1px 1px #aaaa, 1px 1px 1px #333a;
     padding: 1px 15px;
@@ -59,8 +64,6 @@ h1 {
 }
 
 h2 {
-    color: #ddd;
-    font-family: Ubuntu, Sans;
     filter: drop-shadow(4px 4px 4px black);
     text-shadow: -1px -1px 6px #aaa4;
 }

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -41,7 +41,7 @@
 }
 
 .create-game--block {
-    background: #202020; 
+    background: #202020;
     padding: 25px;
 }
 
@@ -50,7 +50,7 @@
 }
 
 .create-game-action {
-    margin: 0 auto;
+    margin: 40px auto;
     text-align: center;
 }
 
@@ -70,18 +70,21 @@
 
 .create-game-player-name {
     color: #020202;
-    max-width: 430px
+    max-width: 430px;
 }
-.form-input::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+.form-input::placeholder {
+    /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: #888888;
     opacity: 1; /* Firefox */
 }
 
-.form-input::-ms-input-placeholder { /* Internet Explorer 10-11 */
+.form-input::-ms-input-placeholder {
+    /* Internet Explorer 10-11 */
     color: #888888;
 }
 
-.form-input::-ms-input-placeholder { /* Microsoft Edge */
+.form-input::-ms-input-placeholder {
+    /* Microsoft Edge */
     color: #888888;
 }
 

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,0 +1,25 @@
+@import "./variables.less";
+
+.player_red_bg() {
+    background: rgba(@player_red, 0.7);
+}
+
+.player_yellow_bg() {
+    background: rgba(@player_yellow, 0.7);
+}
+
+.player_green_bg() {
+    background: rgba(@player_green, 0.7);
+}
+
+.player_black_bg() {
+    background: rgba(@player_black, 0.7);
+}
+
+.player_blue_bg() {
+    background: rgba(@player_blue, 0.7);
+}
+
+.player_purple_bg() {
+    background: rgba(@player_purple, 0.7);
+}

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -1,17 +1,3 @@
-@player_red: rgb(153, 17, 0);
-@player_yellow: rgb(170, 170, 0);
-@player_green: rgb(0, 153, 0);
-@player_black: rgb(170, 170, 170);
-@player_blue: rgb(0, 102, 255);
-@player_purple: rgb(140, 0, 255);
-
-@player_red_bg: rgba(153, 17, 0, 0.7);
-@player_yellow_bg: rgba(170, 170, 0, 0.7);
-@player_green_bg: rgba(0, 153, 0, 0.7);
-@player_black_bg: rgba(170, 170, 170, 0.7);
-@player_blue_bg: rgba(0, 102, 255, 0.7);
-@player_purple_bg: rgba(140, 0, 255, 0.7);
-
 #player-home {
     padding-left: 20px;
     padding-top: 20px;
@@ -19,26 +5,27 @@
     background-attachment: fixed;
 }
 
-.player_color_red {
+// text shadows
+.player_shadow_color_red {
     text-shadow: -1px -1px 6px @player_red, 1px 1px 1px #333a;
 }
-.player_color_yellow {
+.player_shadow_color_yellow {
     text-shadow: -1px -1px 6px @player_yellow, 1px 1px 1px #333a;
 }
-.player_color_green {
+.player_shadow_color_green {
     text-shadow: -1px -1px 6px @player_green, 1px 1px 1px #333a;
 }
-
-.player_color_black {
+.player_shadow_color_black {
     text-shadow: -1px -1px 6px @player_black, 1px 1px 1px #333a;
 }
-.player_color_blue {
+.player_shadow_color_blue {
     text-shadow: -1px -1px 6px @player_blue, 1px 1px 1px #333a;
 }
-.player_color_purple {
+.player_shadow_color_purple {
     text-shadow: -1px -1px 6px @player_purple, 1px 1px 1px #333a;
 }
 
+// normal backgrounds
 .player_bg_color_red {
     background-color: @player_red;
 }
@@ -63,28 +50,29 @@
     background-color: @player_purple;
 }
 
+// backgroungs with opacity
 .player_overview_bg_color_red {
-    background-color: @player_red_bg;
+    .player_red_bg();
 }
 
 .player_overview_bg_color_yellow {
-    background-color: @player_yellow_bg;
+    .player_yellow_bg();
 }
 
 .player_overview_bg_color_green {
-    background-color: @player_green_bg;
+    .player_green_bg();
 }
 
 .player_overview_bg_color_black {
-    background-color: @player_black_bg;
+    .player_black_bg();
 }
 
 .player_overview_bg_color_blue {
-    background-color: @player_blue_bg;
+    .player_blue_bg();
 }
 
 .player_overview_bg_color_purple {
-    background-color: @player_purple_bg;
+    .player_purple_bg();
 }
 
 .game-title {

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,0 +1,23 @@
+@font_family_main: Ubuntu, Sans;
+//backgrounds
+@bg_main: rgb(48, 48, 48);
+@bg_dynamic: rgb(34, 34, 34);
+@bg_action: rgb(87, 85, 217);
+//borders
+@boder_action: rgb(75, 72, 214);
+//text
+@text_action: rgb(255, 255, 255);
+@text_main: rgb(221, 221, 221);
+//players
+@player_red: rgb(153, 17, 0);
+@player_yellow: rgb(170, 170, 0);
+@player_green: rgb(0, 153, 0);
+@player_black: rgb(170, 170, 170);
+@player_blue: rgb(0, 102, 255);
+@player_purple: rgb(140, 0, 255);
+//font size
+@font_size_big: 23px;
+@font_size_normal: 18px;
+@font_size_small: 14px;
+//#TODO
+//shadows


### PR DESCRIPTION
I started doing some work on the new Log visuals and decided to cleanup something that has been bothering me first:

+ added `variables.less` - a file holding values such as player colors, default action color, warning color, etc.
+ added `mixins.less` - similar to variables but for more complex combinations (like color and opacity)
+ started replacing some of the css values with their variable representation

Note: Should we accept this change we can try to use and replace color, shrift, etc. with variables whenever possible. I'd also suggest we do spacing in increment of 4px / 8px / 16px.

Reasoning: Control over the app outlook with a single source of truth (similar to theming).

Food for though: We have been discussing the change of colors in discord to a different palette. We could easily do that but I guess we have to stick to the original colors and look for rgb values close to them. The biggest concern is black that needs special attention (it is grey apart from the player marker). So my question is - do we ever want to escape the set of colors named "red", "yellow", "green" etc, and replace them with player "one", "two",  "three" and allow for any rgb values for backgrounds, borders and text shadows?

@alrusdi @ssimeonoff @nwai90 