### PR TITLE
use card order for SelectCard component

### DIFF
--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -1,6 +1,8 @@
 
 import Vue from 'vue';
 import {Button} from '../components/common/Button';
+import {CardOrderStorage} from './CardOrderStorage';
+import {PlayerModel} from '../models/PlayerModel';
 import {VueModelCheckbox, VueModelRadio} from './VueTypes';
 
 interface SelectCardModel {
@@ -13,6 +15,9 @@ import {PlayerInputModel} from '../models/PlayerInputModel';
 
 export const SelectCard = Vue.component('select-card', {
   props: {
+    player: {
+      type: Object as () => PlayerModel,
+    },
     playerinput: {
       type: Object as () => PlayerInputModel,
     },
@@ -36,13 +41,22 @@ export const SelectCard = Vue.component('select-card', {
     Button,
   },
   methods: {
+    getOrderedCards: function() {
+      if (this.playerinput.cards === undefined) {
+        return [];
+      }
+      return CardOrderStorage.getOrdered(
+          CardOrderStorage.getCardOrder(this.player.id),
+          this.playerinput.cards,
+      );
+    },
     saveData: function() {
       this.onsave([Array.isArray(this.$data.cards) ? this.$data.cards.map((card) => card.name) : [this.$data.cards.name]]);
     },
   },
   template: `<div class="wf-component wf-component--select-card">
         <div v-if="showtitle === true" class="nofloat wf-component-title" v-i18n>{{playerinput.title}}</div>
-        <label v-for="card in (playerinput.cards || [])" class="cardbox">
+        <label v-for="card in getOrderedCards()" class="cardbox">
             <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" type="radio" v-model="cards" :value="card" />
             <input v-else type="checkbox" v-model="cards" :value="card" :disabled="playerinput.maxCardsToSelect !== undefined && Array.isArray(cards) && cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
             <Card :card="card" />


### PR DESCRIPTION
Orders the cards displayed on `SelectCard` using any pre-defined user order first. This should not impact situations where a player is selecting an opponents card. Those will be displayed in default order.