### PR TITLE
Permit stall actions for some cards

### DIFF
--- a/src/cards/AquiferPumping.ts
+++ b/src/cards/AquiferPumping.ts
@@ -20,9 +20,9 @@ export class AquiferPumping implements IActionCard, IProjectCard {
     }
     public canAct(player: Player, game: Game): boolean {
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
-      if (oceansMaxed) return false;
-
       let oceanCost = 8;
+
+      if (oceansMaxed) return player.canAfford(oceanCost, game, true, false);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
         return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, game, true, false);

--- a/src/cards/SymbioticFungus.ts
+++ b/src/cards/SymbioticFungus.ts
@@ -20,11 +20,12 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
     public play() {
         return undefined;
     }
-    public canAct(player: Player): boolean {
-        return player.getResourceCards(ResourceType.MICROBE).length > 0;
+    public canAct(): boolean {
+        return true;
     }
     public action(player: Player, game: Game) {
         const availableCards = player.getResourceCards(ResourceType.MICROBE);
+        if (availableCards.length === 0) return undefined;
 
         if (availableCards.length === 1) {
             player.addResourceTo(availableCards[0]);

--- a/src/cards/promo/DirectedImpactors.ts
+++ b/src/cards/promo/DirectedImpactors.ts
@@ -27,14 +27,17 @@ export class DirectedImpactors implements IActionCard, IProjectCard, IResourceCa
     }
 
     public canAct(player: Player, game: Game): boolean {
-        const canRaiseTemperature = this.resourceCount > 0 && game.getTemperature() < MAX_TEMPERATURE;
+        const cardHasResources = this.resourceCount > 0;
         const canPayForAsteroid = player.canAfford(6, game, false, true);
 
+        if (game.getTemperature() === MAX_TEMPERATURE && cardHasResources) return true;
+        if (canPayForAsteroid) return true;
+        
         if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-            return canPayForAsteroid || (player.canAfford(REDS_RULING_POLICY_COST) && canRaiseTemperature);
+            return player.canAfford(REDS_RULING_POLICY_COST) && cardHasResources;
         }
 
-        return canPayForAsteroid || canRaiseTemperature;
+        return cardHasResources;
     }
 
     public action(player: Player, game: Game) {
@@ -44,9 +47,10 @@ export class DirectedImpactors implements IActionCard, IProjectCard, IResourceCa
         const addResource = new SelectOption("Pay 6 to add 1 asteroid to a card", "Pay",() => this.addResource(player, game, asteroidCards));
         const spendResource = new SelectOption("Remove 1 asteroid to raise temperature 1 step", "Remove asteroid", () => this.spendResource(player, game));
         const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
+        const temperatureIsMaxed = game.getTemperature() === MAX_TEMPERATURE;
 
-        if (this.resourceCount > 0 && game.getTemperature() < MAX_TEMPERATURE) {
-            if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
+        if (this.resourceCount > 0) {
+            if (!redsAreRuling || temperatureIsMaxed || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
                 opts.push(spendResource);
             }
         } else {

--- a/tests/cards/AquiferPumping.spec.ts
+++ b/tests/cards/AquiferPumping.spec.ts
@@ -3,6 +3,7 @@ import { AquiferPumping } from "../../src/cards/AquiferPumping";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
+import { maxOutOceans } from "../TestingUtils"
 
 describe("AquiferPumping", function () {
     let card : AquiferPumping, player : Player, game : Game;
@@ -17,16 +18,22 @@ describe("AquiferPumping", function () {
         expect(card.play()).to.eq(undefined);
     });
 
-    it("Should action", function () {
+    it("Should act", function () {
         player.megaCredits = 8;
         const action = card.action(player, game);
         expect(action).to.eq(undefined);
 
         expect(player.megaCredits).to.eq(0);
-
     });
 
-    it("Cannot action if not enough to pay", function () {
+    it("Cannot act if not enough to pay", function () {
         expect(card.canAct(player, game)).to.eq(false);
+    });
+
+    it("Can act if can pay even after oceans are maxed", function () {
+        maxOutOceans(player, game);
+        player.megaCredits = 8;
+        
+        expect(card.canAct(player, game)).to.eq(true);
     });
 });

--- a/tests/cards/SymbioticFungus.spec.ts
+++ b/tests/cards/SymbioticFungus.spec.ts
@@ -24,6 +24,10 @@ describe("SymbioticFungus", function () {
         expect(card.canPlay(player, game)).to.eq(true);
     });
 
+    it("Can act without targets", function () {
+        expect(card.canAct()).to.eq(true);
+    });
+
     it("Should act - single target", function () {
         player.playedCards.push(new Ants());
         card.action(player, game);

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -74,11 +74,11 @@ describe("DirectedImpactors", function () {
         expect(player.titanium).to.eq(0);
     });
 
-    it("Cannot spend resource to raise temperature if max", function () {
+    it("Can still spend resource even if temperature is max", function () {
         player.playedCards.push(card);
         card.resourceCount = 1;
         (game as any).temperature = MAX_TEMPERATURE;
 
-        expect(card.canAct(player, game)).to.eq(false);
+        expect(card.canAct(player, game)).to.eq(true);
     });
 });


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1474

Minimal change. Exit condition for max is already handled in `game.addOceanInterrupt` and `game.increaseTemperature`.