### PR TITLE
Spaces under hazards may not be selected as part of MiningRights and Mining Area.

### DIFF
--- a/src/Board.ts
+++ b/src/Board.ts
@@ -148,9 +148,9 @@ export abstract class Board {
             const hasPlayerMarker = space.player !== undefined;
             // A space is available if it doesn't have a player marker on it or it belongs to |player|
             const safeForPlayer = !hasPlayerMarker || space.player === player;
-            // And also, if it doesn't have a tile. Unless it's a hazard tile. And if it does have a
+            // And also, if it doesn't have a tile. Unless it's a hazard tile. 
             const playableSpace = space.tile === undefined || AresHandler.hasHazardTile(space) 
-            // hazard tile, a player marker on it means it's protected by Desperate Measures.
+            // If it does have a hazard tile, make sure it's not a protected one.
             const blockedByDesperateMeasures = space.tile?.protectedHazard === true;
             return safeForPlayer && playableSpace && !blockedByDesperateMeasures;
         });

--- a/src/cards/MiningCard.ts
+++ b/src/cards/MiningCard.ts
@@ -35,6 +35,8 @@ export abstract class MiningCard implements IProjectCard {
     }
     protected getAvailableSpaces(player: Player, game: Game): Array<ISpace> {
         return game.board.getAvailableSpacesOnLand(player)
+                // Ares-only: exclude spaces already covered (which is only returned if the tile is a hazard tile.)
+                .filter(space => space.tile === undefined)
                 .filter((space) => space.bonus.indexOf(SpaceBonus.STEEL) !== -1 || space.bonus.indexOf(SpaceBonus.TITANIUM) !== -1);
     }
     private getSelectTitle(): string {

--- a/tests/cards/MiningRights.spec.ts
+++ b/tests/cards/MiningRights.spec.ts
@@ -18,7 +18,7 @@ describe("MiningRights", function () {
     });
 
     it("Can't play if no available spaces", function () {
-        for (let land of game.board.getAvailableSpacesOnLand(player)) {
+        for (const land of game.board.getAvailableSpacesOnLand(player)) {
             if (land.bonus.indexOf(SpaceBonus.STEEL) !== -1 || land.bonus.indexOf(SpaceBonus.TITANIUM) !== -1) {
                 game.addTile(player, land.spaceType, land, { tileType: TileType.MINING_RIGHTS });
             }

--- a/tests/cards/ares/MiningRightsAres.spec.ts
+++ b/tests/cards/ares/MiningRightsAres.spec.ts
@@ -38,4 +38,19 @@ describe("MiningRightsAres", function () {
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
         expect(steelSpace!.adjacency).to.deep.eq({bonus: [SpaceBonus.STEEL]});
     });
+
+    it("Candidate spaces can't include hazards", function() {
+        const land = game.board.getAvailableSpacesOnLand(player)
+            .find(land => land.bonus.indexOf(SpaceBonus.STEEL) !== -1)!;
+
+        let action = card.play(player, game) as SelectSpace;
+        const size = action.availableSpaces.length;
+        expect(action.availableSpaces).contains(land);
+
+        land.tile = { tileType: TileType.MINING_RIGHTS };
+        action = card.play(player, game) as SelectSpace;
+        expect(action.availableSpaces).has.length(size - 1);
+        expect(action.availableSpaces).does.not.contain(land);
+    })
+
 });


### PR DESCRIPTION
This is a regression that occurred after moving content to the main branch.