### PR TITLE
Add translation to log messages parameters 

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -322,7 +322,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Print game_id if solo game
       if (players.length === 1) {
-        this.log("The id of this game is ${0}", b => b.string(this.id));
+        this.log("The id of this game is ${0}", b => b.raw_string(this.id));
       }      
 
       this.log("Generation ${0}", b => b.forNewGeneration().number(this.generation));

--- a/src/LogBuilder.ts
+++ b/src/LogBuilder.ts
@@ -30,9 +30,14 @@ export class LogBuilder {
         this.parameters.push(new LogMessageData(LogMessageDataType.STRING, value));
         return this;
     }
+    
+    public raw_string(value: string): LogBuilder {
+        this.parameters.push(new LogMessageData(LogMessageDataType.RAW_STRING, value));
+        return this;
+    }
 
     public number(value: number): LogBuilder {
-        this.parameters.push(new LogMessageData(LogMessageDataType.STRING, value.toString()));
+        this.parameters.push(new LogMessageData(LogMessageDataType.RAW_STRING, value.toString()));
         return this;
     }
 
@@ -65,7 +70,7 @@ export class LogBuilder {
     }
 
     public colony(value: IColony): LogBuilder {
-        this.parameters.push(new LogMessageData(LogMessageDataType.MILESTONE, value.name));
+        this.parameters.push(new LogMessageData(LogMessageDataType.COLONY, value.name));
         return this;
     }
 

--- a/src/LogMessageDataType.ts
+++ b/src/LogMessageDataType.ts
@@ -1,5 +1,6 @@
 export enum LogMessageDataType {
-	STRING,
+    STRING,
+    RAW_STRING,
     PLAYER,
     CARD,
     AWARD,

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -28,6 +28,7 @@ export const LogPanel = Vue.component("log-panel", {
             }
         },
         parseCardType: function(cardType: CardType, cardName: string) {
+            cardName = $t(cardName);
             if (cardType === CardType.EVENT) {
                 return "<log-card class=\"background-color-events\">"+cardName+"</log-card>";
             } else if (cardType === CardType.ACTIVE) {
@@ -42,9 +43,12 @@ export const LogPanel = Vue.component("log-panel", {
         },
         parseData: function(data: LogMessageData) {
             const translatableMessageDataTypes = [
+                LogMessageDataType.STRING,
                 LogMessageDataType.STANDARD_PROJECT,
                 LogMessageDataType.MILESTONE,
-                LogMessageDataType.AWARD
+                LogMessageDataType.AWARD,
+                LogMessageDataType.COLONY,
+                LogMessageDataType.PARTY
             ];
             if (data.type !== undefined && data.value !== undefined) {
                 if (data.type === LogMessageDataType.PLAYER) {
@@ -56,7 +60,7 @@ export const LogPanel = Vue.component("log-panel", {
                 } else if (data.type === LogMessageDataType.CARD) {
                     for (let player of this.players) {
                         if (player.corporationCard !== undefined && data.value === player.corporationCard.name) {
-                            return "<log-card class=\"background-color-corporation\">"+data.value+"</log-card>";
+                            return "<log-card class=\"background-color-corporation\">" + $t(data.value) + "</log-card>";
                         } else {
                             let cards = player.playedCards.concat(player.selfReplicatingRobotsCards);
                             for (let card of cards) {


### PR DESCRIPTION
This will translate every parameters of the log messages except if their type is set as either `PLAYER` or `RAW_STRING` (new type currently only used for the game id).

Tested it both in English and in French, seems to work without issues.