### PR TITLE
tests: fix playwrights unit tests

### DIFF
--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -4,7 +4,6 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { Game } from '../../../src/Game';
 import { ReleaseOfInertGases} from "../../../src/cards/ReleaseOfInertGases";
-import { TechnologyDemonstration } from "../../../src/cards/TechnologyDemonstration";
 import { SelectCard } from "../../../src/inputs/SelectCard";
 import { Resources } from "../../../src/Resources";
 import { IndenturedWorkers } from "../../../src/cards/IndenturedWorkers";
@@ -33,7 +32,7 @@ describe("Playwrights", function () {
 
     it("Can replay own event", function () {
         const event = new ReleaseOfInertGases();
-        let tr = player.getTerraformRating();
+        const tr = player.getTerraformRating();
         event.play(player, game);
         player.playedCards.push(event);
 
@@ -52,15 +51,16 @@ describe("Playwrights", function () {
     });
 
     it("Can replay other player's event", function () {
-        const techDemo = new TechnologyDemonstration();
-        techDemo.play(player2, game);
-        player2.playedCards.push(techDemo);
+        const event = new ReleaseOfInertGases();
+        const tr = player.getTerraformRating();
+        event.play(player2, game);
+        player2.playedCards.push(event);
 
-        player.megaCredits = 5;
+        player.megaCredits = event.cost;
         expect(card.canAct(player, game)).to.eq(true);
         const selectCard = card.action(player, game) as SelectCard<ICard>;
-        selectCard.cb([techDemo]);
-        expect(player.cardsInHand.length).to.eq(2);
+        selectCard.cb([event]);
+        expect(player.getTerraformRating()).to.eq(tr + 2);
         expect(player.megaCredits).eq(0);
         expect(player2.playedCards.length).to.eq(0);
         expect(player.removedFromPlayCards.length).to.eq(1);


### PR DESCRIPTION
I originally fixed an issue in `Can replay own event` and didn't think `Can replay other player's event` would have the same issue. Turns out that it does have the same issue. If while playing `TechnologyDemonstration` you happen to draw a `TechnologyDemonstration` card it will get removed from your hand. This should only be a bug for unit tests as if you were to copy an event the card would not be available to draw and would not be in a players hand. I put in the same fix for this test with using `ReleaseOfIntertGases` to avoid the conflict with drawing cards.