### PR TITLE
chore: remove gameLog sent with PlayerModel

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -585,10 +585,6 @@ function getPlayer(player: Player, game: Game): string {
         titaniumValue: player.getTitaniumValue(game),
         victoryPointsBreakdown: player.getVictoryPoints(game),
         waitingFor: getWaitingFor(player.getWaitingFor()),
-        // DEPRECATED, included for transition to game log route
-        // remove after few days once most users have loaded
-        // new client
-        gameLog: game.gameLog.length > 50 ? game.gameLog.slice(game.gameLog.length - 50) : game.gameLog,
         isSoloModeWin: game.isSoloModeWin(),
         gameAge: game.gameAge,
         isActive: player.id === game.activePlayer,


### PR DESCRIPTION
During the transition to the separate game log route I kept the `gameLog` property coming back on the `PlayerModel`. Anyone who had a copy of `main.js` during the change would have needed this to come through that method. At this point it has been long enough from the change that most people should have a new `main.js` or they have had a game running for multiple days without ever requesting a copy of `main.js` through either browser refresh or some other method.