### PR TITLE
fix: use 2 player game to avoid random tile placements

### DIFF
--- a/tests/cards/LandClaim.spec.ts
+++ b/tests/cards/LandClaim.spec.ts
@@ -24,7 +24,8 @@ describe('LandClaim', function() {
   it('can claim south pole on hellas board', function() {
     const card = new LandClaim();
     const player = new Player('test', Color.BLUE, false);
-    const game = new Game('foobar', [player], player, setCustomGameOptions({
+    const player2= new Player('text2', Color.RED, false);
+    const game = new Game('foobar', [player, player2], player, setCustomGameOptions({
       boardName: BoardName.HELLAS,
     }));
     const action = card.play(player, game) as SelectSpace;


### PR DESCRIPTION
The recently added `LandClaim` change failed once merged and not while I was developing. The solo mode tile placement was placing a tile on the space used in assertion. Using two player game to avoid random tile placement.