### PR TITLE
Fix: Point Luna is starting with 3 MC extra

### DIFF
--- a/src/cards/prelude/PointLuna.ts
+++ b/src/cards/prelude/PointLuna.ts
@@ -10,7 +10,7 @@ import { CardType } from "../CardType"
 export class PointLuna implements CorporationCard {
     public name = CardName.POINT_LUNA;
     public tags = [Tags.SPACE, Tags.EARTH];
-    public startingMegaCredits: number = 41; //Should be 38 but the drawed card when played is payed 3 MC
+    public startingMegaCredits: number = 38;
     public cardType = CardType.CORPORATION;
     public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
         const tagCount = card.tags.filter(tag => tag === Tags.EARTH).length;


### PR DESCRIPTION
Closes https://github.com/bafolts/terraforming-mars/issues/1847 - Point Luna currently starts with 3 MC extra every game. The additional 3 MC may be due to legacy code and is no longer needed.