### PR TITLE
Fix: Ocean from global event should not give TR or placement bonus

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -822,9 +822,10 @@ export class Game implements ILoadable<SerializedGame, Game> {
         }
         return;
       }
+      
       // solar Phase Option
+      this.phase = Phase.SOLAR;
       if (this.gameOptions.solarPhaseOption && ! this.marsIsTerraformed()) {
-        this.phase = Phase.SOLAR;
         this.gotoWorldGovernmentTerraforming();
         return;
       }
@@ -832,7 +833,6 @@ export class Game implements ILoadable<SerializedGame, Game> {
     }
 
     private gotoEndGeneration() {
-      this.phase = Phase.INTERGENERATION
       if (this.gameOptions.coloniesExtension) {
         this.colonies.forEach(colony => {
           colony.endGeneration();
@@ -848,7 +848,8 @@ export class Game implements ILoadable<SerializedGame, Game> {
         this.resolveTurmoilDeferredActions();
         return;
       }
-      
+     
+      this.phase = Phase.INTERGENERATION;
       this.goToDraftOrResearch();
     }
 


### PR DESCRIPTION
Fix from @Lynesth that closes https://github.com/bafolts/terraforming-mars/issues/1830. Game phase should always be set to `Phase.SOLAR` even if solar phase option is not selected or global parameters are maxed, as a lot of core logic checks for this specific phase.