### PR TITLE
Fix console warnings for undefined aresData

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -193,6 +193,12 @@ export class Game implements ILoadable<SerializedGame, Game> {
         } as GameOptions
       }
       this.gameOptions = gameOptions;
+
+      // Initialize Ares data
+      if (gameOptions.aresExtension) {
+        this.aresData = AresHandler.initialData(gameOptions.aresExtension, gameOptions.aresHazards, players);
+      }
+
       this.board = this.boardConstructor(gameOptions.boardName, gameOptions.randomMA, gameOptions.venusNextExtension && gameOptions.includeVenusMA);
 
       this.activePlayer = first.id;
@@ -252,13 +258,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.turmoil = new Turmoil(this);
       }
 
-      if (gameOptions.aresExtension) {
-        this.aresData = AresHandler.initialData(gameOptions.aresExtension, gameOptions.aresHazards, players);
-          // this test is because hazard selection isn't actively part of game options, but needs
-          // to be configurable for tests.
-          if (gameOptions.aresHazards !== false) {
-            AresHandler.setupHazards(this, players.length);
-          }
+      // Setup Ares hazards
+      if (gameOptions.aresExtension && gameOptions.aresHazards !== false) {
+        AresHandler.setupHazards(this, players.length);
       }
 
       // Setup custom corporation list

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -3,6 +3,7 @@ import { Game, GameOptions } from "../src/Game";
 import * as constants from "../src/constants"
 import { SpaceType } from "../src/SpaceType";
 import { BoardName } from "../src/BoardName";
+import { RandomMAOptionType } from "../src/RandomMAOptionType";
 
 export const maxOutOceans = function(player: Player, game: Game, toValue: number = 0): void {
     if (toValue < 1) {
@@ -28,7 +29,7 @@ export const setCustomGameOptions = function(options: object = {}): GameOptions 
         draftVariant: false,
         initialDraftVariant: false,
         corporateEra: true,
-        randomMA: false,
+        randomMA: RandomMAOptionType.NONE,
         preludeExtension: false,
         venusNextExtension: true,
         coloniesExtension: false,
@@ -45,7 +46,12 @@ export const setCustomGameOptions = function(options: object = {}): GameOptions 
         includeVenusMA: true,
         soloTR: false,
         clonedGamedId: undefined,
-        cardsBlackList: []
+        cardsBlackList: [],
+        aresExtension: false,
+        aresHazards: undefined,
+        fastModeOption: false,
+        removeNegativeGlobalEventsOption: false,
+        customColoniesList: [],
       };
 
     return Object.assign(defaultOptions, options) as GameOptions;


### PR DESCRIPTION
Closes https://github.com/bafolts/terraforming-mars/issues/1771. Ares `initialData` should be set up before calling `boardConstructor`