### PR TITLE
fix: map serialized discarded colonies to IColony

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -45,6 +45,7 @@ import {SelectHowToPayInterrupt} from "./interrupts/SelectHowToPayInterrupt";
 import { ILoadable } from "./ILoadable";
 import {LogMessage} from "./LogMessage";
 import {Database} from "./database/Database";
+import { SerializedColony } from "./SerializedColony";
 import { SerializedGame } from "./SerializedGame";
 import { SerializedPlayer } from "./SerializedPlayer";
 import { CardName } from "./CardName";
@@ -1801,6 +1802,24 @@ export class Game implements ILoadable<SerializedGame, Game> {
       return value;
     }
 
+    private loadColoniesFromJSON(colonies: Array<SerializedColony>): Array<IColony> {
+      const result: Array<IColony> = [];
+      for (const serialized of colonies) {
+        const colony = getColonyByName(serialized.name);
+        if (colony !== undefined) {
+          colony.isActive = serialized.isActive;
+          colony.visitor = serialized.visitor;
+          colony.trackPosition = serialized.trackPosition;
+          colony.colonies = serialized.colonies;
+          colony.resourceType = serialized.resourceType;
+          result.push(colony);
+        } else {
+          console.warn(`colony ${serialized.name} not found`);
+        }
+      }
+      return result;
+    }
+
     // Function used to rebuild each objects
     public loadFromJSON(d: SerializedGame): Game {
       // Assign each attributes
@@ -1880,24 +1899,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
       // Reload colonies elements if needed
       if (this.gameOptions.coloniesExtension) {
         this.colonyDealer = new ColonyDealer();
-        this.colonies = new Array<IColony>();
 
-        d.colonyDealer?.discardedColonies.forEach((element: IColony) => {
-          if(this.colonyDealer !== undefined) {
-            this.colonyDealer.discardedColonies.push(element);
-          }
-        });
+        if (d.colonyDealer !== undefined) {
+          this.colonyDealer.discardedColonies = this.loadColoniesFromJSON(d.colonyDealer.discardedColonies);
+        }
 
-        d.colonies.forEach((element: IColony) => {
-          const colony = getColonyByName(element.name);
-
-          // Assign each attributes
-          Object.assign(colony, element);
-
-          if (colony !== undefined) {
-            this.colonies.push(colony);
-          }
-        });
+        this.colonies = this.loadColoniesFromJSON(d.colonies);
       }
 
       // Reload turmoil elements if needed

--- a/src/SerializedColony.ts
+++ b/src/SerializedColony.ts
@@ -1,0 +1,15 @@
+
+import { ColonyName } from "./colonies/ColonyName";
+import { PlayerId } from "./Player";
+import { ResourceType } from "./ResourceType";
+
+export interface SerializedColony {
+    name: ColonyName;
+    description: string;
+    isActive: boolean;
+    visitor: undefined | PlayerId;
+    trackPosition: number;
+    colonies: Array<PlayerId>;
+    resourceType?: ResourceType;
+}
+

--- a/src/SerializedGame.ts
+++ b/src/SerializedGame.ts
@@ -4,12 +4,12 @@ import {ClaimedMilestone} from "./ClaimedMilestone";
 import {FundedAward} from "./FundedAward";
 import {IMilestone} from "./milestones/IMilestone";
 import {IAward} from "./awards/IAward";
-import {IColony} from "./colonies/Colony";
 import {ColonyDealer} from "./colonies/ColonyDealer";
 import {PlayerInterrupt} from "./interrupts/PlayerInterrupt";
 import {Board} from "./Board";
 import { CardName } from "./CardName";
 import { BoardName } from "./BoardName";
+import { SerializedColony } from "./SerializedColony";
 import { SerializedPlayer } from "./SerializedPlayer";
 import { SerializedDealer } from "./SerializedDealer";
 import { SerializedTurmoil } from "./turmoil/SerializedTurmoil";
@@ -56,7 +56,7 @@ export interface SerializedGame {
 
     venusNextExtension: boolean;
     coloniesExtension: boolean;
-    colonies: Array<IColony>;
+    colonies: Array<SerializedColony>;
     colonyDealer: ColonyDealer | undefined;
     preludeExtension: boolean;
     turmoil: SerializedTurmoil;

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -1,21 +1,13 @@
 import { Player, PlayerId } from "../Player";
 import { SelectSpace } from '../inputs/SelectSpace';
+import { SerializedColony } from "../SerializedColony";
 import { Game } from '../Game';
-import { ColonyName } from './ColonyName';
-import { ResourceType } from '../ResourceType';
 import { CorporationName } from '../CorporationName';
 import { Resources } from '../Resources';
 import { LogHelper } from "../components/LogHelper";
 import { MAX_COLONY_TRACK_POSITION } from "../constants";
 
-export interface IColony {
-    name: ColonyName;
-    description: string;
-    isActive: boolean;
-    visitor: undefined | PlayerId;
-    trackPosition: number;
-    colonies: Array<PlayerId>;
-    resourceType?: ResourceType;
+export interface IColony extends SerializedColony {
     trade: (player: Player, game: Game, usesTradeFleet?: boolean) => void;
     onColonyPlaced: (player: Player, game: Game) => undefined | SelectSpace;
     giveTradeBonus: (player: Player, game: Game) => void;
@@ -24,7 +16,7 @@ export interface IColony {
     decreaseTrack(value?: number): void;
 }
 
-export abstract class Colony  {
+export abstract class Colony {
     public isActive: boolean = true;
     public visitor: undefined | PlayerId = undefined;
     public colonies: Array<PlayerId> = [];
@@ -91,4 +83,4 @@ export abstract class Colony  {
           poseidon[0].addProduction(Resources.MEGACREDITS);
         }
     }  
-}    
+}


### PR DESCRIPTION
This fixes #1364 . On `SerializedGame` we only store values which can be stored in JSON and not `IColony`. This introduces a `SerializedColony` interface which represents what we store on the database. We were loading `colonies` but not `discardedColonies`. This updates both with a new function which maps `Array<SerializedColony>` to `Array<IColony>`.