### PR TITLE
catch errors restoring reference games for SQLite

### DIFF
--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -59,11 +59,18 @@ export class SQLite implements IDatabase {
             if (row.game_id === undefined) {
                 return cb(new Error("Game not found"));
             }
-            // Transform string to json
-            const gameToRestore = JSON.parse(row.game);
 
-            // Rebuild each objects
-            game.loadFromJSON(gameToRestore);
+            try {
+                // Transform string to json
+                const gameToRestore = JSON.parse(row.game);
+
+                // Rebuild each objects
+                game.loadFromJSON(gameToRestore);
+            } catch (exception) {
+                console.error(`unable to restore reference game ${game_id}`, exception);
+                cb(exception);
+                return;
+            }
 
             return cb(err);
         });


### PR DESCRIPTION
Fix which was put in for postgres for sqlite. We most likely need to migrate our database towards some shared logic once we get the response. For the time being this will catch the error and prevent crash for postgres parity.