### PR TITLE
Make WGT toggle respond to Venus Next selection

### DIFF
--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -311,6 +311,11 @@ export const CreateGameForm = Vue.component("create-game-form", {
                 .catch(_ => alert("Unexpected server response"));
         }
     },
+    watch: {
+        venusNext: function (enabled) {
+            this.solarPhaseOption = enabled;
+        }
+    },
     template: `
         <div id="create-game">
             <h1><span v-i18n>Terraforming Mars</span> — <span v-i18n>Create New Game</span></h1>


### PR DESCRIPTION
Ref: https://github.com/bafolts/terraforming-mars/issues/1553

- When Venus Next is selected, WGT option is auto preselected (and vice versa). This saves a click in most cases.
- Users can still opt to play a nonstandard game with Venus Next without WGT by deselecting the WGT option
