### PR TITLE
Fix: Don't allow Valley Trust to play preludes it cannot afford

### DIFF
--- a/src/cards/prelude/ValleyTrust.ts
+++ b/src/cards/prelude/ValleyTrust.ts
@@ -26,8 +26,13 @@ export class ValleyTrust implements CorporationCard {
                 game.dealer.dealPreludeCard(),
                 game.dealer.dealPreludeCard()
             ];
+
             return new SelectCard("Choose prelude card to play", "Play", cardsDrawn, (foundCards: Array<IProjectCard>) => {
-                return player.playCard(game, foundCards[0]);
+                if (foundCards[0].canPlay === undefined || foundCards[0].canPlay(player, game)) {
+                    return player.playCard(game, foundCards[0]);
+                } else {
+                    throw new Error("You cannot pay for this card");
+                }
             }, 1, 1);
         }
         else {


### PR DESCRIPTION
Closes https://github.com/bafolts/terraforming-mars/issues/1829. Player is shown an error message and asked to select a different prelude card to play.

<img width="787" alt="Screenshot 2020-11-05 at 12 21 22 PM" src="https://user-images.githubusercontent.com/2408094/98198003-f30e7880-1f62-11eb-9c33-6b96e5c1fb38.png">
