### PR TITLE
Fixed dynamic title wrong type validation warning

### DIFF
--- a/src/components/common/DynamicTitle.ts
+++ b/src/components/common/DynamicTitle.ts
@@ -16,7 +16,7 @@ export const DynamicTitle = Vue.component("dynamic-title", {
             default: false,
         },
         additional: {
-            type: String,
+            type: [String, Number],
             default: "",
         },
     },


### PR DESCRIPTION
This needs a quick merge. Fixes warning in console for incompatible type Int vs String