### PR TITLE
Fix resource decrease interrupts

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -52,7 +52,6 @@ import { Turmoil } from "./turmoil/Turmoil";
 import { PartyHooks } from "./turmoil/parties/PartyHooks";
 import { IParty } from "./turmoil/parties/IParty";
 import { OrOptions } from "./inputs/OrOptions";
-import { SelectOption } from "./inputs/SelectOption";
 import { LogHelper } from "./components/LogHelper";
 import { ColonyName } from "./colonies/ColonyName";
 import { getRandomMilestonesAndAwards } from "./MilestoneAwardSelector";
@@ -603,52 +602,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         if (resource === Resources.PLANTS) this.someoneHasRemovedOtherPlayersPlants = true;
         return;
       }
-
-      let candidates: Array<Player> = [];
-      if (resource === Resources.PLANTS) {
-        candidates = this.getPlayers().filter((p) => p.id !== player.id && !p.plantsAreProtected() && p.getResource(resource) > 0);
-      } else {
-        candidates = this.getPlayers().filter((p) => p.id !== player.id && p.getResource(resource) > 0);
-      }
-
-      if (candidates.length === 0) {
-        return;
-      } else if (candidates.length === 1) {
-        const qtyToRemove = Math.min(candidates[0].plants, count);
-
-        if (resource === Resources.PLANTS) {
-          this.addInterrupt({ player, playerInput: new OrOptions(
-            new SelectOption("Remove " + qtyToRemove + " plants from " + candidates[0].name, "Remove plants", () => {
-              candidates[0].setResource(resource, -qtyToRemove, this, player);
-              return undefined;
-            }),
-            new SelectOption("Skip removing plants", "Confirm", () => {
-              return undefined;
-            })
-          )});
-        } else {
-          candidates[0].setResource(resource, -qtyToRemove, this, player);
-          return;
-        }
-      } else {
-        if (resource === Resources.PLANTS) {
-          const removalOptions = candidates.map((candidate) => {
-            const qtyToRemove = Math.min(candidate.plants, count);
-
-            return new SelectOption("Remove " + qtyToRemove + " plants from " + candidate.name, "Remove plants", () => {
-              candidate.setResource(resource, -qtyToRemove, this, player);
-              return undefined;
-            })
-          });
-
-          this.addInterrupt({ player, playerInput: new OrOptions(
-            ...removalOptions,
-            new SelectOption("Skip removing plants", "Confirm", () => { return undefined; })
-          )});
-        } else {
-          this.addInterrupt(new SelectResourceDecrease(player, candidates, this, resource, count, title));
-        }
-      }
+      this.addInterrupt(new SelectResourceDecrease(player, [], this, resource, count, title));
     }
 
     public addInterrupt(interrupt: PlayerInterrupt): void {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1154,9 +1154,13 @@ export class Game implements ILoadable<SerializedGame, Game> {
           if (interrupt.beforeAction !== undefined) {
             interrupt.beforeAction();
           }
-          interrupt.player.setWaitingFor(interrupt.playerInput, () => {
-            this.playerIsFinishedTakingActions();
-          });
+          if (interrupt.playerInput !== undefined) {
+              interrupt.player.setWaitingFor(interrupt.playerInput, () => {
+                  this.playerIsFinishedTakingActions();
+              });
+          } else {
+              this.playerIsFinishedTakingActions();
+          }
           return;
         }
       }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1962,9 +1962,14 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         if (interrupt !== undefined && interrupt.beforeAction !== undefined) {
           interrupt.beforeAction();
         }
-        this.setWaitingFor(game.interrupts.splice(interruptIndex, 1)[0].playerInput, () => {
+        if (interrupt.playerInput !== undefined) {
+          this.setWaitingFor(game.interrupts.splice(interruptIndex, 1)[0].playerInput, () => {
+            cb();
+          });
+        } else {
+          game.interrupts.splice(interruptIndex, 1);
           cb();
-        });
+        }
       } else {
         cb();
       }
@@ -2209,7 +2214,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       return this.waitingFor;
     }
 
-    public setWaitingFor(input: PlayerInput, cb: () => void): void {
+    public setWaitingFor(input: PlayerInput | undefined, cb: () => void): void {
       this.waitingFor = input;
       this.waitingForCb = cb;
     }

--- a/src/interrupts/PlayerInterrupt.ts
+++ b/src/interrupts/PlayerInterrupt.ts
@@ -2,6 +2,6 @@ import { Player } from '../Player';
 import { PlayerInput } from '../PlayerInput';
 export interface PlayerInterrupt {
     player: Player,
-    playerInput: PlayerInput,
+    playerInput: PlayerInput | undefined,
     beforeAction?(): void
   }

--- a/src/interrupts/SelectResourceDecrease.ts
+++ b/src/interrupts/SelectResourceDecrease.ts
@@ -9,7 +9,7 @@ import { SelectOption } from "../inputs/SelectOption"
 import { SelectPlayer } from "../inputs/SelectPlayer";
 
 export class SelectResourceDecrease implements PlayerInterrupt {
-    public playerInput: PlayerInput;
+    public playerInput: PlayerInput | undefined;
     constructor(
         public player: Player,
         public candidates: Array<Player>,
@@ -37,7 +37,7 @@ export class SelectResourceDecrease implements PlayerInterrupt {
 		}
 
 		if (this.candidates.length === 0) {
-			return;
+			this.playerInput = undefined;
 		} else if (this.candidates.length === 1) {
 			const qtyToRemove = Math.min(this.candidates[0].plants, this.count);
 			if (this.resource === Resources.PLANTS) {
@@ -52,7 +52,7 @@ export class SelectResourceDecrease implements PlayerInterrupt {
 				);
 			} else {
 				this.candidates[0].setResource(this.resource, -qtyToRemove, this.game, this.player);
-				return;
+				this.playerInput = undefined;
 			}
 		} else {
 			if (this.resource === Resources.PLANTS) {

--- a/src/interrupts/SelectResourceDecrease.ts
+++ b/src/interrupts/SelectResourceDecrease.ts
@@ -1,9 +1,11 @@
 
 import { Game } from "../Game";
+import { OrOptions } from "../inputs/OrOptions";
 import { PlayerInput } from "../PlayerInput";
 import { Player } from "../Player";
 import { PlayerInterrupt } from "./PlayerInterrupt";
 import { Resources } from "../Resources";
+import { SelectOption } from "../inputs/SelectOption"
 import { SelectPlayer } from "../inputs/SelectPlayer";
 
 export class SelectResourceDecrease implements PlayerInterrupt {
@@ -26,4 +28,58 @@ export class SelectResourceDecrease implements PlayerInterrupt {
           }
         );
     };
-}    
+
+    public beforeAction(): void {
+		if (this.resource === Resources.PLANTS) {
+			this.candidates = this.game.getPlayers().filter((p) => p.id !== this.player.id && !p.plantsAreProtected() && p.getResource(this.resource) > 0);
+		} else {
+			this.candidates = this.game.getPlayers().filter((p) => p.id !== this.player.id && p.getResource(this.resource) > 0);
+		}
+
+		if (this.candidates.length === 0) {
+			return;
+		} else if (this.candidates.length === 1) {
+			const qtyToRemove = Math.min(this.candidates[0].plants, this.count);
+			if (this.resource === Resources.PLANTS) {
+				this.playerInput = new OrOptions(
+					new SelectOption("Remove " + qtyToRemove + " plants from " + this.candidates[0].name, "Remove plants", () => {
+						this.candidates[0].setResource(this.resource, -qtyToRemove, this.game, this.player);
+						return undefined;
+					}),
+					new SelectOption("Skip removing plants", "Confirm", () => {
+						return undefined;
+					})
+				);
+			} else {
+				this.candidates[0].setResource(this.resource, -qtyToRemove, this.game, this.player);
+				return;
+			}
+		} else {
+			if (this.resource === Resources.PLANTS) {
+				const removalOptions = this.candidates.map((candidate) => {
+					const qtyToRemove = Math.min(candidate.plants, this.count);
+					return new SelectOption("Remove " + qtyToRemove + " plants from " + candidate.name, "Remove plants", () => {
+						candidate.setResource(this.resource, -qtyToRemove, this.game, this.player);
+						return undefined;
+					})
+				});
+				this.playerInput = new OrOptions(
+					...removalOptions,
+					new SelectOption("Skip removing plants", "Confirm", () => {
+						return undefined;
+					})
+				);
+			} else {
+				this.playerInput = new SelectPlayer(
+					this.candidates,
+					this.title,
+					"Remove",
+					(found: Player) => {
+						found.setResource(this.resource, -this.count, this.game, this.player);
+						return undefined;
+					}
+				);
+			}
+		}
+    }
+}


### PR DESCRIPTION
This is in relation with #1371 (and other reports on discord) where interaction between Arctic Algae and multiple astronomical objects such as Comet or Giant Ice Asteroid is not working as intended.

The issue is that interrupts are computed when the card is played. So we end up removing less plants than we should have (probably other interactions could be impacted by that, I'm not sure tbh).

This PR - please bear with me - fixes this by using a method that was used only for the Pluto Colony interrupt as far as I can tell.
This effectively moves candidates computation to the moment the interrupt is actually processed.

Note that I never used Typescript before stumbling upon this repo so there might be things I did really wrong there, feel free to edit the PR directly. That might also not be the best way to fix this, I don't really know about that though.

Tested it a bit on my end, seems to work and didn't break anything in my test games.

-------

Edit: It breaks tests. I might take a look at it tomorrow.