### PR TITLE
Update css for community cards and logic for ValuableGases

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -5523,7 +5523,7 @@ export const HTML_DATA: Map<string, string> =
           <br>
           <div class="delegate effect"></div> : <div class="money resource effect-money">-2</div>
           <div class="description effect">
-            (Effect: You have influence +1. When you send a delegate from the reserve, you pay 2 MC less for it.)
+            (Effect: You have influence +1. When you send a delegate using the lobbying action, you pay 2 MC less for it.)
           </div>
         </div>
       </div>
@@ -5576,12 +5576,14 @@ export const HTML_DATA: Map<string, string> =
 [CardName.VALUABLE_GASES,`
       <div class="content">
         <div class="resource money">6</div>
-        <div class="resource card" style="margin-left:10px">
+        <br>
+        PLAY
+        <div class="resource card">
           <div class="card-icon tag-venus"></div>
         </div>
         &nbsp;: +4 <div class="resource floater"></div>
         <div class="description">
-          Gain 6 MC. Play a Venus card from your hand that collects floaters and add 4 floaters to it.
+          Gain 6 MC. Play a Venus card from your hand and add 4 floaters to it.
         </div>
       </div>
 `],
@@ -5624,7 +5626,7 @@ export const HTML_DATA: Map<string, string> =
         <div>Trade all colonies with</div>
         <div class="tile trade"></div> : <span class="card-sign">+1</span>
         <div class="description">
-          Immediately trade with all active colonies. You may increase the Colony Tile track 1 step before each trade.
+          Immediately trade with all active colonies. You may increase the Colony Tile track 1 step before each of these trades.
           <br><br>Gain 2 MC (SOLO: Gain 10 MC).
         </div>
       </div>

--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -19,13 +19,13 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
     }
 
     public addPlayCardDeferredAction(player: Player, game: Game) {
-        const playableCards = player.getPlayableCards(game).filter((card) => card.resourceType === ResourceType.FLOATER && card.tags.indexOf(Tags.VENUS) !== -1);
+        const playableCards = player.getPlayableCards(game).filter((card) => card.tags.indexOf(Tags.VENUS) !== -1);
             
         if (playableCards.length > 0) {
             game.defer(new DeferredAction(
                 player,
                 () => new SelectCard(
-                    "Select Venus floater card to play and add 4 floaters",
+                    "Select Venus card to play and add 4 floaters",
                     "Save",
                     playableCards,
                     (cards: Array<IProjectCard>) => {
@@ -35,7 +35,11 @@ export class ValuableGases extends PreludeCard implements IProjectCard {
 
                         game.defer(new SelectHowToPayDeferred(player, cardCost, canUseSteel, canUseTitanium, "Select how to pay for card"));
                         player.playCard(game, cards[0]);
-                        player.addResourceTo(cards[0], 4);
+
+                        if (cards[0].resourceType === ResourceType.FLOATER) {
+                            player.addResourceTo(cards[0], 4);
+                        }
+
                         return undefined;
                     }
                 )

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -2002,6 +2002,12 @@ input[type="radio"]:checked + .filterDiv::after {
     }
 }
 
+.card-valuable-gases {
+    .resource.card {
+        margin-top: 10px;
+    }
+}
+
 .splice {
     margin-left: 19px;
     font-size: 29px;


### PR DESCRIPTION
<img width="265" alt="Screenshot 2020-11-03 at 12 58 04 AM" src="https://user-images.githubusercontent.com/2408094/97896991-d01c7280-1d70-11eb-9387-7c0b09062d11.png">

Addresses an edge case: You should be allowed to play a Venus card from hand even if it does not collect floaters, as adding resources to a card is one of the allowed three exceptions.