### PR TITLE
fixing max button to not overspend

### DIFF
--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -81,7 +81,7 @@ export const PaymentWidgetMixin = {
         },
         setMaxValue: function (target: string): void {
             let currentValue: number = (this as any)[target];
-            let cardCost: number = (this as any).$data.cost;
+            const cardCost: number = (this as any).$data.cost;
             let amountHave: number = (this as any).player[target];
 
             let amountNeed: number = -1;

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -84,11 +84,9 @@ export const PaymentWidgetMixin = {
             const cardCost: number = (this as any).$data.cost;
             let amountHave: number = (this as any).player[target];
 
-            let amountNeed: number = -1;
+            let amountNeed: number = cardCost;
             if (["titanium", "steel", "microbes", "floaters"].includes(target)) {
                 amountNeed = Math.floor(cardCost/this.getResourceRate(target));
-            } else if (target === "heat") {
-                amountNeed = cardCost;
             }
 
             if (target === "microbes") amountHave = (this as any).playerinput.microbes;

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -81,12 +81,20 @@ export const PaymentWidgetMixin = {
         },
         setMaxValue: function (target: string): void {
             let currentValue: number = (this as any)[target];
-            let maxValue: number = (this as any).player[target];
+            let cardCost: number = (this as any).$data.cost;
+            let amountHave: number = (this as any).player[target];
 
-            if (target === "microbes") maxValue = (this as any).playerinput.microbes;
-            if (target === "floaters") maxValue = (this as any).playerinput.floaters;
+            let amountNeed: number = -1;
+            if (["titanium", "steel", "microbes", "floaters"].includes(target)) {
+                amountNeed = Math.floor(cardCost/this.getResourceRate(target));
+            } else if (target === "heat") {
+                amountNeed = cardCost;
+            }
 
-            while (currentValue < maxValue) {
+            if (target === "microbes") amountHave = (this as any).playerinput.microbes;
+            if (target === "floaters") amountHave = (this as any).playerinput.floaters;
+
+            while (currentValue < amountHave && currentValue < amountNeed) {
                 this.addValue(target, 1);
                 currentValue++;
             }


### PR DESCRIPTION
From this issue #1367 , the max button should not overpay. Currently it spends all available resources, not taking the card price into account.

This PR fixes that issue.

![image](https://user-images.githubusercontent.com/14239220/95000238-06f24380-058d-11eb-931e-86c9b859d007.png)

Before clicking max:

![image](https://user-images.githubusercontent.com/14239220/95000243-0fe31500-058d-11eb-9c26-1d07f2358136.png)

After clicking max:

![image](https://user-images.githubusercontent.com/14239220/95000248-17a2b980-058d-11eb-8067-2a769a1f3ba5.png)
