### PR TITLE
Dynamically set cardTitle widths and trim Promo text from titles

### DIFF
--- a/src/components/card/CardTitle.ts
+++ b/src/components/card/CardTitle.ts
@@ -34,20 +34,26 @@ export const CardTitle = Vue.component("CardTitle", {
                 classes.push("background-color-prelude");
             }
 
-            if (title.length > 26) {
+            const trimmedTitle = this.getCardTitleWithoutPromoText(title);
+
+            if (trimmedTitle.length > 26) {
                 classes.push("title-smaller");
-            } else if (title.length > 23) {
+            } else if (trimmedTitle.length > 23) {
                 classes.push("title-small");
             }
 
             return classes.join(" ");
         },
+        getCardTitleWithoutPromoText(title: string): string {
+            if (title.toLowerCase().includes("promo")) return title.substring(0, title.length - 6);
+            return title;
+        }
     },
     template: `
         <div class="card-title">
             <div v-if="isPrelude()" class="prelude-label">prelude</div>
             <div v-if="isCorporation()" class="corporation-label">corporation</div>
-            <div v-else :class="getClasses(title)">{{ title }}</div>
+            <div v-else :class="getClasses(title)">{{ getCardTitleWithoutPromoText(title) }}</div>
         </div>
     `,
 });

--- a/src/components/card/CardTitle.ts
+++ b/src/components/card/CardTitle.ts
@@ -21,8 +21,9 @@ export const CardTitle = Vue.component("CardTitle", {
         isPrelude: function (): boolean {
             return this.type === CardType.PRELUDE;
         },
-        getClasses: function (): string {
+        getClasses: function (title: string): string {
             const classes: Array<String> = ["card-title"];
+
             if (this.type === CardType.AUTOMATED) {
                 classes.push("background-color-automated");
             } else if (this.type === CardType.ACTIVE) {
@@ -32,6 +33,13 @@ export const CardTitle = Vue.component("CardTitle", {
             } else if (this.type === CardType.PRELUDE) {
                 classes.push("background-color-prelude");
             }
+
+            if (title.length > 26) {
+                classes.push("title-smaller");
+            } else if (title.length > 23) {
+                classes.push("title-small");
+            }
+
             return classes.join(" ");
         },
     },
@@ -39,7 +47,7 @@ export const CardTitle = Vue.component("CardTitle", {
         <div class="card-title">
             <div v-if="isPrelude()" class="prelude-label">prelude</div>
             <div v-if="isCorporation()" class="corporation-label">corporation</div>
-            <div v-else :class="getClasses()">{{ title }}</div>
+            <div v-else :class="getClasses(title)">{{ title }}</div>
         </div>
     `,
 });

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -429,6 +429,11 @@ input[type="radio"]:checked + .filterDiv::after {
     font-size: 40px;
     cursor: pointer;
 }
+
+/*********** Title text sizing************/
+.title-small { font-size: 15px !important; }
+.title-smaller { font-size: 14px !important; }
+
 /*********** Background colors************/
 
 .background-color-corporation {
@@ -1807,12 +1812,6 @@ input[type="radio"]:checked + .filterDiv::after {
     }
 }
 
-.card-technology-demonstration {
-    .title {
-        font-size: 14px;
-    }
-}
-
 .card-pharmacy-union {
     .corp-logo {
         color: white;
@@ -1884,10 +1883,6 @@ input[type="radio"]:checked + .filterDiv::after {
         margin-left: 20px;
     }
 
-    .title {
-        font-size: 15px;
-    }
-
     .card-icon.requirements {
         border-radius: 0px;
         height: 12px;
@@ -1940,9 +1935,6 @@ input[type="radio"]:checked + .filterDiv::after {
 }
 
 .card-asteroid-deflection-system {
-    .title {
-        font-size: 14px;
-    }
     .description.effect {
         font-size: 10px;
         font-weight: bold;
@@ -1976,23 +1968,8 @@ input[type="radio"]:checked + .filterDiv::after {
 }
 
 .card-magnetic-field-generators-promo {
-    .title {
-        font-size: 14px;
-    }
     .tile-icon {
         margin-left: 3px;
-    }
-}
-
-.card-magnetic-field-generators {
-    .title {
-        font-size: 14px;
-    }
-}
-
-.card-beam-from-a-thorium-asteroid {
-    .title {
-        font-size: 13px;
     }
 }
 

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -1608,7 +1608,7 @@ input[type="radio"]:checked + .filterDiv::after {
     line-height: 25px;
     text-align: left;
     margin-left: 20px;
-    margin-top: -12px;
+    margin-top: -48px;
     text-shadow: 0 0 1px skyblue, 0 2px 2px white;
     font-size: 24px;
 }


### PR DESCRIPTION
<img width="204" alt="Screenshot 2020-10-13 at 1 56 40 AM" src="https://user-images.githubusercontent.com/2408094/95777767-683ab500-0cf9-11eb-8e8e-8f4ee66036f8.png">
<img width="208" alt="Screenshot 2020-10-13 at 1 56 48 AM" src="https://user-images.githubusercontent.com/2408094/95777774-6a047880-0cf9-11eb-8326-285296ea3830.png">
<img width="422" alt="Screenshot 2020-10-13 at 2 07 10 AM" src="https://user-images.githubusercontent.com/2408094/95777778-6bce3c00-0cf9-11eb-855c-d90d23ca7914.png">

- Set cardTitle width dynamically based on title length
- Drop "Promo" text from promo card titles
- Fix CSS for ProjectWorkshop