### PR TITLE
end game ui improvement

### DIFF
--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -3,6 +3,7 @@ import { PlayerModel } from "../models/PlayerModel";
 import { Board } from "./Board";
 import { LogPanel } from "./LogPanel";
 import { Button } from "../components/common/Button";
+import { playerColorClass } from "../utils/utils";
 
 export const GameEnd = Vue.component("game-end", {
     props: {
@@ -19,8 +20,11 @@ export const GameEnd = Vue.component("game-end", {
         "Button": Button
     },
     methods: {
-        getEndGamePlayerColorClass: function (player: PlayerModel): string {
-            return "player_bg_color_" + player.color;
+        getEndGamePlayerHighlightColorClass: function (color: string): string {
+            return playerColorClass(color.toLowerCase(), "bg");
+        },
+        getEndGamePlayerRowColorClass: function (color: string): string {
+            return playerColorClass(color.toLowerCase(), "bg_transparent");
         },
         getSortedPlayers: function () {
             this.player.players.sort(function (a:PlayerModel, b:PlayerModel){
@@ -31,6 +35,17 @@ export const GameEnd = Vue.component("game-end", {
                 return 0;
             });
             return this.player.players.reverse();
+        },
+        getWinners: function(){
+            const sortedPlayers = this.getSortedPlayers();
+            const firstWinner = sortedPlayers[0];
+            const winners: PlayerModel[] = [firstWinner];
+            for (let i = 1; i < sortedPlayers.length; i++)
+                if (sortedPlayers[i].victoryPointsBreakdown.total === firstWinner.victoryPointsBreakdown.total &&
+                    sortedPlayers[i].megaCredits === firstWinner.megaCredits) {
+                        winners.push(sortedPlayers[i]);
+                }
+            return winners;
         },
         isSoloGame: function (): boolean {
             return this.player.players.length === 1;
@@ -79,6 +94,9 @@ export const GameEnd = Vue.component("game-end", {
                         Go to main page
                     </a>
                 </div>
+                <div class="game-end-winer-announcement"> 
+                    <span v-for="p in getWinners()"><log-player :class="getEndGamePlayerHighlightColorClass(p.color)">{{ p.name }}</log-player></span> is the winner!
+                </div>
                 <div class="game_end_victory_points">
                     <h2 v-i18n>Victory points breakdown after<span> {{player.generation}} </span>generations</h2>
                     <table class="table game_end_table">
@@ -93,12 +111,12 @@ export const GameEnd = Vue.component("game-end", {
                                 <th>City</th>
                                 <th>VP</th>
                                 <th>MC</th>
-                                <th>Total</th>
+                                <th class="total-column">Total</th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr v-for="p in getSortedPlayers()">
-                                <td><a :href="'/player?id='+p.id+'&noredirect'" :class="getEndGamePlayerColorClass(p)">{{ p.name }}</a></td>
+                            <tr v-for="p in getSortedPlayers()" :class="getEndGamePlayerRowColorClass(p.color)">
+                                <td><a :href="'/player?id='+p.id+'&noredirect'">{{ p.name }}</a></td>
                                 <td v-i18n>{{ p.corporationCard === undefined ? "" : p.corporationCard.name }}</td>
                                 <td>{{ p.victoryPointsBreakdown.terraformRating }}</td>
                                 <td>{{ p.victoryPointsBreakdown.milestones }}</td>
@@ -112,21 +130,26 @@ export const GameEnd = Vue.component("game-end", {
                         </tbody>
                     </table>
                     <br/>
-                    <div v-for="p in getSortedPlayers()">
-                        <h2 v-i18n>Victory points details for <span> {{p.name}}</span></h2>
-                        <div v-for="v in p.victoryPointsBreakdown.detailsCards">
-                            {{v}}
+                    <h2 v-i18n>Victory points details</h2>
+                    <div class="game-end-flexrow">
+                        <div v-for="p in getSortedPlayers()" class="game-end-column">
+                            <div class="game-end-winer-scorebreak-player-title">
+                                <log-player :class="getEndGamePlayerHighlightColorClass(p.color)"><a :href="'/player?id='+p.id+'&noredirect'">{{p.name}}</a></log-player>
+                            </div>
+                            <div v-for="v in p.victoryPointsBreakdown.detailsCards">
+                                {{v}}
+                            </div>
+                            <div v-for="v in p.victoryPointsBreakdown.detailsMilestones">
+                                {{v}}
+                            </div>
+                            <div v-for="v in p.victoryPointsBreakdown.detailsAwards">
+                                {{v}}
+                            </div>
                         </div>
-                        <div v-for="v in p.victoryPointsBreakdown.detailsMilestones">
-                            {{v}}
-                        </div>
-                        <div v-for="v in p.victoryPointsBreakdown.detailsAwards">
-                            {{v}}
-                        </div>
-                        <br/>
                     </div>
                 </div>
-                <div class="game_end_block--board">
+                <div class="game-end-flexrow">
+                <div class="game_end_block--board game-end-column">
                     <h2 v-i18n>Final situation on the board</h2>
                     <board 
                         :spaces="player.spaces" 
@@ -138,10 +161,10 @@ export const GameEnd = Vue.component("game-end", {
                         :temperature="player.temperature"
                         :shouldNotify="false"></board>
                 </div>
-                <br/>
-                <div class="game_end_block--log">
+                <div class="game_end_block--log game-end-column">
                     <h2 v-i18n>Final game log</h2>
                     <log-panel :id="player.id" :players="player.players"></log-panel>
+                </div>
                 </div>
             </div>
         </div>

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -111,7 +111,7 @@ export const GameEnd = Vue.component("game-end", {
                                 <th>City</th>
                                 <th>VP</th>
                                 <th>MC</th>
-                                <th class="total-column">Total</th>
+                                <th><div class="game-end-total-column">Total</div></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -35,10 +35,6 @@
         border-bottom: .05rem solid #7b7b7b !important;
         padding: 10px 20px;
         text-shadow: 2px 2px 4px #000000;
-
-        .total-column{
-            padding: 10px 40px;
-        }
     }
 
     a {
@@ -58,6 +54,10 @@
 
 .game-end-winer-scorebreak-player-title{
     font-size: 32px
+}
+
+.game-end-total-column{
+    padding: 5px 30px;
 }
 
 .game-end-winer-announcement{

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -28,13 +28,39 @@
 
 .game_end_table {
     border: 2px solid #7b7b7b;
+    width: auto;
 
     td, th {
         text-align: center !important;
         border-bottom: .05rem solid #7b7b7b !important;
+        padding: 10px 20px;
+        text-shadow: 2px 2px 4px #000000;
+
+        .total-column{
+            padding: 10px 40px;
+        }
     }
 
     a {
         text-decoration: underline;
     }
+}
+.game-end-flexrow {
+    display: flex;
+    flex-flow: row wrap;
+
+    .game-end-column {
+        min-width: 400px;
+        padding-right: 20px;
+        padding-bottom: 40px;
+    }
+}
+
+.game-end-winer-scorebreak-player-title{
+    font-size: 32px
+}
+
+.game-end-winer-announcement{
+    text-align: center;
+    font-size: 40px;
 }


### PR DESCRIPTION
This PR can close #1298 and close #1732 .

- Change color of row each to match player color.
- Report score in columns that wrap around
- Move log to be in the same row as board
- Announce who is the winner

![image](https://user-images.githubusercontent.com/14239220/97058553-22cd8180-155c-11eb-94fd-5ad1f12d8dae.png)

Wrap around if all columns don't fit in one row.
![image](https://user-images.githubusercontent.com/14239220/97058505-04678600-155c-11eb-91cb-4217778f1b94.png)

If two winners, say both. Rare to happen.
![image](https://user-images.githubusercontent.com/14239220/97058487-fb76b480-155b-11eb-9356-67d2936fe600.png)
