### PR TITLE
separate webpack command and faster builds for local

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,16 @@
     "clean": "rm -r ./build/ ./styles.css || true",
     "compile": "tsc",
     "prep": "node make_static_json.js && lessc src/styles/common.less styles.css",
-    "build": "npm run prep && npm run compile && npm run lint && npm run templates && webpack --config webpack.config.js",
+    "build": "npm run prep && npm run compile && npm run lint && npm run templates && npm run webpack",
     "start": "node build/server.js",
     "lint": "eslint src server.ts script.ts tests --ext ts",
     "pretest": "tsc --build tsconfig-test.json",
     "templates": "node compile-vue-templates.js && tsc --build tsconfig-vue.json",
     "test": "mocha --file build/tests/utils/Vue.js --recursive build/tests",
-    "testgiven": "tsc --build tsconfig.json && webpack --config webpack.config.js && tsc --build tsconfig-test.json && mocha",
+    "testgiven": "tsc --build tsconfig.json && npm run webpack && tsc --build tsconfig-test.json && mocha",
     "precover": "tsc --build tsconfig-test.json",
-    "cover": "nyc mocha --file build/tests/utils/Vue.js --recursive build/tests"
+    "cover": "nyc mocha --file build/tests/utils/Vue.js --recursive build/tests",
+    "webpack": "webpack --config webpack.config.js"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const CompressionPlugin = require("compression-webpack-plugin");
 
 module.exports = {
   devtool: "source-map",
-  mode: process.env.NODE_ENV === "production" ? "production" : "none",
+  mode: process.env.NODE_ENV === "production" ? "production" : "development",
   entry: [
     './build/script.js'
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,11 @@
 'use strict'
 
+const process = require("process");
 const CompressionPlugin = require("compression-webpack-plugin");
 
 module.exports = {
   devtool: "source-map",
-  mode: 'production',
+  mode: process.env.NODE_ENV === "production" ? "production" : "none",
   entry: [
     './build/script.js'
   ],


### PR DESCRIPTION
In a quest to speed up the local build process. This will cut down the time webpack takes for local builds.

Before: 

```
Hash: c773998b9e687a6242f8
Version: webpack 4.44.2
Time: 7700ms
```

After:

```
Hash: a4c68bf5f2073b038919
Version: webpack 4.44.2
Time: 1874ms
```

This also enables the vue warnings in console. Seems I have the typing information wrong on `props`. Will address in subsequent PR. Those are littering vue debug logs.