### PR TITLE
remove white border around the card icon

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -969,6 +969,7 @@ input[type="radio"]:checked + .filterDiv::after {
     width: 30px;
     background-size: 30px 40px;
     vertical-align: middle;
+    border: none;
 }
 
 .card-icon {


### PR DESCRIPTION
Left without border, right with border.
![image](https://user-images.githubusercontent.com/14239220/97179129-d73ef180-176e-11eb-8e9a-e499ff4d6c73.png)

No need for border in Turmoil policy either.
![image](https://user-images.githubusercontent.com/14239220/97179189-e9b92b00-176e-11eb-8670-ac2a262f16da.png)

@ssimeonoff 