### PR TITLE
Fix Pharmacy Union paying 3MC for its free card

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -797,12 +797,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
       }
 
       player.corporationCard = corporationCard;
-      corporationCard.play(player, this);
       player.megaCredits = corporationCard.startingMegaCredits;
       if (corporationCard.name !== new BeginnerCorporation().name) {
         const cardsToPayFor: number = player.cardsInHand.length;
         player.megaCredits -= cardsToPayFor * player.cardCost;
       }
+      corporationCard.play(player, this);
 
       // trigger other corp's effect, e.g. SaturnSystems,PharmacyUnion,Splice
       for (const somePlayer of this.getPlayers()) {


### PR DESCRIPTION
The free Science card is not its first action but is part of its `play()` method.
Therefore, that card was taken into account when calculating cost of initial hand of cards, effectively making the player start with 43MC instead of 46.