### PR TITLE
use height for log-panel

### DIFF
--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -1,4 +1,5 @@
 .log-panel {
+    height: 180px;
     max-height: 180px;
     border-style:none;
     font-size: 18px;


### PR DESCRIPTION
With the log messages now loading asynchronously the log-panel component ends up growing once the messages are available. To avoid this div growing after the base page has loaded the height is set to the max-height. Once a few log messages are logged the max-height is reached anyway so this should only make the height larger during the first few actions of the first generation when nothing is logged. Eventually this separation of log messages from the main response should allow this log-panel component to filter messages.