### PR TITLE
chore: add no-var and prefer-const eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,8 @@ module.exports = {
   ],
   'rules': {
     'eqeqeq': ['error', 'always'],
-    'quotes': ['error', 'double']
+    'quotes': ['error', 'double'],
+    'no-var': 'error',
+    'prefer-const': 'error'
   },
 };

--- a/src/Board.ts
+++ b/src/Board.ts
@@ -42,7 +42,7 @@ export abstract class Board {
     // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript
     // generate random float in [0,1) with seed
     protected mulberry32(): number {
-        var t = this.seed += 0x6D2B79F5;
+        let t = this.seed += 0x6D2B79F5;
         t = Math.imul(t ^ t >>> 15, t | 1);
         t ^= t + Math.imul(t ^ t >>> 7, t | 61);
         return ((t ^ t >>> 14) >>> 0) / 4294967296;
@@ -71,7 +71,7 @@ export abstract class Board {
                 const land_id = Number(land) - 3;
                 while (oceans[land_id]) {
                     satisfy = false;
-                    let idx = Math.floor(this.mulberry32() * (oceans.length + 1));
+                    const idx = Math.floor(this.mulberry32() * (oceans.length + 1));
                     [oceans[land_id], oceans[idx]] = [oceans[idx], oceans[land_id]];
                 }
             }
@@ -158,7 +158,7 @@ export abstract class Board {
     } 
 
     public getAvailableSpacesForMarker(player: Player): Array<ISpace> {
-        let spaces =  this.getAvailableSpacesOnLand(player)
+        const spaces =  this.getAvailableSpacesOnLand(player)
         .filter(
             (space) => this.getAdjacentSpaces(space).find(
                 (adj) => adj.player === player
@@ -189,7 +189,7 @@ export abstract class Board {
     }
 
     public getAvailableSpacesOnLand(player: Player): Array<ISpace> {
-        let landSpaces = this.getSpaces(SpaceType.LAND, player).filter(
+        const landSpaces = this.getSpaces(SpaceType.LAND, player).filter(
             (space) => space.tile === undefined && (space.player === undefined || space.player === player)
         );
 
@@ -209,7 +209,7 @@ export abstract class Board {
         let safety = 0;
         // avoid bugs which would lock node process
         while (safety < 1000) {
-            let space = this.getRandomSpace(offset);
+            const space = this.getRandomSpace(offset);
             if (this.canPlaceTile(space) && this.getAdjacentSpaces(space).filter(sp => sp.tile?.tileType === TileType.CITY).length === 0 && this.getAdjacentSpaces(space).find(sp => this.canPlaceTile(sp)) !== undefined) {
                 return space;
             }

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -1141,7 +1141,7 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
     // Function used to rebuild each objects
     public loadFromJSON(d: SerializedDealer): Dealer {
         // Assign each attributes
-        let o = Object.assign(this, d);
+        const o = Object.assign(this, d);
 
         // Rebuild deck
         this.deck = d.deck.map((element: IProjectCard)  => {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -266,7 +266,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       corporationCards = this.dealer.shuffleCards(corporationCards);
 
       // Give each player their corporation cards and other cards
-      for (var i = 0; i < players.length; i++) {
+      for (let i = 0; i < players.length; i++) {
         const player = players[i];
         const remainingPlayers = this.players.length - i;
 
@@ -355,9 +355,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     // Function to return an array of players from an array of player ids
     public getPlayersById(ids: Array<string>): Array<Player> {
-      let players: Array<Player> = [];
-      ids.forEach(id => players.push(this.getPlayerById(id)));
-      return players;
+      return ids.map((id) => this.getPlayerById(id));
     }
 
     // Function to construct the board and milestones/awards list
@@ -427,7 +425,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
         const player = new Player("test", Color.BLUE, false, 0);
         const player2 = new Player("test2", Color.RED, false, 0);
-        let gameToRebuild = new Game(gameId,[player,player2], player);
+        const gameToRebuild = new Game(gameId,[player,player2], player);
         Database.getInstance().restoreReferenceGame(gameId, gameToRebuild, function (err) {
           try{
             if (err) {
@@ -460,7 +458,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           game.turmoil = gameToRebuild.turmoil;
 
           // Set active player
-          let playerIndex = gameToRebuild.players.indexOf(gameToRebuild.first);
+          const playerIndex = gameToRebuild.players.indexOf(gameToRebuild.first);
           game.first = game.players[playerIndex];
           game.activePlayer = game.players[playerIndex].id;
 
@@ -483,8 +481,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
           // Update Players
           game.players.forEach(player => {
-            let playerIndex = game.players.indexOf(player);
-            let referencePlayer = gameToRebuild.players[playerIndex];
+            const playerIndex = game.players.indexOf(player);
+            const referencePlayer = gameToRebuild.players[playerIndex];
             player.dealtCorporationCards = referencePlayer.dealtCorporationCards;
             player.dealtPreludeCards = referencePlayer.dealtPreludeCards;
             player.dealtProjectCards = referencePlayer.dealtProjectCards;
@@ -526,7 +524,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public addColonyInterrupt(player: Player, allowDuplicate: boolean = false, title: string): void {
-      let openColonies = this.colonies.filter(colony => colony.colonies.length < 3
+      const openColonies = this.colonies.filter(colony => colony.colonies.length < 3
         && (colony.colonies.indexOf(player.id) === -1 || allowDuplicate)
         && colony.isActive);
       if (openColonies.length >0 ) {
@@ -602,7 +600,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       if (candidates.length === 0) {
         return;
       } else if (candidates.length === 1) {
-        let qtyToRemove = Math.min(candidates[0].plants, count);
+        const qtyToRemove = Math.min(candidates[0].plants, count);
 
         if (resource === Resources.PLANTS) {
           this.addInterrupt({ player, playerInput: new OrOptions(
@@ -621,7 +619,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       } else {
         if (resource === Resources.PLANTS) {
           const removalOptions = candidates.map((candidate) => {
-            let qtyToRemove = Math.min(candidate.plants, count);
+            const qtyToRemove = Math.min(candidate.plants, count);
 
             return new SelectOption("Remove " + qtyToRemove + " plants from " + candidate.name, "Remove plants", () => {
               candidate.setResource(resource, -qtyToRemove, this, player);
@@ -732,7 +730,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       player.pickedCorporationCard = corporationCard;
       // if all players picked corporationCard
       if(this.players.filter(aplayer => aplayer.pickedCorporationCard === undefined).length === 0 ){
-        for (let somePlayer of this.getPlayers()) {
+        for (const somePlayer of this.getPlayers()) {
           this.playCorporationCard(somePlayer, somePlayer.pickedCorporationCard!);
         }
       }
@@ -758,12 +756,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
       corporationCard.play(player, this);
       player.megaCredits = corporationCard.startingMegaCredits;
       if (corporationCard.name !== new BeginnerCorporation().name) {
-        let cardsToPayFor: number = player.cardsInHand.length;
+        const cardsToPayFor: number = player.cardsInHand.length;
         player.megaCredits -= cardsToPayFor * player.cardCost;
       }
 
       // trigger other corp's effect, e.g. SaturnSystems,PharmacyUnion,Splice
-      for (let somePlayer of this.getPlayers()) {
+      for (const somePlayer of this.getPlayers()) {
         if (somePlayer !== player && somePlayer.corporationCard !== undefined && somePlayer.corporationCard.onCorpCardPlayed !== undefined) {
             const actionFromPlayedCard: OrOptions | void = somePlayer.corporationCard.onCorpCardPlayed(player, this, corporationCard);
             if (actionFromPlayedCard !== undefined) {  // always be undefined for the present
@@ -864,7 +862,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         else if (this.draftRound === 1 && preludeDraft) {
           player.runDraftPhase(initialDraft,this,this.getNextDraft(player).name, player.dealtPreludeCards);
         } else {
-          let cards = this.unDraftedCards.get(this.getDraftCardsFrom(player));
+          const cards = this.unDraftedCards.get(this.getDraftCardsFrom(player));
           this.unDraftedCards.delete(this.getDraftCardsFrom(player));
           player.runDraftPhase(initialDraft, this, this.getNextDraft(player).name, cards);
         }
@@ -945,7 +943,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     private resolveTurmoilInterrupts() {
       if (this.interrupts.length > 0) {
-        let interrupt = this.interrupts.shift();
+        const interrupt = this.interrupts.shift();
         if (interrupt) {
           if (interrupt.beforeAction !== undefined) {
             interrupt.beforeAction();
@@ -1034,7 +1032,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
           this.gotoActionPhase();
         } else {
         // Resolve research interrupt (Helion player)
-          let interrupt = this.interrupts.shift();
+          const interrupt = this.interrupts.shift();
           if (interrupt !== undefined && interrupt.playerInput !== undefined) {
             if (interrupt.beforeAction !== undefined) {
               interrupt.beforeAction();
@@ -1072,7 +1070,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       } else {
         // Push last card for each player
         this.players.forEach((player) => {
-          let lastCards  = this.unDraftedCards.get(this.getDraftCardsFrom(player));
+          const lastCards  = this.unDraftedCards.get(this.getDraftCardsFrom(player));
           if (lastCards !== undefined) {
             player.draftedCards.push(...lastCards);
           }
@@ -1182,7 +1180,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Interrupt hook
       if (this.interrupts.length > 0) {
-        let interrupt = this.interrupts.shift();
+        const interrupt = this.interrupts.shift();
         if (interrupt !== undefined && interrupt.playerInput !== undefined) {
           if (interrupt.beforeAction !== undefined) {
             interrupt.beforeAction();
@@ -1224,7 +1222,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     private gotoEndGame(): void {
       Database.getInstance().cleanSaves(this.id, this.lastSaveId);
-      let scores:  Array<Score> = [];
+      const scores:  Array<Score> = [];
       this.players.forEach(player => {
         let corponame: String = "";
         if (player.corporationCard !== undefined) {
@@ -1492,7 +1490,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
 
       // Part 3. Setup for bonuses
-      var arcadianCommunityBonus = space.player === player && player.isCorporation(CorporationName.ARCADIAN_COMMUNITIES);
+      const arcadianCommunityBonus = space.player === player && player.isCorporation(CorporationName.ARCADIAN_COMMUNITIES);
 
       // Part 4. Place the tile
 
@@ -1593,9 +1591,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
     public getPlayers(): Array<Player> {
       // We always return them in turn order
-      let ret: Array<Player> = [];
+      const ret: Array<Player> = [];
       let insertIdx: number = 0;
-      for (let p of this.players) {
+      for (const p of this.players) {
         if (p.id === this.first.id || insertIdx > 0) {
           ret.splice(insertIdx, 0, p);
           insertIdx ++;
@@ -1607,9 +1605,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public getCardPlayer(name: string): Player {
-      for (let player of this.players) {
+      for (const player of this.players) {
         // Check cards player has played
-        for (let card of player.playedCards) {
+        for (const card of player.playedCards) {
           if (card.name === name) {
             return player;
           }
@@ -1708,7 +1706,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     public log(message: string, f?: (builder: LogBuilder) => void) {
-      var builder = new LogBuilder(message);
+      const builder = new LogBuilder(message);
       if (f) {
         f(builder);
       }
@@ -1775,15 +1773,15 @@ export class Game implements ILoadable<SerializedGame, Game> {
     // Function used to rebuild each objects
     public loadFromJSON(d: SerializedGame): Game {
       // Assign each attributes
-      let o = Object.assign(this, d);
+      const o = Object.assign(this, d);
 
       // Rebuild dealer object to be sure that we will have cards in the same order
-      let dealer = new Dealer(this.gameOptions.corporateEra, this.gameOptions.preludeExtension, this.gameOptions.venusNextExtension, this.gameOptions.coloniesExtension, this.gameOptions.promoCardsOption, this.gameOptions.turmoilExtension);
+      const dealer = new Dealer(this.gameOptions.corporateEra, this.gameOptions.preludeExtension, this.gameOptions.venusNextExtension, this.gameOptions.coloniesExtension, this.gameOptions.promoCardsOption, this.gameOptions.turmoilExtension);
       this.dealer = dealer.loadFromJSON(d.dealer);
 
       // Rebuild every player objects
       this.players = d.players.map((element: SerializedPlayer)  => {
-        let player = new Player(element.name, element.color, element.beginner, element.handicap);
+        const player = new Player(element.name, element.color, element.beginner, element.handicap);
         return player.loadFromJSON(element);
       });
 
@@ -1800,7 +1798,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
       this.milestones = [];
       this.awards = [];
 
-      let allMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES);
+      const allMilestones = ELYSIUM_MILESTONES.concat(HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES);
 
       d.milestones.forEach((element: IMilestone) => {
         allMilestones.forEach((ms: IMilestone) => {
@@ -1810,7 +1808,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         });
       });
 
-      let allAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS);
+      const allAwards = ELYSIUM_AWARDS.concat(HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS);
 
       d.awards.forEach((element: IAward) => {
         allAwards.forEach((award: IAward) => {
@@ -1827,9 +1825,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       d.board.spaces.forEach((element: ISpace) => {
         if(element.tile) {
-          let space = this.getSpace(element.id);
-          let tileType = element.tile.tileType;
-          let tileCard = element.tile.card;
+          const space = this.getSpace(element.id);
+          const tileType = element.tile.tileType;
+          const tileCard = element.tile.card;
           if (element.player){
             const player = this.players.find((player) => player.id === element.player!.id);
             // Prevent loss of "neutral" player tile ownership across reloads
@@ -1860,7 +1858,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         });
 
         d.colonies.forEach((element: IColony) => {
-          let colony = getColonyByName(element.name);
+          const colony = getColonyByName(element.name);
 
           // Assign each attributes
           Object.assign(colony, element);
@@ -1873,7 +1871,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Reload turmoil elements if needed
       if (this.gameOptions.turmoilExtension) {
-        let turmoil = new Turmoil(this);
+        const turmoil = new Turmoil(this);
         this.turmoil = turmoil.loadFromJSON(d.turmoil);
 
         // Rebuild lobby
@@ -1881,7 +1879,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
         // Rebuild parties
         d.turmoil.parties.forEach((element: IParty) => {
-          let party = this.turmoil?.getPartyByName(element.name);
+          const party = this.turmoil?.getPartyByName(element.name);
           if (element.partyLeader) {
             if (element.partyLeader === "NEUTRAL") {
               party!.partyLeader = "NEUTRAL";

--- a/src/HellasBoard.ts
+++ b/src/HellasBoard.ts
@@ -13,8 +13,8 @@ export class HellasBoard extends Board{
         this.spaces.push(new BoardColony(SpaceName.GANYMEDE_COLONY));
         this.spaces.push(new BoardColony(SpaceName.PHOBOS_SPACE_HAVEN));
 
-        let is_ocean = [];
-        let bonus = [];
+        const is_ocean = [];
+        const bonus = [];
         // y=0
         is_ocean.push(true, false, false, false, false);
         bonus.push([SpaceBonus.PLANT, SpaceBonus.PLANT], [SpaceBonus.PLANT, SpaceBonus.PLANT], [SpaceBonus.PLANT, SpaceBonus.PLANT], [SpaceBonus.PLANT, SpaceBonus.STEEL], [SpaceBonus.PLANT]);

--- a/src/MASynergy.ts
+++ b/src/MASynergy.ts
@@ -54,12 +54,12 @@ const SYNERGIES = [
 function shuffleArray(arr: Array<number>) {
     arr = arr.slice()
     for (let i = arr.length - 1; i > 0; i--) {
-        let j = Math.floor(Math.random() * (i + 1));
-        let temp = arr[i];
+        const j = Math.floor(Math.random() * (i + 1));
+        const temp = arr[i];
         arr[i] = arr[j];
         arr[j] = temp;
     }
-    return arr
+    return arr;
 }
 
 function getNumbersRange(start: number, end: number): Array<number> {
@@ -72,11 +72,11 @@ export function getRandomMilestonesAndAwards(withVenusian: boolean = true, requi
     let output: Array<number> = [];
     while(maxSynergyDetected > maxSynergyAllowed) {
         maxSynergyDetected = 0;
-        let rows = shuffleArray(getNumbersRange(0, withVenusian ? 15: 14));
-        let cols = shuffleArray(getNumbersRange(16, withVenusian ? 31: 30));
+        const rows = shuffleArray(getNumbersRange(0, withVenusian ? 15: 14));
+        const cols = shuffleArray(getNumbersRange(16, withVenusian ? 31: 30));
 
         output = [...rows.slice(0, requiredQty), ...cols.slice(0, requiredQty)].sort((a, b) => a - b);
-        let bound = requiredQty * 2;
+        const bound = requiredQty * 2;
         for (let i=0; i<bound - 1; i++) {
             for (let j=i+1; j<bound; j++) {
                 maxSynergyDetected = Math.max(
@@ -86,7 +86,7 @@ export function getRandomMilestonesAndAwards(withVenusian: boolean = true, requi
             }
         }
     }
-    let finalItems = output.map(n => MA_ITEMS[n]);
+    const finalItems = output.map(n => MA_ITEMS[n]);
     return {
         "milestones": finalItems.slice(0, requiredQty) as Array<IMilestone>,
         "awards": finalItems.slice(requiredQty) as Array<IAward>,

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -196,7 +196,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
     private resolveMonsInsurance(game: Game) {
       if (game.monsInsuranceOwner !== undefined) {
-        let retribution: number = Math.min(game.getPlayerById(game.monsInsuranceOwner).megaCredits, 3);
+        const retribution: number = Math.min(game.getPlayerById(game.monsInsuranceOwner).megaCredits, 3);
         this.megaCredits += retribution;
         game.getPlayerById(game.monsInsuranceOwner).setResource(Resources.MEGACREDITS,-3);
         if (retribution > 0) {
@@ -320,7 +320,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       // Victory points from cards
-      for (let playedCard of this.playedCards) {
+      for (const playedCard of this.playedCards) {
         if (playedCard.getVictoryPoints !== undefined) {
           this.victoryPointsBreakdown.setVictoryPoints("victoryPoints", playedCard.getVictoryPoints(this, game), playedCard.name);
         }
@@ -429,7 +429,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             this.corporationCard.getRequirementBonus !== undefined) {
               requirementsBonus += this.corporationCard.getRequirementBonus(this, game, venusOnly);
       }
-      for (let playedCard of this.playedCards) {
+      for (const playedCard of this.playedCards) {
         if (playedCard.getRequirementBonus !== undefined &&
            playedCard.getRequirementBonus(this, game)) {
             requirementsBonus += playedCard.getRequirementBonus(this, game);
@@ -525,7 +525,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     public getAllTags(): Array<ITagCount> {
-      let tags: Array<ITagCount> = [];
+      const tags: Array<ITagCount> = [];
       tags.push({tag : Tags.CITY, count : this.getTagCount(Tags.CITY, false, false)} as ITagCount);
       tags.push({tag : Tags.EARTH, count : this.getTagCount(Tags.EARTH, false, false)} as ITagCount);
       tags.push({tag : Tags.ENERGY, count : this.getTagCount(Tags.ENERGY, false, false)} as ITagCount);
@@ -603,7 +603,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     public checkMultipleTagPresence(tags: Array<Tags>): boolean {
-      var distinctCount = 0;
+      let distinctCount = 0;
       tags.forEach(tag => {
         if (this.getTagCount(tag, false, false) > 0) {
           distinctCount++;
@@ -1048,11 +1048,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     
 
     public getSelfReplicatingRobotsCards(game: Game) : Array<CardModel> {
-      let card = this.playedCards.find(card => card.name === CardName.SELF_REPLICATING_ROBOTS);
-      let cards : Array<CardModel> = [];
+      const card = this.playedCards.find(card => card.name === CardName.SELF_REPLICATING_ROBOTS);
+      const cards : Array<CardModel> = [];
       if (card instanceof SelfReplicatingRobots) {
         if (card.targetCards.length > 0) {
-          for (let targetCard of card.targetCards) {
+          for (const targetCard of card.targetCards) {
             cards.push(
               {
                 resources: targetCard.resourceCount,
@@ -1236,7 +1236,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         // Remove card from Self Replicating Robots
         const card = this.playedCards.find(card => card.name === CardName.SELF_REPLICATING_ROBOTS);
         if (card instanceof SelfReplicatingRobots) {
-          for (let targetCard of card.targetCards) {
+          for (const targetCard of card.targetCards) {
             if (targetCard.card.name === selectedCard.name) {
               const index = card.targetCards.indexOf(targetCard);
               card.targetCards.splice(index, 1);
@@ -1258,7 +1258,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             }
         }
 
-        for (let somePlayer of game.getPlayers()) {
+        for (const somePlayer of game.getPlayers()) {
             if (somePlayer.corporationCard !== undefined && somePlayer.corporationCard.onCardPlayed !== undefined) {
                 const actionFromPlayedCard: OrOptions | void = somePlayer.corporationCard.onCardPlayed(this, game, selectedCard);
                 if (actionFromPlayedCard !== undefined) {
@@ -1315,7 +1315,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
   }
 
   private sellPatents(game: Game): PlayerInput {
-      let result = new SelectCard(
+      const result = new SelectCard(
           "Sell patents",
           "Sell",
           this.cardsInHand,
@@ -1341,8 +1341,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     private buildColony(game: Game, openColonies: Array<IColony>): PlayerInput {
-      let coloniesModel: Array<ColonyModel> = game.getColoniesModel(openColonies);
-      let buildColony = new SelectColony("Build colony (" + constants.BUILD_COLONY_COST + " MC)", "Build", coloniesModel, (colonyName: ColonyName) => {
+      const coloniesModel: Array<ColonyModel> = game.getColoniesModel(openColonies);
+      return new SelectColony("Build colony (" + constants.BUILD_COLONY_COST + " MC)", "Build", coloniesModel, (colonyName: ColonyName) => {
         openColonies.forEach(colony => {
           if (colony.name === colonyName) {
             game.addSelectHowToPayInterrupt(this, constants.BUILD_COLONY_COST, false, false, "Select how to pay for Colony project");
@@ -1354,7 +1354,6 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         });
         return undefined;
       });
-      return buildColony;
     }      
 
     private airScrapping(game: Game): PlayerInput {
@@ -1457,10 +1456,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     } 
 
     private tradeWithColony(openColonies: Array<IColony>, game: Game): PlayerInput {
-      var opts: Array<OrOptions | SelectColony> = [];
+      const opts: Array<OrOptions | SelectColony> = [];
       let payWith: Resources | undefined = undefined; 
-      let coloniesModel: Array<ColonyModel> = game.getColoniesModel(openColonies);
-      let selectColony = new SelectColony("Select colony for trade", "trade", coloniesModel, (colonyName: ColonyName) => {
+      const coloniesModel: Array<ColonyModel> = game.getColoniesModel(openColonies);
+      const selectColony = new SelectColony("Select colony for trade", "trade", coloniesModel, (colonyName: ColonyName) => {
         openColonies.forEach(colony => {
           if (colony.name === colonyName) {
             game.log("${0} traded with ${1}", b => b.player(this).colony(colony));
@@ -1477,10 +1476,9 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           return undefined;
         });
         return undefined;
-      }
-      );
+      });
 
-      let howToPayForTrade = new OrOptions();
+      const howToPayForTrade = new OrOptions();
       howToPayForTrade.title = "Pay trade fee";
       howToPayForTrade.buttonLabel = "Pay";
 
@@ -1569,7 +1567,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       let heatAmount: number;
       let floaterAmount: number;
       if (this.isCorporation(CardName.STORMCRAFT_INCORPORATED) && this.getResourcesOnCorporation() > 0 ) {
-        let raiseTempOptions = new AndOptions (
+        const raiseTempOptions = new AndOptions (
           () => {
             if (heatAmount + (floaterAmount * 2) < 8) {
                 throw new Error("Need to pay 8 heat");
@@ -1596,14 +1594,13 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         });
 
       } else {
-
-      return new SelectOption("Convert 8 heat into temperature", "Convert heat",() => {
-        game.increaseTemperature(this, 1);
-        this.heat -= 8;
-        game.log("${0} converted heat into temperature", b => b.player(this));
-        return undefined;
-      });
-    }
+        return new SelectOption("Convert 8 heat into temperature", "Convert heat",() => {
+          game.increaseTemperature(this, 1);
+          this.heat -= 8;
+          game.log("${0} converted heat into temperature", b => b.player(this));
+          return undefined;
+        });
+      }
     }
 
     private claimMilestone(milestone: IMilestone, game: Game): SelectOption {
@@ -1747,7 +1744,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
     private resolveFinalGreeneryInterrupts(game: Game) {
       if (game.interrupts.length > 0) {
-        let interrupt = game.interrupts.shift();
+        const interrupt = game.interrupts.shift();
         if (interrupt) {
           if (interrupt.beforeAction !== undefined) {
             interrupt.beforeAction();
@@ -1764,16 +1761,16 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     private getPlayableCards(game: Game): Array<IProjectCard> {
-      let candidateCards: Array<IProjectCard> = [...this.cardsInHand];
+      const candidateCards: Array<IProjectCard> = [...this.cardsInHand];
       // Self Replicating robots check
       const card = this.playedCards.find(card => card.name === CardName.SELF_REPLICATING_ROBOTS);
       if (card instanceof SelfReplicatingRobots) {
-        for (let targetCard of card.targetCards) {
+        for (const targetCard of card.targetCards) {
           candidateCards.push(targetCard.card);
         }
       }
 
-      let playableCards = candidateCards.filter((card) => {
+      const playableCards = candidateCards.filter((card) => {
         const canUseSteel = card.tags.indexOf(Tags.STEEL) !== -1;
         const canUseTitanium = card.tags.indexOf(Tags.SPACE) !== -1;
         let maxPay = 0;
@@ -1787,7 +1784,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           maxPay += this.titanium * this.getTitaniumValue(game);
         }
 
-        let psychrophiles = this.playedCards.find(
+        const psychrophiles = this.playedCards.find(
           (playedCard) => playedCard.name === CardName.PSYCHROPHILES);
 
         if (psychrophiles !== undefined 
@@ -1796,7 +1793,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             maxPay += psychrophiles.resourceCount * 2;
         }
 
-        let dirigibles = this.playedCards.find(
+        const dirigibles = this.playedCards.find(
           (playedCard) => playedCard.name === CardName.DIRIGIBLES);
 
         if (dirigibles !== undefined 
@@ -1899,7 +1896,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       if ( game.gameOptions.coloniesExtension &&
         this.canAfford(constants.BUILD_COLONY_COST)) {
-        let openColonies = game.colonies.filter(colony => colony.colonies.length < 3 
+        const openColonies = game.colonies.filter(colony => colony.colonies.length < 3
           && colony.colonies.indexOf(this.id) === -1
           && colony.isActive);      
           if (openColonies.length > 0) {
@@ -1929,7 +1926,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       //Interrupt action
       const interruptIndex: number = game.interrupts.findIndex(interrupt => interrupt.player === this);
       if (interruptIndex !== -1) {
-        let interrupt = game.interrupts[interruptIndex];
+        const interrupt = game.interrupts[interruptIndex];
         if (interrupt !== undefined && interrupt.beforeAction !== undefined) {
           interrupt.beforeAction();
         }
@@ -1954,7 +1951,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       // Prelude cards have to be played first
       if (this.preludeCardsInHand.length > 0) {
         game.phase = Phase.PRELUDES;
-        let preludeMcBonus = this.getPreludeMcBonus(this.preludeCardsInHand);
+        const preludeMcBonus = this.getPreludeMcBonus(this.preludeCardsInHand);
 
         // Remove unplayable prelude cards
         this.preludeCardsInHand = this.preludeCardsInHand.filter(card => card.canPlay === undefined || card.canPlay(this, game, preludeMcBonus));
@@ -2019,7 +2016,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
 
       if (game.gameOptions.coloniesExtension) {
-        let openColonies = game.colonies.filter(colony => colony.isActive && colony.visitor === undefined);
+        const openColonies = game.colonies.filter(colony => colony.isActive && colony.visitor === undefined);
         if (openColonies.length > 0 
           && this.fleetSize > this.tradesThisTurn
           && (this.canAfford(9 - this.colonyTradeDiscount) 
@@ -2188,7 +2185,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     // Function used to rebuild each objects
     public loadFromJSON(d: SerializedPlayer): Player {
       // Assign each attributes
-      let o = Object.assign(this, d);
+      const o = Object.assign(this, d);
 
       // Rebuild generation played map
       this.generationPlayed = new Map<string, number>(d.generationPlayed);
@@ -2246,20 +2243,20 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Rebuild each played card
       this.playedCards = d.playedCards.map((element: IProjectCard)  => {
-        let card = getProjectCardByName(element.name)!;
+        const card = getProjectCardByName(element.name)!;
         if(element.resourceCount && element.resourceCount > 0) {
           card.resourceCount = element.resourceCount;
         }  
        
         if(card instanceof SelfReplicatingRobots) {
-          let targetCards = (element as SelfReplicatingRobots).targetCards;
+          const targetCards = (element as SelfReplicatingRobots).targetCards;
           if (targetCards !== undefined) {
             card.targetCards = targetCards;
             card.targetCards.forEach(robotCard => robotCard.card = getProjectCardByName(robotCard.card.name)!);
           }
         }
         if(card instanceof MiningArea || card instanceof MiningRights) {
-          let bonusResource = (element as MiningArea).bonusResource;
+          const bonusResource = (element as MiningArea).bonusResource;
           if (bonusResource !== undefined) {
             card.bonusResource = bonusResource;
           }


### PR DESCRIPTION
I noticed a pull request yesterday that was using `var`. The usage of `var` can lead to bugs. This requires `let` or `const`. Only `src/*.ts` is being linted. I will include other PRs to put every file under the linter. This should help us catch bugs.