### PR TITLE
Card effect to Vue

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -215,19 +215,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
         </div>
 `],
-    [CardName.ARCTIC_ALGAE, ` 
-        <div class="content ">
-            <div class="requirements requirements-max ">max -12 C </div>
-            <div class="tile ocean-tile red-outline "></div> : <div class="resource plant "></div><div class="resource plant "></div><br>
-            <div class="description ">
-                (Effect: When anyone places an ocean tile, gain 2 Plants.)
-            </div>
-            <div class="resource plant "></div>
-            <div class="description ">
-                (It must be -12 C or colder to play. Gain 1 Plant.)
-            </div>
-        </div>
-`],
     [CardName.PREDATORS, ` 
         <div class="content ">
             <div class="points ">1/<div class="animal resource "></div></div>
@@ -297,16 +284,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
             <div class="description ">
                 (Decrease your MC production 2 steps and increase your heat production and Energy production 2 steps each.)
-            </div>
-        </div>
-`],
-    [CardName.OPTIMAL_AEROBRAKING, ` 
-        <div class="content ">
-            <div class="nowrap">
-              <div class="resource-tag tag-space "></div> <div class="resource-tag tag-event "></div> : <div class="resource money ">3</div><div class="resource heat "></div><div class="resource heat "></div><div class="resource heat "></div>
-            </div>
-            <div class="description ">
-                (Effect: When you play a Space Event, you gain 3 MC and 3 heat.)
             </div>
         </div>
 `],
@@ -709,15 +686,6 @@ export const HTML_DATA: Map<string, string> =
             <div class="description ">
                 (Effect: When you play a card, you pay 2 MC less for it.)
             </div>
-        </div>
-`],
-    [CardName.ADVANCED_ALLOYS, ` 
-        <div class="content ">
-          <div class="resource titanium"></div> : +<div class="resource money">1</div><br>
-          <div class="resource steel"></div> : +<div class="resource money">1</div>
-          <div class="description">
-            (Effect: Each titanium you have is worth 1 MC extra. Each steel you have is worth 1 MC extra. )
-          </div>
         </div>
 `],
     [CardName.BIRDS, ` 
@@ -1474,19 +1442,6 @@ export const HTML_DATA: Map<string, string> =
     [CardName.CEOS_FAVORITE_PROJECT, ` 
         <div class="content " style="font-size:14px;">
           ADD 1 RESOURCE TO A CARD WITH AT LEAST 1 RESOURCE ON IT
-        </div>
-`],
-    [CardName.ANTI_GRAVITY_TECHNOLOGY, ` 
-        <div class="content ">
-          <div class="points points-big">3</div>
-          <div class="requirements">7 Science</div>
-            : <span class="money resource ">-2</span>
-            <div class="description ">
-                (Effect: When you play a card, you pay 2 MC less for it.)
-            </div><br><br>
-            <div class="description ">
-                (Requires 7 science tags.)
-            </div>
         </div>
 `],
     [CardName.INVESTMENT_LOAN, ` 
@@ -2817,15 +2772,6 @@ export const HTML_DATA: Map<string, string> =
                   </div>
                   <div class="description ">
                       (Requires 4 science tags. Increase your energy production 4 steps.)
-                  </div>
-              </div>
-`],
-    [CardName.CRYO_SLEEP, ` 
-              <div class="content ">
-                <div class="points points-big ">1</div>
-                  <div class="tile trade"></div> : <div class="resource resource--white">-1</div>
-                  <div class="description ">
-                      (Effect: When you trade, you pay 1 less resource for it.)
                   </div>
               </div>
 `],
@@ -4752,14 +4698,6 @@ export const HTML_DATA: Map<string, string> =
       </div>
     </div>
 `],
-    [CardName.ADVERTISING, ` 
-      <div class="content ">
-        <div class="resource money">20</div>* : <div class="production-box"><div class="production money">1</div></div></div>
-        <div class="description" style="text-align:center;margin:0px 10px;">
-          (Effect: When you play a card with a basic cost of 20 MC or more, increase your MC production 1 step.)
-        </div>
-      </div>
-`],
     [CardName.PHARMACY_UNION, `
     <div class="promo-icon corporation-icon"></div>
     <div class="contentCorporation">
@@ -5118,31 +5056,6 @@ export const HTML_DATA: Map<string, string> =
       <div class="description" style="margin-top:5px;">
         (Requires that Reds are ruling or that you have 2 delegates there. Gain 1MC for each Jovian tag in play.)
       </div>
-  </div>
-`],
-    [CardName.EVENT_ANALYSTS, ` 
-  <div class="content ">
-    <div class="requirements"><span class="party">Scientists</span></div>
-    <div class="plus"></div> <div class="influence"></div><br>
-    <div class="description" style="margin-top:5px;">
-      (Effect: You have influence +1.)
-    </div>
-    <br>
-    <div class="description">
-      (Requires that Scientists are ruling or that you have 2 delegates there.)
-    </div>
-  </div>
-`],
-    [CardName.GMO_CONTRACT, ` 
-  <div class="content">
-    <div class="requirements"><span class="party">Greens</span></div>
-    <div class="tag-animal resource-tag"></div> / <div class="tag-plant resource-tag"></div> / <div class="tag-microbe resource-tag"></div> : <div class="money resource">2</div>
-    <div class="description">
-      (Effect: Each time you play a plant, animal, or microbe tag, including this, gain 2MC.)
-    </div>
-    <div class="description" style="margin-top:10px;">
-      (Requires that Greens are ruling or that you have 2 delegates there.)
-    </div>
   </div>
 `],
     [CardName.MARTIAN_MEDIA_CENTER, ` 

--- a/src/cards/AdvancedAlloys.ts
+++ b/src/cards/AdvancedAlloys.ts
@@ -3,6 +3,9 @@ import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {CardName} from '../CardName';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
+import {CardRenderItemSize} from './render/CardRenderItemSize';
 
 export class AdvancedAlloys implements IProjectCard {
   public cost = 9;
@@ -20,4 +23,9 @@ export class AdvancedAlloys implements IProjectCard {
     player.decreaseTitaniumValue();
     player.decreaseSteelValue();
   }
+
+  public metadata: CardMetadata = {
+    cardNumber: '071',
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.titanium(1).startEffect.plus(CardRenderItemSize.SMALL).megacredits(1).description('Each titanium you have is worth 1 MC extra')).br.effectBox((be) => be.steel(1).startEffect.plus(CardRenderItemSize.SMALL).megacredits(1).description('Each steel you have is worth 1 MC extra'))),
+  };
 }

--- a/src/cards/AdvancedAlloys.ts
+++ b/src/cards/AdvancedAlloys.ts
@@ -5,19 +5,19 @@ import {Player} from '../Player';
 import {CardName} from '../CardName';
 
 export class AdvancedAlloys implements IProjectCard {
-    public cost = 9;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.ADVANCED_ALLOYS;
-    public cardType = CardType.ACTIVE;
+  public cost = 9;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.ADVANCED_ALLOYS;
+  public cardType = CardType.ACTIVE;
 
-    public play(player: Player) {
-      player.increaseTitaniumValue();
-      player.increaseSteelValue();
-      return undefined;
-    }
+  public play(player: Player) {
+    player.increaseTitaniumValue();
+    player.increaseSteelValue();
+    return undefined;
+  }
 
-    public onDiscard(player: Player): void {
-      player.decreaseTitaniumValue();
-      player.decreaseSteelValue();
-    }
+  public onDiscard(player: Player): void {
+    player.decreaseTitaniumValue();
+    player.decreaseSteelValue();
+  }
 }

--- a/src/cards/AntiGravityTechnology.ts
+++ b/src/cards/AntiGravityTechnology.ts
@@ -5,20 +5,20 @@ import {Player} from '../Player';
 import {CardName} from '../CardName';
 
 export class AntiGravityTechnology implements IProjectCard {
-    public cost = 14;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.ANTI_GRAVITY_TECHNOLOGY;
-    public cardType = CardType.ACTIVE;
-    public canPlay(player: Player): boolean {
-      return player.getTagCount(Tags.SCIENCE) >= 7;
-    }
-    public getCardDiscount() {
-      return 2;
-    }
-    public play() {
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 3;
-    }
+  public cost = 14;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.ANTI_GRAVITY_TECHNOLOGY;
+  public cardType = CardType.ACTIVE;
+  public canPlay(player: Player): boolean {
+    return player.getTagCount(Tags.SCIENCE) >= 7;
+  }
+  public getCardDiscount() {
+    return 2;
+  }
+  public play() {
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 3;
+  }
 }

--- a/src/cards/AntiGravityTechnology.ts
+++ b/src/cards/AntiGravityTechnology.ts
@@ -3,6 +3,9 @@ import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {CardName} from '../CardName';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRequirements} from '../cards/CardRequirements';
 
 export class AntiGravityTechnology implements IProjectCard {
   public cost = 14;
@@ -21,4 +24,12 @@ export class AntiGravityTechnology implements IProjectCard {
   public getVictoryPoints() {
     return 3;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Requires 7 science tags',
+    cardNumber: '150',
+    requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 7)),
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.empty().startEffect.megacredits(-2).description('When you play a card, you pay 2 MC less for it'))),
+    victoryPoints: 3,
+  };
 }

--- a/src/cards/ArcticAlgae.ts
+++ b/src/cards/ArcticAlgae.ts
@@ -8,22 +8,20 @@ import {TileType} from '../TileType';
 import {CardName} from '../CardName';
 
 export class ArcticAlgae implements IProjectCard {
-    public cost = 12;
-    public tags = [Tags.PLANT];
-    public name = CardName.ARCTIC_ALGAE;
-    public cardType = CardType.ACTIVE;
-    public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() <= -12 + (
-        player.getRequirementsBonus(game) * 2
-      );
+  public cost = 12;
+  public tags = [Tags.PLANT];
+  public name = CardName.ARCTIC_ALGAE;
+  public cardType = CardType.ACTIVE;
+  public canPlay(player: Player, game: Game): boolean {
+    return game.getTemperature() <= -12 + player.getRequirementsBonus(game) * 2;
+  }
+  public onTilePlaced(player: Player, space: ISpace) {
+    if (space.tile !== undefined && space.tile.tileType === TileType.OCEAN) {
+      player.plants += 2;
     }
-    public onTilePlaced(player: Player, space: ISpace) {
-      if (space.tile !== undefined && space.tile.tileType === TileType.OCEAN) {
-        player.plants += 2;
-      }
-    }
-    public play(player: Player) {
-      player.plants++;
-      return undefined;
-    }
+  }
+  public play(player: Player) {
+    player.plants++;
+    return undefined;
+  }
 }

--- a/src/cards/ArcticAlgae.ts
+++ b/src/cards/ArcticAlgae.ts
@@ -6,6 +6,9 @@ import {Game} from '../Game';
 import {ISpace} from '../ISpace';
 import {TileType} from '../TileType';
 import {CardName} from '../CardName';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRequirements} from '../cards/CardRequirements';
+import {CardRenderer} from '../cards/render/CardRenderer';
 
 export class ArcticAlgae implements IProjectCard {
   public cost = 12;
@@ -24,4 +27,11 @@ export class ArcticAlgae implements IProjectCard {
     player.plants++;
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'It must be -12 C or colder to play. Gain 1 plant',
+    cardNumber: '023',
+    requirements: CardRequirements.builder((b) => b.temperature(-12).max()),
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.oceans(1).any.startEffect.plants(2).description('When anyone places an ocean tile, gain 2 plants')).br.plants(1)),
+  };
 }

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -37,6 +37,6 @@ export class Asteroid implements IProjectCard {
   public metadata: CardMetadata = {
     description: 'Raise temperature 1 step and gain 2 titanium. Remove up to 3 Plants from any player.',
     cardNumber: '009',
-    renderData: CardRenderer.builder((b) => b.temperature(1).br.titanium(2).br.plants(-3).any),
+    renderData: CardRenderer.builder((b) => b.temperature(1).br.titanium(2).br.minus().plants(-3).any),
   };
 }

--- a/src/cards/AsteroidMiningConsortium.ts
+++ b/src/cards/AsteroidMiningConsortium.ts
@@ -32,7 +32,7 @@ export class AsteroidMiningConsortium implements IProjectCard {
     description: 'Requires that you have titanium production. Decrease any titanium production 1 step and increase your own 1 step.',
     cardNumber: '002',
     requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM)),
-    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.titanium(-1).any.br.plus().titanium(1))),
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.minus().titanium(-1).any.br.plus().titanium(1))),
     victoryPoints: 1,
   };
 }

--- a/src/cards/BigAsteroid.ts
+++ b/src/cards/BigAsteroid.ts
@@ -39,6 +39,6 @@ export class BigAsteroid implements IProjectCard {
   public metadata: CardMetadata = {
     description: 'Raise temperature 2 steps and gain 4 titanium. Remove up to 4 Plants from any player.',
     cardNumber: '011',
-    renderData: CardRenderer.builder((b) => b.temperature(2).br.titanium(4).br.plants(-4).any),
+    renderData: CardRenderer.builder((b) => b.temperature(2).br.titanium(4).br.minus().plants(-4).any),
   };
 }

--- a/src/cards/BiomassCombustors.ts
+++ b/src/cards/BiomassCombustors.ts
@@ -31,7 +31,7 @@ export class BiomassCombustors implements IProjectCard {
     description: 'Requires 6% oxygen. Decrease any Plant production 1 step and increase your Energy production 2 steps.',
     cardNumber: '183',
     requirements: CardRequirements.builder((b) => b.oxygen(6)),
-    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.plants(-1).any.br.energy(2))),
+    renderData: CardRenderer.builder((b) => b.productionBox((pb) => pb.minus().plants(-1).any.br.energy(2))),
     victoryPoints: -1,
   };
 }

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -42,6 +42,6 @@ export class GiantIceAsteroid implements IProjectCard {
   public metadata: CardMetadata = {
     description: 'Raise temperature 2 steps and place 2 ocean tiles. Remove up to 6 plants from any player.',
     cardNumber: '080',
-    renderData: CardRenderer.builder((b) => b.temperature(2).br.oceans(2).br.plants(-6).any),
+    renderData: CardRenderer.builder((b) => b.temperature(2).br.oceans(2).br.minus().plants(-6).any),
   };
 }

--- a/src/cards/OptimalAerobraking.ts
+++ b/src/cards/OptimalAerobraking.ts
@@ -4,6 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {CardName} from '../CardName';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class OptimalAerobraking implements IProjectCard {
   public cost = 7;
@@ -20,4 +22,9 @@ export class OptimalAerobraking implements IProjectCard {
   public play() {
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    cardNumber: '031',
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.space().played.event().played.startEffect.megacredits(3).heat(3).description('When you play a Space Event, you gain 3 MC and 3 heat'))),
+  };
 }

--- a/src/cards/OptimalAerobraking.ts
+++ b/src/cards/OptimalAerobraking.ts
@@ -1,4 +1,3 @@
-
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
@@ -7,18 +6,18 @@ import {Game} from '../Game';
 import {CardName} from '../CardName';
 
 export class OptimalAerobraking implements IProjectCard {
-    public cost = 7;
-    public tags = [Tags.SPACE];
-    public cardType = CardType.ACTIVE;
-    public name = CardName.OPTIMAL_AEROBRAKING;
+  public cost = 7;
+  public tags = [Tags.SPACE];
+  public cardType = CardType.ACTIVE;
+  public name = CardName.OPTIMAL_AEROBRAKING;
 
-    public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
-      if (card.cardType === CardType.EVENT && card.tags.indexOf(Tags.SPACE) !== -1) {
-        player.megaCredits += 3;
-        player.heat += 3;
-      }
+  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+    if (card.cardType === CardType.EVENT && card.tags.indexOf(Tags.SPACE) !== -1) {
+      player.megaCredits += 3;
+      player.heat += 3;
     }
-    public play() {
-      return undefined;
-    }
+  }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/colonies/CryoSleep.ts
+++ b/src/cards/colonies/CryoSleep.ts
@@ -5,21 +5,21 @@ import {Player} from '../../Player';
 import {CardName} from '../../CardName';
 
 export class CryoSleep implements IProjectCard {
-    public cost = 10;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.CRYO_SLEEP;
-    public cardType = CardType.ACTIVE;
+  public cost = 10;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.CRYO_SLEEP;
+  public cardType = CardType.ACTIVE;
 
-    public play(player: Player) {
-      player.colonyTradeDiscount++;
-      return undefined;
-    }
+  public play(player: Player) {
+    player.colonyTradeDiscount++;
+    return undefined;
+  }
 
-    public getVictoryPoints() {
-      return 1;
-    }
+  public getVictoryPoints() {
+    return 1;
+  }
 
-    public onDiscard(player: Player): void {
-      player.colonyTradeDiscount--;
-    }
+  public onDiscard(player: Player): void {
+    player.colonyTradeDiscount--;
+  }
 }

--- a/src/cards/colonies/CryoSleep.ts
+++ b/src/cards/colonies/CryoSleep.ts
@@ -3,6 +3,8 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../CardName';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class CryoSleep implements IProjectCard {
   public cost = 10;
@@ -22,4 +24,10 @@ export class CryoSleep implements IProjectCard {
   public onDiscard(player: Player): void {
     player.colonyTradeDiscount--;
   }
+
+  public metadata: CardMetadata = {
+    cardNumber: 'C07',
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.trade().startEffect.tradeDiscount(1).description('When you trade, you pay 1 less resource for it'))),
+    victoryPoints: 1,
+  };
 }

--- a/src/cards/promo/Advertising.ts
+++ b/src/cards/promo/Advertising.ts
@@ -5,6 +5,8 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class Advertising implements IProjectCard {
   public name = CardName.ADVERTISING;
@@ -21,4 +23,8 @@ export class Advertising implements IProjectCard {
   public play() {
     return undefined;
   }
+  public metadata: CardMetadata = {
+    cardNumber: 'X14',
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.megacredits(20).asterix().startEffect.productionBox((pb) => pb.megacredits(1)).description('When you play a card with a basic cost of 20 MC or more, increase your MC production 1 step'))),
+  };
 }

--- a/src/cards/promo/Advertising.ts
+++ b/src/cards/promo/Advertising.ts
@@ -7,18 +7,18 @@ import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 
 export class Advertising implements IProjectCard {
-    public name = CardName.ADVERTISING;
-    public cost = 4;
-    public tags = [Tags.EARTH];
-    public cardType = CardType.ACTIVE;
+  public name = CardName.ADVERTISING;
+  public cost = 4;
+  public tags = [Tags.EARTH];
+  public cardType = CardType.ACTIVE;
 
-    public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
-      if (card.cost >= 20) {
-        player.addProduction(Resources.MEGACREDITS);
-      }
+  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+    if (card.cost >= 20) {
+      player.addProduction(Resources.MEGACREDITS);
     }
+  }
 
-    public play() {
-      return undefined;
-    }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/render/CardRenderItem.ts
+++ b/src/cards/render/CardRenderItem.ts
@@ -7,7 +7,8 @@ import {CardRenderItemType} from './CardRenderItemType';
 export class CardRenderItem {
   public anyPlayer: boolean = false; // activated for any player
   public showDigit: boolean = false; // rendering a digit instead of chain of items
-  public amountInside: boolean = false; // showing the amount for the item in its
+  public amountInside: boolean = false; // showing the amount for the item in its container
+  public isPlayed: boolean = false; // used to mark an item as 'played' e.g. event tags
   constructor(public type: CardRenderItemType, public amount: number = -1) {
     if (Math.abs(this.amount) > 5) {
       this.showDigit = true;

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -7,7 +7,18 @@ export enum CardRenderItemType {
   HEAT = 'heat',
   ENERGY = 'energy',
   TITANIUM = 'titanium',
+  STEEL = 'steel',
   MEGACREDITS = 'megacredits',
   MICROBES = 'microbes',
+  ANIMALS = 'animals',
+  EVENT = 'event',
+  SPACE = 'space',
+  TRADE = 'trade',
+  TRADE_DISCOUNT = 'trade_discount',
+  TRADE_FLEET = 'trade_fleet',
+  CHAIRMAN = 'chairman',
+  PARTY_LEADERS = 'party_leaders',
+  DELEGATES = 'delegates',
+  INFLUENCE = 'influence',
   // more to come...
 }

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -78,7 +78,7 @@ export class CardRenderEffect extends CardRenderer {
   public get description(): ItemType {
     this._validate();
     // TODO (chosta): validate builder method to make sure it's the last element
-    return `Effect: ${this.rows[2].pop()}`;
+    return `Effect: ${this.rows[2].slice(-1)[0]}`;
   }
 }
 
@@ -268,16 +268,16 @@ class Builder {
 
     const row = this._getCurrentRow();
     if (row !== undefined) {
-      const item = row?.pop();
+      const item = row.pop();
+      if (item === undefined) {
+        throw new Error('Called "any" without a CardRenderItem.');
+      }
       if (!(item instanceof CardRenderItem)) {
         throw new Error('"any" could be called on CardRenderItem only');
       }
 
-      if (item === undefined) {
-        throw new Error('Called "any" without a CardRenderItem.');
-      }
       item.anyPlayer = true;
-      row?.push(item);
+      row.push(item);
       this._data.push(row);
     }
 
@@ -293,7 +293,7 @@ class Builder {
 
     const row = this._getCurrentRow();
     if (row !== undefined) {
-      const item = row?.pop();
+      const item = row.pop();
       if (!(item instanceof CardRenderItem)) {
         throw new Error('"played" could be called on CardRenderItem only');
       }
@@ -302,7 +302,7 @@ class Builder {
         throw new Error('Called "played" without a CardRenderItem.');
       }
       item.isPlayed = true;
-      row?.push(item);
+      row.push(item);
       this._data.push(row);
     }
 

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -3,7 +3,7 @@ import {CardRenderSymbol} from './CardRenderSymbol';
 import {CardRenderItemSize} from './CardRenderItemSize';
 import {CardRenderItemType} from './CardRenderItemType';
 
-type ItemType = CardRenderItem | CardRenderProductionBox | CardRenderSymbol | undefined;
+type ItemType = CardRenderItem | CardRenderProductionBox | CardRenderSymbol | CardRenderEffect | string | undefined;
 
 export class CardRenderer {
   constructor(protected _rows: Array<Array<ItemType>> = [[]]) {}
@@ -23,10 +23,62 @@ export class CardRenderProductionBox extends CardRenderer {
   constructor(rows: Array<Array<CardRenderItem | CardRenderSymbol>>) {
     super(rows);
   }
+
   public static builder(f: (builder: ProductionBoxBuilder) => void): CardRenderProductionBox {
     const builder = new ProductionBoxBuilder();
     f(builder);
     return builder.build();
+  }
+}
+
+export class CardRenderEffect extends CardRenderer {
+  constructor(rows: Array<Array<CardRenderItem | CardRenderSymbol | CardRenderProductionBox | string>>) {
+    super(rows);
+  }
+
+  public static builder(f: (builder: EffectBuilder) => void): CardRenderEffect {
+    const builder = new EffectBuilder();
+    f(builder);
+    return builder.build();
+  }
+
+  /**
+   * Check if the card effect structure is valid
+   */
+  protected _validate(): void {
+    if (this.rows.length !== 3) {
+      throw new Error('Card effect must have 3 arrays representing cause, delimiter and effect');
+    }
+    if (this.rows[1].length !== 1) {
+      throw new Error('Card effect delimiter array must contain exactly 1 item');
+    }
+    if (!(this.rows[1][0] instanceof CardRenderSymbol)) {
+      throw new Error('Effect delimiter must be a symbol');
+    }
+  }
+
+  public get cause(): Array<ItemType> | undefined {
+    this._validate();
+    return this.rows[0];
+  }
+
+  public get delimiter(): ItemType {
+    this._validate();
+    if (this.cause?.length === 0) {
+      return undefined;
+    }
+    return this.rows[1][0];
+  }
+
+  public get effect(): Array<ItemType> {
+    this._validate();
+    return this.rows[2];
+  }
+
+  public get description(): ItemType {
+    this._validate();
+    // TODO (chosta): validate builder method to make sure it's the last element
+    return `Effect: ${this.rows[2].slice(-1)[0]}`;
   }
 }
 
@@ -37,79 +89,16 @@ class Builder {
     return new CardRenderer(this._data);
   }
 
-  public getCurrentRow(): Array<ItemType> | undefined {
+  protected _getCurrentRow(): Array<ItemType> | undefined {
     return this._data.pop();
   }
 
-  public addRowItem(item: ItemType): void {
-    const currentRow = this.getCurrentRow();
+  protected _addRowItem(item: ItemType): void {
+    const currentRow = this._getCurrentRow();
     if (currentRow !== undefined) {
       currentRow.push(item);
       this._data.push(currentRow);
     }
-  }
-
-  public temperature(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.TEMPERATURE, amount));
-    return this;
-  }
-
-  public oceans(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.OCEANS, amount));
-    return this;
-  }
-
-  public oxygen(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.OXYGEN, amount));
-    return this;
-  }
-
-  public venus(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.VENUS, amount));
-    return this;
-  }
-
-  public plants(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.PLANTS, amount));
-    return this;
-  }
-
-  public microbes(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.MICROBES, amount));
-    return this;
-  }
-
-  public productionBox(pb: (builder: ProductionBoxBuilder) => void): Builder {
-    this.addRowItem(CardRenderProductionBox.builder(pb));
-    return this;
-  }
-
-  public heat(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.HEAT, amount));
-    return this;
-  }
-
-  public energy(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.ENERGY, amount));
-    return this;
-  }
-
-  public titanium(amount: number): Builder {
-    this.addRowItem(new CardRenderItem(CardRenderItemType.TITANIUM, amount));
-    return this;
-  }
-
-  public megacredits(amount: number): Builder {
-    const item = new CardRenderItem(CardRenderItemType.MEGACREDITS, amount);
-    item.amountInside = true;
-    this.addRowItem(item);
-    return this;
-  }
-
-  public get br(): Builder {
-    const newRow: Array<ItemType> = [];
-    this._data.push(newRow);
-    return this;
   }
 
   protected _checkExistingItem(): void {
@@ -119,52 +108,214 @@ class Builder {
   }
 
   protected _addSymbol(Symbol: CardRenderSymbol): void {
-    const row = this.getCurrentRow();
+    const row = this._getCurrentRow();
     if (row !== undefined) {
       row.push(Symbol);
       this._data.push(row);
     }
   }
 
+  public temperature(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.TEMPERATURE, amount));
+    return this;
+  }
+
+  public oceans(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.OCEANS, amount));
+    return this;
+  }
+
+  public oxygen(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.OXYGEN, amount));
+    return this;
+  }
+
+  public venus(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.VENUS, amount));
+    return this;
+  }
+
+  public plants(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.PLANTS, amount));
+    return this;
+  }
+
+  public microbes(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.MICROBES, amount));
+    return this;
+  }
+
+  public animals(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.ANIMALS, amount));
+    return this;
+  }
+
+  public heat(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.HEAT, amount));
+    return this;
+  }
+
+  public energy(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.ENERGY, amount));
+    return this;
+  }
+
+  public titanium(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.TITANIUM, amount));
+    return this;
+  }
+
+  public steel(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.STEEL, amount));
+    return this;
+  }
+
+  public megacredits(amount: number): Builder {
+    const item = new CardRenderItem(CardRenderItemType.MEGACREDITS, amount);
+    item.amountInside = true;
+    item.showDigit = false;
+    this._addRowItem(item);
+    return this;
+  }
+
+  public event(): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.EVENT));
+    return this;
+  }
+
+  public space(): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.SPACE));
+    return this;
+  }
+
+  public trade(): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.TRADE));
+    return this;
+  }
+
+  public tradeDiscount(amount: number): Builder {
+    const item = new CardRenderItem(CardRenderItemType.TRADE_DISCOUNT, amount * (-1));
+    item.amountInside = true;
+    this._addRowItem(item);
+    return this;
+  }
+
+  public influence(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.INFLUENCE, amount));
+    return this;
+  }
+
+  public description(description: string): Builder {
+    this._checkExistingItem();
+    this._addRowItem(description);
+    return this;
+  }
+
+  public productionBox(pb: (builder: ProductionBoxBuilder) => void): Builder {
+    this._addRowItem(CardRenderProductionBox.builder(pb));
+    return this;
+  }
+
+  public effectBox(eb: (builder: EffectBuilder) => void): Builder {
+    this._addRowItem(CardRenderEffect.builder(eb));
+    return this;
+  }
+
   public or(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
     this._checkExistingItem();
-    this._addSymbol(CardRenderSymbol.asterix(size));
-
+    this._addSymbol(CardRenderSymbol.or(size));
     return this;
   }
 
   public asterix(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
     this._checkExistingItem();
     this._addSymbol(CardRenderSymbol.asterix(size));
-
     return this;
   }
 
   public plus(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
     this._checkExistingItem();
     this._addSymbol(CardRenderSymbol.plus(size));
+    return this;
+  }
 
+  public minus(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.minus(size));
+    return this;
+  }
+
+  public slash(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.slash(size));
+    return this;
+  }
+
+  public empty(): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.empty());
+    return this;
+  }
+
+  public get br(): Builder {
+    const newRow: Array<ItemType> = [];
+    this._data.push(newRow);
     return this;
   }
 
   public get any(): Builder {
     this._checkExistingItem();
 
-    const row = this.getCurrentRow();
+    const row = this._getCurrentRow();
     if (row !== undefined) {
       const item = row?.pop();
       if (!(item instanceof CardRenderItem)) {
-        throw new Error('Any() could be called on CardRenderItem only');
+        throw new Error('"any" could be called on CardRenderItem only');
       }
 
       if (item === undefined) {
-        throw new Error('Called any() without a CardRenderItem.');
+        throw new Error('Called "any" without a CardRenderItem.');
       }
       item.anyPlayer = true;
       row?.push(item);
       this._data.push(row);
     }
 
+    return this;
+  }
+
+  /**
+   * Mark the last item in the queue as 'isPlayed'
+   * e.g. titanium().played will result in a resource circle instead of square
+   */
+  public get played(): Builder {
+    this._checkExistingItem();
+
+    const row = this._getCurrentRow();
+    if (row !== undefined) {
+      const item = row?.pop();
+      if (!(item instanceof CardRenderItem)) {
+        throw new Error('"played" could be called on CardRenderItem only');
+      }
+
+      if (item === undefined) {
+        throw new Error('Called "played" without a CardRenderItem.');
+      }
+      item.isPlayed = true;
+      row?.push(item);
+      this._data.push(row);
+    }
+
+    return this;
+  }
+
+  /**
+   * Used to start the effect for effectBox and actionBox, also adds a delimiter symbol
+   */
+  public get startEffect(): Builder {
+    this.br;
+    this._addSymbol(CardRenderSymbol.colon());
+    this.br;
     return this;
   }
 }
@@ -174,5 +325,13 @@ class ProductionBoxBuilder extends Builder {
 
   public build(): CardRenderProductionBox {
     return new CardRenderProductionBox(this._data);
+  }
+}
+
+class EffectBuilder extends Builder {
+  protected _data: Array<Array<CardRenderItem | CardRenderSymbol | CardRenderProductionBox>> = [[]];
+
+  public build(): CardRenderEffect {
+    return new CardRenderEffect(this._data);
   }
 }

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -78,7 +78,7 @@ export class CardRenderEffect extends CardRenderer {
   public get description(): ItemType {
     this._validate();
     // TODO (chosta): validate builder method to make sure it's the last element
-    return `Effect: ${this.rows[2].slice(-1)[0]}`;
+    return `Effect: ${this.rows[2].pop()}`;
   }
 }
 

--- a/src/cards/turmoil/AerialLenses.ts
+++ b/src/cards/turmoil/AerialLenses.ts
@@ -37,7 +37,7 @@ export class AerialLenses implements IProjectCard {
     description: 'Requires that Kelvinists are ruling or that you have 2 delegates there. Remove up to 2 plants from any player. Increase your heat production 2 steps.',
     cardNumber: 'T01',
     requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
-    renderData: CardRenderer.builder((b) => b.plants(-2).any.productionBox((pb) => pb.heat(2))),
+    renderData: CardRenderer.builder((b) => b.minus().plants(-2).any.productionBox((pb) => pb.heat(2))),
     victoryPoints: -1,
   };
 }

--- a/src/cards/turmoil/EventAnalysts.ts
+++ b/src/cards/turmoil/EventAnalysts.ts
@@ -5,6 +5,9 @@ import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PartyName} from '../../turmoil/parties/PartyName';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRequirements} from '../CardRequirements';
 
 export class EventAnalysts implements IProjectCard {
   public cost = 5;
@@ -25,4 +28,11 @@ export class EventAnalysts implements IProjectCard {
     }
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Requires that Scientists are ruling or that you have 2 delegates there',
+    cardNumber: 'T05',
+    requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.startEffect.influence(1).description('You have  +1 influence'))),
+  };
 }

--- a/src/cards/turmoil/EventAnalysts.ts
+++ b/src/cards/turmoil/EventAnalysts.ts
@@ -33,6 +33,6 @@ export class EventAnalysts implements IProjectCard {
     description: 'Requires that Scientists are ruling or that you have 2 delegates there',
     cardNumber: 'T05',
     requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
-    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.startEffect.influence(1).description('You have  +1 influence'))),
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.startEffect.influence(1).description('You have +1 influence'))),
   };
 }

--- a/src/cards/turmoil/EventAnalysts.ts
+++ b/src/cards/turmoil/EventAnalysts.ts
@@ -6,24 +6,23 @@ import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PartyName} from '../../turmoil/parties/PartyName';
 
-
 export class EventAnalysts implements IProjectCard {
-    public cost = 5;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.EVENT_ANALYSTS;
-    public cardType = CardType.ACTIVE;
+  public cost = 5;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.EVENT_ANALYSTS;
+  public cardType = CardType.ACTIVE;
 
-    public canPlay(player: Player, game: Game): boolean {
-      if (game.turmoil !== undefined) {
-        return game.turmoil.canPlay(player, PartyName.SCIENTISTS);
-      }
-      return false;
+  public canPlay(player: Player, game: Game): boolean {
+    if (game.turmoil !== undefined) {
+      return game.turmoil.canPlay(player, PartyName.SCIENTISTS);
     }
+    return false;
+  }
 
-    public play(player: Player, game: Game) {
-      if (game.turmoil) {
-        game.turmoil.addInfluenceBonus(player);
-      }
-      return undefined;
+  public play(player: Player, game: Game) {
+    if (game.turmoil) {
+      game.turmoil.addInfluenceBonus(player);
     }
+    return undefined;
+  }
 }

--- a/src/cards/turmoil/GMOContract.ts
+++ b/src/cards/turmoil/GMOContract.ts
@@ -9,32 +9,31 @@ import {Resources} from '../../Resources';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
 
 export class GMOContract implements IProjectCard {
-    public cost = 3;
-    public tags = [Tags.MICROBES, Tags.SCIENCE];
-    public name = CardName.GMO_CONTRACT;
-    public cardType = CardType.ACTIVE;
+  public cost = 3;
+  public tags = [Tags.MICROBES, Tags.SCIENCE];
+  public name = CardName.GMO_CONTRACT;
+  public cardType = CardType.ACTIVE;
 
-    public canPlay(player: Player, game: Game): boolean {
-      if (game.turmoil !== undefined) {
-        return game.turmoil.canPlay(player, PartyName.GREENS);
-      }
-      return false;
+  public canPlay(player: Player, game: Game): boolean {
+    if (game.turmoil !== undefined) {
+      return game.turmoil.canPlay(player, PartyName.GREENS);
     }
+    return false;
+  }
 
-    public onCardPlayed(player: Player, game: Game, card: IProjectCard): void {
-      const amount = card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES).length;
-      if (amount > 0) {
-        game.defer(new DeferredAction(
-            player,
-            () => {
-              player.setResource(Resources.MEGACREDITS, amount * 2);
-              return undefined;
-            },
-        ));
-      }
+  public onCardPlayed(player: Player, game: Game, card: IProjectCard): void {
+    const amount = card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES).length;
+    if (amount > 0) {
+      game.defer(
+        new DeferredAction(player, () => {
+          player.setResource(Resources.MEGACREDITS, amount * 2);
+          return undefined;
+        })
+      );
     }
+  }
 
-    public play() {
-      return undefined;
-    }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/turmoil/GMOContract.ts
+++ b/src/cards/turmoil/GMOContract.ts
@@ -7,6 +7,9 @@ import {Game} from '../../Game';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {Resources} from '../../Resources';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRequirements} from '../CardRequirements';
 
 export class GMOContract implements IProjectCard {
   public cost = 3;
@@ -25,10 +28,10 @@ export class GMOContract implements IProjectCard {
     const amount = card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBES).length;
     if (amount > 0) {
       game.defer(
-        new DeferredAction(player, () => {
-          player.setResource(Resources.MEGACREDITS, amount * 2);
-          return undefined;
-        })
+          new DeferredAction(player, () => {
+            player.setResource(Resources.MEGACREDITS, amount * 2);
+            return undefined;
+          }),
       );
     }
   }
@@ -36,4 +39,11 @@ export class GMOContract implements IProjectCard {
   public play() {
     return undefined;
   }
+
+  public metadata: CardMetadata = {
+    description: 'Requires that Greens are ruling or that you have 2 delegates there',
+    cardNumber: 'T06',
+    requirements: CardRequirements.builder((b) => b.party(PartyName.GREENS)),
+    renderData: CardRenderer.builder((b) => b.effectBox((be) => be.animals(1).played.slash().plants(1).played.slash().microbes(1).played.slash().startEffect.megacredits(2).description('Each time you play a plant, animal or microbe tag, including this, gain 2MC'))),
+  };
 }

--- a/src/components/card/CardContent.ts
+++ b/src/components/card/CardContent.ts
@@ -27,7 +27,7 @@ export const CardContent = Vue.component('CardContent', {
   template: `
         <div :class="getClasses()">
             <CardRequirementsComponent v-if="metadata.requirements !== undefined" :requirements="metadata.requirements"/>
-            <CardRenderData v-if="metadata.renderData !== undefined" :data="metadata.renderData" />
+            <CardRenderData v-if="metadata.renderData !== undefined" :renderData="metadata.renderData" />
             <CardDescription v-if="metadata.description !== undefined" :text="metadata.description" />
             <CardVictoryPoints v-if="metadata.victoryPoints !== undefined" :amount="metadata.victoryPoints" />
         </div>

--- a/src/components/card/CardRenderData.ts
+++ b/src/components/card/CardRenderData.ts
@@ -4,7 +4,7 @@ import {CardRowData} from './CardRowData';
 
 export const CardRenderData = Vue.component('CardRenderData', {
   props: {
-    data: {
+    renderData: {
       type: Object as () => CardRenderer,
       required: true,
     },
@@ -14,7 +14,7 @@ export const CardRenderData = Vue.component('CardRenderData', {
   },
   template: `
         <div class="card-rows">
-            <CardRowData v-for="(cardData, i) in data.rows" :data="cardData" :key="i" />
+            <CardRowData v-for="(cardData, i) in renderData.rows" :rowData="cardData" :key="i" />
         </div>
     `,
 });

--- a/src/components/card/CardRenderEffectBoxComponent.ts
+++ b/src/components/card/CardRenderEffectBoxComponent.ts
@@ -9,7 +9,7 @@ import {CardDescription} from './CardDescription';
 
 export const CardRenderEffectBoxComponent = Vue.component('CardRenderEffectBoxComponent', {
   props: {
-    data: {
+    effectData: {
       type: Object as () => CardRenderEffect,
       required: true,
     },
@@ -39,22 +39,22 @@ export const CardRenderEffectBoxComponent = Vue.component('CardRenderEffectBoxCo
   template: `
       <div :class="getClasses()">
         <div class="card-effect-box-row">
-            <div v-if="data.delimiter !== undefined" class="card-effect-box-content">
-                <div v-for="(rowItem, rowIndex) in data.cause" class="card-effect-box-item" :key="rowIndex">
+            <div v-if="effectData.delimiter !== undefined" class="card-effect-box-content">
+                <div v-for="(rowItem, rowIndex) in effectData.cause" class="card-effect-box-item" :key="rowIndex">
                   <CardRenderItemComponent v-if="getComponentType(rowItem) === 'item'" :item="rowItem"/>
                   <CardRenderSymbolComponent v-else-if="getComponentType(rowItem) === 'symbol'" :item="rowItem" />
                 </div>
             </div>
-            <CardRenderSymbolComponent v-if="data.delimiter !== undefined" :item="data.delimiter" />
+            <CardRenderSymbolComponent v-if="effectData.delimiter !== undefined" :item="effectData.delimiter" />
             <div class="card-effect-box-content">
-                <div v-for="(rowItem, rowIndex) in data.effect" class="card-effect-box-item" :key="rowIndex">
+                <div v-for="(rowItem, rowIndex) in effectData.effect" class="card-effect-box-item" :key="rowIndex">
                     <CardRenderItemComponent v-if="getComponentType(rowItem) === 'item'" :item="rowItem"/>
                     <CardRenderSymbolComponent v-else-if="getComponentType(rowItem) === 'symbol'" :item="rowItem" />
                     <CardProductionBoxComponent v-else-if="getComponentType(rowItem) === 'production'" :rows="rowItem.rows" />
                 </div>
             </div>
         </div>
-        <CardDescription :text="data.description" />
+        <CardDescription :text="effectData.description" />
       </div>
     `,
 });

--- a/src/components/card/CardRenderEffectBoxComponent.ts
+++ b/src/components/card/CardRenderEffectBoxComponent.ts
@@ -1,0 +1,60 @@
+import Vue from 'vue';
+import {CardRenderItemComponent} from './CardRenderItemComponent';
+import {CardRenderSymbolComponent} from './CardRenderSymbolComponent';
+import {CardRenderEffect, CardRenderProductionBox} from '../../cards/render/CardRenderer';
+import {CardProductionBoxComponent} from './CardProductionBoxComponent';
+import {CardRenderSymbol} from '../../cards/render/CardRenderSymbol';
+import {CardRenderItem} from '../../cards/render/CardRenderItem';
+import {CardDescription} from './CardDescription';
+
+export const CardRenderEffectBoxComponent = Vue.component('CardRenderEffectBoxComponent', {
+  props: {
+    data: {
+      type: Object as () => CardRenderEffect,
+      required: true,
+    },
+  },
+  components: {
+    CardRenderItemComponent,
+    CardRenderSymbolComponent,
+    CardProductionBoxComponent,
+    CardDescription,
+  },
+  methods: {
+    getClasses: function(): string {
+      const classes: Array<string> = ['card-effect-box'];
+      return classes.join(' ');
+    },
+    getComponentType: function(rowItem: CardRenderSymbol | CardRenderItem): string {
+      if (rowItem instanceof CardRenderSymbol) {
+        return 'symbol';
+      } else if (rowItem instanceof CardRenderProductionBox) {
+        return 'production';
+      } else if (rowItem instanceof CardRenderItem) {
+        return 'item';
+      }
+      return '';
+    },
+  },
+  template: `
+      <div :class="getClasses()">
+        <div class="card-effect-box-row">
+            <div v-if="data.delimiter !== undefined" class="card-effect-box-content">
+                <div v-for="(rowItem, rowIndex) in data.cause" class="card-effect-box-item" :key="rowIndex">
+                  <CardRenderItemComponent v-if="getComponentType(rowItem) === 'item'" :item="rowItem"/>
+                  <CardRenderSymbolComponent v-else-if="getComponentType(rowItem) === 'symbol'" :item="rowItem" />
+                </div>
+            </div>
+            <CardRenderSymbolComponent v-if="data.delimiter !== undefined" :item="data.delimiter" />
+            <div class="card-effect-box-content">
+                <div v-for="(rowItem, rowIndex) in data.effect" class="card-effect-box-item" :key="rowIndex">
+                    <CardRenderItemComponent v-if="getComponentType(rowItem) === 'item'" :item="rowItem"/>
+                    <CardRenderSymbolComponent v-else-if="getComponentType(rowItem) === 'symbol'" :item="rowItem" />
+                    <CardProductionBoxComponent v-else-if="getComponentType(rowItem) === 'production'" :rows="rowItem.rows" />
+                </div>
+            </div>
+        </div>
+        <CardDescription :text="data.description" />
+      </div>
+    `,
+});

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -16,38 +16,66 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
   methods: {
     getComponentClasses: function(): string {
       const classes: Array<string> = [''];
-      if (this.item.type === CardRenderItemType.TEMPERATURE) {
-        // global
+      const type: CardRenderItemType = this.item.type;
+      if (type === CardRenderItemType.TEMPERATURE) {
         classes.push('card-global-requirement');
         classes.push('card-temperature-global-requirement');
-      } else if (this.item.type === CardRenderItemType.OXYGEN) {
+      } else if (type === CardRenderItemType.OXYGEN) {
         classes.push('card-global-requirement');
         classes.push('card-oxygen-global-requirement');
-      } else if (this.item.type === CardRenderItemType.OCEANS) {
+      } else if (type === CardRenderItemType.OCEANS) {
         classes.push('card-global-requirement');
         classes.push('card-ocean-global-requirement');
-      } else if (this.item.type === CardRenderItemType.VENUS) {
+      } else if (type === CardRenderItemType.VENUS) {
         classes.push('card-global-requirement');
         classes.push('card-venus-global-requirement');
-      } else if (this.item.type === CardRenderItemType.TITANIUM) {
-        // resources
+      } else if (type === CardRenderItemType.TITANIUM) {
         classes.push('card-resource');
         classes.push('card-resource-titanium');
-      } else if (this.item.type === CardRenderItemType.HEAT) {
+      } else if (type === CardRenderItemType.STEEL) {
+        classes.push('card-resource');
+        classes.push('card-resource-steel');
+      } else if (type === CardRenderItemType.HEAT) {
         classes.push('card-resource');
         classes.push('card-resource-heat');
-      } else if (this.item.type === CardRenderItemType.ENERGY) {
+      } else if (type === CardRenderItemType.ENERGY) {
         classes.push('card-resource');
         classes.push('card-resource-energy');
-      } else if (this.item.type === CardRenderItemType.PLANTS) {
+      } else if (type === CardRenderItemType.PLANTS) {
         classes.push('card-resource');
         classes.push('card-resource-plant');
-      } else if (this.item.type === CardRenderItemType.MEGACREDITS) {
+      } else if (type === CardRenderItemType.MEGACREDITS) {
         classes.push('card-resource');
         classes.push('card-resource-money');
-      } else if (this.item.type === CardRenderItemType.MICROBES) {
+      } else if (type === CardRenderItemType.MICROBES) {
         classes.push('card-resource');
         classes.push('card-resource-microbe');
+      } else if (type === CardRenderItemType.ANIMALS) {
+        classes.push('card-resource');
+        classes.push('card-resource-animal');
+      } else if (type === CardRenderItemType.TRADE) {
+        classes.push('card-resource-trade');
+      } else if (type === CardRenderItemType.TRADE_DISCOUNT) {
+        classes.push('card-resource');
+        classes.push('card-resource-trade-discount');
+      } else if (type === CardRenderItemType.TRADE_FLEET) {
+        classes.push('card-resource-trade-fleet');
+      } else if (type === CardRenderItemType.CHAIRMAN) {
+        classes.push('card-chairman');
+      } else if (type === CardRenderItemType.PARTY_LEADERS) {
+        classes.push('card-party-leader');
+      } else if (type === CardRenderItemType.DELEGATES) {
+        classes.push('card-delegate');
+      } else if (type === CardRenderItemType.INFLUENCE) {
+        classes.push('card-influence');
+      } else if (type === CardRenderItemType.EVENT) {
+        classes.push('card-tag-event');
+      } else if (type === CardRenderItemType.SPACE) {
+        classes.push('card-tag-space');
+      }
+      // round tags
+      if (this.item.isPlayed) {
+        classes.push('card-resource-tag');
       }
 
       // act upon any player
@@ -64,9 +92,6 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
     getMinus: function(): CardRenderSymbol {
       return CardRenderSymbol.minus();
     },
-    isSubtract: function(): boolean {
-      return this.item.amount < 0;
-    },
     itemsToShow: function(): number {
       if (this.item.showDigit) return 1;
       return this.getAmountAbs();
@@ -74,13 +99,11 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
     itemHtmlContent: function(): string {
       // in case of symbols inside
       if (this.item instanceof CardRenderItem && this.item.amountInside) return this.item.amount.toString();
-
       return '';
     },
   },
   template: `
         <div class="card-item-container">
-            <CardRenderSymbolComponent v-if="isSubtract()" :item="getMinus()" />
             <div class="card-res-amount" v-if="item.showDigit">{{ getAmountAbs() }}</div>
             <div :class="getComponentClasses()" v-for="index in itemsToShow()" v-html="itemHtmlContent()" :key="index"/>
         </div>

--- a/src/components/card/CardRowComponent.ts
+++ b/src/components/card/CardRowComponent.ts
@@ -10,7 +10,7 @@ import {CardRenderEffect} from '../../cards/render/CardRenderer';
 
 export const CardRowComponent = Vue.component('CardRowComponent', {
   props: {
-    data: {
+    componentData: {
       type: Object as () => CardRenderItem | CardRenderProductionBox | CardRenderSymbol | CardRenderEffect,
       required: true,
     },
@@ -23,23 +23,23 @@ export const CardRowComponent = Vue.component('CardRowComponent', {
   },
   methods: {
     isItem: function(): boolean {
-      return this.data instanceof CardRenderItem;
+      return this.componentData instanceof CardRenderItem;
     },
     isSymbol: function(): boolean {
-      return this.data instanceof CardRenderSymbol;
+      return this.componentData instanceof CardRenderSymbol;
     },
     isProduction: function(): boolean {
-      return this.data instanceof CardRenderProductionBox;
+      return this.componentData instanceof CardRenderProductionBox;
     },
     isEffect: function(): boolean {
-      return this.data instanceof CardRenderEffect;
+      return this.componentData instanceof CardRenderEffect;
     },
   },
   template: ` 
-        <CardRenderItemComponent v-if="isItem()" :item="data"/>
-        <CardRenderSymbolComponent v-else-if="isSymbol()" :item="data" />
-        <CardProductionBoxComponent v-else-if="isProduction()" :rows="data.rows" />
-        <CardRenderEffectBoxComponent v-else-if="isEffect()" :data="data" />
+        <CardRenderItemComponent v-if="isItem()" :item="componentData"/>
+        <CardRenderSymbolComponent v-else-if="isSymbol()" :item="componentData" />
+        <CardProductionBoxComponent v-else-if="isProduction()" :rows="componentData.rows" />
+        <CardRenderEffectBoxComponent v-else-if="isEffect()" :effectData="componentData" />
         <div v-else>n/a</div>
     `,
 });

--- a/src/components/card/CardRowComponent.ts
+++ b/src/components/card/CardRowComponent.ts
@@ -4,12 +4,14 @@ import {CardRenderSymbol} from '../../cards/render/CardRenderSymbol';
 import {CardRenderProductionBox} from '../../cards/render/CardRenderer';
 import {CardRenderItemComponent} from './CardRenderItemComponent';
 import {CardProductionBoxComponent} from './CardProductionBoxComponent';
+import {CardRenderEffectBoxComponent} from './CardRenderEffectBoxComponent';
 import {CardRenderSymbolComponent} from './CardRenderSymbolComponent';
+import {CardRenderEffect} from '../../cards/render/CardRenderer';
 
 export const CardRowComponent = Vue.component('CardRowComponent', {
   props: {
     data: {
-      type: Object as () => CardRenderItem | CardRenderProductionBox | CardRenderSymbol,
+      type: Object as () => CardRenderItem | CardRenderProductionBox | CardRenderSymbol | CardRenderEffect,
       required: true,
     },
   },
@@ -17,6 +19,7 @@ export const CardRowComponent = Vue.component('CardRowComponent', {
     CardRenderSymbolComponent,
     CardRenderItemComponent,
     CardProductionBoxComponent,
+    CardRenderEffectBoxComponent,
   },
   methods: {
     isItem: function(): boolean {
@@ -28,11 +31,15 @@ export const CardRowComponent = Vue.component('CardRowComponent', {
     isProduction: function(): boolean {
       return this.data instanceof CardRenderProductionBox;
     },
+    isEffect: function(): boolean {
+      return this.data instanceof CardRenderEffect;
+    },
   },
   template: ` 
         <CardRenderItemComponent v-if="isItem()" :item="data"/>
         <CardRenderSymbolComponent v-else-if="isSymbol()" :item="data" />
         <CardProductionBoxComponent v-else-if="isProduction()" :rows="data.rows" />
+        <CardRenderEffectBoxComponent v-else-if="isEffect()" :data="data" />
         <div v-else>n/a</div>
     `,
 });

--- a/src/components/card/CardRowData.ts
+++ b/src/components/card/CardRowData.ts
@@ -3,7 +3,7 @@ import {CardRowComponent} from './CardRowComponent';
 
 export const CardRowData = Vue.component('CardRowData', {
   props: {
-    data: {
+    rowData: {
       type: Array,
       required: true,
     },
@@ -13,7 +13,7 @@ export const CardRowData = Vue.component('CardRowData', {
   },
   template: `
         <div class="card-row">
-            <CardRowComponent v-for="(componentData, i) in data" :data="componentData" :key="i" />
+            <CardRowComponent v-for="(componentData, i) in rowData" :componentData="componentData" :key="i" />
         </div>
     `,
 });

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -287,6 +287,8 @@
                 display: inline-block;
                 text-align: center;
                 border-radius: 50%;
+                margin-left: 3px;
+                margin-right: 3px;
                 width: 30px;
                 height: 30px;
                 background-size: 34px 34px;


### PR DESCRIPTION
* CardRenderEffect implementation following the builder pattern. A card effect has 4 parts `cause - delimiter - effect - description`
* Implemented some effect cards and added some new builder functions

I tried to reduce boilerplate and focused on clean API, just not sure about the `startEffect` function. I wanted to announce end of cause and start of effect part with a function that also generates two new arrays which then can be fetched via getters in the Vue component. It does do the job and hopefully it's intuitive.
```
  public get startEffect(): Builder {
    this.br;
    this._addSymbol(CardRenderSymbol.colon());
    this.br;
    return this;
  }
```

```
...
public get cause(): Array<ItemType> | undefined {
    this._validate();
    return this.rows[0];
  }

  public get delimiter(): ItemType {
    this._validate();
    if (this.cause?.length === 0) {
      return undefined;
    }
    return this.rows[1][0];
  }
...
```