### PR TITLE
Fix typo closing tag

### DIFF
--- a/src/components/card/CardRequirementsComponent.ts
+++ b/src/components/card/CardRequirementsComponent.ts
@@ -19,7 +19,7 @@ export const CardRequirementsComponent = Vue.component('CardRequirements', {
   },
   template: `
         <div v-if="requirements.hasParty()" :class="getClasses()">
-            <span class="party">{{ requirements.getRequirementsText() }}<span/>
+            <span class="party">{{ requirements.getRequirementsText() }}</span>
         </div>
         <div v-else :class="getClasses()">{{ requirements.getRequirementsText() }}</div>
     `,


### PR DESCRIPTION
It actually gives a warning when running the tests but doesn't show up in the recap. Could we get those summarized at the bottom as well somehow @bafolts ?
![mintty_2020-11-16_11-38-30](https://user-images.githubusercontent.com/5318258/99201667-4785e380-2800-11eb-9e72-d730e9f5e482.png)
