### PR TITLE
show log-player provided color

### DIFF
--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -34,7 +34,6 @@
     padding: 1px 5px;
     border-radius: 4px;
     font-weight: bold;
-    background-color: #333; 
 }
 
 .log-card {


### PR DESCRIPTION
A `log-player` element was being used that was never registered. I changed this to `span` yesterday. The CSS styling receives two `background-color` both through class name before. Previously I believe the class name was taking priority over the element name based selector. After my change they were conflicting. As far as I can tell we always provide the background color so we shouldn't need it on the span element.