### PR TITLE
catch errors loading reference games

### DIFF
--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -91,13 +91,18 @@ export class PostgreSQL implements IDatabase {
             if (res.rows.length === 0) {
                 return cb(new Error("Game not found"));
             }
-            // Transform string to json
-            const gameToRestore = JSON.parse(res.rows[0].game);
+            try {
+                // Transform string to json
+                const gameToRestore = JSON.parse(res.rows[0].game);
 
-            // Rebuild each objects
-            game.loadFromJSON(gameToRestore);
-
-            return cb(err);
+                // Rebuild each objects
+                game.loadFromJSON(gameToRestore);
+            } catch (exception) {
+                console.error(`Unable to restore game ${game_id}`, exception);
+                cb(exception);
+                return;
+            }
+            return cb(undefined);
         });
     }
 


### PR DESCRIPTION
In most places we catch errors so that we don't take down the server. When loading cloned games we were not catching errors when loading game from JSON. This led to an uncaught error which crashed the node process. This change catches the error for now. There is some issue where the final community card manifest in `decks` is always `undefined`.

If you log this value it is `undefined`.

https://github.com/bafolts/terraforming-mars/blob/master/src/Dealer.ts#L27

Anytime we can't find a card we will error. If you use community cards you are most likely screwed.