### PR TITLE
Turn game.deferredActions into a DeferredActionsQueue DS 

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -40,6 +40,7 @@ import { ResourceType } from "./ResourceType";
 import { Resources } from "./Resources";
 import { SelectCard } from "./inputs/SelectCard";
 import { DeferredAction } from "./deferredActions/DeferredAction";
+import { DeferredActionsQueue } from "./deferredActions/DeferredActionsQueue";
 import { SelectHowToPayDeferred } from "./deferredActions/SelectHowToPayDeferred";
 import { PlaceOceanTile } from "./deferredActions/PlaceOceanTile";
 import { RemoveColonyFromGame } from "./deferredActions/RemoveColonyFromGame";
@@ -104,7 +105,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     public lastSaveId: number = 0;
     private clonedGamedId: string | undefined;
     public seed: number = Math.random();
-    public deferredActions: Array<DeferredAction> = [];
+    public deferredActions: DeferredActionsQueue = new DeferredActionsQueue();
     public gameAge: number = 0; // Each log event increases it
     public gameLog: Array<LogMessage> = [];
     
@@ -537,31 +538,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
         }
     }
 
-    public getNextDeferredAction(): DeferredAction | undefined {
-        return this.deferredActions[0];
-    }
-
-    public getNextDeferredActionForPlayer(playerId: string): DeferredAction | undefined {
-        return this.deferredActions.find(action => action.player.id === playerId);
-    }
-
-    private removeDeferredAction(action: DeferredAction): void {
-        this.deferredActions.splice(this.deferredActions.indexOf(action), 1);
-    }
-
-    public runDeferredAction(action: DeferredAction, cb: () => void): void {
-        const input = action.execute();
-        if (input !== undefined) {
-            action.player.setWaitingFor(input, () => {
-                this.removeDeferredAction(action);
-                cb();
-            });
-        } else {
-            this.removeDeferredAction(action);
-            cb();
-        }
-    }
-
     public getColoniesModel(colonies: Array<IColony>) : Array<ColonyModel> {
       return colonies.map(
         (colony): ColonyModel => ({
@@ -875,13 +851,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     private resolveTurmoilDeferredActions() {
-        const action = this.getNextDeferredAction();
-        if (action !== undefined) {
-            this.runDeferredAction(action, () => this.resolveTurmoilDeferredActions());
-            return;
-        }
-        // All turmoil deferred actions have been resolved, continue game flow
-        this.goToDraftOrResearch();
+        this.deferredActions.runAll(() => this.goToDraftOrResearch());
     }
 
     private goToDraftOrResearch() {
@@ -953,12 +923,7 @@ export class Game implements ILoadable<SerializedGame, Game> {
     public playerIsFinishedWithResearchPhase(player: Player): void {
         this.researchedPlayers.add(player.id);
         if (this.allPlayersHaveFinishedResearch()) {
-            const action = this.getNextDeferredAction();
-            if (action !== undefined) {
-                this.runDeferredAction(action, () => this.playerIsFinishedWithResearchPhase(player));
-                return;
-            }
-            this.gotoActionPhase();
+            this.deferredActions.runAll(() => this.gotoActionPhase());
         }
     }
 
@@ -1096,11 +1061,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
 
       // Deferred actions hook
       if (this.deferredActions.length > 0) {
-        const action = this.getNextDeferredAction();
-        if (action !== undefined) {
-          this.runDeferredAction(action, () => this.playerIsFinishedTakingActions());
-          return;
-        }
+          this.deferredActions.runAll(() => this.playerIsFinishedTakingActions());
+        return;
       }
 
       if (this.allPlayersHavePassed()) {
@@ -1735,6 +1697,9 @@ export class Game implements ILoadable<SerializedGame, Game> {
     public loadFromJSON(d: SerializedGame): Game {
       // Assign each attributes
       const o = Object.assign(this, d);
+
+      // Brand new deferred actions queue
+      this.deferredActions = new DeferredActionsQueue();
 
       // Rebuild dealer object to be sure that we will have cards in the same order
       const dealer = new Dealer(this.gameOptions.corporateEra, this.gameOptions.preludeExtension, this.gameOptions.venusNextExtension, this.gameOptions.coloniesExtension, this.gameOptions.promoCardsOption, this.gameOptions.turmoilExtension, this.gameOptions.communityCardsOption);

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -971,12 +971,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     private doneWorldGovernmentTerraforming(game: Game): void {
-        const action = game.getNextDeferredActionForPlayer(this.id);
-        if (action !== undefined) {
-            game.runDeferredAction(action, () => this.doneWorldGovernmentTerraforming(game));
-            return;
-        }
-        game.doneWorldGovernmentTerraforming();
+        game.deferredActions.runAllForPlayer(this.id, () => game.doneWorldGovernmentTerraforming());
     }
 
     public worldGovernmentTerraforming(game: Game): void {
@@ -1825,14 +1820,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     private resolveFinalGreeneryDeferredActions(game: Game) {
-        const action = game.getNextDeferredAction();
-        if (action !== undefined) {
-            game.runDeferredAction(action, () => this.resolveFinalGreeneryDeferredActions(game));
-            return;
-        }
-
-        // All final greenery deferred actions have been resolved, continue game flow
-        this.takeActionForFinalGreenery(game);
+        game.deferredActions.runAll(() => this.takeActionForFinalGreenery(game));
     }
 
     private getPlayablePreludeCards(game: Game): Array<IProjectCard> {
@@ -2003,9 +1991,8 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }
 
     public takeAction(game: Game): void {
-      const deferredAction = game.getNextDeferredActionForPlayer(this.id);
-      if (deferredAction !== undefined) {
-        game.runDeferredAction(deferredAction, () => this.takeAction(game));
+      if (game.deferredActions.nextForPlayer(this.id) !== undefined) {
+        game.deferredActions.runAllForPlayer(this.id, () => { this.takeAction(game) });
         return;
       }
  

--- a/src/deferredActions/DeferredActionsQueue.ts
+++ b/src/deferredActions/DeferredActionsQueue.ts
@@ -1,0 +1,77 @@
+import { PlayerId } from "../Player";
+import { DeferredAction } from "./DeferredAction";
+
+export class DeferredActionsQueue {
+    private queue: Array<DeferredAction> = [];
+
+    get length(): number {
+        return this.queue.length;
+    }
+
+    public unshift(action: DeferredAction): void {
+        this.queue.unshift(action);
+    }
+
+    public push(action: DeferredAction): void {
+        this.queue.push(action);
+    }
+
+    public next(): DeferredAction | undefined {
+        return this.queue[0];
+    }
+
+    public nextForPlayer(playerId: PlayerId): DeferredAction | undefined {
+        return this.queue.find(action => action.player.id === playerId);
+    }
+
+    public remove(action: DeferredAction): void {
+        this.queue.splice(this.queue.indexOf(action), 1);
+    }
+
+    public run(action: DeferredAction, cb: () => void): void {
+        const input = action.execute();
+        if (input !== undefined) {
+            action.player.setWaitingFor(input, () => {
+                this.remove(action);
+                cb();
+            });
+        } else {
+            this.remove(action);
+            cb();
+        }
+    }
+
+    public runAll(cb: () => void): void {
+        const action = this.next();
+        if (action === undefined) {
+            cb();
+            return;
+        }
+
+        this.run(action, () => this.runAll(cb));
+    }
+
+    public runAllForPlayer(playerId: PlayerId, cb: () => void): void {
+        const action = this.nextForPlayer(playerId);
+        if (action === undefined) {
+            cb();
+            return;
+        }
+
+        this.run(action, () => this.runAllForPlayer(playerId, cb));
+    }
+
+
+    // The following methods are used in tests
+
+    public shift(): DeferredAction | undefined {
+        return this.queue.shift();
+    }
+
+    public runNext(): void {
+        const action = this.next();
+        if (action !== undefined) {
+            this.run(action, () => {});
+        }
+    }
+}

--- a/tests/ares/AresHandler.spec.ts
+++ b/tests/ares/AresHandler.spec.ts
@@ -87,7 +87,7 @@ describe("AresHandler", function () {
 
         const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
         game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
-        game.deferredActions[0].execute();
+        game.deferredActions.next()!.execute();
 
         // player who placed next to Nuclear zone, loses two money.
         expect(player.megaCredits).is.eq(0);
@@ -130,7 +130,7 @@ describe("AresHandler", function () {
 
         player.addProduction(Resources.PLANTS, 7);
         game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
-        const input = game.deferredActions[0].execute() as SelectProductionToLose;
+        const input = game.deferredActions.next()!.execute() as SelectProductionToLose;
         expect(input.unitsToLose).eq(1);
         input.cb({ plants: 1 } as IProductionUnits)
         expect(player.getProduction(Resources.PLANTS)).eq(6);
@@ -153,7 +153,7 @@ describe("AresHandler", function () {
         player.addProduction(Resources.PLANTS, 7);
         game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
 
-        const input = game.deferredActions[0].execute() as SelectProductionToLose;
+        const input = game.deferredActions.next()!.execute() as SelectProductionToLose;
         expect(input.unitsToLose).eq(2);
         input.cb({ plants: 2 } as IProductionUnits)
         expect(player.getProduction(Resources.PLANTS)).eq(5);
@@ -166,7 +166,7 @@ describe("AresHandler", function () {
         expect(player.getTerraformRating()).eq(20);
 
         game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
-        game.deferredActions[0].execute();
+        game.deferredActions.next()!.execute();
 
         expect(space.tile!.tileType).eq(TileType.GREENERY);
         expect(player.megaCredits).is.eq(0);
@@ -180,7 +180,7 @@ describe("AresHandler", function () {
         expect(player.getTerraformRating()).eq(20);
 
         game.addTile(player, space.spaceType, space, {tileType: TileType.GREENERY});
-        game.deferredActions[0].execute();
+        game.deferredActions.next()!.execute();
 
         expect(space.tile!.tileType).eq(TileType.GREENERY);
         expect(player.megaCredits).is.eq(0);

--- a/tests/cards/AquiferPumping.spec.ts
+++ b/tests/cards/AquiferPumping.spec.ts
@@ -22,7 +22,7 @@ describe("AquiferPumping", function () {
         player.megaCredits = 8;
         const action = card.action(player, game);
         expect(action).is.undefined;
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
     });
 

--- a/tests/cards/Asteroid.spec.ts
+++ b/tests/cards/Asteroid.spec.ts
@@ -21,7 +21,7 @@ describe("Asteroid", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[1].cb(); // do nothing
         expect(player2.getResource(Resources.PLANTS)).to.eq(2);
 

--- a/tests/cards/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/AsteroidMiningConsortium.spec.ts
@@ -28,7 +28,7 @@ describe("AsteroidMiningConsortium", function () {
     it("Should play - auto select if single target", function () {
         player.addProduction(Resources.TITANIUM);
         card.play(player, game); // can decrease own production
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
     });
@@ -40,7 +40,7 @@ describe("AsteroidMiningConsortium", function () {
         expect(player.getProduction(Resources.TITANIUM)).to.eq(2);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.TITANIUM)).to.eq(0);
     });

--- a/tests/cards/BigAsteroid.spec.ts
+++ b/tests/cards/BigAsteroid.spec.ts
@@ -20,7 +20,7 @@ describe("BigAsteroid", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[1].cb(); // do nothing
         expect(player2.plants).to.eq(5);
 
@@ -35,7 +35,7 @@ describe("BigAsteroid", function () {
         player.plants = 5;
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
 
         expect(player.plants).to.eq(5);

--- a/tests/cards/BiomassCombustors.spec.ts
+++ b/tests/cards/BiomassCombustors.spec.ts
@@ -37,7 +37,7 @@ describe("BiomassCombustors", function () {
         expect(card.canPlay(player, game)).is.true;
 
         card.play(player, game);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);

--- a/tests/cards/Birds.spec.ts
+++ b/tests/cards/Birds.spec.ts
@@ -31,7 +31,7 @@ describe("Birds", function () {
 
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
 
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);

--- a/tests/cards/BlackPolarDust.spec.ts
+++ b/tests/cards/BlackPolarDust.spec.ts
@@ -27,7 +27,7 @@ describe("BlackPolarDust", function () {
         expect(player.getProduction(Resources.HEAT)).to.eq(3);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
         selectSpace.cb(selectSpace.availableSpaces[0]);
         expect(player.getTerraformRating()).to.eq(21);
     });
@@ -35,7 +35,7 @@ describe("BlackPolarDust", function () {
     it("Cannot place ocean if no oceans left", function () {
         maxOutOceans(player, game);
         card.play(player, game);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
     })
 });

--- a/tests/cards/BusinessNetwork.spec.ts
+++ b/tests/cards/BusinessNetwork.spec.ts
@@ -53,7 +53,7 @@ describe("BusinessNetwork", function () {
 
         player.megaCredits = 3;
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand).has.lengthOf(1);
     });

--- a/tests/cards/CloudSeeding.spec.ts
+++ b/tests/cards/CloudSeeding.spec.ts
@@ -44,7 +44,7 @@ describe("CloudSeeding", function () {
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
 
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player2.getProduction(Resources.HEAT)).to.eq(0);
     });
@@ -58,7 +58,7 @@ describe("CloudSeeding", function () {
         expect(player.getProduction(Resources.PLANTS)).to.eq(2);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.HEAT)).to.eq(0);
     });

--- a/tests/cards/Comet.spec.ts
+++ b/tests/cards/Comet.spec.ts
@@ -26,11 +26,11 @@ describe("Comet", function () {
         expect(game.getTemperature()).to.eq(-28);
         expect(game.deferredActions).has.lengthOf(2);
 
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.shift()!.execute() as SelectSpace;
         selectSpace.cb(selectSpace.availableSpaces[0]);
         expect(player.getTerraformRating()).to.eq(22);
 
-        const orOptions = game.deferredActions[1].execute() as OrOptions;
+        const orOptions = game.deferredActions.shift()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player2.plants).to.eq(0);
     });
@@ -40,7 +40,7 @@ describe("Comet", function () {
         player.plants = 8;
 
         card.play(player, game);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
 
         expect(player.plants).to.eq(8); // self plants are not removed

--- a/tests/cards/DeimosDown.spec.ts
+++ b/tests/cards/DeimosDown.spec.ts
@@ -20,7 +20,7 @@ describe("DeimosDown", function () {
         card.play(player, game);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
 
         expect(game.getTemperature()).to.eq(-24);

--- a/tests/cards/EnergyTapping.spec.ts
+++ b/tests/cards/EnergyTapping.spec.ts
@@ -19,7 +19,7 @@ describe("EnergyTapping", function () {
     it("Should play - auto select if single target", function () {
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     });
@@ -31,7 +31,7 @@ describe("EnergyTapping", function () {
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         expect(game.deferredActions).has.lengthOf(1);
         
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         expect(player2.getProduction(Resources.ENERGY)).to.eq(2);

--- a/tests/cards/Fish.spec.ts
+++ b/tests/cards/Fish.spec.ts
@@ -32,7 +32,7 @@ describe("Fish", function () {
         expect(card.canPlay(player, game)).is.true;
         card.play(player, game);
 
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });
@@ -46,7 +46,7 @@ describe("Fish", function () {
         card.play(player, game);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });

--- a/tests/cards/GiantIceAsteroid.spec.ts
+++ b/tests/cards/GiantIceAsteroid.spec.ts
@@ -23,12 +23,12 @@ describe("GiantIceAsteroid", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(3);
 
-        const firstOcean = game.deferredActions[0].execute() as SelectSpace;
+        const firstOcean = game.deferredActions.shift()!.execute() as SelectSpace;
         firstOcean.cb(firstOcean.availableSpaces[0]);
-        const secondOcean = game.deferredActions[1].execute() as SelectSpace;
+        const secondOcean = game.deferredActions.shift()!.execute() as SelectSpace;
         secondOcean.cb(secondOcean.availableSpaces[1]);
 
-        const orOptions = game.deferredActions[2].execute() as OrOptions;
+        const orOptions = game.deferredActions.shift()!.execute() as OrOptions;
         expect(orOptions.options).has.lengthOf(3);
 
         orOptions.options[0].cb();

--- a/tests/cards/GreatEscarpmentConsortium.spec.ts
+++ b/tests/cards/GreatEscarpmentConsortium.spec.ts
@@ -28,7 +28,7 @@ describe("GreatEscarpmentConsortium", function () {
     it("Should play - auto select if single target", function () {
         player.addProduction(Resources.STEEL);
         card.play(player, game); // can decrease own production
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.STEEL)).to.eq(1);
     });
@@ -40,7 +40,7 @@ describe("GreatEscarpmentConsortium", function () {
         expect(player.getProduction(Resources.STEEL)).to.eq(2);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.STEEL)).to.eq(0);
     });
@@ -52,7 +52,7 @@ describe("GreatEscarpmentConsortium", function () {
         
         card.play(player, game);
 
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.STEEL)).to.eq(2); // should increase
     });

--- a/tests/cards/HeatTrappers.spec.ts
+++ b/tests/cards/HeatTrappers.spec.ts
@@ -35,7 +35,7 @@ describe("HeatTrappers", function () {
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
 
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player2.getProduction(Resources.HEAT)).to.eq(5);
     });
@@ -48,7 +48,7 @@ describe("HeatTrappers", function () {
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.HEAT)).to.eq(5);
     });

--- a/tests/cards/Herbivores.spec.ts
+++ b/tests/cards/Herbivores.spec.ts
@@ -35,7 +35,7 @@ describe("Herbivores", function () {
         card.play(player, game);
         expect(card.resourceCount).to.eq(1);
 
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });
@@ -48,7 +48,7 @@ describe("Herbivores", function () {
         expect(card.resourceCount).to.eq(1);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });

--- a/tests/cards/IndustrialCenter.spec.ts
+++ b/tests/cards/IndustrialCenter.spec.ts
@@ -23,7 +23,7 @@ describe("IndustrialCenter", function () {
     it("Should action", function () {
         player.megaCredits = 7;
         card.action(player, game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.STEEL)).to.eq(1);
     });

--- a/tests/cards/InventorsGuild.spec.ts
+++ b/tests/cards/InventorsGuild.spec.ts
@@ -31,7 +31,7 @@ describe("InventorsGuild", function () {
         player.megaCredits = 3;
 
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand).has.lengthOf(1);
     });

--- a/tests/cards/LakeMarineris.spec.ts
+++ b/tests/cards/LakeMarineris.spec.ts
@@ -24,9 +24,9 @@ describe("LakeMarineris", function () {
         card.play(player, game);
 
         expect(game.deferredActions).has.lengthOf(2);
-        const firstOcean = game.deferredActions[0].execute() as SelectSpace;
+        const firstOcean = game.deferredActions.shift()!.execute() as SelectSpace;
         firstOcean.cb(firstOcean.availableSpaces[0]);
-        const secondOcean = game.deferredActions[1].execute() as SelectSpace;
+        const secondOcean = game.deferredActions.shift()!.execute() as SelectSpace;
         secondOcean.cb(secondOcean.availableSpaces[1]);
         expect(player.getTerraformRating()).to.eq(22);
         

--- a/tests/cards/MarsUniversity.spec.ts
+++ b/tests/cards/MarsUniversity.spec.ts
@@ -27,7 +27,7 @@ describe("MarsUniversity", function () {
         card.onCardPlayed(player, game, card);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions.options[0].cb([card]);
         expect(player.cardsInHand).has.lengthOf(1);
@@ -48,11 +48,11 @@ describe("MarsUniversity", function () {
         card.onCardPlayed(player, game, new Research());
         expect(game.deferredActions).has.lengthOf(2);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions.options[1].cb();
 
-        const orOptions2 = game.deferredActions[0].execute() as OrOptions;
+        const orOptions2 = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions2.options[1].cb();
 

--- a/tests/cards/MiningExpedition.spec.ts
+++ b/tests/cards/MiningExpedition.spec.ts
@@ -20,7 +20,7 @@ describe("MiningExpedition", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player2.plants).to.eq(6);
 

--- a/tests/cards/OlympusConference.spec.ts
+++ b/tests/cards/OlympusConference.spec.ts
@@ -8,6 +8,7 @@ import { Game } from "../../src/Game";
 import { Bushes } from "../../src/cards/Bushes";
 import { OrOptions } from "../../src/inputs/OrOptions";
 import { Research } from "../../src/cards/Research";
+import { DeferredActionsQueue } from "../../src/deferredActions/DeferredActionsQueue";
 
 describe("OlympusConference", function () {
     let card : OlympusConference, player : Player, game : Game;
@@ -31,7 +32,7 @@ describe("OlympusConference", function () {
         // No resource
         card.onCardPlayed(player, game, card);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input).is.undefined;
         expect(card.resourceCount).to.eq(1);
@@ -40,7 +41,7 @@ describe("OlympusConference", function () {
         card.onCardPlayed(player, game, card);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions.options[1].cb();
         expect(card.resourceCount).to.eq(2);
@@ -57,13 +58,13 @@ describe("OlympusConference", function () {
         expect(game.deferredActions).has.lengthOf(2);
 
         // No resource, can't draw, resource automatically added
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input).is.undefined;
         expect(card.resourceCount).to.eq(1);
 
         // Resource on card, can draw
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions.options[0].cb();
         expect(card.resourceCount).to.eq(0);
@@ -88,14 +89,14 @@ describe("OlympusConference", function () {
         expect(game.deferredActions).has.lengthOf(2);
 
         // OC's trigger should be the first one
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions.options[1].cb();
         expect(card.resourceCount).to.eq(2);
 
 
         // Reset the state
-        game.deferredActions = [];
+        game.deferredActions = new DeferredActionsQueue();
         player.playedCards = [];
 
 
@@ -111,7 +112,7 @@ describe("OlympusConference", function () {
         expect(game.deferredActions).has.lengthOf(2);
 
         // OC's trigger should be the first one
-        const orOptions2 = game.deferredActions[0].execute() as OrOptions;
+        const orOptions2 = game.deferredActions.next()!.execute() as OrOptions;
         game.deferredActions.shift();
         orOptions2.options[1].cb();
         expect(card.resourceCount).to.eq(2);

--- a/tests/cards/PowerSupplyConsortium.spec.ts
+++ b/tests/cards/PowerSupplyConsortium.spec.ts
@@ -27,7 +27,7 @@ describe("PowerSupplyConsortium", function () {
 
         card.play(player, game);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     });
@@ -39,7 +39,7 @@ describe("PowerSupplyConsortium", function () {
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectPlayer = game.deferredActions[0].execute() as SelectPlayer;
+        const selectPlayer = game.deferredActions.next()!.execute() as SelectPlayer;
         selectPlayer.cb(player2);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
         expect(player2.getProduction(Resources.ENERGY)).to.eq(2);

--- a/tests/cards/RestrictedArea.spec.ts
+++ b/tests/cards/RestrictedArea.spec.ts
@@ -35,7 +35,7 @@ describe("RestrictedArea", function () {
         expect(card.canAct(player)).is.true;
         card.action(player, game);
 
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.cardsInHand).has.lengthOf(1);
     });

--- a/tests/cards/SearchForLife.spec.ts
+++ b/tests/cards/SearchForLife.spec.ts
@@ -42,7 +42,7 @@ describe("SearchForLife", function () {
                game.dealer.discarded.find((c) => c.tags.length === 1 && c.tags[0] !== Tags.MICROBES) === undefined) {
             player.megaCredits = 1;
             card.action(player, game);
-            game.runDeferredAction(game.deferredActions[0], () => {});
+            game.deferredActions.runNext();
             expect(player.megaCredits).to.eq(0);
         }
         

--- a/tests/cards/SmallAnimals.spec.ts
+++ b/tests/cards/SmallAnimals.spec.ts
@@ -39,7 +39,7 @@ describe("SmallAnimals", function () {
         
         player.playedCards.push(card);
         card.play(player, game);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player2.getProduction(Resources.PLANTS)).to.eq(0);
     });

--- a/tests/cards/SpaceMirrors.spec.ts
+++ b/tests/cards/SpaceMirrors.spec.ts
@@ -24,7 +24,7 @@ describe("SpaceMirrors", function () {
         expect(card.canAct(player)).is.true;
 
         card.action(player, game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     });

--- a/tests/cards/UndergroundDetonations.spec.ts
+++ b/tests/cards/UndergroundDetonations.spec.ts
@@ -24,7 +24,7 @@ describe("UndergroundDetonations", function () {
         expect(card.canAct(player)).is.true;
         
         card.action(player, game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
     });

--- a/tests/cards/ViralEnhancers.spec.ts
+++ b/tests/cards/ViralEnhancers.spec.ts
@@ -29,16 +29,16 @@ describe("ViralEnhancers", function () {
         card.onCardPlayed(player, game, birds);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.shift()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player.getResourcesOnCard(birds)).to.eq(1);
         orOptions.options[1].cb();
         expect(player.plants).to.eq(1);
 
         card.onCardPlayed(player, game, ants);
-        expect(game.deferredActions).has.lengthOf(2);
+        expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions2 = game.deferredActions[1].execute() as OrOptions;
+        const orOptions2 = game.deferredActions.shift()!.execute() as OrOptions;
         orOptions2.options[0].cb();
         expect(player.getResourcesOnCard(ants)).to.eq(1);
         orOptions2.options[1].cb();
@@ -52,14 +52,12 @@ describe("ViralEnhancers", function () {
         card.onCardPlayed(player, game, ecologicalZone);
         expect(game.deferredActions).has.lengthOf(2);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
-        game.deferredActions.shift();
+        const orOptions = game.deferredActions.shift()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player.getResourcesOnCard(ecologicalZone)).to.eq(1);
         expect(game.deferredActions).has.lengthOf(1);
         
-        const orOptions2 = game.deferredActions[0].execute() as OrOptions;
-        game.deferredActions.shift();
+        const orOptions2 = game.deferredActions.shift()!.execute() as OrOptions;
         orOptions2.options[1].cb();
         expect(player.plants).to.eq(1);
         expect(game.deferredActions).has.lengthOf(0);

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -34,7 +34,7 @@ describe("Virus", function () {
         orOptions.options[1].cb();
         expect(game.deferredActions).has.lengthOf(1);
         
-        const orOptions2 = game.deferredActions[0].execute() as OrOptions;
+        const orOptions2 = game.deferredActions.next()!.execute() as OrOptions;
         orOptions2.options[0].cb();
         expect(player.plants).to.eq(0);
     });
@@ -42,7 +42,7 @@ describe("Virus", function () {
     it("Can play when no other player has resources", function () {
         player.plants = 5;
         expect(card.play(player, game)).is.undefined
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(player.plants).to.eq(5);
     });

--- a/tests/cards/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/WaterImportFromEuropa.spec.ts
@@ -31,11 +31,11 @@ describe("WaterImportFromEuropa", function () {
         const action = card.action(player, game);
         expect(action).is.undefined;
 
-        game.runDeferredAction(game.deferredActions[0], () => {}); // HowToPay
+        game.deferredActions.runNext(); // HowToPay
         expect(player.megaCredits).to.eq(1);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectOcean = game.deferredActions[0].execute() as SelectSpace;
+        const selectOcean = game.deferredActions.next()!.execute() as SelectSpace;
         selectOcean.cb(selectOcean.availableSpaces[0]);
         expect(player.getTerraformRating()).to.eq(21);
     });

--- a/tests/cards/ares/BioengineeringEnclosure.spec.ts
+++ b/tests/cards/ares/BioengineeringEnclosure.spec.ts
@@ -70,11 +70,11 @@ describe("BioengineeringEnclosure", function () {
     expect(card.canAct(player)).is.true;
     expect(card.resourceCount).eq(2);
     expect(animalHost.resourceCount).eq(0);
-    expect(game.deferredActions).is.empty;
+    expect(game.deferredActions).has.lengthOf(0);
 
     card.action(player, game);
 
-    game.deferredActions[0].execute();
+    game.deferredActions.next()!.execute();
 
     expect(card.resourceCount).eq(1);
     expect(animalHost.resourceCount).eq(1);

--- a/tests/cards/ares/BiofertilizerFacility.spec.ts
+++ b/tests/cards/ares/BiofertilizerFacility.spec.ts
@@ -53,7 +53,7 @@ describe("BiofertilizerFacility", function () {
     // Initial expectations that will change after playing the card.
     expect(player.getProduction(Resources.PLANTS)).is.eq(0);
     expect(microbeHost.resourceCount || 0).is.eq(0);
-    expect(game.deferredActions).is.empty;
+    expect(game.deferredActions).has.lengthOf(0);
 
     expect(card.canPlay(player, game)).is.true;
     const action = card.play(player, game);
@@ -66,7 +66,7 @@ describe("BiofertilizerFacility", function () {
     expect(citySpace.tile!.tileType).to.eq(TileType.BIOFERTILIZER_FACILITY);
     expect(citySpace.adjacency).to.deep.eq({bonus: [SpaceBonus.PLANT, SpaceBonus.MICROBE]});
 
-    game.deferredActions[0].execute();
+    game.deferredActions.next()!.execute();
 
     expect(microbeHost.resourceCount).is.eq(2);
   });

--- a/tests/cards/ares/ButterflyEffect.spec.ts
+++ b/tests/cards/ares/ButterflyEffect.spec.ts
@@ -26,7 +26,7 @@ describe("ButterflyEffect", function () {
         expect(originalHazardData.severeErosionTemperature.threshold).eq(-4);
         expect(originalHazardData.severeDustStormOxygen.threshold).eq(5);
 
-        const input = game.deferredActions[0].execute() as ShiftAresGlobalParameters;
+        const input = game.deferredActions.next()!.execute() as ShiftAresGlobalParameters;
         input.cb(
             {
                 lowOceanDelta: -1,

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -70,9 +70,9 @@ describe("EcologicalSurvey", function () {
 
     const adjacentSpace = game.board.getAdjacentSpaces(firstSpace)[0];
     game.addTile(player, adjacentSpace.spaceType, adjacentSpace, {tileType: TileType.GREENERY});
-    game.deferredActions[0].execute();
+    game.deferredActions.next()!.execute();
     game.deferredActions.shift();
-    game.deferredActions[0].execute();
+    game.deferredActions.next()!.execute();
     game.deferredActions.shift();
 
     expect(player.megaCredits).eq(2);

--- a/tests/cards/ares/MetallicAsteroid.spec.ts
+++ b/tests/cards/ares/MetallicAsteroid.spec.ts
@@ -22,7 +22,7 @@ describe("MetallicAsteroid", function () {
 
         expect(player.titanium).eq(0);
         expect(game.getTemperature()).eq(-30);
-        expect(game.deferredActions).is.empty;
+        expect(game.deferredActions).has.lengthOf(0);
 
         const action = card.play(player, game);
         expect(player.titanium).eq(1);

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -40,10 +40,10 @@ describe("EcologyResearch", function () {
 
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(2);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input).is.undefined;
-        const input2 = game.deferredActions[0].execute();
+        const input2 = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input2).is.undefined;
 
@@ -61,7 +61,7 @@ describe("EcologyResearch", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // add two microbes to Ants
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([ants]);
         
         expect(ants.resourceCount).to.eq(2);

--- a/tests/cards/colonies/FloaterTechnology.spec.ts
+++ b/tests/cards/colonies/FloaterTechnology.spec.ts
@@ -32,7 +32,7 @@ describe("FloaterTechnology", function () {
 
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(dirigibles.resourceCount).to.eq(1);
     });
@@ -45,7 +45,7 @@ describe("FloaterTechnology", function () {
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([floatingHabs]);
         expect(floatingHabs.resourceCount).to.eq(1);
         expect(dirigibles.resourceCount).to.eq(0);

--- a/tests/cards/colonies/ImpactorSwarm.spec.ts
+++ b/tests/cards/colonies/ImpactorSwarm.spec.ts
@@ -26,7 +26,7 @@ describe("ImpactorSwarm", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player2.plants).to.eq(0);
         expect(player.heat).to.eq(12);

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -21,7 +21,7 @@ describe("NitrogenFromTitan", function () {
         const tr = player.getTerraformRating();
         card.play(player, game);
         expect(player.getTerraformRating()).to.eq(tr + 2);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
     });
 
@@ -30,7 +30,7 @@ describe("NitrogenFromTitan", function () {
         player.playedCards.push(jovianLanterns);
 
         card.play(player, game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(jovianLanterns.resourceCount).to.eq(2);
     });
 
@@ -41,7 +41,7 @@ describe("NitrogenFromTitan", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([jovianLanterns]);
         expect(jovianLanterns.resourceCount).to.eq(2);
     });

--- a/tests/cards/colonies/Polyphemos.spec.ts
+++ b/tests/cards/colonies/Polyphemos.spec.ts
@@ -31,7 +31,7 @@ describe("Polyphemos", function () {
         expect(action).is.not.undefined;
         expect(action instanceof SelectCard).is.true;
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(35);
         expect(player.cardsInHand).has.lengthOf(3);
     });

--- a/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
+++ b/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
@@ -33,7 +33,7 @@ describe("TitanFloatingLaunchPad", function () {
         // No resource and no other card to add to
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input).is.undefined;
         expect(card.resourceCount).to.eq(1);
@@ -41,7 +41,7 @@ describe("TitanFloatingLaunchPad", function () {
         // No open colonies and no other card to add to
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input2 = game.deferredActions[0].execute();
+        const input2 = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input2).is.undefined;
         expect(card.resourceCount).to.eq(2);
@@ -54,7 +54,7 @@ describe("TitanFloatingLaunchPad", function () {
 
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([card]);
         expect(card.resourceCount).to.eq(1);
     });
@@ -74,14 +74,14 @@ describe("TitanFloatingLaunchPad", function () {
 
         orOptions.options[0].cb(); // Add resource
         expect(game.deferredActions).has.lengthOf(1);
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         game.deferredActions.shift();
         selectCard.cb([card]);
         expect(card.resourceCount).to.eq(8);
 
         orOptions.options[1].cb(); // Trade for free
         expect(game.deferredActions).has.lengthOf(1);
-        const selectColony = game.deferredActions[0].execute() as SelectColony;
+        const selectColony = game.deferredActions.next()!.execute() as SelectColony;
         selectColony.cb((<any>ColonyName)[selectColony.coloniesModel[0].name.toUpperCase()]);
         expect(card.resourceCount).to.eq(7);
         expect(player.megaCredits).to.eq(2);

--- a/tests/cards/colonies/TitanShuttles.spec.ts
+++ b/tests/cards/colonies/TitanShuttles.spec.ts
@@ -35,7 +35,7 @@ describe("TitanShuttles", function () {
     it("Auto add floaters if only 1 option and 1 target available", function () {
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
         expect(card.resourceCount).to.eq(2);
     });
@@ -47,7 +47,7 @@ describe("TitanShuttles", function () {
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([card]);
         expect(card.resourceCount).to.eq(2);
     });
@@ -70,7 +70,7 @@ describe("TitanShuttles", function () {
         orOptions.options[0].cb();
         expect(game.deferredActions).has.lengthOf(1);
 
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([card2]);
         expect(card2.resourceCount).to.eq(2);
     });

--- a/tests/cards/colonies/UrbanDecomposers.spec.ts
+++ b/tests/cards/colonies/UrbanDecomposers.spec.ts
@@ -54,7 +54,7 @@ describe("UrbanDecomposers", function () {
 
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         game.deferredActions.shift();
         expect(input).is.undefined;
         expect(decomposers.resourceCount).to.eq(2);
@@ -70,7 +70,7 @@ describe("UrbanDecomposers", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // add two microbes to Ants
-        const selectCard = game.deferredActions[0].execute() as SelectCard<ICard>;
+        const selectCard = game.deferredActions.next()!.execute() as SelectCard<ICard>;
         selectCard.cb([ants]);
         expect(ants.resourceCount).to.eq(2);
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);

--- a/tests/cards/community/AerospaceMission.spec.ts
+++ b/tests/cards/community/AerospaceMission.spec.ts
@@ -22,11 +22,11 @@ describe("AerospaceMission", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(2);
 
-        const selectColony = game.deferredActions[0].execute() as SelectColony;
+        const selectColony = game.deferredActions.next()!.execute() as SelectColony;
         game.deferredActions.shift();
         selectColony.cb((<any>ColonyName)[selectColony.coloniesModel[0].name.toUpperCase()]);
 
-        const selectColony2 = game.deferredActions[0].execute() as SelectColony;
+        const selectColony2 = game.deferredActions.next()!.execute() as SelectColony;
         game.deferredActions.shift();
         selectColony2.cb((<any>ColonyName)[selectColony2.coloniesModel[0].name.toUpperCase()]);
 

--- a/tests/cards/community/ByElection.spec.ts
+++ b/tests/cards/community/ByElection.spec.ts
@@ -22,7 +22,7 @@ describe("ByElection", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         const subOptions = orOptions.options[0] as OrOptions;
         subOptions.cb();
 

--- a/tests/cards/community/Incite.spec.ts
+++ b/tests/cards/community/Incite.spec.ts
@@ -36,7 +36,7 @@ describe("Incite", function () {
         card.initialAction(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
 
         const marsFirst = game.turmoil!.getPartyByName(PartyName.MARS);

--- a/tests/cards/community/PoliticalUprising.spec.ts
+++ b/tests/cards/community/PoliticalUprising.spec.ts
@@ -23,7 +23,7 @@ describe("PoliticalUprising", function () {
         expect(game.deferredActions).has.lengthOf(4);
 
         while (game.deferredActions.length) {
-            const orOptions = game.deferredActions[0].execute() as OrOptions;
+            const orOptions = game.deferredActions.next()!.execute() as OrOptions;
             orOptions.options[0].cb();
             game.deferredActions.shift();
         }

--- a/tests/cards/community/TradeAdvance.spec.ts
+++ b/tests/cards/community/TradeAdvance.spec.ts
@@ -22,7 +22,7 @@ describe("TradeAdvance", function () {
         expect(player.megaCredits).not.to.eq(0);
 
         while (game.deferredActions.length) {
-            const orOptions = game.deferredActions[0].execute() as OrOptions;
+            const orOptions = game.deferredActions.next()!.execute() as OrOptions;
             orOptions.options[0].cb();
             game.deferredActions.shift();
         }

--- a/tests/cards/prelude/AcquiredSpaceAgency.spec.ts
+++ b/tests/cards/prelude/AcquiredSpaceAgency.spec.ts
@@ -14,7 +14,7 @@ describe("AcquiredSpaceAgency", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.titanium).to.eq(6);
         expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/cards/prelude/AquiferTurbines.spec.ts
+++ b/tests/cards/prelude/AquiferTurbines.spec.ts
@@ -27,7 +27,7 @@ describe("AquiferTurbines", function () {
         game.deferredActions.shift();
 
         // SelectHowToPayDeferred
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.getProduction(Resources.ENERGY)).to.eq(2);
         expect(player.megaCredits).to.eq(0);

--- a/tests/cards/prelude/Biolab.spec.ts
+++ b/tests/cards/prelude/Biolab.spec.ts
@@ -14,7 +14,7 @@ describe("Biolab", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(player.cardsInHand).has.lengthOf(3);

--- a/tests/cards/prelude/BusinessEmpire.spec.ts
+++ b/tests/cards/prelude/BusinessEmpire.spec.ts
@@ -25,7 +25,7 @@ describe("BusinessEmpire", function () {
         card.play(player, game);
 
         // SelectHowToPayDeferred
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.MEGACREDITS)).to.eq(6);

--- a/tests/cards/prelude/EarlySettlement.spec.ts
+++ b/tests/cards/prelude/EarlySettlement.spec.ts
@@ -14,7 +14,7 @@ describe("EarlySettlement", function () {
         const game = new Game("foobar", [player], player);
 
         card.play(player, game);
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
 
         expect(player.getProduction(Resources.PLANTS)).to.eq(1);
         expect(selectSpace.cb(selectSpace.availableSpaces[0])).is.undefined;

--- a/tests/cards/prelude/ExperimentalForest.spec.ts
+++ b/tests/cards/prelude/ExperimentalForest.spec.ts
@@ -15,10 +15,10 @@ describe("ExperimentalForest", function () {
         expect(game.deferredActions).has.lengthOf(2);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         // Select Greenery space
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
 
         expect(selectSpace).is.not.undefined;
         expect(selectSpace instanceof SelectSpace).is.true;

--- a/tests/cards/prelude/GalileanMining.spec.ts
+++ b/tests/cards/prelude/GalileanMining.spec.ts
@@ -26,7 +26,7 @@ describe("GalileanMining", function () {
         card.play(player, game);
 
         // SelectHowToPayDeferred
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.TITANIUM)).to.eq(2);

--- a/tests/cards/prelude/HugeAsteroid.spec.ts
+++ b/tests/cards/prelude/HugeAsteroid.spec.ts
@@ -27,7 +27,7 @@ describe("HugeAsteroid", function () {
         card.play(player, game);
 
         // SelectHowToPayDeferred
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.megaCredits).to.eq(0);
         expect(player.getProduction(Resources.HEAT)).to.eq(1);

--- a/tests/cards/prelude/IoResearchOutpost.spec.ts
+++ b/tests/cards/prelude/IoResearchOutpost.spec.ts
@@ -14,7 +14,7 @@ describe("IoResearchOutpost", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
         expect(player.cardsInHand).has.lengthOf(1);

--- a/tests/cards/prelude/LavaTubeSettlement.spec.ts
+++ b/tests/cards/prelude/LavaTubeSettlement.spec.ts
@@ -45,7 +45,7 @@ describe("LavaTubeSettlement", function () {
         expect(card.canPlay(player, game)).is.true;
 
         card.play(player, game);
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
         selectSpace.cb(selectSpace.availableSpaces[0]);
 
         expect(selectSpace.availableSpaces[0].tile && selectSpace.availableSpaces[0].tile.tileType).to.eq(TileType.CITY);

--- a/tests/cards/prelude/MartianSurvey.spec.ts
+++ b/tests/cards/prelude/MartianSurvey.spec.ts
@@ -24,7 +24,7 @@ describe("MartianSurvey", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(card.getVictoryPoints()).to.eq(1);
         expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/cards/prelude/UNMIContractor.spec.ts
+++ b/tests/cards/prelude/UNMIContractor.spec.ts
@@ -13,7 +13,7 @@ describe("UNMIContractor", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Draw cards
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
 
         expect(player.getTerraformRating()).to.eq(17);
         expect(player.cardsInHand).has.lengthOf(1);

--- a/tests/cards/promo/AsteroidRights.spec.ts
+++ b/tests/cards/promo/AsteroidRights.spec.ts
@@ -50,7 +50,7 @@ describe("AsteroidRights", function () {
         card.resourceCount = 0;
         
         card.action(player, game);
-        game.deferredActions[0].execute();
+        game.deferredActions.next()!.execute();
         expect(player.megaCredits).to.eq(0);
         expect(card.resourceCount).to.eq(1);
     });

--- a/tests/cards/promo/CometAiming.spec.ts
+++ b/tests/cards/promo/CometAiming.spec.ts
@@ -37,7 +37,7 @@ describe("CometAiming", function () {
 
         card.action(player, game);
         expect(game.deferredActions).has.lengthOf(1);
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
         selectSpace.cb(selectSpace.availableSpaces[0]);
         expect(player.getTerraformRating()).to.eq(21);
     });

--- a/tests/cards/promo/CrashSiteCleanup.spec.ts
+++ b/tests/cards/promo/CrashSiteCleanup.spec.ts
@@ -27,7 +27,7 @@ describe("CrashSiteCleanup", function () {
         const smallAsteroid = new SmallAsteroid();
         smallAsteroid.play(player, game);
         // Choose Remove 1 plant option
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb([player2]);
 
         expect(card.canPlay(player, game)).is.true;
@@ -47,7 +47,7 @@ describe("CrashSiteCleanup", function () {
 
         // Trigger plants removal
         expect(game.deferredActions).has.lengthOf(1);
-        game.deferredActions[0].execute();
+        game.deferredActions.next()!.execute();
 
         expect(card.canPlay(player, game)).is.true;
         expect(game.someoneHasRemovedOtherPlayersPlants).is.true;

--- a/tests/cards/promo/DeimosDownPromo.spec.ts
+++ b/tests/cards/promo/DeimosDownPromo.spec.ts
@@ -21,7 +21,7 @@ describe("DeimosDownPromo", function () {
         expect(action instanceof SelectSpace).is.true;
         expect(game.getTemperature()).to.eq(-24);
         expect(player.steel).to.eq(4);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
     });
 
@@ -36,7 +36,7 @@ describe("DeimosDownPromo", function () {
         expect(game.deferredActions).has.lengthOf(1);
 
         // Choose Remove 5 plants option
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb([player2]);
 
         expect(player2.plants).to.eq(0);

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -33,7 +33,7 @@ describe("DirectedImpactors", function () {
         // can add resource to itself
         card.action(player,game);
         expect(game.deferredActions).has.lengthOf(1);
-        const selectHowToPay = game.deferredActions[0].execute() as SelectHowToPay;
+        const selectHowToPay = game.deferredActions.next()!.execute() as SelectHowToPay;
         selectHowToPay.cb({ steel: 0, heat: 0, titanium: 1, megaCredits: 3, microbes: 0, floaters: 0 } as HowToPay);
         
         expect(player.megaCredits).to.eq(0);
@@ -66,7 +66,7 @@ describe("DirectedImpactors", function () {
         // can add resource to any card
         const selectCard = action.options[1].cb();
         expect(game.deferredActions).has.lengthOf(1);
-        const selectHowToPay = game.deferredActions[0].execute() as SelectHowToPay;
+        const selectHowToPay = game.deferredActions.next()!.execute() as SelectHowToPay;
         selectHowToPay.cb({ steel: 0, heat: 0, titanium: 1, megaCredits: 3, microbes: 0, floaters: 0 } as HowToPay);
 
         selectCard!.cb([card2]);

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -22,7 +22,7 @@ describe("MoholeLake", function () {
         card.play(player, game);
 
         expect(game.deferredActions).has.lengthOf(1);
-        const selectSpace = game.deferredActions[0].execute() as SelectSpace;
+        const selectSpace = game.deferredActions.next()!.execute() as SelectSpace;
         selectSpace.cb(selectSpace.availableSpaces[0]);
         
         expect(game.getTemperature()).to.eq(-28);

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -67,7 +67,7 @@ describe("PharmacyUnion", function () {
         player.playedCards.push(searchForLife);
         card.onCardPlayed(player, game, searchForLife);
         expect(game.deferredActions).has.lengthOf(1);
-        expect(game.deferredActions[0].execute()).is.undefined;
+        expect(game.deferredActions.next()!.execute()).is.undefined;
         game.deferredActions.shift();
 
         expect(card.resourceCount).to.eq(1);
@@ -89,9 +89,9 @@ describe("PharmacyUnion", function () {
         player.playedCards.push(research);
         card.onCardPlayed(player, game, research);
         expect(game.deferredActions).has.lengthOf(2);
-        expect(game.deferredActions[0].execute()).is.undefined;
+        expect(game.deferredActions.next()!.execute()).is.undefined;
         game.deferredActions.shift();
-        expect(game.deferredActions[0].execute()).is.undefined;
+        expect(game.deferredActions.next()!.execute()).is.undefined;
         game.deferredActions.shift();
 
         expect(card.resourceCount).to.eq(0);
@@ -106,8 +106,8 @@ describe("PharmacyUnion", function () {
         card.onCardPlayed(player, game, searchForLife);
         expect(game.deferredActions).has.lengthOf(1);
         
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
-        game.deferredActions.splice(0, 1);
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
+        game.deferredActions.shift();
         orOptions.options[0].cb();
 
         expect(player.getTerraformRating()).to.eq(23);
@@ -129,7 +129,7 @@ describe("PharmacyUnion", function () {
         card.resourceCount = 0;
         card.onCardPlayed(player, game, new SearchForLife());
         
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(card.isDisabled).is.true;
         expect(player.getTagCount(Tags.MICROBES)).to.eq(0);
@@ -158,7 +158,7 @@ describe("PharmacyUnion", function () {
         card.onCardPlayed(player, game, viralEnhancers);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[1].cb(); // Add disease then remove it
         expect(card.resourceCount).to.eq(0);
         expect(player.megaCredits).to.eq(4);

--- a/tests/cards/promo/SmallAsteroid.spec.ts
+++ b/tests/cards/promo/SmallAsteroid.spec.ts
@@ -21,7 +21,7 @@ describe("SmallAsteroid", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[1].cb(); // do nothing
         expect(player2.plants).to.eq(3);
 
@@ -46,7 +46,7 @@ describe("SmallAsteroid", function () {
         card.play(player, game);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         expect(orOptions.options).has.lengthOf(3);
 
         orOptions.options[2].cb(); // do nothing

--- a/tests/cards/turmoil/AerialLenses.spec.ts
+++ b/tests/cards/turmoil/AerialLenses.spec.ts
@@ -31,7 +31,7 @@ describe("AerialLenses", function () {
     it("Should play without plants", function () {
         card.play(player, game);
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
-        const input = game.deferredActions[0].execute();
+        const input = game.deferredActions.next()!.execute();
         expect(input).is.undefined;
     });
 
@@ -41,7 +41,7 @@ describe("AerialLenses", function () {
         expect(player.getProduction(Resources.HEAT)).to.eq(2);
         expect(game.deferredActions).has.lengthOf(1);
 
-        const orOptions = game.deferredActions[0].execute() as OrOptions;
+        const orOptions = game.deferredActions.next()!.execute() as OrOptions;
         orOptions.options[0].cb();
         expect(player2.plants).to.eq(3);
     });

--- a/tests/cards/turmoil/TerralabsResearch.spec.ts
+++ b/tests/cards/turmoil/TerralabsResearch.spec.ts
@@ -31,7 +31,7 @@ describe("TerralabsResearch", function () {
         expect(action).is.not.undefined;
         expect(action instanceof SelectCard).is.true;
         (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.megaCredits).to.eq(11);
         expect(player.cardsInHand).has.lengthOf(3);
     });

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -33,7 +33,7 @@ describe("FloatingHabs", function () {
         player.megaCredits = 10;
 
         card.action(player, game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(card.resourceCount).to.eq(1);
         expect(player.megaCredits).to.eq(8);
     });
@@ -45,7 +45,7 @@ describe("FloatingHabs", function () {
         expect(action instanceof SelectCard).is.true;
         
         (action as SelectCard<ICard>).cb([card]);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(card.resourceCount).to.eq(1);
         expect(player.megaCredits).to.eq(8);
     });

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -24,7 +24,7 @@ describe("ForcedPrecipitation", function () {
         player.megaCredits = 10;
 
         const action = card.action(player,game);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(action).is.undefined;
         expect(card.resourceCount).to.eq(1);
         expect(player.megaCredits).to.eq(8);

--- a/tests/globalEvents/CloudSocieties.spec.ts
+++ b/tests/globalEvents/CloudSocieties.spec.ts
@@ -19,7 +19,7 @@ describe("CloudSocieties", function () {
         turmoil.dominantParty.partyLeader = player.id;
         turmoil.dominantParty.delegates.push(player.id);
         card.resolve(game, turmoil);
-        game.runDeferredAction(game.deferredActions[0], () => {});
+        game.deferredActions.runNext();
         expect(player.playedCards[0].resourceCount).to.eq(3);
     });
 });

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -24,12 +24,9 @@ describe("CorrosiveRain", function () {
         player2.megaCredits = 15;
         
         card.resolve(game, turmoil);
-        while (game.deferredActions.length) {
-            const action = game.getNextDeferredAction();
-            if (action !== undefined) {
-                game.runDeferredAction(action, () => {});
-            }
-        }
+        expect(game.deferredActions).has.lengthOf(2);
+        game.deferredActions.runAll(() => {});
+        expect(game.deferredActions).has.lengthOf(0);
         expect(player2.cardsInHand).has.lengthOf(3);
         expect(player.cardsInHand).has.lengthOf(0);
         expect(player.megaCredits).to.eq(5);

--- a/tests/globalEvents/ParadigmBreakdown.spec.ts
+++ b/tests/globalEvents/ParadigmBreakdown.spec.ts
@@ -38,7 +38,7 @@ describe("ParadigmBreakdown", function () {
         
         card.resolve(game, turmoil);
         while (game.deferredActions.length) {
-            const action = game.deferredActions[0];
+            const action = game.deferredActions.next()!;
             const input = action.execute();
             if (input !== undefined && input instanceof SelectCard) {
                 // Only |player| should be asked which cards to discard


### PR DESCRIPTION
It was asked by @kberg a few times that this should be its own class.
I agree with that idea so I tried to make something that, I think, turned out okay.

It moves the logic of dealing with deferred actions in the `DeferredActionsQueue` class and simplifies the code in Game.ts, Player.ts and some the tests.

First commit is the logic, second only deals with tests.

Note: I'm not even sure why we're making a distinction between taking care of _all_ the deferred actions and taking care of those for a specific player only. Are we ever deferring actions without setting the active player as `player` ? Needs more tests but could probably remove `runAllForPlayer` and use `runAll` everywhere.