### PR TITLE
Fix not being able to play Stratospheric Birds

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1205,7 +1205,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           totalToPay += howToPay.microbes * 2;
         }
 
-        if (howToPay.floaters !== undefined) {
+        if (howToPay.floaters !== undefined && howToPay.floaters > 0) {
           if (selectedCard.name === CardName.STRATOSPHERIC_BIRDS && howToPay.floaters === this.getFloatersCanSpend()) {
             const cardsWithFloater = this.getCardsWithResources().filter(card => card.resourceType === ResourceType.FLOATER);
             if (cardsWithFloater.length === 1) {


### PR DESCRIPTION
Card shows up as playable, since it is, but when validating the play, `howToPay.floaters` is set to 0, not undefined, so it triggers a check, and if you have only 1 cards with floaters, you can't play Stratospheric Birds.

This fix makes sure that `howToPay.floaters` is greater than 0 to process the check, fixing the issue.