### PR TITLE
[WIP] Fix: Some plays that can benefit from ocean adjacency bonus are blocked by Reds tax

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1112,6 +1112,20 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       return Math.max(cost, 0);
     }
 
+    public getMaxOceanPlacementBonus(game: Game) : number {
+      const spaces = game.board.getAvailableSpacesOnLand(this);
+      let maxRebate = 0;
+
+      spaces.forEach((space) => {
+        const adjacentSpaces = game.board.getAdjacentSpaces(space);
+        const oceanAdjacencyBonus = adjacentSpaces.map((s) => s.spaceType === SpaceType.OCEAN && s.tile ? this.oceanBonus : 0).reduce((acc, val) => acc + val);
+        
+        if (oceanAdjacencyBonus > maxRebate) maxRebate = oceanAdjacencyBonus;
+      })
+
+      return maxRebate;
+    }
+
     private addPlayedCard(game: Game, card: IProjectCard): void {
       this.playedCards.push(card);
       game.log("${0} played ${1}", b => b.player(this).card(card));
@@ -1830,6 +1844,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         }
 
         maxPay += this.megaCredits;
+
         return maxPay >= this.getCardCost(game, card) &&
                    (card.canPlay === undefined || card.canPlay(this, game));
       });

--- a/tests/cards/ArtificialLake.spec.ts
+++ b/tests/cards/ArtificialLake.spec.ts
@@ -2,11 +2,13 @@ import { expect } from "chai";
 import { ArtificialLake } from "../../src/cards/ArtificialLake";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
-import { Game } from "../../src/Game";
+import { Game, GameOptions } from "../../src/Game";
 import { SelectSpace } from "../../src/inputs/SelectSpace";
 import { SpaceType } from "../../src/SpaceType";
 import { TileType } from "../../src/TileType";
 import * as constants from '../../src/constants';
+import { maxOutOceans, setCustomGameOptions } from "../TestingUtils";
+import { Reds } from "../../src/turmoil/parties/Reds";
 
 describe("ArtificialLake", function () {
     let card : ArtificialLake, player : Player, game : Game;
@@ -54,5 +56,30 @@ describe("ArtificialLake", function () {
         // ...but an action to place ocean is not unavailable
         const action = card.play(player, game);
         expect(action).to.eq(undefined);
+    });
+
+    it("Can place ocean when Reds are ruling after counting ocean placement bonus", function () {
+        const gameOptions = setCustomGameOptions() as GameOptions;
+        game = new Game("foobar", [player], player, gameOptions);
+        game.turmoil!.rulingParty = new Reds();
+
+        (game as any).temperature = -6;
+        maxOutOceans(player, game, 7);
+        player.steel = 0;
+
+        // Scenario 1: Player can pay for card + Reds tax without needing ocean placement bonus
+        player.megaCredits = 18;
+        expect(card.canPlay(player, game)).to.eq(true);
+        const action = card.play(player, game);
+        const availableSpaces = (action as SelectSpace).availableSpaces.length;
+
+        // Scenario 2: Player can pay for card + Reds tax only after getting ocean placement bonus
+        player.megaCredits = 15;
+        expect(card.canPlay(player, game)).to.eq(true);
+        const action2 = card.play(player, game);
+        const availableSpaces2 = (action2 as SelectSpace).availableSpaces.length;
+
+        // Check: Available spaces in S2 always < S1 as part of the ocean bonus is used to pay Reds tax
+        expect(availableSpaces > availableSpaces2).to.eq(true);
     });
 });


### PR DESCRIPTION
**Ref:** https://github.com/bafolts/terraforming-mars/issues/1152

**Example scenario for 1 card:** Artificial Lake should be playable here. There is a valid spot that gives 4 MC upon placement. Current logic deems the card to be unplayable.

<img width="894" alt="Screenshot 2020-10-05 at 6 05 08 PM" src="https://user-images.githubusercontent.com/2408094/95071948-07c9d780-073d-11eb-8202-e65f3b8f6e53.png">

**Result:** Player is left with 1 MC (4 MC - 3 MC paid for Reds tax)

<img width="897" alt="Screenshot 2020-10-05 at 6 19 21 PM" src="https://user-images.githubusercontent.com/2408094/95072005-2039f200-073d-11eb-808c-b4d3d7391208.png">

This is a draft of a possible partial fix for the one-tile scenario. However it gets a lot more complicated as some cards can place 2-3 tiles on the board (e.g Ice Asteroid, Deimos Down / Giant Ice Asteroid triggering the bonus ocean).

