### PR TITLE
Fix iconography for Mining Expedition

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -1010,8 +1010,8 @@ export const HTML_DATA: Map<string, string> =
       <div class="card-number">063</div>
         <div class="content ">
           <div class="tile oxygen-tile"></div><br>
-            <div class="resource steel"></div><div class="resource steel"></div>
-            <div class="resource plant red-outline"></div><div class="resource plant red-outline"></div>
+          - <div class="resource plant red-outline"></div><div class="resource plant red-outline"></div>
+          <div class="resource steel"></div><div class="resource steel"></div>
             <div class="description ">
                 (Raise oxygen 1 step. Remove 2 plants from any player. Gain 2 steel.)
             </div>


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1303

<img width="221" alt="Screenshot 2020-09-25 at 10 35 08 AM" src="https://user-images.githubusercontent.com/2408094/94220143-ec7bf280-ff1a-11ea-85f5-90903e7b4882.png">
