### PR TITLE
Card render api improvements

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -3,19 +3,6 @@ import {CardName} from './CardName';
 /* eslint-disable no-irregular-whitespace */
 export const HTML_DATA: Map<string, string> =
   new Map([
-    [CardName.ASTEROID_MINING_CONSORTIUM, ` 
-        <div class="content ">
-            <div class="points points-big ">1</div>
-            <div class="requirements ">Titanium production</div>
-            <div class="production-box production-box-size1a ">
-                <div class="production-prefix minus"></div><div class="titanium production red-outline "></div><br>
-                <div class="production-prefix plus"></div><div class="titanium production "></div>
-            </div>
-            <div class="description " style="margin-top:0px;">
-                (Requires that you have titanium production. Decrease any titanium production 1 step and increase your own 1 step.)
-            </div>
-        </div>
-`],
     [CardName.DEEP_WELL_HEATING, ` 
         <div class="content">
             <div class="production-box ">
@@ -87,16 +74,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
         </div>
 `],
-    [CardName.ASTEROID, ` 
-        <div class="content ">
-            <div class="tile temperature-tile "></div><br>
-            <div class=" titanium resource "></div><div class=" titanium resource "></div><br>
-            - <div class="resource plant red-outline "></div><div class="plant resource red-outline "></div><div class="plant resource red-outline "></div>
-            <div class="description ">
-                (Raise temperature 1 step and gain 2 titanium. Remove up to 3 Plants from any player.)
-            </div>
-        </div>
-`],
     [CardName.COMET, ` 
         <div class="content ">
             <div class="tile temperature-tile "></div><div class="tile ocean-tile "></div>
@@ -104,17 +81,6 @@ export const HTML_DATA: Map<string, string> =
           - <div class="plant resource red-outline "></div><div class="plant resource red-outline "></div><div class="plant resource red-outline "></div>
             <div class="description ">
                 (Raise temperature 1 step and place an ocean tile. Remove up to 3 Plants from any player.)
-            </div>
-        </div>
-`],
-    [CardName.BIG_ASTEROID, ` 
-        <div class="content ">
-            <div class="tile temperature-tile "></div>
-            <div class="tile temperature-tile "></div><br>
-            <div class="titanium resource "></div><div class="titanium resource "></div><div class="titanium resource "></div><div class="titanium resource "></div> <br>
-          - <div class="plant resource red-outline "></div><div class="plant resource red-outline "></div><div class="plant resource red-outline "></div><div class="plant resource red-outline "></div>
-            <div class="description ">
-                (Raise temperature 2 steps and gain 4 titanium. Remove up to 4 Plants from any player.)
             </div>
         </div>
 `],
@@ -443,17 +409,6 @@ export const HTML_DATA: Map<string, string> =
       </div>
     </div>
 `],
-    [CardName.ARCHAEBACTERIA, ` 
-    <div class="content">
-      <div class="requirements requirements-max">max -18 C</div>
-      <div class="production-box">
-        <div class="plant production"></div>
-      </div>
-      <div class="description">
-        (It must be -18 C or colder. Increase your Plant production 1 step.)
-      </div>
-    </div>
-`],
     [CardName.CARBONATE_PROCESSING, ` 
     <div class="content">
       <div class="production-box production-box-size3a">
@@ -498,16 +453,6 @@ export const HTML_DATA: Map<string, string> =
       </div>
       <div class="description">
         (Requires 3 Science tags. Increase your Energy production and your MC production up one step each.)
-      </div>
-    </div>
-`],
-    [CardName.ADAPTED_LICHEN, ` 
-    <div class="content">
-      <div class="production-box">
-        <div class="plant production"></div>
-      </div>
-      <div class="description">
-        (Increase your Plant production 1 step.)
       </div>
     </div>
 `],
@@ -1120,16 +1065,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
         </div>
 `],
-    [CardName.ACQUIRED_COMPANY, ` 
-      <div class="content">
-        <div class="production-box">
-          <div class="money production">3</div>
-        </div>
-        <div class="description">
-          (Increase your MC production 3 steps.)
-        </div>
-      </div>
-`],
     [CardName.MEDIA_ARCHIVES, ` 
       <div class="content">
           <div class="money resource">1</div> / &nbsp;<div class="resource-tag tag-event red-outline"></div>
@@ -1195,26 +1130,6 @@ export const HTML_DATA: Map<string, string> =
                 (Increase your energy production 1 step.)
             </div>
         </div>
-`],
-    [CardName.ARTIFICIAL_PHOTOSYNTHESIS, ` 
-        <div class="content ">
-          <div class="production-box production-box-size4">
-            <div class="production plant"></div> OR <div class="production energy"></div><div class="production energy"></div>
-          </div>
-            <div class="description ">
-                (Increase your plant production 1 step or your energy production 2 steps.)
-            </div>
-        </div>
-`],
-    [CardName.ARTIFICIAL_LAKE, ` 
-      <div class="content">
-        <div class="points points-big">1</div>
-        <div class="requirements">-6 C</div>
-        <div class="tile ocean-tile"></div>*
-        <div class="description">
-          (Requires -6 C or warmer. Place 1 ocean tile ON AN AREA NOT RESERVED FOR OCEAN.)
-        </div>
-      </div>
 `],
     [CardName.GEOTHERMAL_POWER, ` 
         <div class="content ">
@@ -1785,18 +1700,6 @@ export const HTML_DATA: Map<string, string> =
             (Requires -6 C or warmer. Increase your Plant production 1 step and your MC production 2 steps. Gain 1 Plant.)
           </div>
         </div>
-`],
-    [CardName.AEROBRAKED_AMMONIA_ASTEROID, ` 
-          <div class="content ">
-            <div class="production-box production-box-size3">
-                <div class="heat production"></div><div class="heat production"></div><div class="heat production"></div>
-                <div class="plant production"></div>
-            </div><br>
-             <div class="microbe resource"></div><div class="microbe resource"></div>*
-              <div class="description ">
-                (Add 2 Microbes to ANOTHER card. Increase your heat production 3 steps and your Plant productions 1 step.)
-              </div>
-          </div>
 `],
     [CardName.MAGNETIC_FIELD_DOME, ` 
         <div class="content">

--- a/src/cards/AcquiredCompany.ts
+++ b/src/cards/AcquiredCompany.ts
@@ -4,6 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AcquiredCompany implements IProjectCard {
   public cost = 10;
@@ -15,4 +17,10 @@ export class AcquiredCompany implements IProjectCard {
     player.addProduction(Resources.MEGACREDITS, 3);
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Increase your MC production 3 steps.',
+    cardNumber: '106',
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.megacredits(3))),
+  };
 }

--- a/src/cards/AcquiredCompany.ts
+++ b/src/cards/AcquiredCompany.ts
@@ -6,13 +6,13 @@ import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 
 export class AcquiredCompany implements IProjectCard {
-    public cost = 10;
-    public tags = [Tags.EARTH];
-    public name = CardName.ACQUIRED_COMPANY;
-    public cardType = CardType.AUTOMATED;
+  public cost = 10;
+  public tags = [Tags.EARTH];
+  public name = CardName.ACQUIRED_COMPANY;
+  public cardType = CardType.AUTOMATED;
 
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, 3);
-      return undefined;
-    }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, 3);
+    return undefined;
+  }
 }

--- a/src/cards/AdaptedLichen.ts
+++ b/src/cards/AdaptedLichen.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -7,12 +6,12 @@ import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 
 export class AdaptedLichen implements IProjectCard {
-    public cost = 9;
-    public tags = [Tags.PLANT];
-    public cardType = CardType.AUTOMATED;
-    public name = CardName.ADAPTED_LICHEN;
-    public play(player: Player) {
-      player.addProduction(Resources.PLANTS);
-      return undefined;
-    }
+  public cost = 9;
+  public tags = [Tags.PLANT];
+  public cardType = CardType.AUTOMATED;
+  public name = CardName.ADAPTED_LICHEN;
+  public play(player: Player) {
+    player.addProduction(Resources.PLANTS);
+    return undefined;
+  }
 }

--- a/src/cards/AdaptedLichen.ts
+++ b/src/cards/AdaptedLichen.ts
@@ -4,6 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AdaptedLichen implements IProjectCard {
   public cost = 9;
@@ -14,4 +16,10 @@ export class AdaptedLichen implements IProjectCard {
     player.addProduction(Resources.PLANTS);
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Increase your Plant production 1 step.',
+    cardNumber: '048',
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(1))),
+  };
 }

--- a/src/cards/AdvancedEcosystems.ts
+++ b/src/cards/AdvancedEcosystems.ts
@@ -7,26 +7,24 @@ import {CardMetadata} from '../cards/CardMetadata';
 import {CardRequirements} from '../cards/CardRequirements';
 
 export class AdvancedEcosystems implements IProjectCard {
-    public cost = 11;
-    public tags = [Tags.PLANT, Tags.MICROBES, Tags.ANIMAL];
-    public cardType = CardType.AUTOMATED;
-    public name = CardName.ADVANCED_ECOSYSTEMS;
-    public canPlay(player: Player): boolean {
-      return player.checkMultipleTagPresence([Tags.PLANT, Tags.ANIMAL, Tags.MICROBES]);
-    }
-    public play() {
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 3;
-    }
+  public cost = 11;
+  public tags = [Tags.PLANT, Tags.MICROBES, Tags.ANIMAL];
+  public cardType = CardType.AUTOMATED;
+  public name = CardName.ADVANCED_ECOSYSTEMS;
+  public canPlay(player: Player): boolean {
+    return player.checkMultipleTagPresence([Tags.PLANT, Tags.ANIMAL, Tags.MICROBES]);
+  }
+  public play() {
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 3;
+  }
 
-    public metadata: CardMetadata = {
-      description: 'Requires a Plant tag, a Microbe tag, and an Animal tag.',
-      cardNumber: '135',
-      requirements: CardRequirements.builder((b) =>
-        b.tag(Tags.PLANT).tag(Tags.ANIMAL).tag(Tags.MICROBES),
-      ),
-      victoryPoints: 3,
-    };
+  public metadata: CardMetadata = {
+    description: 'Requires a Plant tag, a Microbe tag, and an Animal tag.',
+    cardNumber: '135',
+    requirements: CardRequirements.builder((b) => b.tag(Tags.PLANT).tag(Tags.ANIMAL).tag(Tags.MICROBES)),
+    victoryPoints: 3,
+  };
 }

--- a/src/cards/AerobrakedAmmoniaAsteroid.ts
+++ b/src/cards/AerobrakedAmmoniaAsteroid.ts
@@ -9,6 +9,8 @@ import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
 import {Game} from '../Game';
 import {LogHelper} from '../components/LogHelper';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AerobrakedAmmoniaAsteroid implements IProjectCard {
   public cost = 26;
@@ -35,4 +37,9 @@ export class AerobrakedAmmoniaAsteroid implements IProjectCard {
       return undefined;
     });
   }
+  public metadata: CardMetadata = {
+    description: 'Increase your heat production 3 steps and your Plant productions 1 step. Add 2 Microbes to ANOTHER card.',
+    cardNumber: '170',
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.heat(3).br.plants(1)).br.microbes(2).asterix()),
+  };
 }

--- a/src/cards/AerobrakedAmmoniaAsteroid.ts
+++ b/src/cards/AerobrakedAmmoniaAsteroid.ts
@@ -11,31 +11,28 @@ import {Game} from '../Game';
 import {LogHelper} from '../components/LogHelper';
 
 export class AerobrakedAmmoniaAsteroid implements IProjectCard {
-    public cost = 26;
-    public tags = [Tags.SPACE];
-    public name = CardName.AEROBRAKED_AMMONIA_ASTEROID;
-    public cardType = CardType.EVENT;
+  public cost = 26;
+  public tags = [Tags.SPACE];
+  public name = CardName.AEROBRAKED_AMMONIA_ASTEROID;
+  public cardType = CardType.EVENT;
 
-    public play(player: Player, game: Game) {
-      const cardsToPick = player.getResourceCards(ResourceType.MICROBE);
-      player.addProduction(Resources.HEAT, 3);
-      player.addProduction(Resources.PLANTS);
+  public play(player: Player, game: Game) {
+    const cardsToPick = player.getResourceCards(ResourceType.MICROBE);
+    player.addProduction(Resources.HEAT, 3);
+    player.addProduction(Resources.PLANTS);
 
-      if (cardsToPick.length < 1) return undefined;
+    if (cardsToPick.length < 1) return undefined;
 
-      if (cardsToPick.length === 1) {
-        player.addResourceTo(cardsToPick[0], 2);
-        LogHelper.logAddResource(game, player, cardsToPick[0], 2);
-        return undefined;
-      }
-
-      return new SelectCard(
-          'Select card to add 2 microbes', 'Add microbes', cardsToPick,
-          (foundCards: Array<ICard>) => {
-            player.addResourceTo(foundCards[0], 2);
-            LogHelper.logAddResource(game, player, foundCards[0], 2);
-            return undefined;
-          },
-      );
+    if (cardsToPick.length === 1) {
+      player.addResourceTo(cardsToPick[0], 2);
+      LogHelper.logAddResource(game, player, cardsToPick[0], 2);
+      return undefined;
     }
+
+    return new SelectCard('Select card to add 2 microbes', 'Add microbes', cardsToPick, (foundCards: Array<ICard>) => {
+      player.addResourceTo(foundCards[0], 2);
+      LogHelper.logAddResource(game, player, foundCards[0], 2);
+      return undefined;
+    });
+  }
 }

--- a/src/cards/ArchaeBacteria.ts
+++ b/src/cards/ArchaeBacteria.ts
@@ -7,17 +7,15 @@ import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 
 export class ArchaeBacteria implements IProjectCard {
-    public cost = 6;
-    public tags = [Tags.MICROBES];
-    public name = CardName.ARCHAEBACTERIA;
-    public cardType = CardType.AUTOMATED;
-    public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() <= -18 + (
-        player.getRequirementsBonus(game) * 2
-      );
-    }
-    public play(player: Player) {
-      player.addProduction(Resources.PLANTS);
-      return undefined;
-    }
+  public cost = 6;
+  public tags = [Tags.MICROBES];
+  public name = CardName.ARCHAEBACTERIA;
+  public cardType = CardType.AUTOMATED;
+  public canPlay(player: Player, game: Game): boolean {
+    return game.getTemperature() <= -18 + player.getRequirementsBonus(game) * 2;
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.PLANTS);
+    return undefined;
+  }
 }

--- a/src/cards/ArchaeBacteria.ts
+++ b/src/cards/ArchaeBacteria.ts
@@ -5,6 +5,9 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRequirements} from '../cards/CardRequirements';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class ArchaeBacteria implements IProjectCard {
   public cost = 6;
@@ -18,4 +21,11 @@ export class ArchaeBacteria implements IProjectCard {
     player.addProduction(Resources.PLANTS);
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'It must be -18 C or colder. Increase your Plant production 1 step.',
+    cardNumber: '042',
+    requirements: CardRequirements.builder((b) => b.temperature(-18).max()),
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(1))),
+  };
 }

--- a/src/cards/ArtificialLake.ts
+++ b/src/cards/ArtificialLake.ts
@@ -12,33 +12,29 @@ import {PartyName} from '../turmoil/parties/PartyName';
 import {MAX_OCEAN_TILES, REDS_RULING_POLICY_COST} from '../constants';
 
 export class ArtificialLake implements IProjectCard {
-    public cost = 15;
-    public tags = [Tags.STEEL];
-    public name = CardName.ARTIFICIAL_LAKE;
-    public cardType = CardType.AUTOMATED;
-    public canPlay(player: Player, game: Game): boolean {
-      const meetsTemperatureRequirements = game.getTemperature() >= -6 - (player.getRequirementsBonus(game) * 2);
-      const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
+  public cost = 15;
+  public tags = [Tags.STEEL];
+  public name = CardName.ARTIFICIAL_LAKE;
+  public cardType = CardType.AUTOMATED;
+  public canPlay(player: Player, game: Game): boolean {
+    const meetsTemperatureRequirements = game.getTemperature() >= -6 - player.getRequirementsBonus(game) * 2;
+    const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
-        return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true) && meetsTemperatureRequirements;
-      }
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {
+      return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, true) && meetsTemperatureRequirements;
+    }
 
-      return meetsTemperatureRequirements;
-    }
-    public play(player: Player, game: Game) {
-      if (game.board.getOceansOnBoard() >= MAX_OCEAN_TILES) return undefined;
+    return meetsTemperatureRequirements;
+  }
+  public play(player: Player, game: Game) {
+    if (game.board.getOceansOnBoard() >= MAX_OCEAN_TILES) return undefined;
 
-      return new SelectSpace(
-          'Select a land space to place an ocean',
-          game.board.getAvailableSpacesOnLand(player),
-          (foundSpace: ISpace) => {
-            game.addOceanTile(player, foundSpace.id, SpaceType.LAND);
-            return undefined;
-          },
-      );
-    }
-    public getVictoryPoints() {
-      return 1;
-    }
+    return new SelectSpace('Select a land space to place an ocean', game.board.getAvailableSpacesOnLand(player), (foundSpace: ISpace) => {
+      game.addOceanTile(player, foundSpace.id, SpaceType.LAND);
+      return undefined;
+    });
+  }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/ArtificialLake.ts
+++ b/src/cards/ArtificialLake.ts
@@ -10,6 +10,9 @@ import {CardName} from '../CardName';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {MAX_OCEAN_TILES, REDS_RULING_POLICY_COST} from '../constants';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRequirements} from '../cards/CardRequirements';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class ArtificialLake implements IProjectCard {
   public cost = 15;
@@ -37,4 +40,12 @@ export class ArtificialLake implements IProjectCard {
   public getVictoryPoints() {
     return 1;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Requires -6 C or warmer. Place 1 ocean tile ON AN AREA NOT RESERVED FOR OCEAN',
+    cardNumber: '116',
+    requirements: CardRequirements.builder((b) => b.temperature(-6)),
+    renderData: CardRenderer.builder((b) => b.oceans(1).asterix()),
+    victoryPoints: 1,
+  };
 }

--- a/src/cards/ArtificialPhotosynthesis.ts
+++ b/src/cards/ArtificialPhotosynthesis.ts
@@ -6,6 +6,9 @@ import {OrOptions} from '../inputs/OrOptions';
 import {SelectOption} from '../inputs/SelectOption';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRenderItemSize} from '../cards/render/CardRenderItemSize';
 
 export class ArtificialPhotosynthesis implements IProjectCard {
   public cost = 12;
@@ -25,4 +28,10 @@ export class ArtificialPhotosynthesis implements IProjectCard {
         }),
     );
   }
+
+  public metadata: CardMetadata = {
+    description: 'Increase your plant production 1 step or your energy production 2 steps.',
+    cardNumber: '115',
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(1).or(CardRenderItemSize.SMALL).energy(2))),
+  };
 }

--- a/src/cards/ArtificialPhotosynthesis.ts
+++ b/src/cards/ArtificialPhotosynthesis.ts
@@ -8,21 +8,21 @@ import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 
 export class ArtificialPhotosynthesis implements IProjectCard {
-    public cost = 12;
-    public tags = [Tags.SCIENCE];
-    public cardType = CardType.AUTOMATED;
-    public name = CardName.ARTIFICIAL_PHOTOSYNTHESIS;
+  public cost = 12;
+  public tags = [Tags.SCIENCE];
+  public cardType = CardType.AUTOMATED;
+  public name = CardName.ARTIFICIAL_PHOTOSYNTHESIS;
 
-    public play(player: Player) {
-      return new OrOptions(
-          new SelectOption('Increase your energy production 2 steps', 'Increase', () => {
-            player.addProduction(Resources.ENERGY, 2);
-            return undefined;
-          }),
-          new SelectOption('Increase your plant production 1 step', 'Increase', () => {
-            player.addProduction(Resources.PLANTS);
-            return undefined;
-          }),
-      );
-    }
+  public play(player: Player) {
+    return new OrOptions(
+        new SelectOption('Increase your energy production 2 steps', 'Increase', () => {
+          player.addProduction(Resources.ENERGY, 2);
+          return undefined;
+        }),
+        new SelectOption('Increase your plant production 1 step', 'Increase', () => {
+          player.addProduction(Resources.PLANTS);
+          return undefined;
+        }),
+    );
+  }
 }

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -8,6 +8,8 @@ import {MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../constants';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class Asteroid implements IProjectCard {
   public cost = 14;
@@ -31,4 +33,10 @@ export class Asteroid implements IProjectCard {
     player.titanium += 2;
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Raise temperature 1 step and gain 2 titanium. Remove up to 3 Plants from any player.',
+    cardNumber: '009',
+    renderData: CardRenderer.builder((b) => b.temperature(1).br.titanium(2).br.plants(-3).any),
+  };
 }

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -10,25 +10,25 @@ import {PartyName} from '../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
 
 export class Asteroid implements IProjectCard {
-    public cost = 14;
-    public tags = [Tags.SPACE];
-    public name = CardName.ASTEROID;
-    public cardType = CardType.EVENT;
-    public hasRequirements = false;
+  public cost = 14;
+  public tags = [Tags.SPACE];
+  public name = CardName.ASTEROID;
+  public cardType = CardType.EVENT;
+  public hasRequirements = false;
 
-    public canPlay(player: Player, game: Game): boolean {
-      const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
-        return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true);
-      }
-
-      return true;
+  public canPlay(player: Player, game: Game): boolean {
+    const temperatureMaxed = game.getVenusScaleLevel() === MAX_TEMPERATURE;
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !temperatureMaxed) {
+      return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, true);
     }
 
-    public play(player: Player, game: Game) {
-      game.increaseTemperature(player, 1);
-      game.defer(new RemoveAnyPlants(player, game, 3));
-      player.titanium += 2;
-      return undefined;
-    }
+    return true;
+  }
+
+  public play(player: Player, game: Game) {
+    game.increaseTemperature(player, 1);
+    game.defer(new RemoveAnyPlants(player, game, 3));
+    player.titanium += 2;
+    return undefined;
+  }
 }

--- a/src/cards/AsteroidMiningConsortium.ts
+++ b/src/cards/AsteroidMiningConsortium.ts
@@ -8,20 +8,20 @@ import {CardName} from '../CardName';
 import {DecreaseAnyProduction} from '../deferredActions/DecreaseAnyProduction';
 
 export class AsteroidMiningConsortium implements IProjectCard {
-    public cost = 13;
-    public tags = [Tags.JOVIAN];
-    public cardType = CardType.AUTOMATED;
-    public name = CardName.ASTEROID_MINING_CONSORTIUM;
+  public cost = 13;
+  public tags = [Tags.JOVIAN];
+  public cardType = CardType.AUTOMATED;
+  public name = CardName.ASTEROID_MINING_CONSORTIUM;
 
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.TITANIUM) >= 1;
-    }
-    public play(player: Player, game: Game) {
-      game.defer(new DecreaseAnyProduction(player, game, Resources.TITANIUM, 1));
-      player.addProduction(Resources.TITANIUM);
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 1;
-    }
+  public canPlay(player: Player): boolean {
+    return player.getProduction(Resources.TITANIUM) >= 1;
+  }
+  public play(player: Player, game: Game) {
+    game.defer(new DecreaseAnyProduction(player, game, Resources.TITANIUM, 1));
+    player.addProduction(Resources.TITANIUM);
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/AsteroidMiningConsortium.ts
+++ b/src/cards/AsteroidMiningConsortium.ts
@@ -6,6 +6,9 @@ import {Game} from '../Game';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 import {DecreaseAnyProduction} from '../deferredActions/DecreaseAnyProduction';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRequirements} from '../cards/CardRequirements';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class AsteroidMiningConsortium implements IProjectCard {
   public cost = 13;
@@ -24,4 +27,11 @@ export class AsteroidMiningConsortium implements IProjectCard {
   public getVictoryPoints() {
     return 1;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Requires that you have titanium production. Decrease any titanium production 1 step and increase your own 1 step.',
+    cardNumber: '002',
+    requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM)),
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.titanium(-1).any.br.plus().titanium(1))),
+  };
 }

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -8,6 +8,8 @@ import {MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../constants';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class BigAsteroid implements IProjectCard {
   public cost = 27;
@@ -33,4 +35,10 @@ export class BigAsteroid implements IProjectCard {
     player.titanium += 4;
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Raise temperature 2 steps and gain 4 titanium. Remove up to 4 Plants from any player.',
+    cardNumber: '011',
+    renderData: CardRenderer.builder((b) => b.temperature(2).br.titanium(2).br.plants(-4).any),
+  };
 }

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -10,27 +10,27 @@ import {PartyName} from '../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
 
 export class BigAsteroid implements IProjectCard {
-    public cost = 27;
-    public tags = [Tags.SPACE];
-    public cardType = CardType.EVENT;
-    public name = CardName.BIG_ASTEROID;
-    public hasRequirements = false;
+  public cost = 27;
+  public tags = [Tags.SPACE];
+  public cardType = CardType.EVENT;
+  public name = CardName.BIG_ASTEROID;
+  public hasRequirements = false;
 
-    public canPlay(player: Player, game: Game): boolean {
-      const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
-      const stepsRaised = Math.min(remainingTemperatureSteps, 2);
+  public canPlay(player: Player, game: Game): boolean {
+    const remainingTemperatureSteps = (MAX_TEMPERATURE - game.getTemperature()) / 2;
+    const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
-      }
-
-      return true;
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+      return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, false, true);
     }
 
-    public play(player: Player, game: Game) {
-      game.increaseTemperature(player, 2);
-      game.defer(new RemoveAnyPlants(player, game, 4));
-      player.titanium += 4;
-      return undefined;
-    }
+    return true;
+  }
+
+  public play(player: Player, game: Game) {
+    game.increaseTemperature(player, 2);
+    game.defer(new RemoveAnyPlants(player, game, 4));
+    player.titanium += 4;
+    return undefined;
+  }
 }

--- a/src/cards/BiomassCombustors.ts
+++ b/src/cards/BiomassCombustors.ts
@@ -31,7 +31,7 @@ export class BiomassCombustors implements IProjectCard {
     description: 'Requires 6% oxygen. Decrease any Plant production 1 step and increase your Energy production 2 steps.',
     cardNumber: '183',
     requirements: CardRequirements.builder((b) => b.oxygen(6)),
-    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(-1).any().br().energy(2))),
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(-1).any.br.energy(2))),
     victoryPoints: -1,
   };
 }

--- a/src/cards/BreathingFilters.ts
+++ b/src/cards/BreathingFilters.ts
@@ -8,23 +8,23 @@ import {CardMetadata} from '../cards/CardMetadata';
 import {CardRequirements} from '../cards/CardRequirements';
 
 export class BreathingFilters implements IProjectCard {
-    public cost = 11;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.BREATHING_FILTERS;
-    public cardType = CardType.AUTOMATED;
-    public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 7 - player.getRequirementsBonus(game);
-    }
-    public play() {
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 2;
-    }
-    public metadata: CardMetadata = {
-      description: 'Requires 7% oxygen.',
-      cardNumber: '114',
-      requirements: CardRequirements.builder((b) => b.oxygen(7)),
-      victoryPoints: 2,
-    };
+  public cost = 11;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.BREATHING_FILTERS;
+  public cardType = CardType.AUTOMATED;
+  public canPlay(player: Player, game: Game): boolean {
+    return game.getOxygenLevel() >= 7 - player.getRequirementsBonus(game);
+  }
+  public play() {
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 2;
+  }
+  public metadata: CardMetadata = {
+    description: 'Requires 7% oxygen.',
+    cardNumber: '114',
+    requirements: CardRequirements.builder((b) => b.oxygen(7)),
+    victoryPoints: 2,
+  };
 }

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -42,6 +42,6 @@ export class GiantIceAsteroid implements IProjectCard {
   public metadata: CardMetadata = {
     description: 'Raise temperature 2 steps and place 2 ocean tiles. Remove up to 6 plants from any player.',
     cardNumber: '080',
-    renderData: CardRenderer.builder((b) => b.temperature(2).br().oceans(2).br().plants(-6).any()),
+    renderData: CardRenderer.builder((b) => b.temperature(2).br.oceans(2).br.plants(-6).any),
   };
 }

--- a/src/cards/render/CardRenderItem.ts
+++ b/src/cards/render/CardRenderItem.ts
@@ -1,42 +1,16 @@
+/*
+  Used to describe any distinct item on a card and prepare it for rendering in Vue
+  e.g. Any tag, tile, production cube, ocean, temperature, etc.
+ */
 import {CardRenderItemType} from './CardRenderItemType';
 
 export class CardRenderItem {
-  private _anyPlayer: boolean = false;
-  private _showDigit: boolean = false;
-  private _amountInside: boolean = false;
-  constructor(protected _cardRenderItemType: CardRenderItemType, protected _amount: number = -1) {
-    if (Math.abs(this._amount) > 5) {
-      this._showDigit = true;
+  public anyPlayer: boolean = false; // activated for any player
+  public showDigit: boolean = false; // rendering a digit instead of chain of items
+  public amountInside: boolean = false; // showing the amount for the item in its
+  constructor(public type: CardRenderItemType, public amount: number = -1) {
+    if (Math.abs(this.amount) > 5) {
+      this.showDigit = true;
     }
-  }
-
-  public get anyPlayer() {
-    return this._anyPlayer;
-  }
-
-  public get type() {
-    return this._cardRenderItemType;
-  }
-
-  public get amount() {
-    return this._amount;
-  }
-
-  public get showDigit() {
-    return this._showDigit;
-  }
-
-  public get amountInside() {
-    return this._amountInside;
-  }
-
-  public any(): CardRenderItem {
-    this._anyPlayer = true;
-    return this;
-  }
-
-  public digit(): CardRenderItem {
-    this._showDigit = true;
-    return this;
   }
 }

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -7,5 +7,7 @@ export enum CardRenderItemType {
   HEAT = 'heat',
   ENERGY = 'energy',
   TITANIUM = 'titanium',
+  MEGACREDITS = 'megacredits',
+  MICROBES = 'microbes',
   // more to come...
 }

--- a/src/cards/render/CardRenderSymbol.ts
+++ b/src/cards/render/CardRenderSymbol.ts
@@ -6,30 +6,30 @@ import {CardRenderSymbolType} from './CardRenderSymbolType';
 import {CardRenderItemSize} from './CardRenderItemSize';
 
 export class CardRenderSymbol {
-  private constructor(public type: CardRenderSymbolType, public isIcon: boolean = false, public size: CardRenderItemSize = CardRenderItemSize.MEDIUM) {}
+  private constructor(public type: CardRenderSymbolType, public size: CardRenderItemSize, public isIcon: boolean = false) {}
 
-  public static asterix(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.ASTERIX);
+  public static asterix(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.ASTERIX, size);
   }
-  public static or(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.OR);
+  public static or(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.OR, size);
   }
-  public static plus(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.PLUS, true);
+  public static plus(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.PLUS, size, true);
   }
-  public static minus(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.MINUS, true);
+  public static minus(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.MINUS, size, true);
   }
-  public static empty(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.EMPTY);
+  public static empty(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.EMPTY, size);
   }
-  public static slash(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.SLASH);
+  public static slash(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.SLASH, size);
   }
-  public static colon(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.COLON);
+  public static colon(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.COLON, size);
   }
-  public static arrow(): CardRenderSymbol {
-    return new CardRenderSymbol(CardRenderSymbolType.ARROW, true);
+  public static arrow(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.ARROW, size, true);
   }
 }

--- a/src/cards/render/CardRenderSymbol.ts
+++ b/src/cards/render/CardRenderSymbol.ts
@@ -1,17 +1,13 @@
+/*
+  Used to describe any distinct symbol on a card and prepare it for rendering in Vue
+  e.g. plus and minus sign, asterix, arrow, dash, slash, etc.
+ */
 import {CardRenderSymbolType} from './CardRenderSymbolType';
 import {CardRenderItemSize} from './CardRenderItemSize';
 
 export class CardRenderSymbol {
-  private constructor(private type: CardRenderSymbolType, private isIcon: boolean = false, private size: CardRenderItemSize = CardRenderItemSize.MEDIUM) {}
-  public getType(): CardRenderSymbolType {
-    return this.type;
-  }
-  public getIsIcon(): boolean {
-    return this.isIcon;
-  }
-  public getSize(): CardRenderItemSize {
-    return this.size;
-  }
+  private constructor(public type: CardRenderSymbolType, public isIcon: boolean = false, public size: CardRenderItemSize = CardRenderItemSize.MEDIUM) {}
+
   public static asterix(): CardRenderSymbol {
     return new CardRenderSymbol(CardRenderSymbolType.ASTERIX);
   }
@@ -35,17 +31,5 @@ export class CardRenderSymbol {
   }
   public static arrow(): CardRenderSymbol {
     return new CardRenderSymbol(CardRenderSymbolType.ARROW, true);
-  }
-  public small(): CardRenderSymbol {
-    this.size = CardRenderItemSize.SMALL;
-    return this;
-  }
-  public medium(): CardRenderSymbol {
-    this.size = CardRenderItemSize.MEDIUM;
-    return this;
-  }
-  public large(): CardRenderSymbol {
-    this.size = CardRenderItemSize.LARGE;
-    return this;
   }
 }

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -92,13 +92,13 @@ class Builder {
     return this;
   }
 
-  public br(): Builder {
+  public get br(): Builder {
     const newRow: Array<ItemType> = [];
     this._data.push(newRow);
     return this;
   }
 
-  public any(): Builder {
+  public get any(): Builder {
     // #TODO (chosta): functions to validate data
     if (this._data.length === 0) {
       throw new Error('No items in builder data to call any()');
@@ -115,8 +115,8 @@ class Builder {
       if (item === undefined) {
         throw new Error('Called any() without a CardRenderItem.');
       }
-
-      row?.push(item.any());
+      item.anyPlayer = true;
+      row?.push(item);
       this._data.push(row);
     }
 

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -1,7 +1,9 @@
 import {CardRenderItem} from './CardRenderItem';
+import {CardRenderSymbol} from './CardRenderSymbol';
+import {CardRenderItemSize} from './CardRenderItemSize';
 import {CardRenderItemType} from './CardRenderItemType';
 
-type ItemType = CardRenderItem | CardRenderProductionBox | undefined;
+type ItemType = CardRenderItem | CardRenderProductionBox | CardRenderSymbol | undefined;
 
 export class CardRenderer {
   constructor(protected _rows: Array<Array<ItemType>> = [[]]) {}
@@ -18,7 +20,7 @@ export class CardRenderer {
 }
 
 export class CardRenderProductionBox extends CardRenderer {
-  constructor(rows: Array<Array<CardRenderItem>>) {
+  constructor(rows: Array<Array<CardRenderItem | CardRenderSymbol>>) {
     super(rows);
   }
   public static builder(f: (builder: ProductionBoxBuilder) => void): CardRenderProductionBox {
@@ -72,6 +74,11 @@ class Builder {
     return this;
   }
 
+  public microbes(amount: number): Builder {
+    this.addRowItem(new CardRenderItem(CardRenderItemType.MICROBES, amount));
+    return this;
+  }
+
   public productionBox(pb: (builder: ProductionBoxBuilder) => void): Builder {
     this.addRowItem(CardRenderProductionBox.builder(pb));
     return this;
@@ -92,19 +99,57 @@ class Builder {
     return this;
   }
 
+  public megacredits(amount: number): Builder {
+    const item = new CardRenderItem(CardRenderItemType.MEGACREDITS, amount);
+    item.amountInside = true;
+    this.addRowItem(item);
+    return this;
+  }
+
   public get br(): Builder {
     const newRow: Array<ItemType> = [];
     this._data.push(newRow);
     return this;
   }
 
-  public get any(): Builder {
-    // #TODO (chosta): functions to validate data
+  protected _checkExistingItem(): void {
     if (this._data.length === 0) {
-      throw new Error('No items in builder data to call any()');
+      throw new Error('No items in builder data!');
     }
+  }
 
-    // #TODO (chosta): this could be possibly improved
+  protected _addSymbol(Symbol: CardRenderSymbol): void {
+    const row = this.getCurrentRow();
+    if (row !== undefined) {
+      row.push(Symbol);
+      this._data.push(row);
+    }
+  }
+
+  public or(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.asterix(size));
+
+    return this;
+  }
+
+  public asterix(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.asterix(size));
+
+    return this;
+  }
+
+  public plus(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.plus(size));
+
+    return this;
+  }
+
+  public get any(): Builder {
+    this._checkExistingItem();
+
     const row = this.getCurrentRow();
     if (row !== undefined) {
       const item = row?.pop();
@@ -125,7 +170,7 @@ class Builder {
 }
 
 class ProductionBoxBuilder extends Builder {
-  protected _data: Array<Array<CardRenderItem>> = [[]];
+  protected _data: Array<Array<CardRenderItem | CardRenderSymbol>> = [[]];
 
   public build(): CardRenderProductionBox {
     return new CardRenderProductionBox(this._data);

--- a/src/cards/turmoil/AerialLenses.ts
+++ b/src/cards/turmoil/AerialLenses.ts
@@ -37,7 +37,7 @@ export class AerialLenses implements IProjectCard {
     description: 'Requires that Kelvinists are ruling or that you have 2 delegates there. Remove up to 2 plants from any player. Increase your heat production 2 steps.',
     cardNumber: 'T01',
     requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
-    renderData: CardRenderer.builder((b) => b.plants(-2).any().productionBox((pb) => pb.heat(2))),
+    renderData: CardRenderer.builder((b) => b.plants(-2).any.productionBox((pb) => pb.heat(2))),
     victoryPoints: -1,
   };
 }

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -42,6 +42,12 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
       } else if (this.item.type === CardRenderItemType.PLANTS) {
         classes.push('card-resource');
         classes.push('card-resource-plant');
+      } else if (this.item.type === CardRenderItemType.MEGACREDITS) {
+        classes.push('card-resource');
+        classes.push('card-resource-money');
+      } else if (this.item.type === CardRenderItemType.MICROBES) {
+        classes.push('card-resource');
+        classes.push('card-resource-microbe');
       }
 
       // act upon any player
@@ -52,6 +58,7 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
       return classes.join(' ');
     },
     getAmountAbs: function(): number {
+      if (this.item.amountInside) return 1;
       return Math.abs(this.item.amount);
     },
     getMinus: function(): CardRenderSymbol {

--- a/src/components/card/CardRenderSymbolComponent.ts
+++ b/src/components/card/CardRenderSymbolComponent.ts
@@ -12,8 +12,8 @@ export const CardRenderSymbolComponent = Vue.component('CardRenderSymbolComponen
   },
   methods: {
     getClasses: function(): string {
-      const type: CardRenderSymbolType = this.item.getType();
-      const size: CardRenderItemSize = this.item.getSize();
+      const type: CardRenderSymbolType = this.item.type;
+      const size: CardRenderItemSize = this.item.size;
       const classes: Array<string> = ['card-special'];
       if (type === CardRenderSymbolType.ASTERIX) {
         classes.push('card-asterix');
@@ -38,10 +38,10 @@ export const CardRenderSymbolComponent = Vue.component('CardRenderSymbolComponen
       return classes.join(' ');
     },
     getContent: function(): string {
-      if (this.item.getIsIcon()) {
+      if (this.item.isIcon) {
         return '';
       } else {
-        return this.item.getType();
+        return this.item.type;
       }
     },
   },

--- a/src/components/card/CardRowComponent.ts
+++ b/src/components/card/CardRowComponent.ts
@@ -1,17 +1,20 @@
 import Vue from 'vue';
 import {CardRenderItem} from '../../cards/render/CardRenderItem';
+import {CardRenderSymbol} from '../../cards/render/CardRenderSymbol';
 import {CardRenderProductionBox} from '../../cards/render/CardRenderer';
 import {CardRenderItemComponent} from './CardRenderItemComponent';
 import {CardProductionBoxComponent} from './CardProductionBoxComponent';
+import {CardRenderSymbolComponent} from './CardRenderSymbolComponent';
 
 export const CardRowComponent = Vue.component('CardRowComponent', {
   props: {
     data: {
-      type: Object as () => CardRenderItem,
+      type: Object as () => CardRenderItem | CardRenderProductionBox | CardRenderSymbol,
       required: true,
     },
   },
   components: {
+    CardRenderSymbolComponent,
     CardRenderItemComponent,
     CardProductionBoxComponent,
   },
@@ -19,13 +22,16 @@ export const CardRowComponent = Vue.component('CardRowComponent', {
     isItem: function(): boolean {
       return this.data instanceof CardRenderItem;
     },
-
+    isSymbol: function(): boolean {
+      return this.data instanceof CardRenderSymbol;
+    },
     isProduction: function(): boolean {
       return this.data instanceof CardRenderProductionBox;
     },
   },
   template: ` 
         <CardRenderItemComponent v-if="isItem()" :item="data"/>
+        <CardRenderSymbolComponent v-else-if="isSymbol()" :item="data" />
         <CardProductionBoxComponent v-else-if="isProduction()" :data="data.rows" />
         <div v-else>n/a</div>
     `,


### PR DESCRIPTION
Some improvements on the card rendering following the advice from @kberg and @Lynesth 
+ Simplified getter / setter methods for CardRenderItem
+ Simplified API builder functions that don't require parameters to not use `()`
+ Added `asterix`, `plus` and `or` to builder functions
+ Added microbes and megacredits
+ Megacredits should have a digit inside by default
+ Refactored some repeating code and improved CardRenderSymbol static builders
+ Added microbes and symbols to vue rendering components
+ Added 10 more cards that use metadata (+ formatting to 2 spaces)