### PR TITLE
refactor: include git log information for version

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,31 +12,29 @@
     <body id="ts-preferences-target">
         <div id="app" :class="'topmost-'+screen">
             <div class="main-container">
-                <start-screen v-if="screen === 'start-screen'"></start-screen>
+                <start-screen v-if="screen === 'start-screen'" version="$$APP_VERSION$$"></start-screen>
                 <create-game-form
-                    v-if="screen === 'create-game-form'"
+                    v-else-if="screen === 'create-game-form'"
                 ></create-game-form>
-                <load-game-form v-if="screen === 'load'"></load-game-form>
+                <load-game-form v-else-if="screen === 'load'"></load-game-form>
                 <game-home
-                    v-if="screen === 'game-home'"
+                    v-else-if="screen === 'game-home'"
                     :game="game"
                 ></game-home>
                 <player-home
-                    v-if="screen === 'player-home'"
+                    v-else-if="screen === 'player-home'"
                     :player="player"
                     :key="playerkey"
                 ></player-home>
                 <game-end
-                    v-if="screen === 'the-end'"
+                    v-else-if="screen === 'the-end'"
                     :player="player"
                     :game="game"
                 ></game-end>
                 <games-overview
-                    v-if="screen === 'games-overview'"
+                    v-else-if="screen === 'games-overview'"
                 ></games-overview>
-                <debug-ui 
-                v-if="screen === 'debug-ui'"
-                ></debug-ui>
+                <debug-ui v-else-if="screen === 'debug-ui'"></debug-ui>
             </div>
         </div>
         <script src="/main.js"></script>

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,8 @@ import * as http from "http";
 import * as fs from "fs";
 import * as path from "path";
 import * as querystring from "querystring";
+import * as child_process from "child_process";
+
 import { AndOptions } from "./src/inputs/AndOptions";
 import { CardModel } from "./src/models/CardModel";
 import { ColonyModel } from "./src/models/ColonyModel";
@@ -48,6 +50,7 @@ const serverId = generateRandomServerId();
 const styles = fs.readFileSync("styles.css");
 const games: Map<string, Game> = new Map<string, Game>();
 const playersToGame: Map<string, Game> = new Map<string, Game>();
+const appVersion = generateAppVersion();
 
 function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.url !== undefined) {
@@ -84,7 +87,8 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
             } else if (
                 req.url.startsWith("/assets/") ||
                 req.url === "/favicon.ico" ||
-                req.url === "/main.js"
+                req.url === "/main.js" ||
+                req.url === "/main.js.map"
             ) {
                 serveAsset(req, res);
             } else if (req.url.startsWith("/api/games")) {
@@ -169,6 +173,15 @@ function generateRandomGameId(): string {
 
 function generateRandomServerId(): string {
     return generateRandomGameId();
+}
+
+function generateAppVersion(): string {
+    try {
+        return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();
+    } catch (error) {
+        console.warn("unable to generate app version", error);
+        return "unknown version";
+    }
 }
 
 function processInput(
@@ -1010,24 +1023,31 @@ function isServerIdValid(req: http.IncomingMessage): boolean {
 }
 
 function serveApp(res: http.ServerResponse): void {
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.write(fs.readFileSync("index.html"));
-    res.end();
+    fs.readFile("index.html", function (err, data) {
+        if (err) {
+            return internalServerError(res, err);
+        }
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.write(data.toString().replace("$$APP_VERSION$$", appVersion));
+        res.end();
+    });
 }
 
 function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.url === undefined) throw new Error("Empty url");
 
+    let file: string | undefined;
+
     if (req.url === "/favicon.ico") {
         res.setHeader("Content-Type", "image/x-icon");
-        res.write(fs.readFileSync("favicon.ico"));
-    } else if (req.url === "/main.js") {
+        file = "favicon.ico";
+    } else if (req.url === "/main.js" || req.url === "/main.js.map") {
         res.setHeader("Content-Type", "text/javascript");
-        res.write(fs.readFileSync("dist/main.js"));
+        file = "dist" + req.url;
     } else if (req.url === "/assets/Prototype.ttf") {
-        res.write(fs.readFileSync("assets/Prototype.ttf"));
+        file = "assets/Prototype.ttf";
     } else if (req.url === "/assets/futureforces.ttf") {
-        res.write(fs.readFileSync("assets/futureforces.ttf"));
+        file = "assets/futureforces.ttf";
     } else if (req.url.endsWith(".png")) {
         const assetsRoot = path.resolve("./assets");
         const reqFile = path.resolve(path.normalize(req.url).slice(1));
@@ -1037,7 +1057,7 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
             return notFound(req, res);
         }
         res.setHeader("Content-Type", "image/png");
-        res.write(fs.readFileSync(reqFile));
+        file = reqFile;
     } else if (req.url.endsWith(".jpg")) {
         const assetsRoot = path.resolve("./assets");
         const reqFile = path.resolve(path.normalize(req.url).slice(1));
@@ -1047,10 +1067,17 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
             return notFound(req, res);
         }
         res.setHeader("Content-Type", "image/jpeg");
-        res.write(fs.readFileSync(reqFile));
+        file = reqFile;
+    } else {
+        return notFound(req, res);
     }
-
-    res.end();
+    fs.readFile(file, function (err, data) {
+        if (err) {
+            return internalServerError(res, err);
+        }
+        res.write(data);
+        res.end();
+    });
 }
 
 function serveResource(res: http.ServerResponse, s: Buffer): void {

--- a/src/components/StartScreen.ts
+++ b/src/components/StartScreen.ts
@@ -22,7 +22,7 @@ export const StartScreen = Vue.component("start-screen", {
     <a class="start-screen-link start-screen-link--chat" href="https://discord.gg/fWXE53K" target="_blank" v-i18n>Join us on Discord</a>
     <div class="start-screen-header start-screen-link--languages">
       <language-switcher />
-      <div>{{version}}</div>
+      <div class="start-version">version: {{version}}</div>
     </div>
   </div>
 </div>`

--- a/src/components/StartScreen.ts
+++ b/src/components/StartScreen.ts
@@ -2,29 +2,28 @@ import Vue from "vue";
 import {LanguageSwitcher} from "./LanguageSwitcher";
 
 export const StartScreen = Vue.component("start-screen", {
+    props: ["version"],
     components: {
         LanguageSwitcher
     },
     template: `
-        <div class="start-screen">           
-            <div v-i18n class="start-screen-links">
-                <div class="start-screen-header start-screen-link--title">
-                    <div class="start-screen-title-top">TERRAFORMING</div> 
-                    <div class="start-screen-title-bottom">MARS</div>
-                </div>
-                <a class="start-screen-link start-screen-link--new-game" href="/new-game" v-i18n>New game</a>
-                <a class="start-screen-link start-screen-link--solo" href="/solo" v-i18n>Solo challenge</a>
-                <a class="start-screen-link start-screen-link--cards-list" href="https://ssimeonoff.github.io/cards-list" v-i18n>Cards list</a>
-                <a class="start-screen-link start-screen-link--board-game" href="https://boardgamegeek.com/boardgame/167791/terraforming-mars" v-i18n>Board game</a>
-                <a class="start-screen-link start-screen-link--about" href="https://github.com/bafolts/terraforming-mars" v-i18n>About us</a>
-                <a class="start-screen-link start-screen-link--changelog" href="https://github.com/bafolts/terraforming-mars/wiki/Changelog" v-i18n>Whats new?</a>
-                <a class="start-screen-link start-screen-link--chat" href="https://discord.gg/fWXE53K" target="_blank" v-i18n>Join us on Discord</a>
-                <div class="start-screen-header start-screen-link--languages">
-                    <language-switcher></language-switcher>
-                </div>
-            </div>
-
-
-        </div>
-    `
+<div class="start-screen">
+  <div v-i18n class="start-screen-links">
+    <div class="start-screen-header start-screen-link--title">
+      <div class="start-screen-title-top">TERRAFORMING</div>
+      <div class="start-screen-title-bottom">MARS</div>
+    </div>
+    <a class="start-screen-link start-screen-link--new-game" href="/new-game" v-i18n>New game</a>
+    <a class="start-screen-link start-screen-link--solo" href="/solo" v-i18n>Solo challenge</a>
+    <a class="start-screen-link start-screen-link--cards-list" href="https://ssimeonoff.github.io/cards-list" v-i18n>Cards list</a>
+    <a class="start-screen-link start-screen-link--board-game" href="https://boardgamegeek.com/boardgame/167791/terraforming-mars" v-i18n>Board game</a>
+    <a class="start-screen-link start-screen-link--about" href="https://github.com/bafolts/terraforming-mars" v-i18n>About us</a>
+    <a class="start-screen-link start-screen-link--changelog" href="https://github.com/bafolts/terraforming-mars/wiki/Changelog" v-i18n>Whats new?</a>
+    <a class="start-screen-link start-screen-link--chat" href="https://discord.gg/fWXE53K" target="_blank" v-i18n>Join us on Discord</a>
+    <div class="start-screen-header start-screen-link--languages">
+      <language-switcher />
+      <div>{{version}}</div>
+    </div>
+  </div>
+</div>`
 });

--- a/src/styles/start_screen.less
+++ b/src/styles/start_screen.less
@@ -126,3 +126,7 @@
     padding-top: 30px;
 
 }
+
+.start-version {
+    white-space: nowrap;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,11 @@
 'use strict'
 
+const child_process = require("child_process");
+const version = child_process.execSync("git log -1 --pretty=format:\"%h %cD\"").toString();
+
 module.exports = {
-  mode: 'development',
+  devtool: "source-map",
+  mode: 'production',
   entry: [
     './dist/script.js'
   ],
@@ -9,5 +13,8 @@ module.exports = {
     alias: {
         'vue$': 'vue/dist/vue.esm.js' // 'vue/dist/vue.common.js' for webpack 1
     }
+  },
+  stats: {
+    warnings: false
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const child_process = require("child_process");
-const version = child_process.execSync("git log -1 --pretty=format:\"%h %cD\"").toString();
-
 module.exports = {
   devtool: "source-map",
   mode: 'production',


### PR DESCRIPTION
This has a few changes related to how the server operates. 

Included with the `StartScreen` component is now the commit hash to display some form of version for users. It will appear as:

`e48ba89a Sun, 4 Oct 2020 15:40:43 -0600`

This should be a simple solution and not get in the way of contributors while allowing users to know which version of the application they are using. If we decide to update what this displays in the future the mechanism will be in place for displaying the value.

I also updated the webpack configuration to link to the source map. I noticed that all of our javascript was attempting to reach the source map through `webpack://` when the developer console was open. With this change the developer console should now link back to out typescript.

I also updated webpack to use production mode which runs minify on our javascript. This leads to a small main.js file. The main.js is now 1.3MB down from 2.6MB. With the map file now in place this should not impact developers as the map file still shows the original line numbers. For users without their devtools open they will now only have to load 1.3MB.

I also changed some of the `readFileSync` to `readFile` so they work asynchronously. As written all other requests would be blocked until the `readFileSync` call were to complete. Node is good at input and output and can get off the main thread while reading files.