### PR TITLE
Fix: SolarFarm test and playability check

### DIFF
--- a/src/cards/ares/SolarFarm.ts
+++ b/src/cards/ares/SolarFarm.ts
@@ -16,6 +16,11 @@ export class SolarFarm implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY, Tags.STEEL];
     public cardType: CardType = CardType.AUTOMATED;
     public name: CardName = CardName.SOLAR_FARM;
+
+    public canPlay(player: Player, game: Game): boolean {
+        return game.board.getAvailableSpacesOnLand(player).length > 0;
+    }
+
     public play(player: Player, game: Game) {
       return new SelectSpace(
         "Select space for Solar Farm tile",

--- a/tests/cards/ares/SolarFarm.spec.ts
+++ b/tests/cards/ares/SolarFarm.spec.ts
@@ -21,8 +21,8 @@ describe("SolarFarm", function () {
     });
 
     it("Play", function () {
-        // Find the first spot to place a city.
-        const space = game.board.getAvailableSpacesForCity(player)[0];
+        // Find the first spot with no hazard tile on it to place a city.
+        const space = game.board.getAvailableSpacesForCity(player).filter(s => !AresHandler.hasHazardTile(s))[0];
         // Hack the space to have a large number of plants, just to show a matching
         // energy production bump - seven.
         space.bonus = [


### PR DESCRIPTION
- Solar Farm should not be playable if there is no spot to place tile (mandatory effect)
- `space` and `citySpace` in the test are not always equivalent if `space` happens to have a hazard tile on it