### PR TITLE
Fix: Cards placing colonies should check for available colony tile

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2430,5 +2430,15 @@ export class Player implements ILoadable<SerializedPlayer, Player>{
     public increaseFleetSize() {
       if (this.fleetSize < MAX_FLEET_SIZE) this.fleetSize++;
     }
+
+    public canPlayColonyPlacementCard(game: Game): boolean {
+        let colonyTilesAlreadyBuiltOn: number = 0;
+
+        game.colonies.forEach(colony => {
+            if (colony.colonies.includes(this.id)) colonyTilesAlreadyBuiltOn++;
+        });
+
+        return colonyTilesAlreadyBuiltOn < game.colonies.length;
+    }
 }
 

--- a/src/cards/colonies/IceMoonColony.ts
+++ b/src/cards/colonies/IceMoonColony.ts
@@ -6,12 +6,27 @@ import { CardName } from "../../CardName";
 import { Game } from "../../Game";
 import { BuildColony } from "../../deferredActions/BuildColony";
 import { PlaceOceanTile } from "../../deferredActions/PlaceOceanTile";
+import { MAX_OCEAN_TILES, REDS_RULING_POLICY_COST } from "../../constants";
+import { PartyHooks } from "../../turmoil/parties/PartyHooks";
+import { PartyName } from "../../turmoil/parties/PartyName";
 
 export class IceMoonColony implements IProjectCard {
     public cost = 23;
     public tags = [Tags.SPACE];
     public name = CardName.ICE_MOON_COLONY;
     public cardType = CardType.AUTOMATED;
+
+    public canPlay(player: Player, game: Game): boolean {
+        const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+        const hasAvailableColonyTile = player.canPlayColonyPlacementCard(game);
+        const canPayForReds = player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST);
+  
+        if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+            return hasAvailableColonyTile && canPayForReds;
+        }
+  
+        return hasAvailableColonyTile;
+    }
 
     public play(player: Player, game: Game) {
         game.defer(new BuildColony(player, game, false, "Select colony for Ice Moon Colony"));

--- a/src/cards/colonies/InterplanetaryColonyShip.ts
+++ b/src/cards/colonies/InterplanetaryColonyShip.ts
@@ -12,6 +12,10 @@ export class InterplanetaryColonyShip implements IProjectCard {
     public name = CardName.INTERPLANETARY_COLONY_SHIP;
     public cardType = CardType.EVENT;
 
+    public canPlay(player: Player, game: Game): boolean {
+        return player.canPlayColonyPlacementCard(game);
+    }
+
     public play(player: Player, game: Game) {
         game.defer(new BuildColony(player, game, false, "Select colony for Interplanetary Colony Ship"));
         return undefined;

--- a/src/cards/colonies/MiningColony.ts
+++ b/src/cards/colonies/MiningColony.ts
@@ -13,6 +13,10 @@ export class MiningColony implements IProjectCard {
     public name = CardName.MINING_COLONY;
     public cardType = CardType.AUTOMATED;
 
+    public canPlay(player: Player, game: Game): boolean {
+        return player.canPlayColonyPlacementCard(game);
+    }
+
     public play(player: Player, game: Game) {
         game.defer(new BuildColony(player, game, false, "Select colony for Mining Colony"));
         player.addProduction(Resources.TITANIUM); 

--- a/src/cards/colonies/MinorityRefuge.ts
+++ b/src/cards/colonies/MinorityRefuge.ts
@@ -14,8 +14,8 @@ export class MinorityRefuge implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public hasRequirements = false;
 
-    public canPlay(player: Player): boolean {
-        return player.getProduction(Resources.MEGACREDITS) >= -3;
+    public canPlay(player: Player, game: Game): boolean {
+        return player.canPlayColonyPlacementCard(game) && player.getProduction(Resources.MEGACREDITS) >= -3;
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/colonies/TradingColony.ts
+++ b/src/cards/colonies/TradingColony.ts
@@ -12,6 +12,10 @@ export class TradingColony implements IProjectCard {
     public name = CardName.TRADING_COLONY;
     public cardType = CardType.ACTIVE;
 
+    public canPlay(player: Player, game: Game): boolean {
+        return player.canPlayColonyPlacementCard(game);
+    }
+
     public play(player: Player, game: Game) {
         game.defer(new BuildColony(player, game, false, "Select colony for Trading Colony"));
         player.colonyTradeOffset++; 


### PR DESCRIPTION
Closes https://github.com/bafolts/terraforming-mars/issues/1845. Also adds missing Reds tax check for IceMoonColony which places an ocean.