### PR TITLE
Fixes #1518

### DIFF
--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -94,7 +94,7 @@ export const GameEnd = Vue.component("game-end", {
                         </thead>
                         <tbody>
                             <tr v-for="p in getSortedPlayers()">
-                                <td><a :href="'/player?id='+p.id+'&noredirect'" :style="getPlayerColorStyle(p)">{{ p.name }}</a></td>
+                                <td :style="getPlayerColorStyle(p)">{{ p.name }}</td>
                                 <td v-i18n>{{ p.corporationCard.name }}</td>
                                 <td>{{ p.victoryPointsBreakdown.terraformRating }}</td>
                                 <td>{{ p.victoryPointsBreakdown.milestones }}</td>


### PR DESCRIPTION
Removes the link to the player that no longer exists as game has ended. It might make sense to add this back in if we add a replay option from the perspective of a player, like in Board Game Arena.