### PR TITLE
Add info button, fixes bafolts#1914

### DIFF
--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -664,7 +664,7 @@ export const CreateGameForm = Vue.component('create-game-form', {
                                 </label>
                                 <input type="checkbox" v-model="requiresVenusTrackCompletion" id="requiresVenusTrackCompletion-checkbox">
                                 <label for="requiresVenusTrackCompletion-checkbox">
-                                    <span v-i18n>Venus Terraforming</span>
+                                    <span v-i18n>Venus Terraforming</span>&nbsp;<a href="https://github.com/bafolts/terraforming-mars/wiki/Variants#venus-terraforming" class="tooltip" target="_blank">&#9432;</a>
                                 </label>
                             </template>
 


### PR DESCRIPTION
Add the info button to link the wiki, fixes #1914. Won't change the label text as adding "Mandatory" would be too long.