### PR TITLE
Use SelectHowToPayForCard in Valuable Gases + remove remains of bonusMc

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1190,8 +1190,7 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
       );
     }
 
-    public playProjectCard(game: Game): PlayerInput {
-      const cb = (selectedCard: IProjectCard, howToPay: HowToPay) => {
+    public checkHowToPayAndPlayCard(selectedCard: IProjectCard, howToPay: HowToPay, game: Game) {
         const cardCost: number = this.getCardCost(game, selectedCard);
         let totalToPay: number = 0;
 
@@ -1240,9 +1239,16 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
           throw new Error("Did not spend enough to pay for card");
         }
         return this.playCard(game, selectedCard, howToPay);
-      };
+    }
 
-      return new SelectHowToPayForCard(this.getPlayableCards(game), this.getMicrobesCanSpend(), this.getFloatersCanSpend(), this.canUseHeatAsMegaCredits, cb);
+    public playProjectCard(game: Game): PlayerInput {
+        return new SelectHowToPayForCard(
+            this.getPlayableCards(game),
+            this.getMicrobesCanSpend(),
+            this.getFloatersCanSpend(),
+            this.canUseHeatAsMegaCredits,
+            (selectedCard, howToPay) => this.checkHowToPayAndPlayCard(selectedCard, howToPay, game)
+        );
     }
 
     public getMicrobesCanSpend(): number {

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -7,11 +7,10 @@ import { Resources } from "../Resources";
 
 export interface IProjectCard extends ICard {
     addPlayCardDeferredAction?: (player: Player, game: Game) => void;
-    canPlay?: (player: Player, game: Game, bonusMc?: number) => boolean;
+    canPlay?: (player: Player, game: Game) => boolean;
     cardType: CardType;
     cost: number;
     resourceType?: ResourceType;
     hasRequirements?: boolean;
     bonusResource?: Resources | undefined;
-    bonusMc?: number | undefined; 
 }

--- a/src/cards/community/AerospaceMission.ts
+++ b/src/cards/community/AerospaceMission.ts
@@ -10,11 +10,8 @@ export class AerospaceMission extends PreludeCard implements IProjectCard {
     public tags = [Tags.SPACE];
     public name = CardName.AEROSPACE_MISSION;
 
-    public canPlay(player: Player, _game: Game, bonusMc?: number) {
-        const requiredPayment = 14 - (bonusMc || 0);
-      
-        if (requiredPayment <= 0) return true;
-        return player.canAfford(requiredPayment);
+    public canPlay(player: Player, _game: Game) {
+        return player.canAfford(14);
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/community/ByElection.ts
+++ b/src/cards/community/ByElection.ts
@@ -12,7 +12,7 @@ import { DeferredAction } from "../../deferredActions/DeferredAction";
 export class ByElection extends PreludeCard implements IProjectCard {
     public tags = [Tags.WILDCARD];
     public name = CardName.BY_ELECTION;
-    public canPlay(__player: Player, game: Game) {
+    public canPlay(_player: Player, game: Game) {
         return game.turmoil !== undefined;
     }
     public play(player: Player, game: Game) {
@@ -26,8 +26,8 @@ export class ByElection extends PreludeCard implements IProjectCard {
         setRulingParty.title = "Select new ruling party";
         setRulingParty.options = [...ALL_PARTIES.map((p) => new SelectOption(
             p.partyName, "Select", () => {
-            turmoil.rulingParty = turmoil.getPartyByName(p.partyName);
-            return undefined;
+                turmoil.rulingParty = turmoil.getPartyByName(p.partyName);
+                return undefined;
             })
         )];
 

--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -4,52 +4,31 @@ import { PreludeCard } from "./../prelude/PreludeCard";
 import { IProjectCard } from "../IProjectCard";
 import { CardName } from "../../CardName";
 import { Game } from "../../Game";
-import { SelectCard } from "../../inputs/SelectCard";
 import { ResourceType } from "../../ResourceType";
-import { SelectHowToPayDeferred } from "../../deferredActions/SelectHowToPayDeferred";
-import { DeferredAction } from "../../deferredActions/DeferredAction";
+import { SelectHowToPayForCard } from "../../inputs/SelectHowToPayForCard";
 
 export class ValuableGases extends PreludeCard implements IProjectCard {
     public tags = [Tags.JOVIAN, Tags.VENUS];
     public name = CardName.VALUABLE_GASES;
 
-    public play(player: Player) {     
+    public play(player: Player, game: Game) {
         player.megaCredits += 6;
-        return undefined;
-    }
 
-    public addPlayCardDeferredAction(player: Player, game: Game) {
         const playableCards = player.getPlayableCards(game).filter((card) => card.tags.indexOf(Tags.VENUS) !== -1);
-            
-        if (playableCards.length > 0) {
-            game.defer(new DeferredAction(
-                player,
-                () => new SelectCard(
-                    "Select Venus card to play and add 4 floaters",
-                    "Save",
-                    playableCards,
-                    (cards: Array<IProjectCard>) => {
-                        const canUseSteel = cards[0].tags.indexOf(Tags.STEEL) !== -1;
-                        const canUseTitanium = cards[0].tags.indexOf(Tags.SPACE) !== -1;
-                        const cardCost = player.getCardCost(game, cards[0]);
-                        game.defer(new SelectHowToPayDeferred(
-                            player,
-                            cardCost,
-                            canUseSteel,
-                            canUseTitanium,
-                            "Select how to pay for card",
-                            () => {
-                                player.playCard(game, cards[0]);
-                                if (cards[0].resourceType === ResourceType.FLOATER) {
-                                    player.addResourceTo(cards[0], 4);
-                                }
-                            }
-                        ));
-                        return undefined;
-                    }
-                )
-            ));
-        }
+
+        return new SelectHowToPayForCard(
+            playableCards,
+            player.getMicrobesCanSpend(),
+            player.getFloatersCanSpend(),
+            player.canUseHeatAsMegaCredits,
+            (selectedCard, howToPay) => {
+                const result = player.checkHowToPayAndPlayCard(selectedCard, howToPay, game);
+                if (selectedCard.resourceType === ResourceType.FLOATER) {
+                    player.addResourceTo(selectedCard, 4);
+                }
+                return result;
+            }
+        );
     }
 }
 

--- a/tests/cards/community/ValuableGases.spec.ts
+++ b/tests/cards/community/ValuableGases.spec.ts
@@ -1,18 +1,20 @@
 import { expect } from "chai";
 import { Color } from "../../../src/Color";
 import { Player } from "../../../src/Player";
+import { Game } from "../../../src/Game";
 import { ValuableGases } from "../../../src/cards/community/ValuableGases";
 
 describe("ValuableGases", function () {
-    let card : ValuableGases, player : Player;
+    let card : ValuableGases, player : Player, game: Game;
 
     beforeEach(function() {
         card = new ValuableGases();
         player = new Player("test", Color.BLUE, false);
+        game = new Game("foobar", [player, player], player);
     });
 
     it("Should play", function () {
-        card.play(player);
+        card.play(player, game);
         expect(player.megaCredits).to.eq(6);
     });
 });


### PR DESCRIPTION
Checking community preludes I ended up doing:
- Split `player.playProjectCard` in two to be able to use `SelectHowToPayForCard` outside of it (in **Valuable Gases** in this case).
- Finished removing bonusMc from cards since it's not used anymore.