### PR TITLE
Fix: Mining Guild placement bonus for WGT

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1547,6 +1547,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
         space.player = undefined;
       }
 
+      // Mining Guild tile placement effects should resolve before removing space.player for Oceans
       this.players.forEach((p) => {
         if (p.corporationCard !== undefined &&
             p.corporationCard.onTilePlaced !== undefined) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1510,13 +1510,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
       const arcadianCommunityBonus = space.player === player && player.isCorporation(CorporationName.ARCADIAN_COMMUNITIES);
 
       // Part 4. Place the tile
-
-      if (tile.tileType === TileType.OCEAN) {
-        space.player = undefined;
-      } else {
-        space.player = player;
-      }
       space.tile = tile;
+      space.player = player;
       LogHelper.logTilePlacement(this, player, space, tile.tileType);
 
       // Part 5. Collect the bonuses
@@ -1563,6 +1558,10 @@ export class Game implements ILoadable<SerializedGame, Game> {
           }
         });
       });
+
+      if (tile.tileType === TileType.OCEAN) {
+        space.player = undefined;
+      }
     }
 
     public addGreenery(

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -5601,13 +5601,13 @@ export const HTML_DATA: Map<string, string> =
 `],
 [CardName.VALUABLE_GASES,`
       <div class="content">
-        <div class="resource money">10</div>
+        <div class="resource money">6</div>
         <div class="resource card" style="margin-left:10px">
           <div class="card-icon tag-venus"></div>
         </div>
         &nbsp;: +4 <div class="resource floater"></div>
         <div class="description">
-          Gain 10 MC. Play a Venus card from your hand that collects floaters and add 4 floaters to it.
+          Gain 6 MC. Play a Venus card from your hand that collects floaters and add 4 floaters to it.
         </div>
       </div>
 `],
@@ -5637,10 +5637,10 @@ export const HTML_DATA: Map<string, string> =
           <div class="tile colony"></div>
           <div class="tile colony"></div>
           <br>
-          - <div class="resource money">12</div>
+          - <div class="resource money">14</div>
         </div>
         <div class="description">
-          Place 2 colonies. Pay 12 MC.
+          Place 2 colonies. Pay 14 MC.
         </div>
       </div>
 `],

--- a/src/cards/community/AerospaceMission.ts
+++ b/src/cards/community/AerospaceMission.ts
@@ -11,6 +11,13 @@ export class AerospaceMission extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.SPACE];
     public name: CardName = CardName.AEROSPACE_MISSION;
 
+    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+      const requiredPayment = 14 - (bonusMc || 0);
+      
+      if (requiredPayment <= 0) return true;
+      return player.canAfford(requiredPayment);
+    }
+
     public play(player: Player, game: Game) {
         const openColonies = game.colonies.filter((colony) => colony.isActive);
         const selectColonies = new OrOptions();
@@ -50,7 +57,7 @@ export class AerospaceMission extends PreludeCard implements IProjectCard {
             playerInput: selectColonies,
         });
 
-        player.megaCredits -= 12;
+        player.megaCredits -= 14;
         return undefined;
     }
 }

--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -12,7 +12,7 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
     public name: CardName = CardName.VALUABLE_GASES;
 
     public play(player: Player) {     
-        player.megaCredits += 10;
+        player.megaCredits += 6;
         return undefined;
     }
 

--- a/src/cards/corporation/MiningGuild.ts
+++ b/src/cards/corporation/MiningGuild.ts
@@ -18,6 +18,7 @@ export class MiningGuild implements CorporationCard {
     public onTilePlaced(player: Player, space: ISpace) {
         if (
             player.isCorporation(this.name)
+            && space.player === player
             && (space.bonus.indexOf(SpaceBonus.STEEL) !== -1 || space.bonus.indexOf(SpaceBonus.TITANIUM) !== -1)) {
             player.addProduction(Resources.STEEL);
         }

--- a/tests/cards/community/ValuableGases.spec.ts
+++ b/tests/cards/community/ValuableGases.spec.ts
@@ -13,6 +13,6 @@ describe("ValuableGases", function () {
 
     it("Should play", function () {
         card.play(player);
-        expect(player.megaCredits).to.eq(10);
+        expect(player.megaCredits).to.eq(6);
     });
 });

--- a/tests/cards/corporation/MiningGuild.spec.ts
+++ b/tests/cards/corporation/MiningGuild.spec.ts
@@ -60,7 +60,7 @@ describe("MiningGuild", function () {
         const oceanSpaces = game.board.getOceansTiles();
 
         oceanSpaces.forEach((space) => {
-            game.addTile(player, SpaceType.OCEAN, space, { tileType: TileType.OCEAN }, true); 
+            game.addTile(player, SpaceType.OCEAN, space, { tileType: TileType.OCEAN }); 
         })
 
         expect(player.getProduction(Resources.STEEL)).to.eq(0);

--- a/tests/cards/corporation/MiningGuild.spec.ts
+++ b/tests/cards/corporation/MiningGuild.spec.ts
@@ -7,6 +7,7 @@ import { SpaceType } from "../../../src/SpaceType";
 import { Resources } from '../../../src/Resources';
 import { maxOutOceans } from "../../TestingUtils";
 import { Game } from "../../../src/Game";
+import { TileType } from "../../../src/TileType";
 
 describe("MiningGuild", function () {
     let card : MiningGuild, player : Player, player2 : Player, game: Game;
@@ -16,45 +17,52 @@ describe("MiningGuild", function () {
         player = new Player("test", Color.BLUE, false);
         player2 = new Player("test2", Color.RED, false);
         game = new Game("foobar", [player, player], player);
+
+        player.corporationCard = card;
     });
 
     it("Should play", function () {
-        player.corporationCard = card;
         card.play(player);
         expect(player.steel).to.eq(5);
         expect(player.getProduction(Resources.STEEL)).to.eq(1);
     });
 
     it("Gives steel production bonus when placing tiles", function () {
-        player.corporationCard = card;
-        card.play(player);
-
         card.onTilePlaced(player, { player, spaceType: SpaceType.LAND, x: 0, y: 0, id: "foobar", bonus: [] });
-        expect(player.getProduction(Resources.STEEL)).to.eq(1);
+        expect(player.getProduction(Resources.STEEL)).to.eq(0);
 
         card.onTilePlaced(player, { player, spaceType: SpaceType.LAND, x: 0, y: 0, id: "foobar", bonus: [SpaceBonus.STEEL, SpaceBonus.TITANIUM] });
-        expect(player.getProduction(Resources.STEEL)).to.eq(2);
+        expect(player.getProduction(Resources.STEEL)).to.eq(1);
 
         card.onTilePlaced(player, { player, spaceType: SpaceType.LAND, x: 0, y: 0, id: "foobar", bonus: [SpaceBonus.STEEL] });
-        expect(player.getProduction(Resources.STEEL)).to.eq(3);
+        expect(player.getProduction(Resources.STEEL)).to.eq(2);
         
         card.onTilePlaced(player, { player, spaceType: SpaceType.LAND, x: 0, y: 0, id: "foobar", bonus: [SpaceBonus.TITANIUM] });
-        expect(player.getProduction(Resources.STEEL)).to.eq(4);
+        expect(player.getProduction(Resources.STEEL)).to.eq(3);
     });
 
     it("Gives steel production bonus when placing ocean tile", function () {
-        player.corporationCard = card;
-        card.play(player);
-        expect(player.getProduction(Resources.STEEL)).to.eq(1);
-
         maxOutOceans(player, game); // 1 ocean with titanium and 1 with steel
-        expect(player.getProduction(Resources.STEEL)).to.eq(3);
+        expect(player.getProduction(Resources.STEEL)).to.eq(2);
     });
 
-    it("Does not give bonus when other players place tiles", function () {
-        player.corporationCard = card;
-        
+    it("Does not give bonus when other players place tiles", function () {        
         card.onTilePlaced(player2, { player, spaceType: SpaceType.LAND, x: 0, y: 0, id: "foobar", bonus: [SpaceBonus.TITANIUM] });
+        expect(player.getProduction(Resources.STEEL)).to.eq(0);
+    });
+
+    it("Does not give bonus when other players place ocean tiles", function () {
+        maxOutOceans(player2, game); // 1 ocean with titanium and 1 with steel
+        expect(player.getProduction(Resources.STEEL)).to.eq(0);
+    });
+
+    it("Does not give bonus for WGT", function () {
+        const oceanSpaces = game.board.getOceansTiles();
+
+        oceanSpaces.forEach((space) => {
+            game.addTile(player, SpaceType.OCEAN, space, { tileType: TileType.OCEAN }, true); 
+        })
+
         expect(player.getProduction(Resources.STEEL)).to.eq(0);
     });
 });


### PR DESCRIPTION
This fixes https://github.com/bafolts/terraforming-mars/issues/1564 caused by incorrect timing of setting `space.player` to `undefined` and adds a unit test for WGT placements not triggering Mining Guild's effect.