### PR TITLE
Prompt player for corporation's first action

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -101,6 +101,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public actionsTakenThisRound: number = 0;
     private actionsThisGeneration: Set<string> = new Set<string>();
     public lastCardPlayed: IProjectCard | undefined;
+    private corporationInitialActionDone: boolean = false;
 
     // Cards
     public dealtCorporationCards: Array<CorporationCard> = [];
@@ -2019,31 +2020,34 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
         game.phase = Phase.ACTION;
       }
 
-      if (
-        game.getGeneration() === 1 &&
-            this.corporationCard !== undefined &&
-            this.corporationCard.initialAction !== undefined &&
-            !this.actionsThisGeneration.has("CORPORATION_INITIAL_ACTION") &&
-            this.actionsTakenThisRound === 0
-      ) {
-        const input = this.corporationCard.initialAction(this, game);
-        if (input !== undefined) {
-          game.defer(new DeferredAction(
-            this,
-            () => input
-          ));
+        if (game.hasPassedThisActionPhase(this) || this.actionsTakenThisRound >= 2) {
+            this.actionsTakenThisRound = 0;
+            game.playerIsFinishedTakingActions();
+            return;
         }
-        this.actionsThisGeneration.add("CORPORATION_INITIAL_ACTION");
-        this.actionsTakenThisRound++;
-        this.takeAction(game);
-        return;
-      }
 
-      if (game.hasPassedThisActionPhase(this) || this.actionsTakenThisRound >= 2) {
-        this.actionsTakenThisRound = 0;
-        game.playerIsFinishedTakingActions();
-        return;
-      }         
+        const corporationCard = this.corporationCard;
+        if (corporationCard !== undefined &&
+            corporationCard.initialAction !== undefined &&
+            corporationCard.initialActionText !== undefined &&
+            this.corporationInitialActionDone === false
+        ) {
+            const initialAction = corporationCard.initialAction;
+            const initialActionOption = new SelectOption("Take " + corporationCard.name + "'s first action", corporationCard.initialActionText, () => {
+                game.defer(new DeferredAction(this, () => initialAction(this, game)));
+                this.corporationInitialActionDone = true;
+                return undefined;
+            })
+            const initialActionOrPass = new OrOptions(
+                initialActionOption,
+                this.passOption(game)
+            );
+            this.setWaitingFor(initialActionOrPass, () => {
+                this.actionsTakenThisRound++;
+                this.takeAction(game);
+            });
+            return;
+        }
 
       const action: OrOptions = new OrOptions();
       action.title = "Take action for action phase, select one " +

--- a/src/cards/colonies/Aridor.ts
+++ b/src/cards/colonies/Aridor.ts
@@ -18,7 +18,7 @@ export class Aridor implements CorporationCard {
     public allTags = new Set();
     public cardType = CardType.CORPORATION;
 
-
+    public initialActionText: string = "Add a colony tile";
     public initialAction(player: Player, game: Game) {
         if (game.colonyDealer === undefined || !game.gameOptions.coloniesExtension) return undefined;
         

--- a/src/cards/colonies/Poseidon.ts
+++ b/src/cards/colonies/Poseidon.ts
@@ -11,6 +11,7 @@ export class Poseidon implements CorporationCard {
     public startingMegaCredits: number = 45;
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Place a colony";
     public initialAction(player: Player, game: Game) {
         if (game.gameOptions.coloniesExtension) {
             game.defer(new BuildColony(player, game, false, "Poseidon first action - Select where to build colony"));

--- a/src/cards/community/Incite.ts
+++ b/src/cards/community/Incite.ts
@@ -18,6 +18,7 @@ export class Incite implements CorporationCard {
         return undefined;
     }
 
+    public initialActionText: string = "Place 2 delegates in one party";
     public initialAction(player: Player, game: Game) {
         if (game.turmoil) {
             const title = "Incite first action - Select where to send two delegates";

--- a/src/cards/community/ProjectWorkshop.ts
+++ b/src/cards/community/ProjectWorkshop.ts
@@ -23,6 +23,7 @@ export class ProjectWorkshop implements CorporationCard {
         return undefined;
     }
 
+    public initialActionText: string = "Draw a blue card";
     public initialAction(player: Player, game: Game) {
         const drawnCard = game.drawCardsByType(CardType.ACTIVE, 1)[0];
         player.cardsInHand.push(drawnCard);

--- a/src/cards/corporation/CorporationCard.ts
+++ b/src/cards/corporation/CorporationCard.ts
@@ -11,6 +11,7 @@ import { SelectSpace } from "../../inputs/SelectSpace";
 import { CardType } from "../CardType";
 
 export interface CorporationCard extends ICard {
+    initialActionText?: string;
     initialAction?: (player: Player, game: Game) => PlayerInput | undefined;
     startingMegaCredits: number;
     play: (

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -12,6 +12,7 @@ export class Inventrix implements CorporationCard {
     public startingMegaCredits: number = 45;
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Draw 3 cards";
     public initialAction(player: Player, game: Game) {
         player.cardsInHand.push(
             game.dealer.dealCard(),

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -17,6 +17,7 @@ export class TharsisRepublic implements CorporationCard {
     public startingMegaCredits: number = 40;
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Place a city tile";
     public initialAction(player: Player, game: Game) {
         return new SelectSpace("Select space on mars for city tile", game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
             game.addCityTile(player, space.id);

--- a/src/cards/prelude/ValleyTrust.ts
+++ b/src/cards/prelude/ValleyTrust.ts
@@ -18,6 +18,7 @@ export class ValleyTrust implements CorporationCard {
         return card.tags.filter(tag => tag === Tags.SCIENCE).length * 2;
     }
 
+    public initialActionText: string = "Draw 3 Prelude cards, and play one of them";
     public initialAction(player: Player, game: Game) {
         if (game.gameOptions.preludeExtension) {
             const cardsDrawn: Array<IProjectCard> = [

--- a/src/cards/prelude/Vitor.ts
+++ b/src/cards/prelude/Vitor.ts
@@ -22,6 +22,7 @@ export class Vitor implements CorporationCard {
         });
     }
 
+    public initialActionText: string = "Fund an award for free";
     public initialAction(player: Player, game: Game) {
         // Awards are disabled for 1 player games
         if (game.isSoloMode()) {

--- a/src/cards/promo/ArcadianCommunities.ts
+++ b/src/cards/promo/ArcadianCommunities.ts
@@ -14,6 +14,7 @@ export class ArcadianCommunities implements IActionCard, CorporationCard {
     public startingMegaCredits: number = 40; 
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Place a community (player marker) on a non-reserved area";
     public initialAction(player: Player, game: Game) {
         return new SelectSpace(
             "Select space for claim", 

--- a/src/cards/promo/Philares.ts
+++ b/src/cards/promo/Philares.ts
@@ -17,6 +17,7 @@ export class Philares implements CorporationCard {
     public startingMegaCredits: number = 47;
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Place a greenery tile and raise the oxygen 1 step";
     public initialAction(player: Player, game: Game) {
         return new SelectSpace("Select space for greenery tile", 
         game.board.getAvailableSpacesForGreenery(player), (space: ISpace) => {

--- a/src/cards/promo/Splice.ts
+++ b/src/cards/promo/Splice.ts
@@ -16,6 +16,7 @@ export class Splice implements CorporationCard {
     public startingMegaCredits: number = 48; // 44 + 4 as card resolution when played
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Draw a card with a microbe tag";
     public initialAction(player: Player, game: Game) { 
         player.cardsInHand.push(game.drawCardsByTag(Tags.MICROBES, 1)[0]);
         

--- a/src/cards/venusNext/Celestic.ts
+++ b/src/cards/venusNext/Celestic.ts
@@ -33,6 +33,7 @@ export class Celestic implements IActionCard, CorporationCard, IResourceCard {
         CardName.STRATOSPHERIC_BIRDS
     ]);
 
+    public initialActionText: string = "Draw 2 cards with a floater icon on it";
     public initialAction(player: Player, game: Game) {
         const requiredCardsCount = 2;
         if (game.hasCardsWithResource(ResourceType.FLOATER, requiredCardsCount)) {

--- a/src/cards/venusNext/MorningStarInc.ts
+++ b/src/cards/venusNext/MorningStarInc.ts
@@ -12,6 +12,7 @@ export class MorningStarInc implements CorporationCard {
     public startingMegaCredits: number = 50;
     public cardType = CardType.CORPORATION;
 
+    public initialActionText: string = "Draw 3 Venus-tag cards";
     public initialAction(player: Player, game: Game) {
         if (game.hasCardsWithTag(Tags.VENUS, 3)) {
             for (const foundCard of game.drawCardsByTag(Tags.VENUS, 3)) {


### PR DESCRIPTION
This change prompts the player to actually play the first action of their corporation if they have one (Tharsis, Inventrix, etc).
It also gives them the right to pass the generation instead if they prefer. They will still have to take that action as their first before they are allowed to do anything else than pass.

![explorer_2020-11-03_01-54-16](https://user-images.githubusercontent.com/5318258/97882239-7ff4de80-1d77-11eb-8583-d55d5eb4b1e0.png)


While it is a correct implementation of the rules since delaying that first action is [a legal move](https://boardgamegeek.com/thread/1784175/article/25942959#25942959), some might say that it adds 1 extra click per game (if you have one of those corps) while you would have near 0 reason to ever not take it.
I'll let you guys be the judge of that.

Closes https://github.com/bafolts/terraforming-mars/issues/1576