### PR TITLE
fix: flaky playwright unit test

### DIFF
--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -45,13 +45,12 @@ export class Playwrights implements CorporationCard {
 
                 const removedCard = player.playedCards.pop() as IProjectCard;
                 player.removedFromPlayCards.push(removedCard); // Remove card from play
-              
                 return undefined;
             }
         );
     }
 
-    private getReplayableEvents(player: Player, game: Game) {
+    private getReplayableEvents(player: Player, game: Game): Array<IProjectCard> {
         const players = game.getPlayers();
         let playedEvents : IProjectCard[] = [];
 
@@ -63,8 +62,7 @@ export class Playwrights implements CorporationCard {
             const card = getProjectCardByName(e.name)!;
             const cost = player.getCardCost(game, card);
             const canAffordCard = player.canAfford(cost);
-            const canPlayCard = card.canPlay === undefined || (card.canPlay !== undefined && card.canPlay(player, game));
-            
+            const canPlayCard = card.canPlay === undefined || card.canPlay(player, game);
             return canAffordCard && canPlayCard;
         });
 

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -3,6 +3,7 @@ import { Playwrights } from "../../../src/cards/community/Playwrights";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from '../../../src/Game';
+import { ReleaseOfInertGases} from "../../../src/cards/ReleaseOfInertGases";
 import { TechnologyDemonstration } from "../../../src/cards/TechnologyDemonstration";
 import { SelectCard } from "../../../src/inputs/SelectCard";
 import { Resources } from "../../../src/Resources";
@@ -31,19 +32,20 @@ describe("Playwrights", function () {
     });
 
     it("Can replay own event", function () {
-        const techDemo = new TechnologyDemonstration();
-        techDemo.play(player, game);
-        player.playedCards.push(techDemo);
+        const event = new ReleaseOfInertGases();
+        let tr = player.getTerraformRating();
+        event.play(player, game);
+        player.playedCards.push(event);
 
-        expect(player.cardsInHand.length).to.eq(2);
+        expect(player.getTerraformRating()).to.eq(tr + 2);
         expect(card.canAct(player, game)).to.eq(false);
 
-        player.megaCredits = 5;
+        player.megaCredits = event.cost;
         expect(card.canAct(player, game)).to.eq(true);
 
         const selectCard = card.action(player, game) as SelectCard<ICard>;
-        selectCard.cb([techDemo]);
-        expect(player.cardsInHand.length).to.eq(4);
+        selectCard.cb([event]);
+        expect(player.getTerraformRating()).to.eq(tr + 4);
         expect(player.megaCredits).eq(0);
         expect(player.playedCards.length).to.eq(0);
         expect(player.removedFromPlayCards.length).to.eq(1);
@@ -56,7 +58,6 @@ describe("Playwrights", function () {
 
         player.megaCredits = 5;
         expect(card.canAct(player, game)).to.eq(true);
-
         const selectCard = card.action(player, game) as SelectCard<ICard>;
         selectCard.cb([techDemo]);
         expect(player.cardsInHand.length).to.eq(2);


### PR DESCRIPTION
This addresses #1388 

The failed run:

https://github.com/bafolts/terraforming-mars/pull/1442/checks?check_run_id=1196738089

Was failing on:

```
  1) Playwrights
       Can replay own event:

      AssertionError: expected 3 to equal 4
      + expected - actual

      -3
      +4
```

This would fail if when playing `TechnologyDemonstration` the first time a `TechnologyDemonstration` card were drawn. When repeating the playing of the card the `TechnologyDemonstration` card would be removed from hand so the final count would be 3 instead of 4. I modified the test to use an action that increases terraform rating instead as it should avoid these side effects.