### PR TITLE
create settings.json for passing server settings to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .nyc_output/
 styles.css
 .vscode/
+assets/settings.json
 assets/translations.json
 pid
 *.log

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A [.env](https://www.npmjs.com/package/dotenv) file allows you to store environm
 * CERT_PATH: Your TLS certificate path (=> `fullchain.pem` created by certbot)
 * KEY_PATH: Your TLS private key path (=> `privkey.pem` created by certbot)
 * MAX_GAME_DAYS: How many days to keep unfinished games before deleting them
+* WAITING_FOR_TIMEOUT: (default 5000) How many milliseconds to check for game update on multi-player games
 
 ### Deployment
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <body id="ts-preferences-target">
         <div id="app" :class="'topmost-'+screen">
             <div class="main-container">
-                <start-screen v-if="screen === 'start-screen'" version="$$APP_VERSION$$"></start-screen>
+                <start-screen v-if="screen === 'start-screen'" :version="settings.version"></start-screen>
                 <create-game-form
                     v-else-if="screen === 'create-game-form'"
                 ></create-game-form>
@@ -25,6 +25,7 @@
                     v-else-if="screen === 'player-home'"
                     :player="player"
                     :key="playerkey"
+                    :settings="settings"
                 ></player-home>
                 <game-end
                     v-else-if="screen === 'the-end'"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   },
   "scripts": {
     "clean": "rm -r ./dist/ ./styles.css",
-    "build": "node make_locales.js && eslint src/*.ts src/database/**/*.ts && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js",
-    "start": "node make_locales.js && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js && node dist/server.js",
+    "build": "node make_static_json.js && eslint src/*.ts src/database/**/*.ts && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js",
+    "start": "node make_static_json.js && lessc src/styles/common.less styles.css && tsc --build tsconfig.json && webpack --config webpack.config.js && node dist/server.js",
     "pretest": "tsc --build tsconfig-test.json",
     "test": "mocha --recursive dist/tests",
     "testgiven": "tsc --build tsconfig.json && webpack --config webpack.config.js && tsc --build tsconfig-test.json && mocha",

--- a/server.ts
+++ b/server.ts
@@ -5,7 +5,6 @@ import * as http from "http";
 import * as fs from "fs";
 import * as path from "path";
 import * as querystring from "querystring";
-import * as child_process from "child_process";
 
 import { AndOptions } from "./src/inputs/AndOptions";
 import { BoardName } from "./src/BoardName";
@@ -52,7 +51,6 @@ import { SelectColony } from "./src/inputs/SelectColony";
 
 const serverId = generateRandomServerId();
 const styles = fs.readFileSync("styles.css");
-const appVersion = generateAppVersion();
 const gameLoader = new GameLoader();
 const route = new Route();
 const gameLogs = new GameLogs(gameLoader);
@@ -187,19 +185,6 @@ function generateRandomGameId(): string {
 
 function generateRandomServerId(): string {
     return generateRandomGameId();
-}
-
-function generateAppVersion(): string {
-    // assumes SOURCE_VERSION is git hash
-    if (process.env.SOURCE_VERSION) {
-        return process.env.SOURCE_VERSION.substring(0, 7) + " deployed " + new Date().toISOString();
-    }
-    try {
-        return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();
-    } catch (error) {
-        console.warn("unable to generate app version", error);
-        return "unknown version";
-    }
 }
 
 function processInput(
@@ -992,7 +977,7 @@ function serveApp(req: http.IncomingMessage, res: http.ServerResponse): void {
             return route.internalServerError(req, res, err);
         }
         res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.write(data.toString().replace("$$APP_VERSION$$", appVersion));
+        res.write(data);
         res.end();
     });
 }

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -8,11 +8,14 @@ import { LoadGameForm } from "./LoadGameForm";
 import { DebugUI } from "./DebugUI";
 import { HelpIconology } from "./HelpIconology";
 
+import * as raw_settings from "../../assets/settings.json";
+
 export const mainAppSettings = {
     "el": "#app",
     "data": {
         screen: "empty",
         playerkey: 0,
+        settings: raw_settings,
         isServerSideRequestInProgress: false,
         componentsVisibility: {
             "millestones_list": true,

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -19,7 +19,7 @@ import { Button } from "../components/common/Button";
 const dialogPolyfill = require("dialog-polyfill");
 
 export const PlayerHome = Vue.component("player-home", {
-    props: ["player"],
+    props: ["player", "settings"],
     components: {
         "board": Board,
         "dynamic-title": DynamicTitle,
@@ -153,7 +153,7 @@ export const PlayerHome = Vue.component("player-home", {
                 <div class="player_home_block player_home_block--actions nofloat">
                     <a name="actions" class="player_home_anchor"></a>
                     <dynamic-title title="Actions" :color="player.color" />
-                    <waiting-for v-if="player.phase !== 'end'" :players="player.players" :player="player" :waitingfor="player.waitingFor"></waiting-for>
+                    <waiting-for v-if="player.phase !== 'end'" :players="player.players" :player="player" :settings="settings" :waitingfor="player.waitingFor"></waiting-for>
                 </div>
 
                 <div class="player_home_block player_home_block--hand" v-if="player.draftedCards.length > 0">
@@ -217,7 +217,7 @@ export const PlayerHome = Vue.component("player-home", {
                 </div>
 
                 <dynamic-title title="Select initial cards:" :color="player.color"/>
-                <waiting-for v-if="player.phase !== 'end'" :players="player.players" :player="player" :waitingfor="player.waitingFor"></waiting-for>
+                <waiting-for v-if="player.phase !== 'end'" :players="player.players" :player="player" :settings="settings" :waitingfor="player.waitingFor"></waiting-for>
 
                 <dynamic-title title="Game details" :color="player.color"/>
 

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -19,9 +19,11 @@ import { SelectColony } from "./SelectColony";
 var ui_update_timeout_id: number | undefined = undefined;
 
 export const WaitingFor = Vue.component("waiting-for", {
-    props: ["player", "players", "waitingfor"],
+    props: ["player", "players", "settings", "waitingfor"],
     data: function () {
-        return {}
+        return {
+            waitingForTimeout: this.settings.waitingForTimeout
+        }
     },
     components: {
         "and-options": AndOptions,
@@ -79,7 +81,7 @@ export const WaitingFor = Vue.component("waiting-for", {
                 xhr.responseType = "json";
                 xhr.send();
             }
-            ui_update_timeout_id = (setTimeout(askForUpdate, 5000) as any);
+            ui_update_timeout_id = (setTimeout(askForUpdate, this.waitingForTimeout) as any);
         }
     },
     render: function (createElement) {


### PR DESCRIPTION
During the recent change to display the server version on the client I took a rudimentary approach. There was a request to pass another server variable to the client to configure how often the client checks for updates. This change creates a `settings.json` similar to the `translations.json`. This file is then passed to the `App` component making it available on the client. In the future if we need to pass more data from server to client we can add it here.