### PR TITLE
Fix create game players form CSS

### DIFF
--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -323,7 +323,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
                         <div>
                             <input class="form-input form-inline create-game-player-name" placeholder="Your name" v-model="newPlayer.name" />
                         </div>
-                        <div>
+                        <div class="create-game-colors-wrapper">
                             <label class="form-label form-inline create-game-color-label" v-i18n>Color:</label>
                             <span class="create-game-colors-cont">
                             <label class="form-radio form-inline create-game-color" v-for="color in ['Red', 'Green', 'Yellow', 'Blue', 'Black', 'Purple']">

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -4,15 +4,17 @@
         margin: 4px 20px 0 0;
     }
 
-    .create-game-colors-cont {
-        margin-top: 9px;
-        display: inline-block;
-        margin-left: 70px;
+    .create-game-colors-wrapper {
+        display: flex;
     }
 
     .create-game-color-label {
-        margin-top: 6px;
-        position: absolute;
+        margin: 9px 10px 0 0;
+    }
+
+    .create-game-colors-cont {
+        margin-top: 9px;
+        display: inline-block;
     }
 
     .create-game-color {
@@ -28,7 +30,6 @@
 .create-game-player {
     padding: 25px;
     margin-right: 25px;
-    height: 210px;
     margin-bottom: 25px !important;
 }
 


### PR DESCRIPTION
Because of absolute positioning of the "Color" label it currently looks like this when translated:

![firefox_2020-10-08_12-13-52](https://user-images.githubusercontent.com/5318258/95405805-7f2d8000-0964-11eb-97ee-be970ce3bde2.png)

Also since it has a defined height, it looks like this with too many options (last option is out of the box):

![firefox_2020-10-08_15-04-24](https://user-images.githubusercontent.com/5318258/95413625-975aca80-0977-11eb-88e6-4b890b21c94b.png)

-----

This aims to fix both issues:

![firefox_2020-10-08_12-35-29](https://user-images.githubusercontent.com/5318258/95405936-d3386480-0964-11eb-9eeb-11468be4dbe0.png)
![firefox_2020-10-08_12-39-57](https://user-images.githubusercontent.com/5318258/95405937-d3d0fb00-0964-11eb-85c9-fb4eac745a3f.png)
