### PR TITLE
Fix Energy Tapping and Power Supply Consortium play requirements

### DIFF
--- a/src/cards/EnergyTapping.ts
+++ b/src/cards/EnergyTapping.ts
@@ -1,29 +1,25 @@
-
-import {IProjectCard} from './IProjectCard';
-import {Tags} from './Tags';
-import {CardType} from './CardType';
-import {Player} from '../Player';
-import {Game} from '../Game';
-import { Resources } from '../Resources';
-import { CardName } from '../CardName';
+import { IProjectCard } from "./IProjectCard";
+import { Tags } from "./Tags";
+import { CardType } from "./CardType";
+import { Player } from "../Player";
+import { Game } from "../Game";
+import { Resources } from "../Resources";
+import { CardName } from "../CardName";
 
 export class EnergyTapping implements IProjectCard {
-  public cost: number = 3;
-  public tags: Array<Tags> = [Tags.ENERGY];
-  public name: CardName = CardName.ENERGY_TAPPING;
-  public cardType: CardType = CardType.AUTOMATED;
-  public hasRequirements = false;
-  public canPlay(_player: Player, game: Game): boolean {
-    return game.someoneHasResourceProduction(Resources.ENERGY,1)
-  }
+    public cost: number = 3;
+    public tags: Array<Tags> = [Tags.ENERGY];
+    public name: CardName = CardName.ENERGY_TAPPING;
+    public cardType: CardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
-  public play(player: Player, game: Game) {
-    game.addResourceProductionDecreaseInterrupt(player, Resources.ENERGY, 1);
-    player.addProduction(Resources.ENERGY);
-    return undefined;
-  }
+    public play(player: Player, game: Game) {
+        player.addProduction(Resources.ENERGY);
+        game.addResourceProductionDecreaseInterrupt(player, Resources.ENERGY, 1);
+        return undefined;
+    }
 
-  public getVictoryPoints() {
-    return -1;
-  }
+    public getVictoryPoints() {
+        return -1;
+    }
 }

--- a/src/cards/PowerSupplyConsortium.ts
+++ b/src/cards/PowerSupplyConsortium.ts
@@ -3,8 +3,8 @@ import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
-import { Resources } from '../Resources';
-import { CardName } from '../CardName';
+import { Resources } from "../Resources";
+import { CardName } from "../CardName";
 
 export class PowerSupplyConsortium implements IProjectCard {
     public cost: number = 5;
@@ -12,14 +12,12 @@ export class PowerSupplyConsortium implements IProjectCard {
     public name: CardName = CardName.POWER_SUPPLY_CONSORTIUM;
     public cardType: CardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player, game: Game): boolean {
-        return player.getTagCount(Tags.ENERGY) >= 2 && game.someoneHasResourceProduction(Resources.ENERGY,1); 
+    public canPlay(player: Player): boolean {
+        return player.getTagCount(Tags.ENERGY) >= 2;
     }
     public play(player: Player, game: Game) {
-        if ( ! game.isSoloMode()) {
-            game.addResourceProductionDecreaseInterrupt(player, Resources.ENERGY, 1);
-        }
         player.addProduction(Resources.ENERGY);
+        game.addResourceProductionDecreaseInterrupt(player, Resources.ENERGY, 1);
         return undefined;
     }
 }

--- a/tests/cards/EnergyTapping.spec.ts
+++ b/tests/cards/EnergyTapping.spec.ts
@@ -16,24 +16,17 @@ describe("EnergyTapping", function () {
         game = new Game("foobar", [player, player2], player);
     });
 
-    it("Can't play", function () {
-        expect(card.canPlay(player, game)).to.eq(false);
-    });
-
     it("Should play - auto select if single target", function () {
-        player2.addProduction(Resources.ENERGY, 3);
-        expect(card.canPlay(player, game)).to.eq(true);
+        player.addProduction(Resources.ENERGY, 3);
 
         card.play(player, game);
         expect(game.interrupts.length).to.eq(0);
-        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
-        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(3);
     });
 
     it("Should play - multiple targets", function () {
         player.addProduction(Resources.ENERGY, 3);
         player2.addProduction(Resources.ENERGY, 3);
-        expect(card.canPlay(player, game)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(4);
@@ -46,7 +39,6 @@ describe("EnergyTapping", function () {
 
     it("Playable in solo mode", function () {
         const game = new Game("foobar", [player], player);
-        expect(card.canPlay(player, game)).to.eq(true);
         card.play(player, game);
         
         player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/EnergyTapping.spec.ts
+++ b/tests/cards/EnergyTapping.spec.ts
@@ -3,7 +3,7 @@ import { EnergyTapping } from "../../src/cards/EnergyTapping";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
-import { Resources } from '../../src/Resources';
+import { Resources } from "../../src/Resources";
 import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("EnergyTapping", function () {
@@ -41,7 +41,7 @@ describe("EnergyTapping", function () {
         const game = new Game("foobar", [player], player);
         card.play(player, game);
         
-        player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
+        player.victoryPointsBreakdown.setVictoryPoints("victoryPoints", card.getVictoryPoints());
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-1);
     });

--- a/tests/cards/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/PowerSupplyConsortium.spec.ts
@@ -18,18 +18,17 @@ describe("PowerSupplyConsortium", function () {
 
     it("Can't play without power tags", function () {
         player.addProduction(Resources.ENERGY, 3);
-        expect(card.canPlay(player, game)).to.eq(false);
+        expect(card.canPlay(player)).to.eq(false);
     });
 
     it("Can play - single target", function () {
-        player2.addProduction(Resources.ENERGY, 3);
+        player.addProduction(Resources.ENERGY, 3);
         player.playedCards.push(card, card);
-        expect(card.canPlay(player, game)).to.eq(true);
+        expect(card.canPlay(player)).to.eq(true);
 
         card.play(player, game);
         expect(game.interrupts.length).to.eq(0);
-        expect(player.getProduction(Resources.ENERGY)).to.eq(1);
-        expect(player2.getProduction(Resources.ENERGY)).to.eq(2);
+        expect(player.getProduction(Resources.ENERGY)).to.eq(3);
     });
 
     it("Can play - multiple targets", function () {
@@ -48,7 +47,7 @@ describe("PowerSupplyConsortium", function () {
     it("Can play in solo mode if have enough power tags", function () {
         const game = new Game("foobar2", [player], player);
         player.playedCards.push(card, card);
-        expect(card.canPlay(player, game)).to.eq(true);
+        expect(card.canPlay(player)).to.eq(true);
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1); // incremented

--- a/tests/cards/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/PowerSupplyConsortium.spec.ts
@@ -3,7 +3,7 @@ import { PowerSupplyConsortium } from "../../src/cards/PowerSupplyConsortium";
 import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
-import { Resources } from '../../src/Resources';
+import { Resources } from "../../src/Resources";
 import { SelectPlayer } from "../../src/inputs/SelectPlayer";
 
 describe("PowerSupplyConsortium", function () {


### PR DESCRIPTION
You can increase your own energy production and then decrease it.
There's really little reasons you would do that (maybe playing Energy Tapping into Magnetic Field or delaying your action late game) but it would be valid. So there we go.