### PR TITLE
allowing custom corp even without expansion

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -262,8 +262,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
             }
         }
         corporationCards = customCorporationCards;
-      } else if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length < minCorpsRequired){
-        throw new Error("Not enough custom corps selected for all players");
       }
 
       corporationCards = this.dealer.shuffleCards(corporationCards);

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -59,6 +59,8 @@ import { getRandomMilestonesAndAwards } from "./MilestoneAwardSelector";
 import { CardType } from "./cards/CardType";
 import { ColonyModel } from "./models/ColonyModel";
 import { LogBuilder } from "./LogBuilder";
+import { Decks } from "./Deck";
+import { ALL_CORPORATION_DECKS } from "./cards/AllCards";
 
 export interface Score {
   corporation: String;
@@ -251,10 +253,17 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       const minCorpsRequired = players.length * gameOptions.startingCorporations;
       if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length >= minCorpsRequired) {
-
-        corporationCards = this.dealer.corporationCards.filter(
-          (corpCard) => gameOptions !== undefined && gameOptions.customCorporationsList.includes(corpCard.name)
-        );
+        
+        const customCorporationCards: CorporationCard[] = [];
+        for (const corp of gameOptions.customCorporationsList) {
+            const customCorp = Decks.findByName(ALL_CORPORATION_DECKS, corp)
+            if (customCorp){
+                customCorporationCards.push(customCorp);
+            }
+        }
+        corporationCards = customCorporationCards;
+      } else if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length < minCorpsRequired){
+        throw new Error("Not enough custom corps selected for all players");
       }
 
       corporationCards = this.dealer.shuffleCards(corporationCards);

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -77,7 +77,7 @@ describe("Game", function () {
         game.addGreenery(player, SpaceName.PAVONIS_MONS);
    
         // Claim milestone
-        let milestone = new Mayor();
+        const milestone = new Mayor();
 
         game.claimedMilestones.push({
             player: player,
@@ -136,7 +136,7 @@ describe("Game", function () {
         const game = new Game("vp_game", [player,player2], player);
 
         (game as any).temperature = 6;
-        var initialTR = player.getTerraformRating();
+        let initialTR = player.getTerraformRating();
         game.increaseTemperature(player, 2);
 
         expect(game.getTemperature()).to.eq(constants.MAX_TEMPERATURE);
@@ -273,7 +273,7 @@ describe("Game", function () {
         const player4 = new Player("p4", Color.RED, false);
         const game = new Game("gto", [player1, player2, player3, player4], player3);
 
-        var players = game.getPlayers();
+        let players = game.getPlayers();
         expect(players[0].name).to.eq("p3");
         expect(players[1].name).to.eq("p4");
         expect(players[2].name).to.eq("p1");
@@ -389,13 +389,13 @@ describe("Game", function () {
         const gameOptions = setCustomGameOptions({boardName: BoardName.HELLAS, randomMA: true}) as GameOptions;
         const game = new Game("foobar", [player, player2], player, gameOptions);
 
-        let prevMilestones = game.milestones.map(m => m.name).sort();
-        let prevAwards = game.awards.map(a => a.name).sort();
+        const prevMilestones = game.milestones.map(m => m.name).sort();
+        const prevAwards = game.awards.map(a => a.name).sort();
 
         const game2 = new Game("foobar2", [player, player2], player, gameOptions);
 
-        let milestones = game2.milestones.map(m => m.name).sort();
-        let awards = game2.awards.map(a => a.name).sort();
+        const milestones = game2.milestones.map(m => m.name).sort();
+        const awards = game2.awards.map(a => a.name).sort();
 
         expect(prevMilestones).to.not.eq(milestones)
         expect(prevAwards).to.not.eq(awards)


### PR DESCRIPTION
**Problem**: Currently, you cannot play any expansion corp without the expansion it comes from. For example, you cannot play Manutech without Venus Next expansion. Previously, this was possible.

**Source**: #1444 changed the code such that custom corps only filter on top of the corps available by selected expansion(s) instead of all corps as it was previously.

**Fix:** Getting CorporationCard from the custom corp list and use this instead of the corps available by selected expansion(s). 

I tested it, it works, however, two problems.
1) This is probably a bad code, there must be a way of doing this. Do I need to use Decks.findByName()? 
2) I would like to throw an error but I don't think I can do that in a constructor. I get "Unexpected Server Response" instead of the error message I put in. This will also cause `npm run start` to fail if there is any existing game that might cause this error. I had to `rm db/game.db && touch db/game.db` before I can `npm run start`.