### PR TITLE
Add browser cache to assets via .env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A [.env](https://www.npmjs.com/package/dotenv) file allows you to store environm
 * KEY_PATH: Your TLS private key path (=> `privkey.pem` created by certbot)
 * MAX_GAME_DAYS: How many days to keep unfinished games before deleting them
 * WAITING_FOR_TIMEOUT: (default 5000) How many milliseconds to check for game update on multi-player games
+* ASSET_CACHE_MAX_AGE: (default 0) How many seconds should assets (fonts, stylesheets, images) be cached by browsers
 
 ### Deployment
 

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const child_process = require("child_process");
 const fs = require("fs");
 const path = require("path");

--- a/server.ts
+++ b/server.ts
@@ -54,6 +54,7 @@ const styles = fs.readFileSync("styles.css");
 const gameLoader = new GameLoader();
 const route = new Route();
 const gameLogs = new GameLogs(gameLoader);
+const assetCacheMaxAge = process.env.ASSET_CACHE_MAX_AGE || 0;
 
 function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     if (req.url !== undefined) {
@@ -83,10 +84,12 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
                 apiGetWaitingFor(req, res);
             } else if (req.url.startsWith("/assets/translations.json")) {
                 res.setHeader("Content-Type", "application/json");
+                res.setHeader("Cache-Control", "max-age=" + assetCacheMaxAge);
                 res.write(fs.readFileSync("assets/translations.json"));
                 res.end();
             } else if (req.url === "/styles.css") {
                 res.setHeader("Content-Type", "text/css");
+                res.setHeader("Cache-Control", "max-age=" + assetCacheMaxAge);
                 serveResource(res, styles);
             } else if (
                 req.url.startsWith("/assets/") ||
@@ -1027,6 +1030,9 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
         file = reqFile;
     } else {
         return route.notFound(req, res);
+    }
+    if (req.url !== "/main.js" && req.url !== "/main.js.map") {
+        res.setHeader("Cache-Control", "max-age=" + assetCacheMaxAge);
     }
     fs.readFile(file, function (err, data) {
         if (err) {


### PR DESCRIPTION
Since the app is still in constant development, the default value is still 0.
But this will allow server admins to set a different value to prevent multiple refreshes (like when streaming a game) to burn through bandwidth :)

This also fixes WAITING_FOR_TIMEOUT not working (missing dotenv in make_static_json.js file).