### PR TITLE
Reduce code duplication in cards that remove resources from other cards and allow self removal on Ants and Predators.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -498,7 +498,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           if (removingPlayer !== this) this.resolveMonsInsurance(game);
 
           if (shouldLogAction) {
-              game.log("${0} removed ${1} resource" + (count > 1 ? "(s)" : "") + " from ${2}'s ${3}", b =>
+              game.log("${0} removed ${1} resource" + (count > 1 ? "s" : "") + " from ${2}'s ${3}", b =>
               b.player(removingPlayer)
               .number(count)
               .player(this)

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -498,11 +498,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           if (removingPlayer !== this) this.resolveMonsInsurance(game);
 
           if (shouldLogAction) {
-            game.log("${0} loses ${1} resource(s) on ${2} by ${3}", b =>
-                  b.player(this)
-                  .number(count)
-                  .card(card)
-                  .player(removingPlayer));
+              game.log("${0} removed ${1} resource" + (count > 1 ? "(s)" : "") + " from ${2}'s ${3}", b =>
+              b.player(removingPlayer)
+              .number(count)
+              .player(this)
+              .card(card));
           }
         }
         // Lawsuit hook
@@ -527,23 +527,20 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       }
     }
 
-    public getCardsWithResources(): Array<ICard> {
-      const result: Array<ICard> = [];
-
-      this.playedCards.forEach((card) => {
-        if (card.resourceType !== undefined && card.resourceCount && card.resourceCount > 0) {
-          result.push(card);
+    public getCardsWithResources(resource?: ResourceType): Array<ICard> {
+        let result: Array<ICard> = this.playedCards.filter((card) => card.resourceType !== undefined && card.resourceCount && card.resourceCount > 0);
+        if (this.corporationCard !== undefined 
+            && this.corporationCard.resourceType !== undefined 
+            && this.corporationCard.resourceCount !== undefined 
+            && this.corporationCard.resourceCount > 0) {
+                result.push(this.corporationCard);
         }
-      });
 
-      if (this.corporationCard !== undefined 
-          && this.corporationCard.resourceType !== undefined 
-          && this.corporationCard.resourceCount !== undefined 
-          && this.corporationCard.resourceCount > 0) {
-        result.push(this.corporationCard);
-      }
-      
-      return result;      
+        if (resource !== undefined) {
+            result = result.filter((card) => card.resourceType === resource)
+        }
+
+        return result;      
     }
 
     public getResourceCards(resource: ResourceType | undefined): Array<ICard> {
@@ -561,11 +558,11 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     }  
 
     public getResourceCount(resource: ResourceType): number {
-      let count: number = 0;
-      this.getCardsWithResources().filter(card => card.resourceType === resource).forEach((card) => {
-        count += this.getResourcesOnCard(card)!;
-      });
-      return count;
+        let count: number = 0;
+        this.getCardsWithResources(resource).forEach((card) => {
+            count += this.getResourcesOnCard(card)!;
+        });
+        return count;
     }
 
     public getCardsByCardType(cardType: CardType) {
@@ -1221,7 +1218,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
 
         if (howToPay.floaters !== undefined && howToPay.floaters > 0) {
           if (selectedCard.name === CardName.STRATOSPHERIC_BIRDS && howToPay.floaters === this.getFloatersCanSpend()) {
-            const cardsWithFloater = this.getCardsWithResources().filter(card => card.resourceType === ResourceType.FLOATER);
+            const cardsWithFloater = this.getCardsWithResources(ResourceType.FLOATER);
             if (cardsWithFloater.length === 1) {
               throw new Error("Cannot spend all floaters to play Stratospheric Birds");
             }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -498,7 +498,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           if (removingPlayer !== this) this.resolveMonsInsurance(game);
 
           if (shouldLogAction) {
-              game.log("${0} removed ${1} resource" + (count > 1 ? "s" : "") + " from ${2}'s ${3}", b =>
+              game.log("${0} removed ${1} resource(s) from ${2}'s ${3}", b =>
               b.player(removingPlayer)
               .number(count)
               .player(this)

--- a/src/cards/Ants.ts
+++ b/src/cards/Ants.ts
@@ -1,12 +1,13 @@
-import { IActionCard, ICard, IResourceCard } from "./ICard";
-import {IProjectCard} from "./IProjectCard";
-import {Tags} from "./Tags";
-import {CardType} from "./CardType";
-import {Player} from "../Player";
-import {Game} from "../Game";
-import {SelectCard} from "../inputs/SelectCard";
-import {ResourceType} from "../ResourceType";
+import { IActionCard, IResourceCard } from "./ICard";
+import { IProjectCard } from "./IProjectCard";
+import { Tags } from "./Tags";
+import { CardType } from "./CardType";
+import { Player } from "../Player";
+import { Game } from "../Game";
+import { ResourceType } from "../ResourceType";
 import { CardName } from "../CardName";
+import { DeferredAction } from "../deferredActions/DeferredAction";
+import { RemoveResourcesFromCard } from "../deferredActions/RemoveResourcesFromCard";
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {
     public cost = 9;
@@ -15,62 +16,33 @@ export class Ants implements IActionCard, IProjectCard, IResourceCard {
     public resourceType = ResourceType.MICROBE;
     public resourceCount: number = 0;
     public cardType = CardType.ACTIVE;
+
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
+        return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
     }
+
     public getVictoryPoints(): number {
-      return Math.floor(this.resourceCount / 2);
+        return Math.floor(this.resourceCount / 2);
     }
+
     public play() {
-      return undefined;
+        return undefined;
     }
+
     public canAct(player: Player, game: Game): boolean {
-      if (game.isSoloMode()) return true;
-      return this.getAvailableCards(game, player).length > 0;
+        if (game.isSoloMode()) return true;
+        return RemoveResourcesFromCard.getAvailableTargetCards(player, game, this.resourceType).length > 0;
     }
-    private getAvailableCards(game: Game, currentPlayer: Player): Array<ICard> {
-      const availableCards: Array<ICard> = [];
-      for (const gamePlayer of game.getPlayers()) {
-        // Microbes of this player are protected
-        if (gamePlayer.hasProtectedHabitats() && gamePlayer.id !== currentPlayer.id) continue;
-        availableCards.push(...gamePlayer.getCardsWithResources().filter(card => card.resourceType === ResourceType.MICROBE 
-          && card.name !== this.name));
-      }
-      return availableCards;
-    }
+
     public action(player: Player, game: Game) {
-      // Solo play, can always steal from immaginary opponent
-      if (game.isSoloMode()) {
-        player.addResourceTo(this);
+        game.defer(new RemoveResourcesFromCard(player, game, this.resourceType));
+        game.defer(new DeferredAction(
+            player,
+            () => {
+                player.addResourceTo(this);
+                return undefined;
+            }
+        ));
         return undefined;
-      }
-
-      const availableCards: Array<ICard> = this.getAvailableCards(game, player);
-
-      // Auto select if there is only one possible target
-      if (availableCards.length === 1) {
-        game.getCardPlayer(availableCards[0].name).removeResourceFrom(availableCards[0], 1, game, player, false);    
-        player.addResourceTo(this);
-        this.logCardAction(game, player, availableCards[0]);
-        return undefined;
-      }
-
-      return new SelectCard("Select card to remove microbe", "Remove microbe", availableCards,
-          (foundCards: Array<ICard>) => {
-            game.getCardPlayer(foundCards[0].name).removeResourceFrom(foundCards[0], 1, game, player, false);
-            player.addResourceTo(this);
-            this.logCardAction(game, player, foundCards[0]);
-            return undefined;
-          }
-      );
-    }
-
-    private logCardAction(game: Game, player: Player, card?: ICard) {
-      if (card) {
-        var otherPlayer = game.getCardPlayer(card.name);
-        game.log("${0} removed a microbe from ${1}'s ${2}", b => b.player(player).player(otherPlayer).card(card));
-      } else {
-        game.log("${0} removed a microbe from ${1}", b => b.player(player).string("Neutral Player"));
-      }
     }
 }

--- a/src/cards/Predators.ts
+++ b/src/cards/Predators.ts
@@ -1,12 +1,13 @@
-import { IActionCard, ICard, IResourceCard } from "./ICard";
+import { IActionCard, IResourceCard } from "./ICard";
 import { IProjectCard } from "./IProjectCard";
 import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
 import { ResourceType } from "../ResourceType";
-import { SelectCard } from "../inputs/SelectCard";
 import { CardName } from "../CardName";
+import { DeferredAction } from "../deferredActions/DeferredAction";
+import { RemoveResourcesFromCard } from "../deferredActions/RemoveResourcesFromCard";
 
 export class Predators implements IProjectCard, IActionCard, IResourceCard {
     public cost = 14;
@@ -15,71 +16,33 @@ export class Predators implements IProjectCard, IActionCard, IResourceCard {
     public cardType = CardType.ACTIVE;
     public resourceType = ResourceType.ANIMAL;
     public resourceCount: number = 0;
+
     public canPlay(player: Player, game: Game): boolean {
         return game.getOxygenLevel() >= 11 - player.getRequirementsBonus(game);
     }
+
     public getVictoryPoints(): number {
         return this.resourceCount;
     }
+
     public play() {
         return undefined;
     }
 
-    private getPossibleTargetCards(player: Player, game: Game): Array<ICard> {
-        const result: Array<ICard> = [];
-        game.getPlayers().forEach((p) => {
-            if (p.hasProtectedHabitats() && player.id !== p.id) return;
-            // TODO(kberg): the list of cards that can't have animals removed is now 2.
-            // This logic is duplicated in Predators.ts.
-            result.push(...p.getCardsWithResources().filter(card => card.resourceType === ResourceType.ANIMAL 
-                                                                && card.name !== CardName.PETS
-                                                                && card.name !== CardName.BIOENGINEERING_ENCLOSURE
-                                                                && card.name !== this.name));
-        });
-        return result;
-    }
-
-    private doAction(targetCard:ICard, player: Player, game: Game): void {
-        game.getCardPlayer(targetCard.name).removeResourceFrom(targetCard, 1, game, player, false);
-        this.logCardAction(game, player, targetCard);
-        player.addResourceTo(this);
-    }
-
     public canAct(player: Player, game: Game): boolean {
         if (game.isSoloMode()) return true;
-        return this.getPossibleTargetCards(player, game).length > 0;
+        return RemoveResourcesFromCard.getAvailableTargetCards(player, game, this.resourceType).length > 0;
     }
 
     public action(player: Player, game: Game) {
-        // Solo play, can always steal from immaginary opponent
-        if (game.isSoloMode()) {
-            player.addResourceTo(this);
-            return undefined;
-        }
-        const animalCards = this.getPossibleTargetCards(player, game);
-        if (animalCards.length === 1) {
-            this.doAction(animalCards[0], player, game)
-            return undefined;
-        }
-
-        return new SelectCard(
-            "Select card to remove animal from",
-            "Remove animal", 
-            animalCards, 
-            (foundCards: Array<ICard>) => {
-                this.doAction(foundCards[0], player, game)
+        game.defer(new RemoveResourcesFromCard(player, game, this.resourceType));
+        game.defer(new DeferredAction(
+            player,
+            () => {
+                player.addResourceTo(this);
                 return undefined;
             }
-        );
+        ));
+        return undefined;
     }
-
-    private logCardAction(game: Game, player: Player, card?: ICard) {
-        game.log("${0} removed an animal from ${1}", b => {
-            if (card) {
-                b.player(player).card(card);
-            } else {
-                b.player(player).string("Neutral Player")
-            }
-        });
-      }
 }

--- a/src/cards/Virus.ts
+++ b/src/cards/Virus.ts
@@ -3,14 +3,13 @@ import { Tags } from "./Tags";
 import { CardType } from "./CardType";
 import { Player } from "../Player";
 import { Game } from "../Game";
-import { SelectCard } from "../inputs/SelectCard";
 import { OrOptions } from "../inputs/OrOptions";
 import { PlayerInput } from "../PlayerInput";
 import { CardName } from "../CardName";
 import { SelectOption } from "../inputs/SelectOption";
 import { ResourceType } from "../ResourceType";
-import { ICard } from "./ICard";
 import { RemoveAnyPlants } from "../deferredActions/RemoveAnyPlants";
+import { RemoveResourcesFromCard } from "../deferredActions/RemoveResourcesFromCard";
 
 export class Virus implements IProjectCard {
     public cost = 1;
@@ -22,70 +21,36 @@ export class Virus implements IProjectCard {
         return true;
     }
 
-    private getPossibleTargetCards(player: Player, game: Game): Array<ICard> {
-        const result: Array<ICard> = [];
-        game.getPlayers().forEach((p) => {
-            if (p.hasProtectedHabitats() && player.id !== p.id) return;
-            // TODO(kberg): the list of cards that can't have animals removed is now 2.
-            // This logic is duplicated in Predators.ts.
-            // TODO(kberg): Add test for pets & bioengineering enclosure respect a la Predators.
-            result.push(...p.getCardsWithResources().filter(card => card.resourceType === ResourceType.ANIMAL && card.name !== CardName.PETS && card.name !== CardName.BIOENGINEERING_ENCLOSURE));
-        });
-        return result;
-    }
-
     public play(player: Player, game: Game): PlayerInput | undefined {
-        if (game.getPlayers().length === 1)  return undefined;
-        const cards = this.getPossibleTargetCards(player, game);
-        const playersWithPlants: number = game.getPlayers().filter((p) => 
-            ((p.id !== player.id && !p.plantsAreProtected()) 
-            || p.id === player.id)
-            && p.plants > 0).length;
-        const remove5Plants = () => {
-            return new SelectOption("Remove up to 5 plants from a player", "Remove plants", () =>
-            {
-                game.defer(new RemoveAnyPlants(player, game, 5));
-                return undefined;
-            })
-        };
+        if (game.getPlayers().length === 1) {
+            return undefined;
+        }
 
-        const removeAnimals = () => {
-            return new SelectCard(
-                "Select card to remove up to 2 animals from", 
-                "Remove animals",
-                cards, (foundCard: Array<ICard>) => {
-                    game.getCardPlayer(foundCard[0].name).removeResourceFrom(foundCard[0], 2, game, player);
-                    return undefined;
-                }
-            );
-        };
+        const orOptionsAnimals = (new RemoveResourcesFromCard(player, game, ResourceType.ANIMAL, 2, false, false)).execute() as OrOptions;
+        const removeAnimals = orOptionsAnimals !== undefined
+            ? orOptionsAnimals.options[0]
+            : undefined;
+
+        const orOptionsPlants = (new RemoveAnyPlants(player, game, 5)).execute() as OrOptions;
+        const removePlants = orOptionsPlants !== undefined
+            ? orOptionsPlants.options.slice(0, -1)
+            : undefined;
 
         // If no other player has resources to remove
         // assume player will remove nothing from themselves
-        if (cards.length === 0 && playersWithPlants === 0) {
+        if (removeAnimals === undefined && removePlants === undefined) {
             return undefined;
         }
 
-        // Another player has plants to remove
-        if (cards.length === 0 && playersWithPlants > 0) {
-            game.defer(new RemoveAnyPlants(player, game, 5));
-            return undefined;
+        const orOptions = new OrOptions();
+        if (removeAnimals !== undefined) {
+            orOptions.options.push(removeAnimals);
         }
-
-        // Another player has cards to remove animals from
-        if (cards.length > 0 && playersWithPlants === 0) {
-            if (cards.length > 1) {
-                return removeAnimals()
-            }
-
-            if (cards.length === 1) {
-                game.getCardPlayer(cards[0].name).removeResourceFrom(cards[0], 2, game, player);
-                return undefined;
-            }
-            return undefined;
+        if (removePlants !== undefined) {
+            orOptions.options.push(...removePlants);
         }
+        orOptions.options.push(new SelectOption("Skip removal", "Confirm", () => { return undefined; }));
 
-        // Select other animal or plants to remove
-        return new OrOptions(removeAnimals(), remove5Plants());
+        return orOptions;
     }
 }

--- a/src/cards/colonies/AirRaid.ts
+++ b/src/cards/colonies/AirRaid.ts
@@ -4,13 +4,9 @@ import { Player } from "../../Player";
 import { CardName } from "../../CardName";
 import { Game } from "../../Game";
 import { ResourceType } from "../../ResourceType";
-import { SelectCard } from "../../inputs/SelectCard";
-import { ICard } from "../ICard";
 import { Resources } from "../../Resources";
-import { AndOptions } from "../../inputs/AndOptions";
-import { OrOptions } from "../../inputs/OrOptions";
-import { SelectOption } from "../../inputs/SelectOption";
-
+import { RemoveResourcesFromCard } from "../../deferredActions/RemoveResourcesFromCard";
+import { StealResources } from "../../deferredActions/StealResources";
 
 export class AirRaid implements IProjectCard {
     public cost = 0;
@@ -24,65 +20,8 @@ export class AirRaid implements IProjectCard {
     }
 
     public play(player: Player, game: Game) {
-        let resourceCards = player.getCardsWithResources().filter(card => card.resourceType === ResourceType.FLOATER);
-
-        const selectCard = new SelectCard(
-            "Select card to remove one floater from",
-            "Remove floater",
-            resourceCards,
-            (foundCards: Array<ICard>) => {
-            player.removeResourceFrom(foundCards[0]);
-            return undefined;
-            }
-        );
-
-        if (game.isSoloMode()) {
-            player.megaCredits += 5;
-
-            if (resourceCards.length === 1) {
-                player.removeResourceFrom(resourceCards[0]);
-                return undefined;
-            } else {
-                return selectCard;
-            }
-        }
-
-        const eligiblePlayers = game.getPlayers().filter(selectedPlayer => selectedPlayer !== player);
-        let availableTargets = new OrOptions();
-
-        eligiblePlayers.forEach((target) => {
-            const amountStolen= Math.min(5, target.megaCredits);
-            const optionTitle = "Steal " + amountStolen + " MC from " + target.name;
-
-            availableTargets.options.push(new SelectOption(optionTitle, "Confirm", () => {
-                player.megaCredits += amountStolen;
-                target.setResource(Resources.MEGACREDITS, -5, game, player);
-                return undefined;
-            }))
-        });
-
-        var options: Array<OrOptions | SelectCard<ICard>> = [];
-
-        if (resourceCards.length === 1) {
-            player.removeResourceFrom(resourceCards[0]);
-        } else {
-            options.push(selectCard);
-        }
-
-        if (eligiblePlayers.length > 1) {
-            options.push(availableTargets);
-        } else {
-            player.megaCredits += Math.min(5, eligiblePlayers[0].megaCredits);
-            eligiblePlayers[0].setResource(Resources.MEGACREDITS, -5, game, player);
-        }
-        
-        if (options.length > 0) {
-            return new AndOptions(
-                () => {return undefined;},
-                ...options
-            );
-        } else {
-            return undefined;
-        }
+        game.defer(new RemoveResourcesFromCard(player, game, ResourceType.FLOATER, 1, true));
+        game.defer(new StealResources(player, game, Resources.MEGACREDITS, 5));
+        return undefined;
     }
 }

--- a/src/cards/venusNext/StratosphericBirds.ts
+++ b/src/cards/venusNext/StratosphericBirds.ts
@@ -5,8 +5,8 @@ import { CardType } from "../CardType";
 import { Player } from "../../Player";
 import { ResourceType } from "../../ResourceType";
 import { Game } from "../../Game";
-import { SelectCard } from "../../inputs/SelectCard";
 import { CardName } from "../../CardName";
+import { RemoveResourcesFromCard } from "../../deferredActions/RemoveResourcesFromCard";
 
 export class StratosphericBirds implements IActionCard,IProjectCard, IResourceCard {
     public cost = 12;
@@ -31,23 +31,9 @@ export class StratosphericBirds implements IActionCard,IProjectCard, IResourceCa
             return canPayForFloater && meetsVenusRequirements;
         }
     }
-    public play(player: Player) {
-        const cardsWithFloater = player.getCardsWithResources().filter(card => card.resourceType === ResourceType.FLOATER);
-
-        if (cardsWithFloater.length === 1) {
-            player.removeResourceFrom(cardsWithFloater[0], 1);
-            return undefined;
-        }
-
-        return new SelectCard(
-            "Select card to remove 1 floater from", 
-            "Remove floater",
-            cardsWithFloater,
-            (foundCards) => {
-                player.removeResourceFrom(foundCards[0], 1)
-                return undefined;
-            }
-        );
+    public play(player: Player, game: Game) {
+        game.defer(new RemoveResourcesFromCard(player, game, ResourceType.FLOATER, 1, true));
+        return undefined;
     }
     public canAct(): boolean {
         return true;

--- a/src/deferredActions/RemoveResourcesFromCard.ts
+++ b/src/deferredActions/RemoveResourcesFromCard.ts
@@ -1,0 +1,89 @@
+import { Game } from "../Game";
+import { Player } from "../Player";
+import { ResourceType } from "../ResourceType";
+import { OrOptions } from "../inputs/OrOptions";
+import { SelectCard } from "../inputs/SelectCard";
+import { SelectOption } from "../inputs/SelectOption";
+import { CardName } from "../CardName";
+import { ICard } from "../cards/ICard";
+import { DeferredAction } from "./DeferredAction";
+
+const animalsProtectedCards = [ CardName.PETS, CardName.BIOENGINEERING_ENCLOSURE ];
+
+export class RemoveResourcesFromCard implements DeferredAction {
+    constructor(
+        public player: Player,
+        public game: Game,
+        public resourceType: ResourceType | undefined,
+        public count: number = 1,
+        public ownCardsOnly: boolean = false,
+        public mandatory: boolean = true,
+        public title: string = "Select card to remove " + count + " " + resourceType + "(s)"
+    ){}
+
+    public static getAvailableTargetCards(player: Player, game: Game, resourceType: ResourceType | undefined, ownCardsOnly: boolean = false): Array<ICard> {
+        let resourceCards: Array<ICard>;
+        if (ownCardsOnly) {
+            if (resourceType === ResourceType.ANIMAL) {
+                resourceCards = player.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1);
+            } else {
+                resourceCards = player.getCardsWithResources(resourceType);
+            }
+        } else {
+            resourceCards = [];
+            game.getPlayers().forEach(p => {
+                switch (resourceType) {
+                    case ResourceType.ANIMAL:
+                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
+                        resourceCards.push(...p.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1));
+                        break;
+                    case ResourceType.MICROBE:
+                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
+                    default:
+                        resourceCards.push(...p.getCardsWithResources(resourceType));
+                }
+            });
+        }
+        return resourceCards;
+    }
+
+    public execute() {
+        if (this.ownCardsOnly === false && this.game.isSoloMode()) {
+            return undefined;
+        }
+
+        const resourceCards = RemoveResourcesFromCard.getAvailableTargetCards(this.player, this.game, this.resourceType, this.ownCardsOnly);
+
+        if (resourceCards.length === 0) {
+            return undefined;
+        }
+
+        const selectCard = new SelectCard(
+            this.title,
+            "Remove resource(s)",
+            resourceCards,
+            (foundCards: Array<ICard>) => {
+                const card = foundCards[0];
+                const owner = this.game.getCardPlayer(card.name);
+                owner.removeResourceFrom(card, 1, this.game, this.player);
+                return undefined;
+            }
+        );
+
+        if (this.mandatory) {
+            if (resourceCards.length === 1) {
+                const card = resourceCards[0];
+                const owner = this.game.getCardPlayer(card.name);
+                owner.removeResourceFrom(card, 1, this.game, this.player);
+                return undefined;
+            }
+            return selectCard;
+        }
+
+        return new OrOptions(
+            selectCard,
+            new SelectOption("Do not remove", "Confirm", () => { return undefined; })
+        );
+
+    }
+}    

--- a/src/deferredActions/RemoveResourcesFromCard.ts
+++ b/src/deferredActions/RemoveResourcesFromCard.ts
@@ -8,44 +8,19 @@ import { CardName } from "../CardName";
 import { ICard } from "../cards/ICard";
 import { DeferredAction } from "./DeferredAction";
 
+// TODO (kberg chosta): Make this a card attribute instead
 const animalsProtectedCards = [ CardName.PETS, CardName.BIOENGINEERING_ENCLOSURE ];
 
 export class RemoveResourcesFromCard implements DeferredAction {
     constructor(
         public player: Player,
         public game: Game,
-        public resourceType: ResourceType | undefined,
+        public resourceType: ResourceType,
         public count: number = 1,
         public ownCardsOnly: boolean = false,
-        public mandatory: boolean = true,
+        public mandatory: boolean = true, // Resource must be removed (either it's a cost or the icon is not red-bordered)
         public title: string = "Select card to remove " + count + " " + resourceType + "(s)"
     ){}
-
-    public static getAvailableTargetCards(player: Player, game: Game, resourceType: ResourceType | undefined, ownCardsOnly: boolean = false): Array<ICard> {
-        let resourceCards: Array<ICard>;
-        if (ownCardsOnly) {
-            if (resourceType === ResourceType.ANIMAL) {
-                resourceCards = player.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1);
-            } else {
-                resourceCards = player.getCardsWithResources(resourceType);
-            }
-        } else {
-            resourceCards = [];
-            game.getPlayers().forEach(p => {
-                switch (resourceType) {
-                    case ResourceType.ANIMAL:
-                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
-                        resourceCards.push(...p.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1));
-                        break;
-                    case ResourceType.MICROBE:
-                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
-                    default:
-                        resourceCards.push(...p.getCardsWithResources(resourceType));
-                }
-            });
-        }
-        return resourceCards;
-    }
 
     public execute() {
         if (this.ownCardsOnly === false && this.game.isSoloMode()) {
@@ -85,5 +60,31 @@ export class RemoveResourcesFromCard implements DeferredAction {
             new SelectOption("Do not remove", "Confirm", () => { return undefined; })
         );
 
+    }
+
+    public static getAvailableTargetCards(player: Player, game: Game, resourceType: ResourceType | undefined, ownCardsOnly: boolean = false): Array<ICard> {
+        let resourceCards: Array<ICard>;
+        if (ownCardsOnly) {
+            if (resourceType === ResourceType.ANIMAL) {
+                resourceCards = player.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1);
+            } else {
+                resourceCards = player.getCardsWithResources(resourceType);
+            }
+        } else {
+            resourceCards = [];
+            game.getPlayers().forEach(p => {
+                switch (resourceType) {
+                    case ResourceType.ANIMAL:
+                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
+                        resourceCards.push(...p.getCardsWithResources(resourceType).filter(card => animalsProtectedCards.indexOf(card.name) === -1));
+                        break;
+                    case ResourceType.MICROBE:
+                        if (p.hasProtectedHabitats() && player.id !== p.id) return;
+                    default:
+                        resourceCards.push(...p.getCardsWithResources(resourceType));
+                }
+            });
+        }
+        return resourceCards;
     }
 }    

--- a/tests/cards/Ants.spec.ts
+++ b/tests/cards/Ants.spec.ts
@@ -4,6 +4,7 @@ import { Color } from "../../src/Color";
 import { Player } from "../../src/Player";
 import { Game } from "../../src/Game";
 import { SelectCard } from "../../src/inputs/SelectCard";
+import { ICard } from "../../src/cards/ICard";
 import { ProtectedHabitats } from "../../src/cards/ProtectedHabitats";
 import { Tardigrades } from "../../src/cards/Tardigrades";
 import { NitriteReducingBacteria } from "../../src/cards/NitriteReducingBacteria";
@@ -47,12 +48,12 @@ describe("Ants", function () {
         
         expect(card.canAct(player, game)).is.true;
 
-        const action = card.action(player, game);
-        expect(action instanceof SelectCard).is.true;
+        card.action(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard.cards).has.lengthOf(2);
+        selectCard.cb([selectCard.cards[0]]);
+        game.deferredActions.shift()!.execute(); // Add microbe to ants
 
-        expect(action!.cards).has.lengthOf(2);
-        expect(action!.cards[0]).to.eq(tardigrades);
-        action!.cb([action!.cards[0]]);
         expect(card.resourceCount).to.eq(1);
         expect(tardigrades.resourceCount).to.eq(0);
     });
@@ -82,6 +83,10 @@ describe("Ants", function () {
         player2.addResourceTo(securityFleet);
 
         card.action(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard).is.undefined; // Only one option: Tardigrades
+        game.deferredActions.shift()!.execute(); // Add microbe to ants
+
         expect(card.resourceCount).to.eq(1);
         expect(tardigrades.resourceCount).to.eq(0);
     });

--- a/tests/cards/Predators.spec.ts
+++ b/tests/cards/Predators.spec.ts
@@ -8,6 +8,8 @@ import { Pets } from "../../src/cards/Pets";
 import { ProtectedHabitats } from "../../src/cards/ProtectedHabitats";
 import { SmallAnimals } from "../../src/cards/SmallAnimals";
 import { BioengineeringEnclosure } from "../../src/cards/ares/BioengineeringEnclosure";
+import { ICard } from "../../src/cards/ICard";
+import { SelectCard } from "../../src/inputs/SelectCard";
 
 describe("Predators", function () {
     let card : Predators, player : Player, player2 : Player, game : Game;
@@ -39,10 +41,13 @@ describe("Predators", function () {
         player.playedCards.push(card, fish, smallAnimals);
         player.addResourceTo(fish);
         player.addResourceTo(smallAnimals);
-        const action = card.action(player, game);
-        expect(action).is.not.undefined;
 
-        action!.cb(action!.cards);
+        card.action(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard.cards).has.lengthOf(2);
+        selectCard.cb([selectCard.cards[0]]);
+        game.deferredActions.shift()!.execute(); // Add animal to predators
+
         expect(card.resourceCount).to.eq(1);
         expect(player.getResourcesOnCard(fish)).to.eq(0);
     });
@@ -58,8 +63,10 @@ describe("Predators", function () {
 
         expect(card.canAct(player, game)).is.true;
         
-        const action = card.action(player, game);
-        expect(action).is.undefined; // No option to choose Pets card provided
+        card.action(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard).is.undefined; // Only one option: Fish
+        game.deferredActions.shift()!.execute(); // Add animal to predators
 
         expect(card.resourceCount).to.eq(1);
         expect(player2.getResourcesOnCard(fish)).to.eq(0);
@@ -77,8 +84,10 @@ describe("Predators", function () {
 
         expect(card.canAct(player, game)).is.true;
         
-        const action = card.action(player, game);
-        expect(action).is.undefined; // No option to choose BioEngineering Enclosure card provided
+        card.action(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard).is.undefined; // Only one option: Fish
+        game.deferredActions.shift()!.execute(); // Add animal to predators
 
         expect(card.resourceCount).to.eq(1);
         expect(player2.getResourcesOnCard(fish)).to.eq(0);

--- a/tests/cards/Virus.spec.ts
+++ b/tests/cards/Virus.spec.ts
@@ -32,18 +32,12 @@ describe("Virus", function () {
         expect(player.getResourcesOnCard(birds)).to.eq(0);
 
         orOptions.options[1].cb();
-        expect(game.deferredActions).has.lengthOf(1);
-        
-        const orOptions2 = game.deferredActions.next()!.execute() as OrOptions;
-        orOptions2.options[0].cb();
         expect(player.plants).to.eq(0);
     });
 
     it("Can play when no other player has resources", function () {
         player.plants = 5;
         expect(card.play(player, game)).is.undefined
-        const input = game.deferredActions.next()!.execute();
-        expect(input).is.undefined;
         expect(player.plants).to.eq(5);
     });
 

--- a/tests/cards/colonies/AirRaid.spec.ts
+++ b/tests/cards/colonies/AirRaid.spec.ts
@@ -5,7 +5,6 @@ import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
 import { StormCraftIncorporated } from '../../../src/cards/colonies/StormCraftIncorporated';
 import { Game } from '../../../src/Game';
-import { AndOptions } from '../../../src/inputs/AndOptions';
 import { SelectCard } from '../../../src/inputs/SelectCard';
 import { ICard } from '../../../src/cards/ICard';
 import { OrOptions } from "../../../src/inputs/OrOptions";
@@ -38,9 +37,9 @@ describe("AirRaid", function () {
         player.addResourceTo(otherCardWithFloater);
         player2.megaCredits = 4;
 
-        const andOptions = card.play(player, game) as AndOptions;
-        const option1 = andOptions.options[0] as SelectCard<ICard>;
-        const option2 = andOptions.options[1] as OrOptions;
+        card.play(player, game);
+        const option1 = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        const option2 = game.deferredActions.shift()!.execute() as OrOptions;
 
         option1.cb([corpo]);
         expect(player.getResourcesOnCard(corpo)).to.eq(0);
@@ -56,6 +55,11 @@ describe("AirRaid", function () {
         
         player2.megaCredits = 4;
         card.play(player, game);
+
+        game.deferredActions.shift()!.execute(); // Remove floater
+        const option = game.deferredActions.shift()!.execute() as OrOptions; // Steal money
+        expect(option.options).has.lengthOf(2);
+        option.options[0].cb();
 
         expect(player.getResourcesOnCard(corpo)).to.eq(0);
         expect(player2.megaCredits).to.eq(0);

--- a/tests/cards/venusNext/StratosphericBirds.spec.ts
+++ b/tests/cards/venusNext/StratosphericBirds.spec.ts
@@ -7,6 +7,7 @@ import { DeuteriumExport } from "../../../src/cards/venusNext/DeuteriumExport";
 import { ExtractorBalloons } from "../../../src/cards/venusNext/ExtractorBalloons";
 import { SelectCard } from "../../../src/inputs/SelectCard";
 import { Dirigibles } from "../../../src/cards/venusNext/Dirigibles";
+import { ICard } from "../../../src/cards/ICard";
 
 describe("StratosphericBirds", function () {
     let card : StratosphericBirds, player : Player, game : Game, deuteriumExport: DeuteriumExport;
@@ -37,8 +38,9 @@ describe("StratosphericBirds", function () {
         expect(card.canPlay(player,game)).is.true;
         player.playedCards.push(card);
 
-        const action = card.play(player);
-        expect(action).is.undefined;
+        card.play(player, game);
+        expect(game.deferredActions).has.lengthOf(1);
+        expect(game.deferredActions.shift()!.execute()).is.undefined;
     });
 
     it("Should act", function () {
@@ -58,11 +60,11 @@ describe("StratosphericBirds", function () {
         player.addResourceTo(deuteriumExport, 1);
         player.addResourceTo(extractorBalloons, 1);
 
-        const action = card.play(player);
-        expect(action instanceof SelectCard).is.true;
-        expect(action!.cards).has.lengthOf(2);
+        card.play(player, game);
+        const selectCard = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+        expect(selectCard.cards).has.lengthOf(2);
 
-        action!.cb([deuteriumExport]);
+        selectCard.cb([deuteriumExport]);
         expect(player.getResourcesOnCard(deuteriumExport)).to.eq(0);
         expect(player.getResourcesOnCard(extractorBalloons)).to.eq(1);
     });
@@ -92,6 +94,7 @@ describe("StratosphericBirds", function () {
 
         // Pay with MC only: Can play
         selectHowToPayForCard.cb(card, { steel: 0, heat: 0, titanium: 0, megaCredits: 12, microbes: 0, floaters: 0 });
+        game.deferredActions.shift()!.execute(); // Remove floater
         expect(dirigibles.resourceCount).to.eq(0);
     });
 
@@ -109,6 +112,7 @@ describe("StratosphericBirds", function () {
 
         // Spend all 3 floaters from Dirigibles to pay for the card
         selectHowToPayForCard.cb(card, { steel: 0, heat: 0, titanium: 0, megaCredits: 3, microbes: 0, floaters: 3 });
+        game.deferredActions.shift()!.execute(); // Remove floater
         expect(player.getResourcesOnCard(dirigibles)).to.eq(0);
         expect(player.getResourcesOnCard(deuteriumExport)).to.eq(0);
         expect(player.megaCredits).to.eq(0);


### PR DESCRIPTION
Adds a new deferred action called **RemoveResourcesFromCard** that is used by cards or actions that can remove resources from other cards.
It is now used by **Ants**, **Predators**, **Virus**, **Stratospheric Birds** and **Air Raid**.

Also added an argument to `player.getCardsWithResources()` to allow filtering what kind of cards we're looking for.

First commit is functional, second is for tests.