### PR TITLE
+fixed issue #1316 and refactored the way setVisibilityState works

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -36,10 +36,6 @@ export const mainAppSettings = {
     },
     "methods": {
         setVisibilityState: function (targetVar: string, isVisible: boolean) {
-            console.log(
-                this.getVisibilityState(targetVar),
-                "GET VISIBILITY STATE for" + targetVar
-            );
             if (isVisible === this.getVisibilityState(targetVar)) return;
             (this as any).componentsVisibility[targetVar] = isVisible;
         },

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -14,6 +14,12 @@ export const mainAppSettings = {
         componentsVisibility: {
             "millestones_list": true,
             "awards_list": true,
+            "tags_concise": false,
+            "pinned_player_0": false,
+            "pinned_player_1": false,
+            "pinned_player_2": false,
+            "pinned_player_3": false,
+            "pinned_player_4": false,
         },
         game: {
             players: [],
@@ -30,9 +36,12 @@ export const mainAppSettings = {
     },
     "methods": {
         setVisibilityState: function (targetVar: string, isVisible: boolean) {
+            console.log(
+                this.getVisibilityState(targetVar),
+                "GET VISIBILITY STATE for" + targetVar
+            );
             if (isVisible === this.getVisibilityState(targetVar)) return;
             (this as any).componentsVisibility[targetVar] = isVisible;
-            (this as any).playerkey++;
         },
         getVisibilityState: function (targetVar: string): boolean {
             return (this as any).componentsVisibility[targetVar] ? true : false;

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -5,18 +5,18 @@ import { PlayerMixin } from "./PlayerMixin";
 import { hidePlayerData } from "./overview/PlayerStatus";
 
 export const OtherPlayer = Vue.component("other-player", {
-    props: ["player"],
+    props: ["player", "playerIndex"],
     components: {
-        "stacked-cards": StackedCards
+        "stacked-cards": StackedCards,
     },
     mixins: [PlayerMixin],
     methods: {
         hideMe: function () {
-            hidePlayerData(this.$root, this.player);
+            hidePlayerData(this.$root, this.playerIndex);
         },
         isVisible: function () {
             return (this.$root as any).getVisibilityState(
-                "other_player_" + this.player.id
+                "pinned_player_" + this.playerIndex
             );
         },
     },

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -16,10 +16,6 @@ import { playerBgColorClass } from "../utils/utils";
 
 const dialogPolyfill = require("dialog-polyfill");
 
-export const hidePlayerData = (root: any, player: PlayerModel) => {
-    (root as any).setVisibilityState("other_player_" + player.id, false);
-};
-
 export const PlayerHome = Vue.component("player-home", {
     props: ["player"],
     components: {
@@ -52,14 +48,6 @@ export const PlayerHome = Vue.component("player-home", {
                 classes.push(playerBgColorClass(player.color));
             }
             return classes.join(" ");
-        },
-        showPlayerDetails: function (player: PlayerModel) {
-            if (player.id === this.player.id) return;
-
-            (this.$root as any).setVisibilityState(
-                "other_player_" + player.id,
-                true
-            );
         },
         getFleetsCountRange: function (player: PlayerModel): Array<number> {
             const fleetsRange: Array<number> = [];

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -5,7 +5,13 @@ import { PlayerStatus } from "./PlayerStatus";
 import { playerBgColorClass } from "../../utils/utils";
 
 export const PlayerInfo = Vue.component("player-info", {
-    props: ["player", "activePlayer", "firstForGen", "actionLabel"],
+    props: [
+        "player",
+        "activePlayer",
+        "firstForGen",
+        "actionLabel",
+        "playerIndex",
+    ],
     components: {
         "player-resources": PlayerResources,
         "player-tags": PlayerTags,
@@ -23,12 +29,12 @@ export const PlayerInfo = Vue.component("player-info", {
         },
         getIsActivePlayer: function (): boolean {
             return this.player.id === this.activePlayer.id;
-        }
+        },
     },
     template: ` 
         <div :class="getClasses()">
             <div :class="getPlayerStatusAndResClasses()">
-                <player-status :player="player" :activePlayer="activePlayer" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel"/>
+                <player-status :player="player" :activePlayer="activePlayer" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" :playerIndex="playerIndex"/>
                 <player-resources :player="player" v-trim-whitespace />
             </div>
             <player-tags :player="player" v-trim-whitespace :isActivePlayer="getIsActivePlayer()"/> 

--- a/src/components/overview/PlayerStatus.ts
+++ b/src/components/overview/PlayerStatus.ts
@@ -1,21 +1,25 @@
 import Vue from "vue";
 import { ActionLabel } from "./ActionLabel";
-import { PlayerModel } from "../../models/PlayerModel";
+import { range } from "../../utils/utils";
 
-const isPinned = (root: any, player: PlayerModel): boolean => {
-    return (root as any).getVisibilityState("pinned_player_" + player.id);
+const isPinned = (root: any, playerIndex: string): boolean => {
+    return (root as any).getVisibilityState("pinned_player_" + playerIndex);
 };
-const showPlayerData = (root: any, player: PlayerModel) => {
-    (root as any).setVisibilityState("pinned_player_" + player.id, true);
-    (root as any).setVisibilityState("other_player_" + player.id, true);
+const showPlayerData = (root: any, playerIndex: string) => {
+    (root as any).setVisibilityState("pinned_player_" + playerIndex, true);
 };
-export const hidePlayerData = (root: any, player: PlayerModel) => {
-    (root as any).setVisibilityState("pinned_player_" + player.id, false);
-    (root as any).setVisibilityState("other_player_" + player.id, false);
+export const hidePlayerData = (root: any, playerIndex: string) => {
+    (root as any).setVisibilityState("pinned_player_" + playerIndex, false);
 };
 
 export const PlayerStatus = Vue.component("player-status", {
-    props: ["player", "activePlayer", "firstForGen", "actionLabel"],
+    props: [
+        "player",
+        "activePlayer",
+        "firstForGen",
+        "actionLabel",
+        "playerIndex",
+    ],
     methods: {
         togglePlayerDetails: function () {
             // for active player => scroll to cards UI
@@ -57,32 +61,25 @@ export const PlayerStatus = Vue.component("player-status", {
             return this.player.playedCards.length;
         },
         pinPlayer: function () {
-            const player = this.player;
-            const players = this.activePlayer.players;
+            let hiddenPlayersIndexes: Array<Number> = [];
+            let playerPinned = isPinned(this.$root, this.playerIndex);
 
-            let hiddenPlayers: Array<PlayerModel> = [];
-            let playerPinned = isPinned(this.$root, player);
-
-            // if player is already pinned, on unpin add to hidden players
-            if (playerPinned) {
-                hiddenPlayers = players;
-            } else {
-                showPlayerData(this.$root, player);
-
-                for (i = 0; i < players.length; i++) {
-                    let p = players[i];
-                    if (p.id === this.activePlayer.id || player.id !== p.id) {
-                        hiddenPlayers.push(p);
-                    }
-                }
+            // if player is already pinned, add to hidden players (toggle)
+            hiddenPlayersIndexes = range(this.activePlayer.players.length - 1);
+            if (!playerPinned) {
+                showPlayerData(this.$root, this.playerIndex);
+                hiddenPlayersIndexes = hiddenPlayersIndexes.filter(
+                    (index) => index !== this.playerIndex
+                );
             }
-
-            for (var i = 0; i < hiddenPlayers.length; i++) {
-                hidePlayerData(this.$root, hiddenPlayers[i]);
+            for (var i = 0; i < hiddenPlayersIndexes.length; i++) {
+                if (hiddenPlayersIndexes.includes(i)) {
+                    hidePlayerData(this.$root, i.toString());
+                }
             }
         },
         buttonLabel: function (): string {
-            return isPinned(this.$root, this.player) ? "hide" : "show";
+            return isPinned(this.$root, this.playerIndex) ? "hide" : "show";
         },
     },
     template: `

--- a/src/components/overview/PlayersOverview.ts
+++ b/src/components/overview/PlayersOverview.ts
@@ -89,13 +89,13 @@ export const PlayersOverview = Vue.component("players-overview", {
         <div class="players-overview" v-if="hasPlayers()">
             <overview-settings />
             <div class="other_player" v-if="player.players.length > 1">
-                <div v-for="otherPlayer in player.players" :key="otherPlayer.id">
-                    <other-player v-if="otherPlayer.id !== player.id" :player="otherPlayer" />
+                <div v-for="(otherPlayer, index) in getPlayersInOrder()" :key="otherPlayer.id">
+                    <other-player v-if="otherPlayer.id !== player.id" :player="otherPlayer" :playerIndex="index"/>
                 </div>
             </div>
-            <player-info v-for="p in getPlayersInOrder()" :activePlayer="player" :player="p"  :key="p.id" :firstForGen="getIsFirstForGen(p)" :actionLabel="getActionLabel(p)"/>
+            <player-info v-for="(p, index) in getPlayersInOrder()" :activePlayer="player" :player="p"  :key="p.id" :firstForGen="getIsFirstForGen(p)" :actionLabel="getActionLabel(p)" :playerIndex="index"/>
             <div v-if="player.players.length > 1" class="player-divider" />
-            <player-info :player="getPlayerOnFocus()" :activePlayer="player" :key="player.players.length - 1" :firstForGen="getIsFirstForGen(player)" :actionLabel="getActionLabel(player)"/>
+            <player-info :player="getPlayerOnFocus()" :activePlayer="player" :key="player.players.length - 1" :firstForGen="getIsFirstForGen(player)" :actionLabel="getActionLabel(player)" :playerIndex="-1"/>
         </div>
     `,
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,3 +3,5 @@ export const playerTextColorClass = (color: string): string =>
 
 export const playerBgColorClass = (color: string): string =>
     `player_overview_bg_color_${color}`;
+
+export const range = (n: number): Array<Number> => Array.from(Array(n).keys());


### PR DESCRIPTION
Concerning #1316

The problem was that `playerkey++` on `setVisibilityState` refreshes the whole Vue state which subsequently "resets" all child components that have local "data" to thier defaults. That is why on any toggle for milestone or award the cards got deselected or anything that has a local state actually. The solution was to remove the increment of `playerkey` from `setVisibiltyState` which led to some changes that need to be considered whenever global state is used in `componentsVisibility`. In order for everything to work, any item that is added to `componentVisibilty` needs to be initialized. By doing that I had to refactor the way `pinPlayer` works so now it uses indices which are initialized to be 0 to 5 (since its max 6 players and we can only pin all other players so its 6-1=5 indices that are initialized. I realise in games with less players the indices are unused but this is the best I could come up with).
