### PR TITLE
Seedable rng 1733

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -420,7 +420,7 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
             if (gameReq.board === "random") {
                 const boards = Object.values(BoardName);
-                boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
+                gameReq.board = boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
             }
 
             const gameOptions = {

--- a/server.ts
+++ b/server.ts
@@ -420,7 +420,7 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
             if (gameReq.board === "random") {
                 const boards = Object.values(BoardName);
-                gameReq.board = boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
+                boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
             }
 
             const gameOptions = {
@@ -436,6 +436,8 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
                 coloniesExtension: gameReq.colonies,
                 preludeExtension: gameReq.prelude,
                 turmoilExtension: gameReq.turmoil,
+                aresExtension: gameReq.aresExtension,
+                aresHazards: true, // Not a runtime option.
                 promoCardsOption: gameReq.promoCardsOption,
                 communityCardsOption: gameReq.communityCardsOption,
                 solarPhaseOption: gameReq.solarPhaseOption,

--- a/server.ts
+++ b/server.ts
@@ -420,7 +420,7 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 
             if (gameReq.board === "random") {
                 const boards = Object.values(BoardName);
-                gameReq.board = boards[Math.floor(Math.random() * boards.length)];
+                gameReq.board = boards[Math.floor(parseInt(gameId, 16) / Math.pow(16, 12) * boards.length)];
             }
 
             const gameOptions = {
@@ -436,8 +436,6 @@ function createGame(req: http.IncomingMessage, res: http.ServerResponse): void {
                 coloniesExtension: gameReq.colonies,
                 preludeExtension: gameReq.prelude,
                 turmoilExtension: gameReq.turmoil,
-                aresExtension: gameReq.aresExtension,
-                aresHazards: true, // Not a runtime option.
                 promoCardsOption: gameReq.promoCardsOption,
                 communityCardsOption: gameReq.communityCardsOption,
                 solarPhaseOption: gameReq.solarPhaseOption,

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -15,6 +15,7 @@ import { ICardFactory } from "./cards/ICardFactory";
 import { CardTypes, Deck } from "./Deck";
 import { Expansion } from "./Expansion";
 import { CardFinder} from "./CardFinder";
+import { ARES_CARD_MANIFEST } from "./cards/ares/AresCardManifest";
 import { Random } from "./Random";
 
 export class Dealer implements ILoadable<SerializedDealer, Dealer>{
@@ -28,6 +29,7 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
     private useColoniesNextExtension: boolean = false;
     private usePromoCards: boolean = false;
     private useTurmoilExtension: boolean = false;
+    private useAresExtension: boolean = false;
     private deckRng: Random;
 
     constructor(
@@ -38,6 +40,7 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
             useColoniesNextExtension : boolean,
             usePromoCards: boolean,
             useTurmoilExtension: boolean,
+            useAresExtension: boolean,
             useCommunityCards: boolean = false,
             cardsBlackList?: Array<CardName>
         ) {
@@ -47,6 +50,7 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
         this.useColoniesNextExtension = useColoniesNextExtension;
         this.usePromoCards = usePromoCards;
         this.useTurmoilExtension = useTurmoilExtension;
+        this.useAresExtension = useAresExtension
 
         const deck:Array<IProjectCard> = [];
         const preludeDeck:Array<IProjectCard> = [];
@@ -95,6 +99,9 @@ export class Dealer implements ILoadable<SerializedDealer, Dealer>{
         }
         if (this.useTurmoilExtension) {
             addToDecks(TURMOIL_CARD_MANIFEST);
+        }
+        if (this.useAresExtension) {
+            addToDecks(ARES_CARD_MANIFEST);
         }
         if (this.usePromoCards) {
             addToDecks(PROMO_CARD_MANIFEST);

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -37,16 +37,16 @@ describe("Game", function () {
 
     it("correctly separates 71 corporate era cards", function() {
         // include corporate era
-        const dealer = new Dealer(true, false, false, false, false, false, false);
+        const dealer = new Dealer("123", true, false, false, false, false, false, false);
         expect(dealer.getDeckSize()).to.eq(208);
 
         // exclude corporate era
-        const dealer2 = new Dealer(false, false, false, false, false,  false, false);
+        const dealer2 = new Dealer("123", false, false, false, false, false,  false, false);
         expect(dealer2.getDeckSize()).to.eq(137);
     });
 
     it("excludes expansion-specific preludes if those expansions are not selected ", function() {
-        const dealer = new Dealer(true, false, false, false, false, false,  false, true);
+        const dealer = new Dealer("123", true, false, false, false, false, false,  false, true);
         const preludeDeck = dealer.preludeDeck;
 
         const turmoilPreludes = COMMUNITY_CARD_MANIFEST.preludeCards.cards.map((c) => c.cardName);


### PR DESCRIPTION
The shuffling of corporate, prelude and project decks use the game.id as the seed for the random number generator (rng).
Also the when using the random board selection (1 of the 3 main boards), this is done using the game.id.