### PR TITLE
Fix: Only show cards that player can afford for ValuableGases

### DIFF
--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -17,8 +17,8 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
     }
 
     public addPlayCardInterrupt(player: Player, game: Game) {
-        const playableCards = player.cardsInHand.filter((card) => card.resourceType === ResourceType.FLOATER && card.tags.indexOf(Tags.VENUS) !== -1);
-            
+        const playableCards = player.getPlayableCards(game).filter((card) => card.resourceType === ResourceType.FLOATER && card.tags.indexOf(Tags.VENUS) !== -1);
+
         if (playableCards.length > 0) {
             game.interrupts.push({
                 player: player,


### PR DESCRIPTION
![photo_2020-10-21_13-41-56](https://user-images.githubusercontent.com/2408094/96678971-5619e000-13a5-11eb-99a7-9453f01be62b.jpg)
![photo_2020-10-21_13-42-03](https://user-images.githubusercontent.com/2408094/96678973-56b27680-13a5-11eb-9d0e-bbfed99870a7.jpg)

`player.getPlayableCards(game)` should be called instead of `player.cardsInHand`