### PR TITLE
Fix Preludes play order + allow Helion to pay with heat

### DIFF
--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -8,11 +8,10 @@ import { CardName } from "../../CardName";
 export class AlliedBanks extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: CardName = CardName.ALLIED_BANKS;
-    public bonusMc: number = 3;
 
     public play(player: Player) {
         player.addProduction(Resources.MEGACREDITS, 4);
-	    player.megaCredits += this.bonusMc; 
+	    player.megaCredits += 3;
 	    return undefined;   
     }
 }

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -6,18 +6,18 @@ import { IProjectCard } from "../IProjectCard";
 import { Resources } from "../../Resources";
 import { CardName } from "../../CardName";
 import { PlaceOceanTile } from "../../deferredActions/PlaceOceanTile";
+import { SelectHowToPayDeferred } from "../../deferredActions/SelectHowToPayDeferred";
 
 export class AquiferTurbines extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.ENERGY];
     public name: CardName = CardName.AQUIFER_TURBINES;
-    public canPlay(player: Player, _game: Game, bonusMc?: number) {
-        let requiredPayment = 3 - (bonusMc || 0);
-        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
+    public canPlay(player: Player, _game: Game) {
+        return player.canAfford(3);
     }
     public play(player: Player, game: Game) {
         player.addProduction(Resources.ENERGY, 2);
-        player.megaCredits -= 3;
         game.defer(new PlaceOceanTile(player, game));
+        game.defer(new SelectHowToPayDeferred(player, 3, false, false));
         return undefined;
     }
 }

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -5,19 +5,18 @@ import { IProjectCard } from "../IProjectCard";
 import { Resources } from "../../Resources";
 import { CardName } from "../../CardName";
 import { Game } from "../../Game";
+import { SelectHowToPayDeferred } from "../../deferredActions/SelectHowToPayDeferred";
 
 export class BusinessEmpire extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.EARTH];
     public name: CardName = CardName.BUSINESS_EMPIRE;
-    public canPlay(player: Player, _game: Game, bonusMc?: number) {
+    public canPlay(player: Player, _game: Game) {
         if (player.isCorporation(CardName.MANUTECH)) return true;
-
-        const requiredPayment = 6 - (bonusMc || 0);
-        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
+        return player.canAfford(6);
     }
-    public play(player: Player) {
-	    player.megaCredits -= 6;
+    public play(player: Player, game: Game) {
         player.addProduction(Resources.MEGACREDITS, 6);
+        game.defer(new SelectHowToPayDeferred(player, 6, false, false));
         return undefined;
     }
 }

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -7,10 +7,9 @@ import { CardName } from "../../CardName";
 export class Donation extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.DONATION;
-    public bonusMc: number = 21;
 
     public play(player: Player) {     
-        player.megaCredits += this.bonusMc;
+        player.megaCredits += 21;
         return undefined;
     }
 }

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -5,17 +5,17 @@ import { IProjectCard } from "../IProjectCard";
 import { Resources } from "../../Resources";
 import { CardName } from "../../CardName";
 import { Game } from "../../Game";
+import { SelectHowToPayDeferred } from "../../deferredActions/SelectHowToPayDeferred";
 
 export class GalileanMining extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.JOVIAN];
     public name: CardName = CardName.GALILEAN_MINING;
-    public canPlay(player: Player, _game: Game, bonusMc?: number) {
-        let requiredPayment = 5 - (bonusMc || 0);
-        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
+    public canPlay(player: Player, _game: Game) {
+        return player.canAfford(5);
     }
-    public play(player: Player) {
+    public play(player: Player, game: Game) {
         player.addProduction(Resources.TITANIUM, 2);
-        player.megaCredits -= 5;
+        game.defer(new SelectHowToPayDeferred(player, 5, false, false));
         return undefined;
     }
 }

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -4,16 +4,17 @@ import { Game } from "../../Game";
 import { PreludeCard } from "./PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 import { CardName } from "../../CardName";
+import { SelectHowToPayDeferred } from "../../deferredActions/SelectHowToPayDeferred";
 
 export class HugeAsteroid extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.HUGE_ASTEROID;
-    public canPlay(player: Player, _game: Game, bonusMc?: number) {
-        let requiredPayment = 5 - (bonusMc || 0);
-        return requiredPayment <= 0 ? true : player.canAfford(requiredPayment);
+    public canPlay(player: Player, _game: Game) {
+        return player.canAfford(5);
     }
     public play(player: Player, game: Game) {
-        player.megaCredits -= 5;
-        return game.increaseTemperature(player, 3);
+        game.increaseTemperature(player, 3);
+        game.defer(new SelectHowToPayDeferred(player, 5, false, false));
+        return undefined;
     }
 }

--- a/src/cards/prelude/Loan.ts
+++ b/src/cards/prelude/Loan.ts
@@ -8,14 +8,13 @@ import { CardName } from "../../CardName";
 export class Loan extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.LOAN;
-    public bonusMc: number = 30;
 
     public canPlay(player: Player): boolean {
         return player.getProduction(Resources.MEGACREDITS) >= -3;
     }    
     public play(player: Player) {
         player.addProduction(Resources.MEGACREDITS,-2);
-        player.megaCredits += this.bonusMc;
+        player.megaCredits += 30;
         return undefined;
     }
 }

--- a/src/cards/prelude/MartianIndustries.ts
+++ b/src/cards/prelude/MartianIndustries.ts
@@ -8,12 +8,11 @@ import { CardName } from "../../CardName";
 export class MartianIndustries extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [Tags.STEEL];
     public name: CardName = CardName.MARTIAN_INDUSTRIES;
-    public bonusMc: number = 6;
 
     public play(player: Player) {
         player.addProduction(Resources.ENERGY);
         player.addProduction(Resources.STEEL);
-        player.megaCredits += this.bonusMc;
+        player.megaCredits += 6;
         return undefined;
     }
 }

--- a/src/cards/prelude/NitrogenDelivery.ts
+++ b/src/cards/prelude/NitrogenDelivery.ts
@@ -9,10 +9,9 @@ import { Game } from "../../Game";
 export class NitrogenDelivery extends PreludeCard implements IProjectCard {
     public tags: Array<Tags> = [];
     public name: CardName = CardName.NITROGEN_SHIPMENT;
-    public bonusMc: number = 5;
 
     public play(player: Player, game: Game) {     
-        player.megaCredits += this.bonusMc;
+        player.megaCredits += 5;
         player.increaseTerraformRating(game);
         player.addProduction(Resources.PLANTS);
         return undefined;

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -6,7 +6,7 @@ export abstract class PreludeCard  {
     public cost: number = 0;
     public cardType: CardType = CardType.PRELUDE;
     public hasRequirements = false;
-    public canPlay(_player: Player, _game: Game, _bonusMc: number = 0): boolean {
+    public canPlay(_player: Player, _game: Game): boolean {
         return true;
     }
 }

--- a/tests/cards/prelude/AquiferTurbines.spec.ts
+++ b/tests/cards/prelude/AquiferTurbines.spec.ts
@@ -22,6 +22,13 @@ describe("AquiferTurbines", function () {
     it("Should play", function () {
         player.megaCredits = 3;
         card.play(player, game);
+
+        // PlaceOceanTile
+        game.deferredActions.shift();
+
+        // SelectHowToPayDeferred
+        game.runDeferredAction(game.deferredActions[0], () => {});
+
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
         expect(player.megaCredits).to.eq(0);
     });

--- a/tests/cards/prelude/BusinessEmpire.spec.ts
+++ b/tests/cards/prelude/BusinessEmpire.spec.ts
@@ -22,7 +22,11 @@ describe("BusinessEmpire", function () {
     it("Should play", function () {
         player.megaCredits = 6;
         expect(card.canPlay(player, game)).to.eq(true);
-        card.play(player);
+        card.play(player, game);
+
+        // SelectHowToPayDeferred
+        game.runDeferredAction(game.deferredActions[0], () => {});
+
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(6);
     });

--- a/tests/cards/prelude/GalileanMining.spec.ts
+++ b/tests/cards/prelude/GalileanMining.spec.ts
@@ -23,7 +23,11 @@ describe("GalileanMining", function () {
         player.megaCredits = 5;
         expect(card.canPlay(player, game)).to.eq(true);
 
-        card.play(player);
+        card.play(player, game);
+
+        // SelectHowToPayDeferred
+        game.runDeferredAction(game.deferredActions[0], () => {});
+
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(2);
     });

--- a/tests/cards/prelude/HugeAsteroid.spec.ts
+++ b/tests/cards/prelude/HugeAsteroid.spec.ts
@@ -25,6 +25,10 @@ describe("HugeAsteroid", function () {
         const initialTR = player.getTerraformRating();
 
         card.play(player, game);
+
+        // SelectHowToPayDeferred
+        game.runDeferredAction(game.deferredActions[0], () => {});
+
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(1);
         expect(player.getTerraformRating()).to.eq(initialTR + 3);


### PR DESCRIPTION
This properly only allows you to play preludes that you can afford to.
It is properly computed at the time you need to play the card.

Which means you can now play **Interplanetary Cinematics**, buy 9 cards (end with 3 MC), pick **Eccentric Sponsor (ES)** and **Huge Asteroid (HA)** preludes, play **ES** into **Lava Flows**, get 2 MC from your corp (now at 5 MC) and then play **HA** (leaving you at 0 MC).
_Note: If you don't get at least 5 MC before having only **HA** left in your hand, you won't be able to play it, of course._

**Helion** can also now lose heat (if gotten any from placing a tile or from a prelude card) when asked to lose MC from a prelude card.