### PR TITLE
Fix: Prevent Helion from using heat to raise temp if can't pay for Reds

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2181,7 +2181,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       const temperatureIsMaxed = game.getTemperature() === constants.MAX_TEMPERATURE;
 
-      if (hasEnoughHeat && !temperatureIsMaxed && canAffordReds) {
+      const canAffordRedsForHeatConversion =
+        !redsAreRuling || (!this.isCorporation(CorporationName.HELION) && this.canAfford(REDS_RULING_POLICY_COST)) || this.canAfford(REDS_RULING_POLICY_COST + 8);
+
+      if (hasEnoughHeat && !temperatureIsMaxed && canAffordRedsForHeatConversion) {
         action.options.push(
             this.convertHeatIntoTemperature(game)
         );


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1375