### PR TITLE
refactor: pull version from SOURCE_VERSION

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -176,6 +176,10 @@ function generateRandomServerId(): string {
 }
 
 function generateAppVersion(): string {
+    // assumes SOURCE_VERSION is git hash
+    if (process.env.SOURCE_VERSION) {
+        return process.env.SOURCE_VERSION.substring(0, 7) + " deployed " + new Date().toISOString();
+    }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();
     } catch (error) {


### PR DESCRIPTION
The heroku plan being used which stays up is the cheapest available plan. There is a heroku buildpack which can provide the git hash through SOURCE_VERSION environment variable. Heroku removes the git directory before the node buildpack is used. I verified this change can work from:

http://terraforming-mars-dev.herokuapp.com/

Since we can't pull the git information with ease I included the date the change was deployed. With this string included in bug reports it should help us to know what version of the code was running.