### PR TITLE
Added onCardPlayedPriority to cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1302,7 +1302,10 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
         this.addPlayedCard(game, selectedCard);
 
-        for (const playedCard of this.playedCards) {
+        const playedCardsOrdered = this.playedCards.filter((card) => card.onCardPlayed !== undefined)
+            .sort((a, b) => ((a.onCardPlayedPriority || 999) < (b.onCardPlayedPriority || 999) ? -1 : 1));
+
+        for (const playedCard of playedCardsOrdered) {
             if (playedCard.onCardPlayed !== undefined) {
                 const actionFromPlayedCard: OrOptions | void = playedCard.onCardPlayed(this, game, selectedCard);
                 if (actionFromPlayedCard !== undefined) {

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -37,6 +37,7 @@ export interface ICard {
     getRequirementBonus?: (player: Player, game: Game, venusOnly?: boolean) => number;
     getVictoryPoints?: (player: Player, game: Game) => number;
     onCardPlayed?: (player: Player, game: Game, card: IProjectCard) => OrOptions | void;
+    onCardPlayedPriority?: number;
     onStandardProject?: (player: Player, projectType: StandardProjectType) => void;
     onTilePlaced?: (player: Player, space: ISpace, game: Game) => void;
     resourceType?: ResourceType;

--- a/src/cards/OlympusConference.ts
+++ b/src/cards/OlympusConference.ts
@@ -17,6 +17,7 @@ export class OlympusConference implements IProjectCard, IResourceCard {
     public resourceType: ResourceType = ResourceType.SCIENCE;
     public resourceCount: number = 0;
     public name: CardName = CardName.OLYMPUS_CONFERENCE;
+    public onCardPlayedPriority: number = 10;
 
     private runInterrupts(player: Player, game: Game, scienceTags: number): void {
 

--- a/src/cards/colonies/SpinoffDepartment.ts
+++ b/src/cards/colonies/SpinoffDepartment.ts
@@ -11,6 +11,7 @@ export class SpinoffDepartment implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.SPINOFF_DEPARTMENT
     public cardType: CardType = CardType.ACTIVE;
+    public onCardPlayerPriority: number = 10;
 
     public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
         if (card.cost >= 20) {

--- a/src/cards/prelude/PointLuna.ts
+++ b/src/cards/prelude/PointLuna.ts
@@ -11,6 +11,7 @@ export class PointLuna implements CorporationCard {
     public name: CardName = CardName.POINT_LUNA;
     public tags: Array<Tags> = [Tags.SPACE, Tags.EARTH];
     public startingMegaCredits: number = 41; //Should be 38 but the drawed card when played is payed 3 MC
+    public onCardPlayedPriority: number = 10;
     public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
         const tagCount = card.tags.filter(tag => tag === Tags.EARTH).length;
         if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.tags.indexOf(Tags.EARTH) !== -1) {


### PR DESCRIPTION
The game will order the cards by ascending priority (smaller is "faster") before calling their `onCardPlayed` method.

This was originally made to fix #848 but I decided to check [all currently available cards with an effect](https://ssimeonoff.github.io/cards-list#CORP23#C24#C41#CORP24#031#CORP22#CORP19#128#074#X14#CORP37#CORP38#CORP40#073#T06#CORP01#CORP05#CORP12#131#185#259#109).
 I only found 4 cards that interact with each other and gave 3 of them a high priority.

Now, if you play:
 - **Mars University** while having **Olympus Conference** down:
   - **Olympus** draw then **Mars University** discard.
 - A Science card while having **Mars University** and **Olympus Conference** down:
   - **Olympus** draw then **Mars University** discard.
 - A 20+ cost Science/Earth card while having **Mars University**, **Olympus Conference**, **Spin-off Department** and **Point Luna** down:
   - **Olympus**/**Point Luna**/**Spin-off** draws then **Mars University** discard.

And so on.