### PR TITLE
defensive coding measures on new cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1326,10 +1326,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
             }
         }
 
-        const preludesWithPlayCardEffects = [CardName.ECOLOGY_EXPERTS, CardName.ECCENTRIC_SPONSOR, CardName.VALUABLE_GASES];
-
-        if (preludesWithPlayCardEffects.includes(selectedCard.name)) {
-            selectedCard.addPlayCardInterrupt!(this, game);
+        if (selectedCard.addPlayCardInterrupt !== undefined) {
+            selectedCard.addPlayCardInterrupt(this, game);
         }
 
         return undefined;

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -7,7 +7,7 @@ import { ResourceType } from "../ResourceType";
 import { Resources } from '../Resources';
 
 export interface IProjectCard extends ICard {
-    addPlayCardInterrupt?: Function;
+    addPlayCardInterrupt?: (player: Player, game: Game) => void;
     canPlay?: (player: Player, game: Game, bonusMc?: number) => boolean;
     cardType: CardType;
     cost: number;

--- a/src/cards/community/ByElection.ts
+++ b/src/cards/community/ByElection.ts
@@ -11,15 +11,21 @@ import { OrOptions } from "../../inputs/OrOptions";
 export class ByElection extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.WILDCARD];
     public name: CardName = CardName.BY_ELECTION;
-
+    public canPlay(__player: Player, game: Game) {
+        return game.turmoil !== undefined;
+    }
     public play(player: Player, game: Game) {
-        game.turmoil!.addInfluenceBonus(player);
+        const turmoil = game.turmoil;
+        if (turmoil === undefined){
+            return;
+        }
+        turmoil.addInfluenceBonus(player);
         const setRulingParty = new OrOptions();
             
         setRulingParty.title = "Select new ruling party";
         setRulingParty.options = [...ALL_PARTIES.map((p) => new SelectOption(
             p.partyName, "Select", () => {
-            game.turmoil!.rulingParty = game.turmoil!.getPartyByName(p.partyName);
+            turmoil.rulingParty = turmoil.getPartyByName(p.partyName);
             return undefined;
             })
         )];

--- a/src/cards/community/VenusFirst.ts
+++ b/src/cards/community/VenusFirst.ts
@@ -18,7 +18,9 @@ export class VenusFirst extends PreludeCard implements IProjectCard {
             }
 
             const drawnCards = game.getCardsInHandByTag(player, Tags.VENUS).slice(-2);
-            game.log("${0} drew ${1} and ${2}", b => b.player(player).card(drawnCards[0]).card(drawnCards[1]));
+            if (drawnCards.length > 1) {
+                game.log("${0} drew ${1} and ${2}", b => b.player(player).card(drawnCards[0]).card(drawnCards[1]));
+            }
         }
 
         return undefined;


### PR DESCRIPTION
The heroku application crashed this morning after the introduction of the new community cards. Unfortunately the cheap hosting plan used only allows me to go back 1500 log entries which isn't including the runtime exception which caused the crash. I have added defensive coding measures to protect the new cards from taking down the server. One of the cards when played without turmoil would have crashed the server then `turmoil` was not defined.