### PR TITLE
Improve player color selection

### DIFF
--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -9,6 +9,7 @@ import { ColoniesFilter } from "./ColoniesFilter";
 import { ColonyName } from "../colonies/ColonyName";
 import { CardsFilter } from "./CardsFilter";
 import { Button } from "../components/common/Button";
+import { playerColorClass } from "../utils/utils";
 
 interface CreateGameModel {
     firstIndex: number;
@@ -178,6 +179,12 @@ export const CreateGameForm = Vue.component("create-game-form", {
             } else {
                 return "create-game-random";
             }
+        },
+        getPlayerCubeColorClass: function(color: string): string{
+            return playerColorClass(color.toLowerCase(), "bg");
+        },
+        getPlayerContainerColorClass: function(color: string): string{
+            return playerColorClass(color.toLowerCase(), "bg_transparent");
         },
         createGame: function () {
             const component = (this as any) as CreateGameModel;
@@ -559,7 +566,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
                 <div class="container">
                     <div class="columns">
                         <template v-for="newPlayer in getPlayers()">
-                        <div :class="'form-group col6 create-game-player create-game--block create-game-playerblock-'+newPlayer.color">
+                        <div :class="'form-group col6 create-game-player create-game--block '+getPlayerContainerColorClass(newPlayer.color)">
                             <div>
                                 <input class="form-input form-inline create-game-player-name" :placeholder="getPlayerNamePlaceholder(newPlayer)" v-model="newPlayer.name" />
                             </div>
@@ -567,7 +574,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
                                 <template v-for="color in ['Red', 'Green', 'Yellow', 'Blue', 'Black', 'Purple']">
                                     <input type="radio" :value="color.toLowerCase()" :name="'playerColor' + newPlayer.index" v-model="newPlayer.color" :id="'radioBox' + color + newPlayer.index">
                                     <label :for="'radioBox' + color + newPlayer.index">
-                                        <div :class="'create-game-colorbox create-game-colorbox-'+color.toLowerCase()"></div>
+                                        <div :class="'create-game-colorbox '+getPlayerCubeColorClass(color)"></div>
                                     </label>
                                 </template>
                             </div>

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -361,7 +361,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
 
                     <div class="create-game-page-container">
                         <div class="create-game-page-column" v-if="! isSoloModePage">
-                            <h4 v-i18n># of Players</h4>
+                            <h4 v-i18n>№ of Players</h4>
                                 <template v-for="pCount in [1,2,3,4,5,6]">
                                     <input type="radio" :value="pCount" name="playersCount" v-model="playersCount" :id="pCount+'-radio'">
                                     <label :for="pCount+'-radio'">

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -416,8 +416,8 @@ export const CreateGameForm = Vue.component("create-game-form", {
 
                             <div class="create-game-subsection-label">Fan-made</div>
 
-                            <input type="checkbox" name="fan-made" id="fan-made-checkbox" v-model="communityCardsOption">
-                            <label for="fan-made-checkbox">
+                            <input type="checkbox" name="community" id="communityCards-checkbox" v-model="communityCardsOption">
+                            <label for="communityCards-checkbox">
                                 <span v-i18n>Community</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#community" class="tooltip" target="_blank">&#9432;</a>
                             </label>
                         </div>

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -21,6 +21,7 @@ interface CreateGameModel {
     randomMA: boolean;
     randomFirstPlayer: boolean;
     showOtherPlayersVP: boolean;
+    beginnerOption: boolean;
     venusNext: boolean;
     colonies: boolean;
     turmoil: boolean;
@@ -77,6 +78,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
             randomMA: false,
             randomFirstPlayer: true,
             showOtherPlayersVP: false,
+            beginnerOption: false,
             venusNext: false,
             colonies: false,
             showColoniesList: false,
@@ -538,6 +540,11 @@ export const CreateGameForm = Vue.component("create-game-form", {
                             <label for="fastMode-checkbox">
                                 <span v-i18n>Fast mode</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#fast-mode" class="tooltip" target="_blank">&#9432;</a>
                             </label>
+
+                            <input type="checkbox" v-model="beginnerOption" id="beginnerOption-checkbox">
+                            <label for="beginnerOption-checkbox">
+                                <span v-i18n>Beginner Options</span>
+                            </label>
                         </div>
 
                         <div class="create-game-action">
@@ -551,29 +558,31 @@ export const CreateGameForm = Vue.component("create-game-form", {
                 <h2 v-i18n>Players</h2>
                 <div class="container">
                     <div class="columns">
-                        <div class="form-group col6 create-game-player create-game--block" v-for="newPlayer in getPlayers()">
+                        <template v-for="newPlayer in getPlayers()">
+                        <div :class="'form-group col6 create-game-player create-game--block create-game-playerblock-'+newPlayer.color">
                             <div>
                                 <input class="form-input form-inline create-game-player-name" :placeholder="getPlayerNamePlaceholder(newPlayer)" v-model="newPlayer.name" />
                             </div>
-                            <div class="flex">
-                                <label class="form-label form-inline create-game-color-label" v-i18n>Color:</label>
-                                <span class="create-game-colors-cont">
-                                <label class="form-radio form-inline create-game-color" v-for="color in ['Red', 'Green', 'Yellow', 'Blue', 'Black', 'Purple']">
-                                    <input type="radio" :value="color.toLowerCase()" :name="'playerColor' + newPlayer.index" v-model="newPlayer.color">
-                                    <i class="form-icon"></i> <div :class="'board-cube board-cube--'+color.toLowerCase()"></div>
-                                </label>
-                                </span>
+                            <div class="create-game-page-color-row">
+                                <template v-for="color in ['Red', 'Green', 'Yellow', 'Blue', 'Black', 'Purple']">
+                                    <input type="radio" :value="color.toLowerCase()" :name="'playerColor' + newPlayer.index" v-model="newPlayer.color" :id="'radioBox' + color + newPlayer.index">
+                                    <label :for="'radioBox' + color + newPlayer.index">
+                                        <div :class="'create-game-colorbox create-game-colorbox-'+color.toLowerCase()"></div>
+                                    </label>
+                                </template>
                             </div>
                             <div>
-                                <label v-if="isBeginnerToggleEnabled()" class="form-switch form-inline">
-                                    <input type="checkbox" v-model="newPlayer.beginner">
-                                    <i class="form-icon"></i> <span v-i18n>Beginner?</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#beginner-corporation" class="tooltip" target="_blank">&#9432;</a>
-                                </label>
+                                <template v-if="beginnerOption">
+                                    <label v-if="isBeginnerToggleEnabled()" class="form-switch form-inline">
+                                        <input type="checkbox" v-model="newPlayer.beginner">
+                                        <i class="form-icon"></i> <span v-i18n>Beginner?</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#beginner-corporation" class="tooltip" target="_blank">&#9432;</a>
+                                    </label>
 
-                                <label class="form-label">
-                                    <input type="number" class="form-input form-inline player-handicap" value="0" min="0" :max="10" v-model="newPlayer.handicap" />
-                                    <i class="form-icon"></i><span v-i18n>TR Boost</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#tr-boost" class="tooltip" target="_blank">&#9432;</a>
-                                </label>
+                                    <label class="form-label">
+                                        <input type="number" class="form-input form-inline player-handicap" value="0" min="0" :max="10" v-model="newPlayer.handicap" />
+                                        <i class="form-icon"></i><span v-i18n>TR Boost</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#tr-boost" class="tooltip" target="_blank">&#9432;</a>
+                                    </label>
+                                </template>
 
                                 <label class="form-radio form-inline" v-if="!randomFirstPlayer">
                                     <input type="radio" name="firstIndex" :value="newPlayer.index" v-model="firstIndex">
@@ -581,6 +590,7 @@ export const CreateGameForm = Vue.component("create-game-form", {
                                 </label>
                             </div>
                         </div>
+                        </template>
                     </div>
                 </div>
             </div>

--- a/src/locales/cn/ui.json
+++ b/src/locales/cn/ui.json
@@ -1,7 +1,7 @@
 {
     "Terraforming Mars": "殖民火星",
     "Create New Game": "新建游戏",
-    "Players count": "玩家人数",
+    "№ of Players": "玩家人数",
     "Expansions": "扩展",
     "Options": "选项",
     "Promos": "Promo卡牌",

--- a/src/locales/de/ui.json
+++ b/src/locales/de/ui.json
@@ -2,7 +2,7 @@
     "Terraforming Mars": "Terraforming Mars",
     "Create New Game": "Neues Spiel erstellen",
 
-    "Players count": "Spieleranzahl",
+    "№ of Players": "Spieleranzahl",
     "Expansions": "Erweiterungen",
     "Options": "Optionen",
     "Board": "Spielbrett",

--- a/src/locales/fr/ui.json
+++ b/src/locales/fr/ui.json
@@ -2,7 +2,7 @@
 	"Terraforming Mars": "Terraforming Mars",
 	"Create New Game": "Créer une Nouvelle Partie",
 
-	"Players count": "Nombre de joueurs",
+	"№ of Players": "Nombre de joueurs",
 	"Solo": "Solo",
 
 	"Expansions": "Extensions",

--- a/src/locales/ru/ui.json
+++ b/src/locales/ru/ui.json
@@ -1,7 +1,7 @@
 {
     "Terraforming Mars": "Покорение Марса",
     "Create New Game": "Новая игра",
-    "Players count": "Кол-во игроков",
+    "№ of Players": "Кол-во игроков",
     "Expansions": "Дополнения",
     "Options": "Настройки",
     "Use promo cards": "Промо карты",

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -103,14 +103,7 @@ h2 {
     filter: drop-shadow(4px 4px 4px black);
     text-shadow: -1px -1px 6px #aaa4;
 }
-/*
-input[type="radio"]:checked + label {
-    border: 2px solid rgb(137, 137, 137);
-    box-shadow: inset 0 0 0 3px rgb(68, 68, 68);
-    filter: brightness(120%) drop-shadow(0 0 5px white);
-    transform: translate(0, 2px);
-}
-*/
+
 .filterDiv {
     font-size: 17px !important;
 }
@@ -130,6 +123,56 @@ input[type="radio"]:checked + label {
 
 .mt-10 {
     margin-top: 10px;
+}
+
+// normal backgrounds
+.player_bg_color_red {
+    background-color: @player_red;
+}
+
+.player_bg_color_yellow {
+    background-color: @player_yellow;
+}
+
+.player_bg_color_green {
+    background-color: @player_green;
+}
+
+.player_bg_color_black {
+    background-color: @player_black;
+}
+
+.player_bg_color_blue {
+    background-color: @player_blue;
+}
+
+.player_bg_color_purple {
+    background-color: @player_purple;
+}
+
+// backgroungs with opacity
+.player_translucent_bg_color_red {
+    .player_red_bg_translucent();
+}
+
+.player_translucent_bg_color_yellow {
+    .player_yellow_bg_translucent();
+}
+
+.player_translucent_bg_color_green {
+    .player_green_bg_translucent();
+}
+
+.player_translucent_bg_color_black {
+    .player_black_bg_translucent();
+}
+
+.player_translucent_bg_color_blue {
+    .player_blue_bg_translucent();
+}
+
+.player_translucent_bg_color_purple {
+    .player_purple_bg_translucent();
 }
 
 @import "./language_switcher.less";

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -101,7 +101,7 @@
 }
 
 .create-game-subsection-label {
-    font-size: 20px;
+    font-size: 22px;
     color: gray;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -140,8 +140,8 @@
   display: inline-block;
   background-color: #303030;
   padding: 10px 20px 10px 20px;
-  font-family: sans-serif, Arial;
-  font-size: 16px;
+  font-family: Ubuntu, Sans;
+  font-size: 23px;
   border-radius: 8px;
   text-align: center;
   margin: 4px;

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -37,8 +37,7 @@
     margin-bottom: 10px;
 }
 
-.create-game--block {
-    background: #202020;	 
+.create-game--block {	 
     padding: 25px;	    
     border-radius: 15px;
 }

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -270,27 +270,5 @@
     text-align: center;
     vertical-align: text-top;
 }
-  
-.create-game-colorbox-red {
-    background-color: @player_red;
-}
-  
-.create-game-colorbox-yellow {
-    background-color: @player_yellow;
-}
-  
-.create-game-colorbox-green {
-    background-color: @player_green;
-}
-  
-.create-game-colorbox-blue {
-    background-color: @player_blue;
-}
-  
-.create-game-colorbox-black {
-    background-color: @player_black;
-}
-  
-.create-game-colorbox-purple {
-    background-color: @player_purple;
+
 }

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -270,5 +270,3 @@
     text-align: center;
     vertical-align: text-top;
 }
-
-}

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -38,8 +38,9 @@
 }
 
 .create-game--block {
-    background: #202020;
-    padding: 25px;
+    background: #202020;	 
+    padding: 25px;	    
+    border-radius: 15px;
 }
 
 .create-game-form {
@@ -198,3 +199,99 @@
     vertical-align: middle;
     margin: 0px 10px;
   }
+
+.create-game-playerblock-red {
+    background-color: fade(@player_red, 60%);
+}
+
+.create-game-playerblock-yellow {
+    background-color: fade(@player_yellow, 60%);
+}
+
+.create-game-playerblock-green {
+    background-color: fade(@player_green, 60%);
+}
+
+.create-game-playerblock-blue {
+    background-color: fade(@player_blue, 60%);
+}
+.create-game-playerblock-black {
+    background-color: fade(@player_black, 60%);
+}
+.create-game-playerblock-purple {
+    background-color: fade(@player_purple, 60%);
+}
+
+.create-game-player-name {
+    color: #020202;	    color: #020202;
+    max-width: 430px;	    max-width: 430px;
+    height: 40px;
+}
+
+.create-game-page-color-row {
+    margin-top: 10px;
+    display: flex;
+    flex-flow: row nowrap;
+    border-radius: 5px;
+    margin-top: 10px;
+}
+
+.create-game-page-color-row > input[type="radio"] {
+    opacity: 0;
+    position: fixed;
+    width: 0;
+}
+
+.create-game-page-color-row > label {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    background-color: rgb(41, 41, 41);
+    border-radius: 8px;
+    text-align: center;
+    vertical-align: middle;
+    padding: 4px 6px;
+    margin: 0px 4px;
+}
+  
+.create-game-page-color-row label:hover {
+    background-color: rgb(104, 104, 104);
+}
+
+  
+.create-game-page-color-row input[type="radio"]:checked + label {
+    background-color: rgb(199, 199, 199);
+}
+  
+.create-game-colorbox {
+    width: 25px;
+    height: 25px;
+    border-radius: 5px;
+    display: inline-block;
+    text-align: center;
+    vertical-align: text-top;
+}
+  
+.create-game-colorbox-red {
+    background-color: @player_red;
+}
+  
+.create-game-colorbox-yellow {
+    background-color: @player_yellow;
+}
+  
+.create-game-colorbox-green {
+    background-color: @player_green;
+}
+  
+.create-game-colorbox-blue {
+    background-color: @player_blue;
+}
+  
+.create-game-colorbox-black {
+    background-color: @player_black;
+}
+  
+.create-game-colorbox-purple {
+    background-color: @player_purple;
+}

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,25 +1,25 @@
 @import "./variables.less";
 
-.player_red_bg() {
+.player_red_bg_translucent() {
     background: rgba(@player_red, 0.7);
 }
 
-.player_yellow_bg() {
+.player_yellow_bg_translucent() {
     background: rgba(@player_yellow, 0.7);
 }
 
-.player_green_bg() {
+.player_green_bg_translucent() {
     background: rgba(@player_green, 0.7);
 }
 
-.player_black_bg() {
+.player_black_bg_translucent() {
     background: rgba(@player_black, 0.7);
 }
 
-.player_blue_bg() {
+.player_blue_bg_translucent() {
     background: rgba(@player_blue, 0.7);
 }
 
-.player_purple_bg() {
+.player_purple_bg_translucent() {
     background: rgba(@player_purple, 0.7);
 }

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -25,56 +25,6 @@
     text-shadow: -1px -1px 6px @player_purple, 1px 1px 1px #333a;
 }
 
-// normal backgrounds
-.player_bg_color_red {
-    background-color: @player_red;
-}
-
-.player_bg_color_yellow {
-    background-color: @player_yellow;
-}
-
-.player_bg_color_green {
-    background-color: @player_green;
-}
-
-.player_bg_color_black {
-    background-color: @player_black;
-}
-
-.player_bg_color_blue {
-    background-color: @player_blue;
-}
-
-.player_bg_color_purple {
-    background-color: @player_purple;
-}
-
-// backgroungs with opacity
-.player_overview_bg_color_red {
-    .player_red_bg();
-}
-
-.player_overview_bg_color_yellow {
-    .player_yellow_bg();
-}
-
-.player_overview_bg_color_green {
-    .player_green_bg();
-}
-
-.player_overview_bg_color_black {
-    .player_black_bg();
-}
-
-.player_overview_bg_color_blue {
-    .player_blue_bg();
-}
-
-.player_overview_bg_color_purple {
-    .player_purple_bg();
-}
-
 .game-title {
     text-transform: uppercase;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,7 +4,7 @@ export const playerColorClass = (
 ): string => {
     let prefix = {
         shadow: "player_shadow_color_",
-        bg_transparent: "player_overview_bg_color_",
+        bg_transparent: "player_translucent_bg_color_",
         bg: "player_bg_color_",
     }[type];
 


### PR DESCRIPTION
- Color boxes instead of radio buttons for picking colors.
- The entire player box changes color to match, making it easier to tell who is playing what color.
- Hiding TR boost and Beginner Corp option under Beginner Options

![image](https://user-images.githubusercontent.com/14239220/95766933-00955300-0c82-11eb-931f-98180d568763.png)
