### PR TITLE
create singleton to get decks

### DIFF
--- a/src/CardFinder.ts
+++ b/src/CardFinder.ts
@@ -1,0 +1,52 @@
+import { ICardFactory } from "./cards/ICardFactory";
+import { IProjectCard } from "./cards/IProjectCard";
+import { CardManifest } from "./cards/CardManifest";
+import { COLONIES_CARD_MANIFEST } from "./cards/colonies/ColoniesCardManifest";
+import { PRELUDE_CARD_MANIFEST } from "./cards/prelude/PreludeCardManifest";
+import { PROMO_CARD_MANIFEST } from "./cards/promo/PromoCardManifest";
+import { BASE_CARD_MANIFEST, CORP_ERA_CARD_MANIFEST } from "./cards/StandardCardManifests";
+import { TURMOIL_CARD_MANIFEST } from "./cards/turmoil/TurmoilCardManifest";
+import { VENUS_CARD_MANIFEST } from "./cards/venusNext/VenusCardManifest";
+import { COMMUNITY_CARD_MANIFEST } from "./cards/community/CommunityCardManifest";
+
+export class CardFinder {
+    private static decks: undefined | Array<CardManifest>;
+    private static getDecks(): Array<CardManifest> {
+        if (CardFinder.decks === undefined) {
+            CardFinder.decks = [
+                BASE_CARD_MANIFEST,
+                CORP_ERA_CARD_MANIFEST,
+                PROMO_CARD_MANIFEST,
+                VENUS_CARD_MANIFEST,
+                COLONIES_CARD_MANIFEST,
+                PRELUDE_CARD_MANIFEST,
+                TURMOIL_CARD_MANIFEST,
+                COMMUNITY_CARD_MANIFEST
+            ];
+        }
+        return CardFinder.decks;
+    }
+
+    // Function to return a card object by its name
+    // NOTE(kberg): This replaces a larger function which searched for both Prelude cards amidst project cards
+    // TODO(kberg): Find the use cases where this is used to find Prelude cards and filter them out to
+    //              another function, perhaps?
+    public getProjectCardByName(cardName: string): IProjectCard | undefined {
+        let found : (ICardFactory<IProjectCard> | undefined);
+        CardFinder.getDecks().forEach((deck) => {
+            // Short circuit
+            if (found !== undefined) {
+                return;
+            }
+            found = deck.projectCards.findByCardName(cardName);
+            if (found === undefined) {
+                found = deck.preludeCards.findByCardName(cardName);
+            }
+        });
+        if (found !== undefined) {
+            return new found.factory();
+        }
+        console.warn(`card not found ${cardName}`);
+        return undefined;
+    }
+}

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -14,37 +14,7 @@ import { CardManifest } from "./cards/CardManifest";
 import { ICardFactory } from "./cards/ICardFactory";
 import { CardTypes, Deck } from "./Deck";
 import { Expansion } from "./Expansion";
-
-
-export const decks: Array<CardManifest> = [
-    BASE_CARD_MANIFEST,
-    CORP_ERA_CARD_MANIFEST,
-    PROMO_CARD_MANIFEST,
-    VENUS_CARD_MANIFEST,
-    COLONIES_CARD_MANIFEST,
-    PRELUDE_CARD_MANIFEST,
-    TURMOIL_CARD_MANIFEST,
-    COMMUNITY_CARD_MANIFEST,
-];
-
-// Function to return a card object by its name
-// NOTE(kberg): This replaces a larger function which searched for both Prelude cards amidst project cards
-// TODO(kberg): Find the use cases where this is used to find Prelude cards and filter them out to
-//              another function, perhaps?
-export function getProjectCardByName(cardName: string): IProjectCard | undefined {
-    let found : (ICardFactory<IProjectCard> | undefined);
-    decks.forEach(deck => {
-        // Short circuit
-        if (found) {
-            return;
-        }
-        found = deck.projectCards.findByCardName(cardName);
-        if (!found) {
-            found = deck.preludeCards.findByCardName(cardName);
-        };
-    });
-    return found ? new found.factory() : undefined;
-}
+import { CardFinder} from "./CardFinder";
 
 export class Dealer implements ILoadable<SerializedDealer, Dealer>{
     public deck: Array<IProjectCard> = [];
@@ -182,20 +152,20 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
     public loadFromJSON(d: SerializedDealer): Dealer {
         // Assign each attributes
         const o = Object.assign(this, d);
-
+        const cardFinder = new CardFinder();
         // Rebuild deck
         this.deck = d.deck.map((element: IProjectCard)  => {
-            return getProjectCardByName(element.name)!;
+            return cardFinder.getProjectCardByName(element.name)!;
         });
 
         // Rebuild prelude deck
         this.preludeDeck = d.preludeDeck.map((element: IProjectCard)  => {
-            return getProjectCardByName(element.name)!;
+            return cardFinder.getProjectCardByName(element.name)!;
         });
 
         // Rebuild the discard
         this.discarded = d.discarded.map((element: IProjectCard)  => {
-            return getProjectCardByName(element.name)!;
+            return cardFinder.getProjectCardByName(element.name)!;
         });
         
         return o;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -31,7 +31,7 @@ import {SelectCity} from "./interrupts/SelectCity";
 import {SpaceType} from "./SpaceType";
 import {ITagCount} from "./ITagCount";
 import {TileType} from "./TileType";
-import {getProjectCardByName} from "./Dealer";
+import {CardFinder} from "./CardFinder";
 import {ILoadable} from "./ILoadable";
 import {Database} from "./database/Database";
 import {SerializedPlayer} from "./SerializedPlayer";
@@ -2240,7 +2240,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public loadFromJSON(d: SerializedPlayer): Player {
       // Assign each attributes
       const o = Object.assign(this, d);
-
+      const cardFinder = new CardFinder();
       // Rebuild generation played map
       this.generationPlayed = new Map<string, number>(d.generationPlayed);
 
@@ -2277,27 +2277,27 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Rebuild dealt prelude array
       this.dealtPreludeCards = d.dealtPreludeCards.map((element: IProjectCard)  => {
-        return getProjectCardByName(element.name)!;
+        return cardFinder.getProjectCardByName(element.name)!;
       });
       
       // Rebuild dealt cards array
       this.dealtProjectCards = d.dealtProjectCards.map((element: IProjectCard)  => {
-        return getProjectCardByName(element.name)!;
+        return cardFinder.getProjectCardByName(element.name)!;
       });      
 
       // Rebuild each cards in hand
       this.cardsInHand = d.cardsInHand.map((element: IProjectCard)  => {
-        return getProjectCardByName(element.name)!;
+        return cardFinder.getProjectCardByName(element.name)!;
       });
 
       // Rebuild each prelude in hand
       this.preludeCardsInHand = d.preludeCardsInHand.map((element: IProjectCard)  => {
-        return getProjectCardByName(element.name)!;
+        return cardFinder.getProjectCardByName(element.name)!;
       });
 
       // Rebuild each played card
       this.playedCards = d.playedCards.map((element: IProjectCard)  => {
-        const card = getProjectCardByName(element.name)!;
+        const card = cardFinder.getProjectCardByName(element.name)!;
         if(element.resourceCount && element.resourceCount > 0) {
           card.resourceCount = element.resourceCount;
         }  
@@ -2306,7 +2306,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           const targetCards = (element as SelfReplicatingRobots).targetCards;
           if (targetCards !== undefined) {
             card.targetCards = targetCards;
-            card.targetCards.forEach(robotCard => robotCard.card = getProjectCardByName(robotCard.card.name)!);
+            card.targetCards.forEach(robotCard => robotCard.card = cardFinder.getProjectCardByName(robotCard.card.name)!);
           }
         }
         if(card instanceof MiningArea || card instanceof MiningRights) {
@@ -2321,7 +2321,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
       // Rebuild each drafted cards
       this.draftedCards = d.draftedCards.map((element: IProjectCard)  => {
-        return getProjectCardByName(element.name)!;
+        return cardFinder.getProjectCardByName(element.name)!;
       });
       
       return o;

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -7,7 +7,7 @@ import { LogMessageData } from "../LogMessageData";
 import { LogMessageDataType } from "../LogMessageDataType";
 import { Card } from "./card/Card";
 import { $t } from "../directives/i18n";
-import { getProjectCardByName } from "./../Dealer";
+import { CardFinder } from "./../CardFinder";
 
 export const LogPanel = Vue.component("log-panel", {
     props: ["id", "players"],
@@ -76,7 +76,7 @@ export const LogPanel = Vue.component("log-panel", {
                             }
                         }
                     }
-                    const card = getProjectCardByName(data.value)
+                    const card = new CardFinder().getProjectCardByName(data.value)
                     if (card && card.cardType) return this.parseCardType(card.cardType, data.value);
                 } else if (translatableMessageDataTypes.includes(data.type)) {
                     return $t(data.value);

--- a/tests/CardFinder.spec.ts
+++ b/tests/CardFinder.spec.ts
@@ -1,0 +1,15 @@
+import { CardName } from "../src/CardName";
+import { expect } from "chai";
+import { CardFinder } from "../src/CardFinder";
+
+describe("CardFinder", function () {
+    it("findProjectCardByName: success", function() {
+        expect(new CardFinder().getProjectCardByName(CardName.AI_CENTRAL)).is.not.undefined;
+    });
+    it("findProjectCardByName: failure", function() {
+        expect(new CardFinder().getProjectCardByName(CardName.ECOLINE)).is.undefined;
+    });
+    it("findProjectCardByName prelude: success", function() {
+        expect(new CardFinder().getProjectCardByName(CardName.ALLIED_BANKS)).is.not.undefined;
+    });
+});

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -17,7 +17,8 @@ import { ISpace } from "../src/ISpace";
 import { ResearchNetwork } from "../src/cards/prelude/ResearchNetwork";
 import { ArcticAlgae } from "../src/cards/ArcticAlgae";
 import { Ecologist } from "../src/milestones/Ecologist";
-import { Dealer, getProjectCardByName } from "../src/Dealer";
+import { CardFinder } from "../src/CardFinder";
+import { Dealer } from "../src/Dealer";
 import { OrOptions } from "../src/inputs/OrOptions";
 import { BoardName } from "../src/BoardName";
 import { SpaceType } from "../src/SpaceType";
@@ -50,7 +51,7 @@ describe("Game", function () {
 
         const turmoilPreludes = COMMUNITY_CARD_MANIFEST.preludeCards.cards.map((c) => c.cardName);
         turmoilPreludes.forEach((preludeName) => {
-            const preludeCard = getProjectCardByName(preludeName)!;
+            const preludeCard = new CardFinder().getProjectCardByName(preludeName)!;
             expect(preludeDeck.includes(preludeCard)).to.eq(false)
         });
     });


### PR DESCRIPTION
Proper fix for #1707 . Self executing javascript complicates module loading. This moves the self executing `decks` into a `CardFinder` class. Unit tests added to find a prelude card and a project card. I also added a warning for when cards are not found. On older games seeing:

```
card not found Magnetic Field Generators Promo
card not found Great Dam Promo
card not found Deimos Down Promo
```

which I believe we expect from the suffix change to `:promo`.