### PR TITLE
virus should always be playable

### DIFF
--- a/src/cards/Virus.ts
+++ b/src/cards/Virus.ts
@@ -1,4 +1,3 @@
-
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";

--- a/src/cards/Virus.ts
+++ b/src/cards/Virus.ts
@@ -20,11 +20,7 @@ export class Virus implements IProjectCard {
     public cardType: CardType = CardType.EVENT;
     public hasRequirements = false;
     public canPlay(player: Player, game: Game): boolean {
-        return this.getPossibleTargetCards(player, game).length +
-            game.getPlayers().filter((p) => 
-                ((p.id !== player.id && !p.plantsAreProtected()) 
-                || p.id === player.id)
-                && p.plants > 0).length > 0;
+        return true;
     }
 
     private getPossibleTargetCards(player: Player, game: Game): Array<ICard> {

--- a/src/cards/Virus.ts
+++ b/src/cards/Virus.ts
@@ -18,7 +18,7 @@ export class Virus implements IProjectCard {
     public name: CardName = CardName.VIRUS;
     public cardType: CardType = CardType.EVENT;
     public hasRequirements = false;
-    public canPlay(player: Player, game: Game): boolean {
+    public canPlay(): boolean {
         return true;
     }
 

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -45,4 +45,8 @@ describe("Virus", function () {
         expect(game.interrupts.length).to.eq(0);
         expect(player.plants).to.eq(5);
     });
+
+    it("Should play", function () {
+        expect(card.canPlay()).to.eq(true);
+    }
 });

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -48,5 +48,5 @@ describe("Virus", function () {
 
     it("Should play", function () {
         expect(card.canPlay()).to.eq(true);
-    }
+    });
 });


### PR DESCRIPTION
Virus should always be playable even when it does have a target. (You may want to play it to gain mc back from Media Group.) Current code prevents that.