### PR TITLE
Priority to PU effects to lose MC before getting any

### DIFF
--- a/src/cards/NitriteReducingBacteria.ts
+++ b/src/cards/NitriteReducingBacteria.ts
@@ -1,4 +1,3 @@
-
 import { IActionCard, IResourceCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
@@ -13,6 +12,7 @@ import { LogHelper } from "../components/LogHelper";
 import { PartyHooks } from "../turmoil/parties/PartyHooks";
 import { PartyName } from "../turmoil/parties/PartyName";
 import { REDS_RULING_POLICY_COST } from "../constants";
+import { SimpleDeferredAction } from "../deferredActions/SimpleDeferredAction";
 
 export class NitriteReducingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost: number = 11;
@@ -22,8 +22,14 @@ export class NitriteReducingBacteria implements IActionCard, IProjectCard, IReso
     public cardType: CardType = CardType.ACTIVE;
     public name: CardName = CardName.NITRITE_REDUCING_BACTERIA;
 
-    public play(player: Player) {
-        player.addResourceTo(this,3);
+    public play(player: Player, game: Game) {
+        game.defer(new SimpleDeferredAction(
+            player,
+            () => {
+                player.addResourceTo(this,3);
+                return undefined;
+            }
+        ));
         return undefined;
     }
     public canAct(): boolean {

--- a/src/cards/promo/PharmacyUnion.ts
+++ b/src/cards/promo/PharmacyUnion.ts
@@ -70,20 +70,11 @@ export class PharmacyUnion implements CorporationCard {
                         orOptions.title = "Choose the order of tag resolution for Pharmacy Union";
                         return orOptions;
                     }
-                ));
+                ), true); // Make it a priority
                 return undefined;
             }
         }
 
-
-        if (hasMicrobesTag) {
-            const microbeTagCount = card.tags.filter((cardTag) => cardTag === Tags.MICROBES).length;
-            const player = game.getPlayers().find((p) => p.isCorporation(this.name))!;
-            const megaCreditsLost = Math.min(player.megaCredits, microbeTagCount * 4);
-            player.addResourceTo(this, microbeTagCount);
-            player.megaCredits -= megaCreditsLost;
-            game.log("${0} added a disease to ${1} and lost ${2} MC", b => b.player(player).card(this).number(megaCreditsLost));
-        }
             
         if (isPharmacyUnion && hasScienceTag) {
             const scienceTags = card.tags.filter((tag) => tag === Tags.SCIENCE).length;
@@ -123,8 +114,24 @@ export class PharmacyUnion implements CorporationCard {
                             })
                         );
                     }
-                ));
+                ), true); // Make it a priority
             }
+        }
+
+
+        if (hasMicrobesTag) {
+            game.defer(new SimpleDeferredAction(
+                player,
+                () => {
+                    const microbeTagCount = card.tags.filter((cardTag) => cardTag === Tags.MICROBES).length;
+                    const player = game.getPlayers().find((p) => p.isCorporation(this.name))!;
+                    const megaCreditsLost = Math.min(player.megaCredits, microbeTagCount * 4);
+                    player.addResourceTo(this, microbeTagCount);
+                    player.megaCredits -= megaCreditsLost;
+                    game.log("${0} added a disease to ${1} and lost ${2} MC", b => b.player(player).card(this).number(megaCreditsLost));
+                    return undefined;
+                }
+            ), true); // Make it a priority
         }
 
         return undefined;

--- a/src/cards/turmoil/GMOContract.ts
+++ b/src/cards/turmoil/GMOContract.ts
@@ -6,6 +6,7 @@ import { Player } from "../../Player";
 import { Game } from "../../Game";
 import { PartyName } from "../../turmoil/parties/PartyName";
 import { Resources } from "../../Resources";
+import { SimpleDeferredAction } from "../../deferredActions/SimpleDeferredAction";
 
 
 export class GMOContract implements IProjectCard {
@@ -21,10 +22,16 @@ export class GMOContract implements IProjectCard {
         return false;
     }
 
-    public onCardPlayed(player: Player, _game: Game, card: IProjectCard): void {
+    public onCardPlayed(player: Player, game: Game, card: IProjectCard): void {
         let amount = card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES).length;
         if (amount > 0) {
-            player.setResource(Resources.MEGACREDITS, amount * 2);
+            game.defer(new SimpleDeferredAction(
+                player,
+                () => {
+                    player.setResource(Resources.MEGACREDITS, amount * 2);
+                    return undefined;
+                }
+            ));
         }
     }
 

--- a/tests/cards/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/NitriteReducingBacteria.spec.ts
@@ -16,7 +16,8 @@ describe("NitriteReducingBacteria", function () {
 
     it("Should play", function () {
         player.playedCards.push(card);
-        card.play(player);
+        card.play(player, game);
+        game.runDeferredAction(game.deferredActions[0], () => {});
         expect(card.resourceCount).to.eq(3);
     });
 

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -49,12 +49,14 @@ describe("PharmacyUnion", function () {
         const ants = new Ants();
         player.playedCards.push(ants);
         card.onCardPlayed(player, game, ants);
+        game.runDeferredAction(game.deferredActions[0], () => {}); // Add microbe and lose 4 MC
         expect(card.resourceCount).to.eq(3);
         expect(player.megaCredits).to.eq(4);
 
         const viralEnhancers = new ViralEnhancers();
         player2.playedCards.push(viralEnhancers);
         card.onCardPlayed(player2, game, viralEnhancers);
+        game.runDeferredAction(game.deferredActions[0], () => {}); // Add microbe and lose 4 MC
         expect(player2.megaCredits).to.eq(8); // should not change
         expect(card.resourceCount).to.eq(4);
         expect(player.megaCredits).to.eq(0);
@@ -147,6 +149,7 @@ describe("PharmacyUnion", function () {
         card.resourceCount = 0;
         player2.playedCards.push(viralEnhancers);
         card.onCardPlayed(player2, game, viralEnhancers);
+        game.runDeferredAction(game.deferredActions[0], () => {}); // Add microbe and lose 4 MC
         expect(card.resourceCount).to.eq(1);
         expect(player.megaCredits).to.eq(8);
         expect(game.deferredActions.length).to.eq(0);

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -23,6 +23,7 @@ describe("GMOContract", function () {
             }
             card.play();
             card.onCardPlayed(player,game,card);
+            game.runDeferredAction(game.deferredActions[0], () => {});
             expect(player.megaCredits).to.eq(2);
         } 
     });


### PR DESCRIPTION
As stated in the title, makes **Pharmacy Union** losing MC a priority so that subsequent effects that can give you MC (GMO, Topsoil, getting money from Mons) happens after that.

Closes #1179