### PR TITLE
refactor: show all log entries

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -64,7 +64,7 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
                     route.notAuthorized(req, res);
                     return;
                 } else {
-                    serveApp(res);
+                    serveApp(req, res);
                 }
             } else if (
                 req.url === "/" ||
@@ -76,7 +76,7 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
                 req.url.startsWith("/load") ||
                 req.url.startsWith("/debug-ui")
             ) {
-                serveApp(res);
+                serveApp(req, res);
             } else if (req.url.startsWith("/api/player?id=")) {
                 apiGetPlayer(req, res);
             } else if (req.url.startsWith("/api/waitingfor?id=")) {
@@ -1005,10 +1005,10 @@ function isServerIdValid(req: http.IncomingMessage): boolean {
     return true;
 }
 
-function serveApp(res: http.ServerResponse): void {
+function serveApp(req: http.IncomingMessage, res: http.ServerResponse): void {
     fs.readFile("index.html", function (err, data) {
         if (err) {
-            return internalServerError(res, err);
+            return route.internalServerError(req, res, err);
         }
         res.setHeader("Content-Type", "text/html; charset=utf-8");
         res.write(data.toString().replace("$$APP_VERSION$$", appVersion));
@@ -1052,11 +1052,11 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
         res.setHeader("Content-Type", "image/jpeg");
         file = reqFile;
     } else {
-        return notFound(req, res);
+        return route.notFound(req, res);
     }
     fs.readFile(file, function (err, data) {
         if (err) {
-            return internalServerError(res, err);
+            return route.internalServerError(req, res, err);
         }
         res.write(data);
         res.end();

--- a/server.ts
+++ b/server.ts
@@ -609,6 +609,10 @@ function getPlayer(player: Player, game: Game): string {
         titaniumValue: player.getTitaniumValue(game),
         victoryPointsBreakdown: player.getVictoryPoints(game),
         waitingFor: getWaitingFor(player.getWaitingFor()),
+        // DEPRECATED, included for transition to game log route
+        // remove after few days once most users have loaded
+        // new client
+        gameLog: game.gameLog.length > 50 ? game.gameLog.slice(game.gameLog.length - 50) : game.gameLog,
         isSoloModeWin: game.isSoloModeWin(),
         gameAge: game.gameAge,
         isActive: player.id === game.activePlayer,

--- a/server.ts
+++ b/server.ts
@@ -12,6 +12,8 @@ import { CardModel } from "./src/models/CardModel";
 import { ColonyModel } from "./src/models/ColonyModel";
 import { Color } from "./src/Color";
 import { Game, GameOptions } from "./src/Game";
+import { GameLogs } from "./src/routes/GameLogs";
+import { Route } from "./src/routes/Route";
 import { ICard } from "./src/cards/ICard";
 import { IProjectCard } from "./src/cards/IProjectCard";
 import { ISpace } from "./src/ISpace";
@@ -51,13 +53,15 @@ const styles = fs.readFileSync("styles.css");
 const games: Map<string, Game> = new Map<string, Game>();
 const playersToGame: Map<string, Game> = new Map<string, Game>();
 const appVersion = generateAppVersion();
+const route = new Route();
+const gameLogs = new GameLogs(playersToGame);
 
 function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.url !== undefined) {
         if (req.method === "GET") {
             if (req.url.replace(/\?.*$/, "").startsWith("/games-overview")) {
                 if (!isServerIdValid(req)) {
-                    notAuthorized(req, res);
+                    route.notAuthorized(req, res);
                     return;
                 } else {
                     serveApp(res);
@@ -93,12 +97,14 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
                 serveAsset(req, res);
             } else if (req.url.startsWith("/api/games")) {
                 apiGetGames(req, res);
-            } else if (req.url.indexOf("/api/game") === 0) {
+            } else if (req.url.indexOf("/api/game?id=") === 0) {
                 apiGetGame(req, res);
+            } else if (gameLogs.canHandle(req.url)) {
+                gameLogs.handle(req, res);
             } else if (req.url.startsWith("/api/clonablegames")) {
                 getClonableGames(res);
             } else {
-                notFound(req, res);
+                route.notFound(req, res);
             }
         } else if (req.method === "PUT" && req.url.indexOf("/game") === 0) {
             createGame(req, res);
@@ -113,20 +119,20 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
             );
             const game = playersToGame.get(playerId);
             if (game === undefined) {
-                notFound(req, res);
+                route.notFound(req, res);
                 return;
             }
             const player = game.getPlayers().find((p) => p.id === playerId);
             if (player === undefined) {
-                notFound(req, res);
+                route.notFound(req, res);
                 return;
             }
             processInput(req, res, player, game);
         } else {
-            notFound(req, res);
+            route.notFound(req, res);
         }
     } else {
-        notFound(req, res);
+        route.notFound(req, res);
     }
 }
 
@@ -137,7 +143,7 @@ function requestHandler(
     try {
         processRequest(req, res);
     } catch (error) {
-        internalServerError(res, error);
+        route.internalServerError(req, res, error);
     }
 }
 
@@ -236,12 +242,12 @@ function apiGetGames(
     res: http.ServerResponse
 ): void {
     if (!isServerIdValid(req)) {
-        notAuthorized(req, res);
+        route.notAuthorized(req, res);
         return;
     }
 
     if (games === undefined) {
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -287,7 +293,7 @@ function loadGame(req: http.IncomingMessage, res: http.ServerResponse): void {
             res.write(getGame(gameToRebuild));
             res.end();
         } catch (error) {
-            internalServerError(res, error);
+            route.internalServerError(req, res, error);
         }
     });
 }
@@ -325,13 +331,13 @@ function apiGetGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
     if (req.url === undefined) {
         console.warn("url not defined");
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
     if (!routeRegExp.test(req.url)) {
         console.warn("no match with regexp");
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -339,7 +345,7 @@ function apiGetGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
     if (matches === null || matches[1] === undefined) {
         console.warn("didn't find game id");
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -349,7 +355,7 @@ function apiGetGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
     if (game === undefined) {
         console.warn("game is undefined");
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -368,12 +374,12 @@ function apiGetWaitingFor(
     const prevGameAge = parseInt((queryParams as any)["prev-game-age"]);
     const game = playersToGame.get(playerId);
     if (game === undefined) {
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
     const player = game.getPlayers().find((player) => player.id === playerId);
     if (player === undefined) {
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -406,12 +412,12 @@ function apiGetPlayer(
     }
     const game = playersToGame.get(playerId);
     if (game === undefined) {
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
     const player = game.getPlayers().find((player) => player.id === playerId);
     if (player === undefined) {
-        notFound(req, res);
+        route.notFound(req, res);
         return;
     }
 
@@ -482,7 +488,7 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
             res.write(getGame(game));
             res.end();
         } catch (error) {
-            internalServerError(res, error);
+            route.internalServerError(req, res, error);
         }
     });
 }
@@ -603,7 +609,6 @@ function getPlayer(player: Player, game: Game): string {
         titaniumValue: player.getTitaniumValue(game),
         victoryPointsBreakdown: player.getVictoryPoints(game),
         waitingFor: getWaitingFor(player.getWaitingFor()),
-        gameLog: game.gameLog,
         isSoloModeWin: game.isSoloModeWin(),
         gameAge: game.gameAge,
         isActive: player.id === game.activePlayer,
@@ -988,32 +993,6 @@ function getGame(game: Game): string {
     return JSON.stringify(output);
 }
 
-function internalServerError(res: http.ServerResponse, err: unknown): void {
-    console.warn("internal server error", err);
-    res.writeHead(500);
-    res.write("Internal server error " + err);
-    res.end();
-}
-
-function notFound(req: http.IncomingMessage, res: http.ServerResponse): void {
-    if (!process.argv.includes("hide-not-found-warnings")) {
-        console.warn("Not found", req.method, req.url);
-    }
-    res.writeHead(404);
-    res.write("Not found");
-    res.end();
-}
-
-function notAuthorized(
-    req: http.IncomingMessage,
-    res: http.ServerResponse
-): void {
-    console.warn("Not authorized", req.method, req.url);
-    res.writeHead(403);
-    res.write("Not authorized");
-    res.end();
-}
-
 function isServerIdValid(req: http.IncomingMessage): boolean {
     const queryParams = querystring.parse(req.url!.replace(/^.*\?/, ""));
     if (
@@ -1058,7 +1037,7 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
 
         // Disallow to go outside of assets directory
         if (!reqFile.startsWith(assetsRoot) || !fs.existsSync(reqFile)) {
-            return notFound(req, res);
+            return route.notFound(req, res);
         }
         res.setHeader("Content-Type", "image/png");
         file = reqFile;
@@ -1068,7 +1047,7 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
 
         // Disallow to go outside of assets directory
         if (!reqFile.startsWith(assetsRoot) || !fs.existsSync(reqFile)) {
-            return notFound(req, res);
+            return route.notFound(req, res);
         }
         res.setHeader("Content-Type", "image/jpeg");
         file = reqFile;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1703,9 +1703,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
       this.gameLog.push(builder.logMessage());
       this.gameAge++;
-      if (this.gameLog.length > 50 ) {
-        (this.gameLog.shift());
-      }
     }
 
     public someoneHasResourceProduction(resource: Resources, minQuantity: number = 1): boolean {

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -137,7 +137,7 @@ export const GameEnd = Vue.component("game-end", {
                 <br/>
                 <div class="game_end_block--log">
                     <h2 v-i18n>Final game log</h2>
-                    <log-panel :messages="player.gameLog" :players="player.players"></log-panel>
+                    <log-panel :id="player.id" :players="player.players"></log-panel>
                 </div>
             </div>
         </div>

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -10,10 +10,11 @@ import { $t } from "../directives/i18n";
 import { getProjectCardByName } from "./../Dealer";
 
 export const LogPanel = Vue.component("log-panel", {
-    props: ["messages", "players"],
+    props: ["id", "players"],
     data: function () {
         return {
             cards: new Array<string>(),
+            messages: new Array<LogMessage>()
         }
     },
     components: {
@@ -132,7 +133,16 @@ export const LogPanel = Vue.component("log-panel", {
         },
     },
     mounted: function () {
-        this.$nextTick(this.scrollToEnd);
+        fetch(`/api/game/logs?id=${this.id}&limit=50`)
+            .then((response) => response.json())
+            .then((messages) => {
+                this.messages.splice(0, this.messages.length);
+                this.messages.push(...messages);
+                this.$nextTick(this.scrollToEnd);
+            })
+            .catch((error) => {
+                console.error("error updating messages", error);
+            });
     },
     template: `
     <div>

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -139,13 +139,13 @@ export const PlayerHome = Vue.component("player-home", {
 
                 <players-overview class="player_home_block player_home_block--players nofloat:" :player="player" v-trim-whitespace />
 
-                <div class="player_home_block player_home_block--log player_home_block--hide_log nofloat" v-if="player.gameLog.length > 0">
+                <div class="player_home_block player_home_block--log player_home_block--hide_log nofloat">
                     <dynamic-title v-if="player.players.length > 1" title="Game log" :color="player.color" :withAdditional="true" :additional="'generation' + player.generation" />
                     <h2 v-else :class="'player_color_'+ player.color">
                         <span v-i18n>Game log</span>
                         <span class="label-additional" v-html="getGenerationText()"></span>
                     </h2>
-                    <log-panel :messages="player.gameLog" :players="player.players"></log-panel>
+                    <log-panel :id="player.id" :players="player.players"></log-panel>
                 </div>
 
                 <div class="player_home_block player_home_block--actions nofloat">

--- a/src/components/overview/PlayerTags.ts
+++ b/src/components/overview/PlayerTags.ts
@@ -78,8 +78,8 @@ export const PlayerTags = Vue.component("player-tags", {
                 <tag-count :tag="'cards'" :count="getCardCount()" :size="'big'" :type="'main'"/>
             </div>
             <div class="player-tags-secondary">
-                <tag-count v-if="showShortTags()" v-for="tag in player.tags" :tag="tag.tag" :count="tag.count" :size="'big'" :type="'secondary'"/>
-                <tag-count v-if="showLongTags()" v-for="tagName in getTagsPlaceholders()" :tag="tagName" :count="getTagCount(tagName)" :size="'big'" :type="'secondary'"/>
+                <tag-count v-if="showShortTags()" v-for="tag in player.tags" :key="tag.tag" :tag="tag.tag" :count="tag.count" :size="'big'" :type="'secondary'"/>
+                <tag-count v-if="showLongTags()" v-for="tagName in getTagsPlaceholders()" :key="tagName" :tag="tagName" :count="getTagCount(tagName)" :size="'big'" :type="'secondary'"/>
             </div>
         </div>
     `,

--- a/src/routes/GameLogs.ts
+++ b/src/routes/GameLogs.ts
@@ -1,0 +1,58 @@
+
+import * as http from "http";
+import * as querystring from "querystring";
+
+import { Game } from "../Game";
+import { Route } from "./Route";
+
+export class GameLogs extends Route {
+    constructor(private games: Map<string, Game>) {
+        super();
+    }
+    public canHandle(url: string): boolean {
+        return url.startsWith("/api/game/logs?");
+    }
+    public handle(req: http.IncomingMessage, res: http.ServerResponse): void {
+
+        if (req.url === undefined) {
+            console.warn("url not defined");
+            this.notFound(req, res);
+            return;
+        }
+
+        const params = querystring.parse(req.url.substring(req.url.indexOf("?") + 1));
+
+        let id = params.id;
+        let limit = params.limit;
+
+        if (id === undefined || Array.isArray(id)) {
+            this.badRequest(req, res);
+            return;
+        }
+
+        const game = this.games.get(id);
+
+        if (game === undefined) {
+            console.warn("game not found");
+            this.notFound(req, res);
+            return;
+        }
+
+        let log = game.gameLog;
+
+        if (limit !== undefined && !Array.isArray(limit)) {
+            const theLimit = parseInt(limit);
+            if (isNaN(theLimit)) {
+                this.badRequest(req, res);
+                return;
+            }
+            if (log.length > theLimit) {
+                log.splice(0, log.length - theLimit);
+            }
+        }
+
+        res.setHeader("Content-Type", "application/json");
+        res.write(JSON.stringify(log));
+        res.end();
+    }
+}

--- a/src/routes/Route.ts
+++ b/src/routes/Route.ts
@@ -1,0 +1,31 @@
+
+import * as http from "http";
+
+export class Route {
+    public badRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+        console.warn("bad request", req.url);
+        res.writeHead(400);
+        res.write("Bad request");
+        res.end();
+    }
+    public notFound(req: http.IncomingMessage, res: http.ServerResponse): void {
+        if (!process.argv.includes("hide-not-found-warnings")) {
+            console.warn("Not found", req.method, req.url);
+        }
+        res.writeHead(404);
+        res.write("Not found");
+        res.end();
+    }
+    public internalServerError(req: http.IncomingMessage, res: http.ServerResponse, err: unknown): void {
+        console.warn("internal server error", req.url, err);
+        res.writeHead(500);
+        res.write("Internal server error " + err);
+        res.end();
+    }
+    public notAuthorized(req: http.IncomingMessage, res: http.ServerResponse): void {
+        console.warn("Not authorized", req.method, req.url);
+        res.writeHead(403);
+        res.write("Not authorized");
+        res.end();
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
         "src/cards/colonies/*.ts",
         "src/inputs/*.ts",
         "src/models/*.ts",
+        "src/routes/*.ts",
         "src/colonies/*.ts",
         "script.ts",
         "server.ts",


### PR DESCRIPTION
We have had an arbitrary limit placed on how much we log for game log entries. With #1110 there are users that want to see the entire log. I am curious to see how our memory will run on the heroku instance if we remove this limit. As long as this doesn't put us above the heroku memory limit it could be fine. I can keep an eye on the memory usage on heroku and remove if it is a problem. 