### PR TITLE
Fix Trade Advance issue with Europa and Hygiea

### DIFF
--- a/src/cards/community/TradeAdvance.ts
+++ b/src/cards/community/TradeAdvance.ts
@@ -17,35 +17,36 @@ export class TradeAdvance extends PreludeCard implements IProjectCard {
         const openColonies = game.colonies.filter(colony => colony.isActive);
 
         openColonies.forEach((colony) => {
-          if (colony.name === ColonyName.EUROPA || colony.name === ColonyName.HYGIEA) {
-            const title = "Increase " + colony.name + " colony track before trade";
-            game.addInterrupt({ player, playerInput: new OrOptions(
-              new SelectOption(title, "Confirm", () => {
-                  colony.increaseTrack();
-                  colony.trade(player, game, false);
-                  return undefined;
-              }),
-              new SelectOption("Do nothing", "Confirm", () => {
-                  colony.trade(player, game, false);
-                  return undefined;
-              })
-            )});
-          } else {
-            colony.increaseTrack();
-            colony.trade(player, game, false);
-          }
+            if (colony.name === ColonyName.EUROPA || colony.name === ColonyName.HYGIEA) {
+                const title = "Increase " + colony.name + " colony track before trade";
+                game.addInterrupt({ player, playerInput: new OrOptions(
+                    new SelectOption(title, "Confirm", () => {
+                        colony.increaseTrack();
+                        colony.trade(player, game, false);
+                        colony.decreaseTrack(MAX_COLONY_TRACK_POSITION);
+                        return undefined;
+                    }),
+                    new SelectOption("Do nothing", "Confirm", () => {
+                        colony.trade(player, game, false);
+                        colony.decreaseTrack(MAX_COLONY_TRACK_POSITION);
+                        return undefined;
+                    })
+                )});
+            } else {
+                colony.increaseTrack();
+                colony.trade(player, game, false);
+                colony.decreaseTrack(MAX_COLONY_TRACK_POSITION);
+            }
 
-          colony.colonies.forEach(playerId => {
-              colony.giveTradeBonus(game.getPlayerById(playerId), game);
-          });
-
-          colony.decreaseTrack(MAX_COLONY_TRACK_POSITION);
+            colony.colonies.forEach(playerId => {
+                colony.giveTradeBonus(game.getPlayerById(playerId), game);
+            });
         });
 
         if (game.isSoloMode()) {
-          player.megaCredits += 10;
+            player.megaCredits += 10;
         } else {
-          player.megaCredits += 2;
+            player.megaCredits += 2;
         }
 
         return undefined;


### PR DESCRIPTION
The change to interrupts broke the way this behaved with Europa and Hygiea, ending up decreasing the colony track before the player is asked if they want to increase it and trade.