### PR TITLE
Update i18n.ts

### DIFF
--- a/src/directives/i18n.ts
+++ b/src/directives/i18n.ts
@@ -15,7 +15,7 @@ export function translateText(englishText: string): string {
     if (TM_translations[lang][englishText]) {
         translatedText = TM_translations[lang][englishText]
     } else {
-        let stripedText = englishText.replace(/^\(|\)$/gm, "");
+        let stripedText = englishText.replace(/^\((.*)\)$/gm, "$1");
         if (stripedText && stripedText !== englishText) {
             stripedText = translateText(stripedText);
             if (stripedText !== englishText) {


### PR DESCRIPTION
Temporary fix to prevent some issues with translated text ending with `)`, like the translation for `${0} bought ${1} card(s)`.

I call this temporary because the issue seems to be that the app tries to translate elements again and again even though the content hasn't changed. It ends up doing the following:
- Translates `${0} bought ${1} card(s)` into `${0} a acheté ${1} carte(s)`
- Tries to translate `${0} a acheté ${1} carte(s)`, cannot find it
- Then tries to translate `${0} a acheté ${1} carte(s` (notice the trimed parenthesis), still cannot find it
- Decides to put back the parenthesis it thinks it removed, and ends up displaying `(${0} a acheté ${1} carte(s)` (notice the leading parenthesis).

I suppose it would probably be better to remember what was translated and what wasn't but I don't feel confident making any PR for that matter as of yet.