### PR TITLE
Cards to Vue - all starting with letter A

### DIFF
--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -1450,17 +1450,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
         </div>
 `],
-    [CardName.ADAPTATION_TECHNOLOGY, ` 
-      <div class="content">
-        <div class="points points-big">1</div>
-        <div class="card-content-requirements">
-          <div class="globals-box">Global requirements</div>: +/- 2
-        </div>
-        <div class="description">
-          (Effect: Your global requirements are +2 or -2 steps, your choice in each case.)
-        </div>
-      </div>
-`],
     [CardName.CARETAKER_CONTRACT, ` 
         <div class="content ">
           <div class="requirements">0 C</div>

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -319,18 +319,6 @@ export const HTML_DATA: Map<string, string> =
             </div>
         </div>
 `],
-    [CardName.ANTS, ` 
-        <div class="content ">
-            <div class="points ">1/2<div class="resource microbe "></div></div>
-            <div class="requirements ">4% O2</div>
-            <div class="microbe resource red-outline "></div> <div class="red-arrow "></div> <div class="microbe resource "></div>
-            <div class="description ">
-                (Action: Remove 1 Microbe from any card to add 1 to this card.)
-                <br><br>
-                (Requires 4% oxygen. 1 VP per 2 Microbes on this card.)
-            </div>
-        </div>
-`],
     [CardName.RELEASE_OF_INERT_GASES, ` 
         <div class="content ">
             <div class="tile rating "></div>  <div class="tile rating "></div>
@@ -4580,20 +4568,6 @@ export const HTML_DATA: Map<string, string> =
             Decrease your energy production 1 step, and increase your titanium production 1 step.
             Gain 4 titanium.)
         </div>
-    </div>
-`],
-    [CardName.ASTEROID_HOLLOWING, ` 
-    <div class="content ">
-        <div class="points" style="line-height:45px;vertical-align:middle">1/2<div class="asteroid resource" style="vertical-align:middle;margin-left:5px">A</div></div>
-        <div class="resource titanium"></div>
-        <span class="red-arrow"></span>
-        <div class="asteroid resource" style="margin-right:5px">A</div>
-        <div class="production-box"><div  class="production money">1</div></div>
-        <div class="description">
-            (Action: Spend 1 titanium to add 1 asteroid resource here and increase MC production 1 step.)
-            <br><br>(1 VP per 2 asteroid resources on this card.)
-        </div>
-      </div>
     </div>
 `],
     [CardName.ASTEROID_RIGHTS, ` 

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -2034,17 +2034,6 @@ export const HTML_DATA: Map<string, string> =
                 </div>
             </div>
 `],
-    [CardName.AIR_SCRAPPING_EXPEDITION, ` 
-            <div class="content ">
-              <div class="tile venus-tile">V</div> &nbsp;&nbsp;
-                <div class="resource floater"><div class="card-icon tag-venus"></div></div>
-                  <div class="resource floater"><div class="card-icon tag-venus"></div></div>
-                    <div class="resource floater"><div class="card-icon tag-venus"></div></div>
-                <div class="description">
-                  (Raise Venus 1 step. Add 3 Floaters to ANY Venus CARD)
-                </div>
-            </div>
-`],
     [CardName.ATALANTA_PLANITIA_LAB, ` 
             <div class="content ">
               <div class="points points-big">2</div>

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -2034,30 +2034,6 @@ export const HTML_DATA: Map<string, string> =
                 </div>
             </div>
 `],
-    [CardName.ATALANTA_PLANITIA_LAB, ` 
-            <div class="content ">
-              <div class="points points-big">2</div>
-              <div class="requirements">3 Science</div>
-              <div class="resource card"></div> <div class="resource card"></div>
-              <div class="description">
-              (Requires 3 science tags. Draw 2 cards.)
-              </div>
-            </div>
-`],
-    [CardName.ATMOSCOOP, ` 
-            <div class="content ">
-              <div class="points points-big">1</div>
-              <div class="requirements">3 Science</div>
-              <div class="nowrap">
-                <div class="tile temperature-tile"></div><div class="tile temperature-tile"></div> OR
-                <div class="tile venus-tile"></div><div class="tile venus-tile"></div>
-              </div>
-              <div class="resource floater"></div><div class="resource floater"></div><span>*</span>
-              <div class="description" style="text-align:left;position:absolute;margin-top:-8px;">
-                (Requires 3 Science tags. Either raise the temperature 2 steps, or raise Venus 2 steps. Add 2 Floaters to ANY card)
-              </div>
-            </div>
-`],
     [CardName.COMET_FOR_VENUS, ` 
             <div class="content ">
             <div class="tile venus-tile"></div> &nbsp;&nbsp;
@@ -2600,19 +2576,6 @@ export const HTML_DATA: Map<string, string> =
                   (Requires 2 Earth tags. Increase MC production 4 steps.)
                 </div>
               </div>
-`],
-    [CardName.AIRLINERS, ` 
-            <div class="content ">
-              <div class="points points-big ">1</div>
-              <div class="requirements ">3 Floaters</div>
-              <div class="production-box">
-                <div class="money production">2</div>
-              </div><br>
-              <div class="floater resource "></div><div class="floater resource "></div>*
-              <div class="description">
-                (Requires that you have 3 floaters. Increase your MC production 2 steps. Add 2 floaters to ANY card.)
-              </div>
-            </div>
 `],
     [CardName.COMMUNITY_SERVICES, ` 
             <div class="content ">
@@ -4529,32 +4492,6 @@ export const HTML_DATA: Map<string, string> =
         </div>
     </div>
 `],
-    [CardName.ASTEROID_RIGHTS, ` 
-    <div class="content">
-        <div>
-            <span class="money resource">1</span>
-            <span class="red-arrow"></span>
-            <span class="asteroid resource"></span>*
-        </div>
-        <div class="effect">
-            <span class="asteroid resource"></span>
-            <span class="red-arrow"></span>
-            <div class="production-box">
-                <div class="money production">1</div>
-            </div>
-             OR <div class="resource titanium"></div><div class="resource titanium"></div>
-        </div>
-        <div class="description">
-            (Action: Spend 1 MC to add 1 asteroid to ANY card, or spend 1 asteroid here to increase MC production 1 step OR gain 2 titanium.)
-        </div>
-        <div class="effect2">
-            <span class="asteroid resource"></span>
-            <span class="asteroid resource"></span>
-            <span class="description">(Add 2 asteroids to this card.)</span>
-        </div>
-      </div>
-    </div>
-`],
     [CardName.PHARMACY_UNION, `
     <div class="promo-icon corporation-icon"></div>
     <div class="contentCorporation">
@@ -4710,27 +4647,6 @@ export const HTML_DATA: Map<string, string> =
       4 <div class="plant resource"></div> 4 <div class="microbe resource"></div>*
       <div class="description">
         (Gain 4 Plants and add 4 Microbes to ANOTHER card.)
-      </div>
-    </div>
-`],
-    [CardName.ASTEROID_DEFLECTION_SYSTEM, ` 
-    <div class="content">
-      <div class="points">1/<div class="asteroid resource">A</div></div>
-      <span class="red-arrow"></span><div class="resource card"></div>*
-      <div class="resource-tag tag-space"></div> : <div class="asteroid resource">A</div>
-      <div class="description">
-        (Action: REVEAL AND DISCARD the top card of the deck. If it has a space tag, add an asteroid resource here.)
-      </div>
-      <br>
-      <div class="description effect">
-        OPPONENTS MAY NOT REMOVE YOUR PLANTS
-      </div>
-      <br>
-      <div class="production-box production-box-size1a">
-        <div class="production-prefix minus"></div><div class="energy production"></div><br>
-      </div>
-      <div class="description bottom" >
-        (Decrease your energy production 1 step. 1 VP per asteroid on this card.)
       </div>
     </div>
 `],

--- a/src/HTML_data.ts
+++ b/src/HTML_data.ts
@@ -2034,16 +2034,6 @@ export const HTML_DATA: Map<string, string> =
                 </div>
             </div>
 `],
-    [CardName.AEROSPORT_TOURNAMENT, ` 
-            <div class="content ">
-                <div class="points points-big ">1</div>
-                <div class="requirements ">5 Floaters</div>
-                <div class="resource money">1</div> / <div class="tile city-tile-small red-outline"></div>
-                <div class="description">
-                  (Requires that you have 5 Floaters. Gain 1 MC per each City tile in play)
-                </div>
-            </div>
-`],
     [CardName.AIR_SCRAPPING_EXPEDITION, ` 
             <div class="content ">
               <div class="tile venus-tile">V</div> &nbsp;&nbsp;
@@ -2632,15 +2622,6 @@ export const HTML_DATA: Map<string, string> =
               <div class="floater resource "></div><div class="floater resource "></div>*
               <div class="description">
                 (Requires that you have 3 floaters. Increase your MC production 2 steps. Add 2 floaters to ANY card.)
-              </div>
-            </div>
-`],
-    [CardName.AIR_RAID, ` 
-            <div class="content">
-              - <div class="resource floater" style="margin-right:20px;"></div>
-              STEAL <div class="resource money red-outline">5</div>
-              <div class="description">
-                (Requires that you lose 1 floater. Steal 5 MC from any player.)
               </div>
             </div>
 `],

--- a/src/cards/AdaptationTechnology.ts
+++ b/src/cards/AdaptationTechnology.ts
@@ -2,6 +2,8 @@ import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {CardName} from '../CardName';
+import {CardMetadata} from './../cards/CardMetadata';
+import {CardRenderer} from './../cards/render/CardRenderer';
 
 export class AdaptationTechnology implements IProjectCard {
   public cost = 12;
@@ -17,5 +19,15 @@ export class AdaptationTechnology implements IProjectCard {
   }
   public getVictoryPoints() {
     return 1;
+  }
+  public metadata: CardMetadata = {
+    cardNumber: '153',
+    renderData: CardRenderer.builder((b) => {
+      b.effectBox((eb) => {
+        eb.plate('Global requirements').startEffect.text('+/- 2');
+        eb.description('Effect: Your global requirements are +2 or -2 steps, your choice in each case.');
+      });
+    }),
+    victoryPoints: 1,
   }
 }

--- a/src/cards/AdaptationTechnology.ts
+++ b/src/cards/AdaptationTechnology.ts
@@ -2,8 +2,8 @@ import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {CardName} from '../CardName';
-import {CardMetadata} from './../cards/CardMetadata';
-import {CardRenderer} from './../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AdaptationTechnology implements IProjectCard {
   public cost = 12;

--- a/src/cards/AdaptationTechnology.ts
+++ b/src/cards/AdaptationTechnology.ts
@@ -4,18 +4,18 @@ import {CardType} from './CardType';
 import {CardName} from '../CardName';
 
 export class AdaptationTechnology implements IProjectCard {
-    public cost = 12;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.ADAPTATION_TECHNOLOGY;
-    public cardType = CardType.ACTIVE;
+  public cost = 12;
+  public tags = [Tags.SCIENCE];
+  public name = CardName.ADAPTATION_TECHNOLOGY;
+  public cardType = CardType.ACTIVE;
 
-    public getRequirementBonus(): number {
-      return 2;
-    }
-    public play() {
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 1;
-    }
+  public getRequirementBonus(): number {
+    return 2;
+  }
+  public play() {
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/AdvancedEcosystems.ts
+++ b/src/cards/AdvancedEcosystems.ts
@@ -3,8 +3,8 @@ import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
 
 export class AdvancedEcosystems implements IProjectCard {
   public cost = 11;

--- a/src/cards/AntiGravityTechnology.ts
+++ b/src/cards/AntiGravityTechnology.ts
@@ -3,9 +3,9 @@ import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
+import {CardRequirements} from './CardRequirements';
 
 export class AntiGravityTechnology implements IProjectCard {
   public cost = 14;

--- a/src/cards/Ants.ts
+++ b/src/cards/Ants.ts
@@ -8,6 +8,10 @@ import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
 import {DeferredAction} from '../deferredActions/DeferredAction';
 import {RemoveResourcesFromCard} from '../deferredActions/RemoveResourcesFromCard';
+import {CardMetadata} from '../cards/CardMetadata';
+import {CardRequirements} from '../cards/CardRequirements';
+import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRenderVictoryPoints} from './render/CardRenderVictoryPoints';
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {
   public cost = 9;
@@ -43,5 +47,18 @@ export class Ants implements IActionCard, IProjectCard, IResourceCard {
         }),
     );
     return undefined;
+  }
+
+  public metadata: CardMetadata = {
+    cardNumber: '035',
+    description: 'Requires 4% oxygen. 1 VP per 2 Microbes on this card.',
+    requirements: CardRequirements.builder((b) => b.oxygen(4)),
+    renderData: CardRenderer.builder((b) => {
+      b.effectBox((eb) => {
+        eb.microbes(1).any.startAction.microbes(1);
+        eb.description('Action: Remove 1 Microbe from any card to add 1 to this card');
+      });
+    }),
+    victoryPoints: CardRenderVictoryPoints.microbes(1, 2),
   }
 }

--- a/src/cards/Ants.ts
+++ b/src/cards/Ants.ts
@@ -8,9 +8,9 @@ import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
 import {DeferredAction} from '../deferredActions/DeferredAction';
 import {RemoveResourcesFromCard} from '../deferredActions/RemoveResourcesFromCard';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
+import {CardRenderer} from './render/CardRenderer';
 import {CardRenderVictoryPoints} from './render/CardRenderVictoryPoints';
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {

--- a/src/cards/Ants.ts
+++ b/src/cards/Ants.ts
@@ -11,7 +11,7 @@ import {RemoveResourcesFromCard} from '../deferredActions/RemoveResourcesFromCar
 import {CardMetadata} from './CardMetadata';
 import {CardRequirements} from './CardRequirements';
 import {CardRenderer} from './render/CardRenderer';
-import {CardRenderVictoryPoints} from './render/CardRenderVictoryPoints';
+import {CardRenderDynamicVictoryPoints} from './render/CardRenderDynamicVictoryPoints';
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {
   public cost = 9;
@@ -59,6 +59,6 @@ export class Ants implements IActionCard, IProjectCard, IResourceCard {
         eb.description('Action: Remove 1 Microbe from any card to add 1 to this card');
       });
     }),
-    victoryPoints: CardRenderVictoryPoints.microbes(1, 2),
+    victoryPoints: CardRenderDynamicVictoryPoints.microbes(1, 2),
   };
 }

--- a/src/cards/Ants.ts
+++ b/src/cards/Ants.ts
@@ -10,39 +10,38 @@ import {DeferredAction} from '../deferredActions/DeferredAction';
 import {RemoveResourcesFromCard} from '../deferredActions/RemoveResourcesFromCard';
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {
-    public cost = 9;
-    public tags = [Tags.MICROBES];
-    public name = CardName.ANTS;
-    public resourceType = ResourceType.MICROBE;
-    public resourceCount: number = 0;
-    public cardType = CardType.ACTIVE;
+  public cost = 9;
+  public tags = [Tags.MICROBES];
+  public name = CardName.ANTS;
+  public resourceType = ResourceType.MICROBE;
+  public resourceCount: number = 0;
+  public cardType = CardType.ACTIVE;
 
-    public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
-    }
+  public canPlay(player: Player, game: Game): boolean {
+    return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
+  }
 
-    public getVictoryPoints(): number {
-      return Math.floor(this.resourceCount / 2);
-    }
+  public getVictoryPoints(): number {
+    return Math.floor(this.resourceCount / 2);
+  }
 
-    public play() {
-      return undefined;
-    }
+  public play() {
+    return undefined;
+  }
 
-    public canAct(player: Player, game: Game): boolean {
-      if (game.isSoloMode()) return true;
-      return RemoveResourcesFromCard.getAvailableTargetCards(player, game, this.resourceType).length > 0;
-    }
+  public canAct(player: Player, game: Game): boolean {
+    if (game.isSoloMode()) return true;
+    return RemoveResourcesFromCard.getAvailableTargetCards(player, game, this.resourceType).length > 0;
+  }
 
-    public action(player: Player, game: Game) {
-      game.defer(new RemoveResourcesFromCard(player, game, this.resourceType));
-      game.defer(new DeferredAction(
-          player,
-          () => {
-            player.addResourceTo(this);
-            return undefined;
-          },
-      ));
-      return undefined;
-    }
+  public action(player: Player, game: Game) {
+    game.defer(new RemoveResourcesFromCard(player, game, this.resourceType));
+    game.defer(
+        new DeferredAction(player, () => {
+          player.addResourceTo(this);
+          return undefined;
+        }),
+    );
+    return undefined;
+  }
 }

--- a/src/cards/ArchaeBacteria.ts
+++ b/src/cards/ArchaeBacteria.ts
@@ -5,9 +5,9 @@ import {Player} from '../Player';
 import {Game} from '../Game';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
+import {CardRenderer} from './render/CardRenderer';
 
 export class ArchaeBacteria implements IProjectCard {
   public cost = 6;

--- a/src/cards/ArcticAlgae.ts
+++ b/src/cards/ArcticAlgae.ts
@@ -6,9 +6,9 @@ import {Game} from '../Game';
 import {ISpace} from '../ISpace';
 import {TileType} from '../TileType';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
+import {CardRenderer} from './render/CardRenderer';
 
 export class ArcticAlgae implements IProjectCard {
   public cost = 12;

--- a/src/cards/ArtificialLake.ts
+++ b/src/cards/ArtificialLake.ts
@@ -10,9 +10,9 @@ import {CardName} from '../CardName';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {MAX_OCEAN_TILES, REDS_RULING_POLICY_COST} from '../constants';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
+import {CardRenderer} from './render/CardRenderer';
 
 export class ArtificialLake implements IProjectCard {
   public cost = 15;

--- a/src/cards/ArtificialPhotosynthesis.ts
+++ b/src/cards/ArtificialPhotosynthesis.ts
@@ -6,9 +6,9 @@ import {OrOptions} from '../inputs/OrOptions';
 import {SelectOption} from '../inputs/SelectOption';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
-import {CardRenderItemSize} from '../cards/render/CardRenderItemSize';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
+import {CardRenderItemSize} from './render/CardRenderItemSize';
 
 export class ArtificialPhotosynthesis implements IProjectCard {
   public cost = 12;

--- a/src/cards/Asteroid.ts
+++ b/src/cards/Asteroid.ts
@@ -8,8 +8,8 @@ import {MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../constants';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class Asteroid implements IProjectCard {
   public cost = 14;

--- a/src/cards/AsteroidMining.ts
+++ b/src/cards/AsteroidMining.ts
@@ -5,7 +5,7 @@ import {Player} from '../Player';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 import {CardMetadata} from './CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AsteroidMining implements IProjectCard {
   public cost = 30;

--- a/src/cards/AsteroidMiningConsortium.ts
+++ b/src/cards/AsteroidMiningConsortium.ts
@@ -6,9 +6,9 @@ import {Game} from '../Game';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 import {DecreaseAnyProduction} from '../deferredActions/DecreaseAnyProduction';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
+import {CardRenderer} from './render/CardRenderer';
 
 export class AsteroidMiningConsortium implements IProjectCard {
   public cost = 13;

--- a/src/cards/BiomassCombustors.ts
+++ b/src/cards/BiomassCombustors.ts
@@ -6,9 +6,9 @@ import {CardType} from './CardType';
 import {Resources} from '../Resources';
 import {CardName} from '../CardName';
 import {DecreaseAnyProduction} from '../deferredActions/DecreaseAnyProduction';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
+import {CardRequirements} from './CardRequirements';
 
 export class BiomassCombustors implements IProjectCard {
   public cost = 4;

--- a/src/cards/BreathingFilters.ts
+++ b/src/cards/BreathingFilters.ts
@@ -4,8 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
 
 export class BreathingFilters implements IProjectCard {
   public cost = 11;

--- a/src/cards/CardMetadata.ts
+++ b/src/cards/CardMetadata.ts
@@ -1,10 +1,11 @@
 import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRenderVictoryPoints} from './render/CardRenderVictoryPoints';
 import {CardRequirements} from './CardRequirements';
 
 export interface CardMetadata {
   cardNumber: string;
   description?: string;
   requirements?: CardRequirements;
-  victoryPoints?: number; // TODO(chosta): class to handle points per tag and other special cases
+  victoryPoints?: number | CardRenderVictoryPoints;
   renderData?: CardRenderer;
 }

--- a/src/cards/CardMetadata.ts
+++ b/src/cards/CardMetadata.ts
@@ -1,11 +1,11 @@
 import {CardRenderer} from '../cards/render/CardRenderer';
-import {CardRenderVictoryPoints} from './render/CardRenderVictoryPoints';
+import {CardRenderDynamicVictoryPoints} from './render/CardRenderDynamicVictoryPoints';
 import {CardRequirements} from './CardRequirements';
 
 export interface CardMetadata {
   cardNumber: string;
   description?: string;
   requirements?: CardRequirements;
-  victoryPoints?: number | CardRenderVictoryPoints;
+  victoryPoints?: number | CardRenderDynamicVictoryPoints;
   renderData?: CardRenderer;
 }

--- a/src/cards/ColonizerTrainingCamp.ts
+++ b/src/cards/ColonizerTrainingCamp.ts
@@ -4,8 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
 
 export class ColonizerTrainingCamp implements IProjectCard {
     public cost = 8;

--- a/src/cards/DustSeals.ts
+++ b/src/cards/DustSeals.ts
@@ -3,8 +3,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
 
 export class DustSeals implements IProjectCard {
     public cost = 2;

--- a/src/cards/GiantIceAsteroid.ts
+++ b/src/cards/GiantIceAsteroid.ts
@@ -9,8 +9,8 @@ import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {PlaceOceanTile} from '../deferredActions/PlaceOceanTile';
 import {RemoveAnyPlants} from '../deferredActions/RemoveAnyPlants';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardMetadata} from './CardMetadata';
+import {CardRenderer} from './render/CardRenderer';
 
 export class GiantIceAsteroid implements IProjectCard {
   public cost = 36;

--- a/src/cards/InterstellarColonyShip.ts
+++ b/src/cards/InterstellarColonyShip.ts
@@ -4,8 +4,8 @@ import {CardType} from './CardType';
 import {Player} from '../Player';
 import {Game} from '../Game';
 import {CardName} from '../CardName';
-import {CardMetadata} from '../cards/CardMetadata';
-import {CardRequirements} from '../cards/CardRequirements';
+import {CardMetadata} from './CardMetadata';
+import {CardRequirements} from './CardRequirements';
 
 export class InterstellarColonyShip implements IProjectCard {
     public cost = 24;

--- a/src/cards/ares/BioengineeringEnclosure.ts
+++ b/src/cards/ares/BioengineeringEnclosure.ts
@@ -9,9 +9,9 @@ import {Tags} from '../Tags';
 import {ICard} from '../../cards/ICard';
 import {SelectCard} from '../../inputs/SelectCard';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
-import {CardMetadata} from './../CardMetadata';
-import {CardRequirements} from './../CardRequirements';
-import {CardRenderer} from './../render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class BioengineeringEnclosure implements IProjectCard, IActionCard, IResourceCard {
   public cost = 7;

--- a/src/cards/colonies/AirRaid.ts
+++ b/src/cards/colonies/AirRaid.ts
@@ -7,6 +7,9 @@ import {ResourceType} from '../../ResourceType';
 import {Resources} from '../../Resources';
 import {RemoveResourcesFromCard} from '../../deferredActions/RemoveResourcesFromCard';
 import {StealResources} from '../../deferredActions/StealResources';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
 
 export class AirRaid implements IProjectCard {
   public cost = 0;
@@ -23,5 +26,14 @@ export class AirRaid implements IProjectCard {
     game.defer(new RemoveResourcesFromCard(player, game, ResourceType.FLOATER, 1, true));
     game.defer(new StealResources(player, game, Resources.MEGACREDITS, 5));
     return undefined;
+  }
+
+  public metadata: CardMetadata = {
+    cardNumber: 'C02',
+    description: 'Requires that you lose 1 floater. Steal 5 MC from any player',
+    renderData: CardRenderer.builder((b) => {
+      b.minus().floaters(1);
+      b.text('steal', CardRenderItemSize.MEDIUM, true).megacredits(5).any;
+    }),
   }
 }

--- a/src/cards/colonies/AirRaid.ts
+++ b/src/cards/colonies/AirRaid.ts
@@ -9,19 +9,19 @@ import {RemoveResourcesFromCard} from '../../deferredActions/RemoveResourcesFrom
 import {StealResources} from '../../deferredActions/StealResources';
 
 export class AirRaid implements IProjectCard {
-    public cost = 0;
-    public tags = [];
-    public name = CardName.AIR_RAID;
-    public cardType = CardType.EVENT;
-    public hasRequirements = false;
+  public cost = 0;
+  public tags = [];
+  public name = CardName.AIR_RAID;
+  public cardType = CardType.EVENT;
+  public hasRequirements = false;
 
-    public canPlay(player: Player): boolean {
-      return player.getResourceCount(ResourceType.FLOATER) > 0;
-    }
+  public canPlay(player: Player): boolean {
+    return player.getResourceCount(ResourceType.FLOATER) > 0;
+  }
 
-    public play(player: Player, game: Game) {
-      game.defer(new RemoveResourcesFromCard(player, game, ResourceType.FLOATER, 1, true));
-      game.defer(new StealResources(player, game, Resources.MEGACREDITS, 5));
-      return undefined;
-    }
+  public play(player: Player, game: Game) {
+    game.defer(new RemoveResourcesFromCard(player, game, ResourceType.FLOATER, 1, true));
+    game.defer(new StealResources(player, game, Resources.MEGACREDITS, 5));
+    return undefined;
+  }
 }

--- a/src/cards/colonies/AirRaid.ts
+++ b/src/cards/colonies/AirRaid.ts
@@ -7,9 +7,9 @@ import {ResourceType} from '../../ResourceType';
 import {Resources} from '../../Resources';
 import {RemoveResourcesFromCard} from '../../deferredActions/RemoveResourcesFromCard';
 import {StealResources} from '../../deferredActions/StealResources';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRenderer} from '../../cards/render/CardRenderer';
-import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class AirRaid implements IProjectCard {
   public cost = 0;

--- a/src/cards/colonies/Airliners.ts
+++ b/src/cards/colonies/Airliners.ts
@@ -6,9 +6,9 @@ import {Resources} from '../../Resources';
 import {ResourceType} from '../../ResourceType';
 import {Game} from '../../Game';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class Airliners implements IProjectCard {
   public cost = 11;

--- a/src/cards/colonies/Airliners.ts
+++ b/src/cards/colonies/Airliners.ts
@@ -6,6 +6,9 @@ import {Resources} from '../../Resources';
 import {ResourceType} from '../../ResourceType';
 import {Game} from '../../Game';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRequirements} from '../../cards/CardRequirements';
+import {CardRenderer} from '../../cards/render/CardRenderer';
 
 export class Airliners implements IProjectCard {
   public cost = 11;
@@ -24,5 +27,15 @@ export class Airliners implements IProjectCard {
   }
   public getVictoryPoints() {
     return 1;
+  }
+  public metadata: CardMetadata = {
+    cardNumber: 'C01',
+    description: 'Requires that you have 3 floaters. Increase your MC production 2 steps. Add 2 floaters to ANY card',
+    requirements: CardRequirements.builder((b) => b.floaters(3)),
+    renderData: CardRenderer.builder((b) => {
+      b.productionBox((pb) => pb.megacredits(1)).br;
+      b.floaters(2).asterix();
+    }),
+    victoryPoints: 1,
   }
 }

--- a/src/cards/colonies/Airliners.ts
+++ b/src/cards/colonies/Airliners.ts
@@ -33,7 +33,7 @@ export class Airliners implements IProjectCard {
     description: 'Requires that you have 3 floaters. Increase your MC production 2 steps. Add 2 floaters to ANY card',
     requirements: CardRequirements.builder((b) => b.floaters(3)),
     renderData: CardRenderer.builder((b) => {
-      b.productionBox((pb) => pb.megacredits(1)).br;
+      b.productionBox((pb) => pb.megacredits(2)).br;
       b.floaters(2).asterix();
     }),
     victoryPoints: 1,

--- a/src/cards/colonies/Airliners.ts
+++ b/src/cards/colonies/Airliners.ts
@@ -8,22 +8,21 @@ import {Game} from '../../Game';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 
 export class Airliners implements IProjectCard {
-    public cost = 11;
-    public tags = [];
-    public name = CardName.AIRLINERS;
-    public cardType = CardType.AUTOMATED;
+  public cost = 11;
+  public tags = [];
+  public name = CardName.AIRLINERS;
+  public cardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player): boolean {
-      return player.getResourceCount(ResourceType.FLOATER) >= 3;
-    }
+  public canPlay(player: Player): boolean {
+    return player.getResourceCount(ResourceType.FLOATER) >= 3;
+  }
 
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.MEGACREDITS, 2);
-      game.defer(new AddResourcesToCard(player, game, ResourceType.FLOATER, 2));
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 1;
-    }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.MEGACREDITS, 2);
+    game.defer(new AddResourcesToCard(player, game, ResourceType.FLOATER, 2));
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 1;
+  }
 }
-

--- a/src/cards/colonies/AtmoCollectors.ts
+++ b/src/cards/colonies/AtmoCollectors.ts
@@ -10,9 +10,9 @@ import {IResourceCard} from '../ICard';
 import {LogHelper} from '../../components/LogHelper';
 import {Resources} from '../../Resources';
 import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
-import {CardMetadata} from './../CardMetadata';
-import {CardRenderer} from './../render/CardRenderer';
-import {CardRenderItemSize} from './../render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class AtmoCollectors implements IProjectCard, IResourceCard {
   public cost = 15;

--- a/src/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/cards/promo/AsteroidDeflectionSystem.ts
@@ -9,36 +9,36 @@ import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 
 export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IResourceCard {
-    public name = CardName.ASTEROID_DEFLECTION_SYSTEM;
-    public cost = 13;
-    public tags = [Tags.SPACE, Tags.EARTH, Tags.STEEL];
-    public resourceType = ResourceType.ASTEROID;
-    public resourceCount: number = 0;
-    public cardType = CardType.ACTIVE;
-    public hasRequirements = false;
+  public name = CardName.ASTEROID_DEFLECTION_SYSTEM;
+  public cost = 13;
+  public tags = [Tags.SPACE, Tags.EARTH, Tags.STEEL];
+  public resourceType = ResourceType.ASTEROID;
+  public resourceCount: number = 0;
+  public cardType = CardType.ACTIVE;
+  public hasRequirements = false;
 
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1;
-    }
+  public canPlay(player: Player): boolean {
+    return player.getProduction(Resources.ENERGY) >= 1;
+  }
 
-    public play(player: Player) {
-      player.addProduction(Resources.ENERGY, -1);
-      return undefined;
-    }
+  public play(player: Player) {
+    player.addProduction(Resources.ENERGY, -1);
+    return undefined;
+  }
 
-    public canAct(): boolean {
-      return true;
-    }
+  public canAct(): boolean {
+    return true;
+  }
 
-    public action(player: Player, game: Game) {
-      const topCard = game.dealer.dealCard();
-      if (topCard.tags.indexOf(Tags.SPACE) !== -1) player.addResourceTo(this);
-      game.log('${0} revealed and discarded ${1}', (b) => b.player(player).card(topCard));
-      game.dealer.discard(topCard);
-      return undefined;
-    }
+  public action(player: Player, game: Game) {
+    const topCard = game.dealer.dealCard();
+    if (topCard.tags.indexOf(Tags.SPACE) !== -1) player.addResourceTo(this);
+    game.log('${0} revealed and discarded ${1}', (b) => b.player(player).card(topCard));
+    game.dealer.discard(topCard);
+    return undefined;
+  }
 
-    public getVictoryPoints(): number {
-      return this.resourceCount;
-    }
+  public getVictoryPoints(): number {
+    return this.resourceCount;
+  }
 }

--- a/src/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/cards/promo/AsteroidDeflectionSystem.ts
@@ -7,10 +7,10 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRenderer} from '../../cards/render/CardRenderer';
-import {CardRenderVictoryPoints} from '../../cards/render/CardRenderVictoryPoints';
-import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderVictoryPoints} from '../render/CardRenderVictoryPoints';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_DEFLECTION_SYSTEM;

--- a/src/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/cards/promo/AsteroidDeflectionSystem.ts
@@ -9,7 +9,7 @@ import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
-import {CardRenderVictoryPoints} from '../render/CardRenderVictoryPoints';
+import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IResourceCard {
@@ -47,7 +47,6 @@ export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IRes
   }
   public metadata: CardMetadata = {
     cardNumber: 'X27',
-    // description: 'Add 2 asteroids to this card',
     renderData: CardRenderer.builder((b) => {
       b.effectBox((eb) => {
         eb.empty().startAction.cards(1).asterix().nbsp.space().played.colon().asteroids(1);
@@ -55,6 +54,6 @@ export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IRes
       }).br;
       b.productionBox((pb) => pb.minus().energy(1)).text('opponents may not remove your plants', CardRenderItemSize.SMALL, true);
     }),
-    victoryPoints: CardRenderVictoryPoints.asteroids(1, 1),
+    victoryPoints: CardRenderDynamicVictoryPoints.asteroids(1, 1),
   }
 }

--- a/src/cards/promo/AsteroidDeflectionSystem.ts
+++ b/src/cards/promo/AsteroidDeflectionSystem.ts
@@ -7,6 +7,10 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderVictoryPoints} from '../../cards/render/CardRenderVictoryPoints';
+import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
 
 export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_DEFLECTION_SYSTEM;
@@ -40,5 +44,17 @@ export class AsteroidDeflectionSystem implements IActionCard, IProjectCard, IRes
 
   public getVictoryPoints(): number {
     return this.resourceCount;
+  }
+  public metadata: CardMetadata = {
+    cardNumber: 'X27',
+    // description: 'Add 2 asteroids to this card',
+    renderData: CardRenderer.builder((b) => {
+      b.effectBox((eb) => {
+        eb.empty().startAction.cards(1).asterix().nbsp.space().played.colon().asteroids(1);
+        eb.description('Action: REVEAL AND DISCARD the top card of the deck. If it has a space tag, add an asteroid here.');
+      }).br;
+      b.productionBox((pb) => pb.minus().energy(1)).text('opponents may not remove your plants', CardRenderItemSize.SMALL, true);
+    }),
+    victoryPoints: CardRenderVictoryPoints.asteroids(1, 1),
   }
 }

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -8,6 +8,9 @@ import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 import {LogHelper} from '../../components/LogHelper';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderVictoryPoints} from '../render/CardRenderVictoryPoints';
 
 export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_HOLLOWING;
@@ -36,5 +39,17 @@ export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCa
 
   public getVictoryPoints(): number {
     return Math.floor(this.resourceCount / 2);
+  }
+
+  public metadata: CardMetadata = {
+    cardNumber: 'x13',
+    description: '1VP for each 2 asteroids on this card',
+    renderData: CardRenderer.builder((b) => {
+      b.effectBox((eb) => {
+        eb.titanium(1).startAction.asteroids(1).productionBox((pb) => pb.megacredits(1));
+        eb.description('Action: Spend 1 titanium to add 1 asteroid resource here and increase MC production 1 step');
+      });
+    }),
+    victoryPoints: CardRenderVictoryPoints.asteroids(1, 2),
   }
 }

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -8,8 +8,8 @@ import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 import {LogHelper} from '../../components/LogHelper';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderVictoryPoints} from '../render/CardRenderVictoryPoints';
 
 export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCard {

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -42,7 +42,7 @@ export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCa
   }
 
   public metadata: CardMetadata = {
-    cardNumber: 'x13',
+    cardNumber: 'X13',
     description: '1VP for each 2 asteroids on this card',
     renderData: CardRenderer.builder((b) => {
       b.effectBox((eb) => {

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -10,7 +10,7 @@ import {Game} from '../../Game';
 import {LogHelper} from '../../components/LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
-import {CardRenderVictoryPoints} from '../render/CardRenderVictoryPoints';
+import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 
 export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_HOLLOWING;
@@ -50,6 +50,6 @@ export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCa
         eb.description('Action: Spend 1 titanium to add 1 asteroid resource here and increase MC production 1 step');
       });
     }),
-    victoryPoints: CardRenderVictoryPoints.asteroids(1, 2),
+    victoryPoints: CardRenderDynamicVictoryPoints.asteroids(1, 2),
   }
 }

--- a/src/cards/promo/AsteroidHollowing.ts
+++ b/src/cards/promo/AsteroidHollowing.ts
@@ -10,31 +10,31 @@ import {Game} from '../../Game';
 import {LogHelper} from '../../components/LogHelper';
 
 export class AsteroidHollowing implements IActionCard, IProjectCard, IResourceCard {
-    public name = CardName.ASTEROID_HOLLOWING;
-    public cost = 16;
-    public tags = [Tags.SPACE];
-    public resourceType = ResourceType.ASTEROID;
-    public resourceCount: number = 0;
-    public cardType = CardType.ACTIVE;
+  public name = CardName.ASTEROID_HOLLOWING;
+  public cost = 16;
+  public tags = [Tags.SPACE];
+  public resourceType = ResourceType.ASTEROID;
+  public resourceCount: number = 0;
+  public cardType = CardType.ACTIVE;
 
-    public play() {
-      return undefined;
-    }
+  public play() {
+    return undefined;
+  }
 
-    public canAct(player: Player): boolean {
-      return player.titanium > 0;
-    }
+  public canAct(player: Player): boolean {
+    return player.titanium > 0;
+  }
 
-    public action(player: Player, game: Game) {
-      player.titanium -= 1;
-      player.addProduction(Resources.MEGACREDITS);
-      player.addResourceTo(this);
-      LogHelper.logAddResource(game, player, this);
+  public action(player: Player, game: Game) {
+    player.titanium -= 1;
+    player.addProduction(Resources.MEGACREDITS);
+    player.addResourceTo(this);
+    LogHelper.logAddResource(game, player, this);
 
-      return undefined;
-    }
+    return undefined;
+  }
 
-    public getVictoryPoints(): number {
-      return Math.floor(this.resourceCount / 2);
-    }
+  public getVictoryPoints(): number {
+    return Math.floor(this.resourceCount / 2);
+  }
 }

--- a/src/cards/promo/AsteroidRights.ts
+++ b/src/cards/promo/AsteroidRights.ts
@@ -12,8 +12,8 @@ import {SelectCard} from '../../inputs/SelectCard';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class AsteroidRights implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_RIGHTS;

--- a/src/cards/promo/AsteroidRights.ts
+++ b/src/cards/promo/AsteroidRights.ts
@@ -12,6 +12,8 @@ import {SelectCard} from '../../inputs/SelectCard';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRenderer} from '../../cards/render/CardRenderer';
 
 export class AsteroidRights implements IActionCard, IProjectCard, IResourceCard {
   public name = CardName.ASTEROID_RIGHTS;
@@ -82,5 +84,20 @@ export class AsteroidRights implements IActionCard, IProjectCard, IResourceCard 
     asteroidCards.length === 1 ? opts.push(addAsteroidToSelf) : opts.push(addAsteroidOption);
 
     return new OrOptions(...opts);
+  }
+  public metadata: CardMetadata = {
+    cardNumber: 'X31',
+    description: 'Add 2 asteroids to this card',
+    renderData: CardRenderer.builder((b) => {
+      b.effectBox((eb) => {
+        eb.megacredits(1).startAction.asteroids(1).asterix();
+        eb.description('Action: Spend 1 MC to add 1 asteroid to ANY card');
+      }).br;
+      b.effectBox((eb) => {
+        eb.asteroids(1).startAction.productionBox((pb) => pb.megacredits(1)).or().titanium(2);
+        eb.description('Action: Spend 1 asteroid here to increase MC production 1 step OR gain 2 titanium');
+      }).br;
+      b.asteroids(2);
+    }),
   }
 }

--- a/src/cards/promo/AsteroidRights.ts
+++ b/src/cards/promo/AsteroidRights.ts
@@ -14,86 +14,73 @@ import {SelectOption} from '../../inputs/SelectOption';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 
 export class AsteroidRights implements IActionCard, IProjectCard, IResourceCard {
-    public name = CardName.ASTEROID_RIGHTS;
-    public cost = 10;
-    public tags = [Tags.EARTH, Tags.SPACE];
-    public resourceType = ResourceType.ASTEROID;
-    public resourceCount: number = 0;
-    public cardType = CardType.ACTIVE;
+  public name = CardName.ASTEROID_RIGHTS;
+  public cost = 10;
+  public tags = [Tags.EARTH, Tags.SPACE];
+  public resourceType = ResourceType.ASTEROID;
+  public resourceCount: number = 0;
+  public cardType = CardType.ACTIVE;
 
-    public play() {
-      this.resourceCount = 2;
-      return undefined;
-    }
+  public play() {
+    this.resourceCount = 2;
+    return undefined;
+  }
 
-    public canAct(player: Player): boolean {
-      return player.canAfford(1) || this.resourceCount > 0;
-    }
+  public canAct(player: Player): boolean {
+    return player.canAfford(1) || this.resourceCount > 0;
+  }
 
-    public action(player: Player, game: Game) {
-      const canAddAsteroid = player.canAfford(1);
-      const hasAsteroids = this.resourceCount > 0;
-      const asteroidCards = player.getResourceCards(ResourceType.ASTEROID);
+  public action(player: Player, game: Game) {
+    const canAddAsteroid = player.canAfford(1);
+    const hasAsteroids = this.resourceCount > 0;
+    const asteroidCards = player.getResourceCards(ResourceType.ASTEROID);
 
-      const spendAsteroidOption = new SelectOption('Remove 1 asteroid on this card to increase MC production 1 step OR gain 2 titanium', 'Remove asteroid', () => {
-        this.resourceCount--;
+    const spendAsteroidOption = new SelectOption('Remove 1 asteroid on this card to increase MC production 1 step OR gain 2 titanium', 'Remove asteroid', () => {
+      this.resourceCount--;
 
-        return new OrOptions(
-            new SelectOption(
-                'Increase MC production 1 step',
-                'Select',
-                () => {
-                  player.addProduction(Resources.MEGACREDITS);
-                  LogHelper.logRemoveResource(game, player, this, 1, 'increase MC production 1 step');
-                  return undefined;
-                },
-            ),
-            new SelectOption(
-                'Gain 2 titanium',
-                'Select',
-                () => {
-                  player.titanium += 2;
-                  LogHelper.logRemoveResource(game, player, this, 1, 'gain 2 titanium');
-                  return undefined;
-                },
-            ),
-        );
-      });
-
-      const addAsteroidToSelf = new SelectOption('Add 1 asteroid to this card', 'Add asteroid', () => {
-        game.defer(new SelectHowToPayDeferred(player, 1, false, false, 'Select how to pay for asteroid'));
-        player.addResourceTo(this);
-        LogHelper.logAddResource(game, player, this);
-
-        return undefined;
-      });
-
-      const addAsteroidOption = new SelectCard(
-          'Select card to add 1 asteroid',
-          'Add asteroid',
-          asteroidCards,
-          (foundCards: Array<ICard>) => {
-            game.defer(new SelectHowToPayDeferred(player, 1, false, false, 'Select how to pay for asteroid'));
-            player.addResourceTo(foundCards[0], 1);
-            LogHelper.logAddResource(game, player, foundCards[0]);
-
+      return new OrOptions(
+          new SelectOption('Increase MC production 1 step', 'Select', () => {
+            player.addProduction(Resources.MEGACREDITS);
+            LogHelper.logRemoveResource(game, player, this, 1, 'increase MC production 1 step');
             return undefined;
-          },
+          }),
+          new SelectOption('Gain 2 titanium', 'Select', () => {
+            player.titanium += 2;
+            LogHelper.logRemoveResource(game, player, this, 1, 'gain 2 titanium');
+            return undefined;
+          }),
       );
+    });
 
-      // Spend asteroid
-      if (!canAddAsteroid) return spendAsteroidOption.cb();
+    const addAsteroidToSelf = new SelectOption('Add 1 asteroid to this card', 'Add asteroid', () => {
+      game.defer(new SelectHowToPayDeferred(player, 1, false, false, 'Select how to pay for asteroid'));
+      player.addResourceTo(this);
+      LogHelper.logAddResource(game, player, this);
 
-      // Add asteroid to any card
-      if (!hasAsteroids) {
-        if (asteroidCards.length === 1) return addAsteroidToSelf.cb();
-        return addAsteroidOption;
-      }
+      return undefined;
+    });
 
-      const opts: Array<SelectOption | SelectCard<ICard>> = [];
-      opts.push(spendAsteroidOption);
-        asteroidCards.length === 1 ? opts.push(addAsteroidToSelf) : opts.push(addAsteroidOption);
+    const addAsteroidOption = new SelectCard('Select card to add 1 asteroid', 'Add asteroid', asteroidCards, (foundCards: Array<ICard>) => {
+      game.defer(new SelectHowToPayDeferred(player, 1, false, false, 'Select how to pay for asteroid'));
+      player.addResourceTo(foundCards[0], 1);
+      LogHelper.logAddResource(game, player, foundCards[0]);
 
-        return new OrOptions(...opts);
+      return undefined;
+    });
+
+    // Spend asteroid
+    if (!canAddAsteroid) return spendAsteroidOption.cb();
+
+    // Add asteroid to any card
+    if (!hasAsteroids) {
+      if (asteroidCards.length === 1) return addAsteroidToSelf.cb();
+      return addAsteroidOption;
     }
+
+    const opts: Array<SelectOption | SelectCard<ICard>> = [];
+    opts.push(spendAsteroidOption);
+    asteroidCards.length === 1 ? opts.push(addAsteroidToSelf) : opts.push(addAsteroidOption);
+
+    return new OrOptions(...opts);
+  }
 }

--- a/src/cards/render/CardRenderDynamicVictoryPoints.ts
+++ b/src/cards/render/CardRenderDynamicVictoryPoints.ts
@@ -3,11 +3,7 @@ import {CardRenderItem} from './CardRenderItem';
 
 export class CardRenderDynamicVictoryPoints {
   public targetOneOrMore: boolean = false; // marking target to be one or more res (Search for Life)
-  constructor(public item: CardRenderItem, public points: number = 1, public target: number = 1) {
-    if (this.points > this.target) {
-      throw new Error(`Illegal victory points setup. Target points have to be greater or equal points and not: ${this.points}/${this.target}`);
-    }
-  }
+  constructor(public item: CardRenderItem, public points: number, public target: number) {}
 
   public getPointsHtml(): string {
     if (this.target === this.points) return `${this.target}/`;
@@ -21,4 +17,3 @@ export class CardRenderDynamicVictoryPoints {
     return new CardRenderDynamicVictoryPoints(new CardRenderItem(CardRenderItemType.MICROBES), points, target);
   }
 }
-

--- a/src/cards/render/CardRenderDynamicVictoryPoints.ts
+++ b/src/cards/render/CardRenderDynamicVictoryPoints.ts
@@ -1,7 +1,7 @@
 import {CardRenderItemType} from './CardRenderItemType';
 import {CardRenderItem} from './CardRenderItem';
 
-export class CardRenderVictoryPoints {
+export class CardRenderDynamicVictoryPoints {
   public targetOneOrMore: boolean = false; // marking target to be one or more res (Search for Life)
   constructor(public item: CardRenderItem, public points: number = 1, public target: number = 1) {
     if (this.points > this.target) {
@@ -13,12 +13,12 @@ export class CardRenderVictoryPoints {
     if (this.target === this.points) return `${this.target}/`;
     return `${this.points}/${this.target}`;
   }
-  public static asteroids(points: number, target: number): CardRenderVictoryPoints {
-    return new CardRenderVictoryPoints(new CardRenderItem(CardRenderItemType.ASTEROIDS), points, target);
+  public static asteroids(points: number, target: number): CardRenderDynamicVictoryPoints {
+    return new CardRenderDynamicVictoryPoints(new CardRenderItem(CardRenderItemType.ASTEROIDS), points, target);
   }
 
-  public static microbes(points: number, target: number): CardRenderVictoryPoints {
-    return new CardRenderVictoryPoints(new CardRenderItem(CardRenderItemType.MICROBES), points, target);
+  public static microbes(points: number, target: number): CardRenderDynamicVictoryPoints {
+    return new CardRenderDynamicVictoryPoints(new CardRenderItem(CardRenderItemType.MICROBES), points, target);
   }
 }
 

--- a/src/cards/render/CardRenderItem.ts
+++ b/src/cards/render/CardRenderItem.ts
@@ -4,8 +4,10 @@
  */
 import {CardRenderItemType} from './CardRenderItemType';
 import {CardRenderItemSize} from './CardRenderItemSize';
+import {Tags} from '../Tags';
 
 export class CardRenderItem {
+  // TODO (chosta): use child classes to describe special behavior
   public anyPlayer?: boolean; // activated for any player
   public showDigit?: boolean; // rendering a digit instead of chain of items
   public amountInside?: boolean; // showing the amount for the item in its container
@@ -14,6 +16,7 @@ export class CardRenderItem {
   public isUppercase?: boolean; // if we have text and it's uppercase
   public isPlate?: boolean; // used to mark plate a.k.a. text with golden background
   public size?: CardRenderItemSize;
+  public secondaryTag?: Tags; // adding tag dependency (top right bubble)
   constructor(public type: CardRenderItemType, public amount: number = -1) {
     if (Math.abs(this.amount) > 5) {
       this.showDigit = true;

--- a/src/cards/render/CardRenderItem.ts
+++ b/src/cards/render/CardRenderItem.ts
@@ -3,12 +3,17 @@
   e.g. Any tag, tile, production cube, ocean, temperature, etc.
  */
 import {CardRenderItemType} from './CardRenderItemType';
+import {CardRenderItemSize} from './CardRenderItemSize';
 
 export class CardRenderItem {
-  public anyPlayer: boolean = false; // activated for any player
-  public showDigit: boolean = false; // rendering a digit instead of chain of items
-  public amountInside: boolean = false; // showing the amount for the item in its container
-  public isPlayed: boolean = false; // used to mark an item as 'played' e.g. event tags
+  public anyPlayer?: boolean; // activated for any player
+  public showDigit?: boolean; // rendering a digit instead of chain of items
+  public amountInside?: boolean; // showing the amount for the item in its container
+  public isPlayed?: boolean; // used to mark an item as 'played' e.g. event tags
+  public text?: string; // we can use text instead of integers in some cases
+  public isUppercase?: boolean; // if we have text and it's uppercase
+  public isPlate?: boolean; // used to mark plate a.k.a. text with golden background
+  public size?: CardRenderItemSize;
   constructor(public type: CardRenderItemType, public amount: number = -1) {
     if (Math.abs(this.amount) > 5) {
       this.showDigit = true;

--- a/src/cards/render/CardRenderItemSize.ts
+++ b/src/cards/render/CardRenderItemSize.ts
@@ -2,4 +2,5 @@ export enum CardRenderItemSize {
   SMALL = 'S',
   MEDIUM = 'M',
   LARGE = 'L',
+  TINY = 'XS',
 }

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -23,6 +23,7 @@ export enum CardRenderItemType {
   PARTY_LEADERS = 'party_leaders',
   DELEGATES = 'delegates',
   INFLUENCE = 'influence',
+  CITY = 'city',
   PLATE = 'plate',
   TEXT = 'text',
   // more to come...

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -11,6 +11,7 @@ export enum CardRenderItemType {
   MEGACREDITS = 'megacredits',
   CARDS = 'cards',
   FLOATERS = 'flaters',
+  ASTEROIDS = 'asteroids',
   MICROBES = 'microbes',
   ANIMALS = 'animals',
   EVENT = 'event',

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -23,5 +23,7 @@ export enum CardRenderItemType {
   PARTY_LEADERS = 'party_leaders',
   DELEGATES = 'delegates',
   INFLUENCE = 'influence',
+  PLATE = 'plate',
+  TEXT = 'text',
   // more to come...
 }

--- a/src/cards/render/CardRenderItemType.ts
+++ b/src/cards/render/CardRenderItemType.ts
@@ -26,5 +26,6 @@ export enum CardRenderItemType {
   CITY = 'city',
   PLATE = 'plate',
   TEXT = 'text',
+  NBSP = 'nbsp',
   // more to come...
 }

--- a/src/cards/render/CardRenderSymbol.ts
+++ b/src/cards/render/CardRenderSymbol.ts
@@ -38,4 +38,7 @@ export class CardRenderSymbol {
   public static bracketClose(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
     return new CardRenderSymbol(CardRenderSymbolType.BRACKET_CLOSE, size);
   }
+  public static nbsp(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): CardRenderSymbol {
+    return new CardRenderSymbol(CardRenderSymbolType.NBSP, size, true);
+  }
 }

--- a/src/cards/render/CardRenderSymbolType.ts
+++ b/src/cards/render/CardRenderSymbolType.ts
@@ -9,4 +9,5 @@ export enum CardRenderSymbolType {
   ARROW = '->',
   BRACKET_OPEN = '(',
   BRACKET_CLOSE = ')',
+  NBSP = 'nbsp',
 }

--- a/src/cards/render/CardRenderVictoryPoints.ts
+++ b/src/cards/render/CardRenderVictoryPoints.ts
@@ -1,0 +1,24 @@
+import {CardRenderItemType} from './CardRenderItemType';
+import {CardRenderItem} from './CardRenderItem';
+
+export class CardRenderVictoryPoints {
+  public targetOneOrMore: boolean = false; // marking target to be one or more res (Search for Life)
+  constructor(public item: CardRenderItem, public points: number = 1, public target: number = 1) {
+    if (this.points > this.target) {
+      throw new Error(`Illegal victory points setup. Target points have to be greater or equal points and not: ${this.points}/${this.target}`);
+    }
+  }
+
+  public getPointsHtml(): string {
+    if (this.target === this.points) return `${this.target}/`;
+    return `${this.points}/${this.target}`;
+  }
+  public static asteroids(points: number, target: number): CardRenderVictoryPoints {
+    return new CardRenderVictoryPoints(new CardRenderItem(CardRenderItemType.ASTEROIDS), points, target);
+  }
+
+  public static microbes(points: number, target: number): CardRenderVictoryPoints {
+    return new CardRenderVictoryPoints(new CardRenderItem(CardRenderItemType.MICROBES), points, target);
+  }
+}
+

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -2,6 +2,7 @@ import {CardRenderItem} from './CardRenderItem';
 import {CardRenderSymbol} from './CardRenderSymbol';
 import {CardRenderItemSize} from './CardRenderItemSize';
 import {CardRenderItemType} from './CardRenderItemType';
+import {Tags} from '../Tags';
 
 type ItemType = CardRenderItem | CardRenderProductionBox | CardRenderSymbol | CardRenderEffect | string | undefined;
 
@@ -333,13 +334,13 @@ class Builder {
     const row = this._getCurrentRow();
     if (row !== undefined) {
       const item = row.pop();
+      if (item === undefined) {
+        throw new Error('Called "played" without a CardRenderItem.');
+      }
       if (!(item instanceof CardRenderItem)) {
         throw new Error('"played" could be called on CardRenderItem only');
       }
 
-      if (item === undefined) {
-        throw new Error('Called "played" without a CardRenderItem.');
-      }
       item.isPlayed = true;
       row.push(item);
       this._data.push(row);
@@ -354,14 +355,36 @@ class Builder {
     const row = this._getCurrentRow();
     if (row !== undefined) {
       const item = row.pop();
+      if (item === undefined) {
+        throw new Error('Called "digit" without a CardRenderItem.');
+      }
       if (!(item instanceof CardRenderItem)) {
         throw new Error('"digit" could be called on CardRenderItem only');
       }
 
-      if (item === undefined) {
-        throw new Error('Called "digit" without a CardRenderItem.');
-      }
       item.showDigit = true;
+      row.push(item);
+
+      this._data.push(row);
+    }
+
+    return this;
+  }
+
+  public secondaryTag(tag: Tags): Builder {
+    this._checkExistingItem();
+
+    const row = this._getCurrentRow();
+    if (row !== undefined) {
+      const item = row.pop();
+      if (item === undefined) {
+        throw new Error('Called "secondaryTag" without a CardRenderItem.');
+      }
+      if (!(item instanceof CardRenderItem)) {
+        throw new Error('"secondaryTag" could be called on CardRenderItem only');
+      }
+
+      item.secondaryTag = tag;
       row.push(item);
 
       this._data.push(row);

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -188,6 +188,10 @@ class Builder {
     return this;
   }
 
+  public asteroids(amount: number): Builder {
+    this._addRowItem(new CardRenderItem(CardRenderItemType.ASTEROIDS, amount));
+    return this;
+  }
 
   public event(): Builder {
     this._addRowItem(new CardRenderItem(CardRenderItemType.EVENT));

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -272,6 +272,23 @@ class Builder {
     return this;
   }
 
+  public plate(text: string): Builder {
+    const item = new CardRenderItem(CardRenderItemType.PLATE);
+    item.text = text;
+    item.isPlate = true;
+    this._addRowItem(item);
+    return this;
+  }
+
+  public text(text: string, size: CardRenderItemSize = CardRenderItemSize.MEDIUM, uppercase: boolean = false): Builder {
+    const item = new CardRenderItem(CardRenderItemType.TEXT);
+    item.text = text;
+    item.size = size;
+    item.isUppercase = uppercase;
+    this._addRowItem(item);
+    return this;
+  }
+
   public get br(): Builder {
     const newRow: Array<ItemType> = [];
     this._data.push(newRow);

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -244,7 +244,7 @@ class Builder {
     return this;
   }
 
-  public or(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+  public or(size: CardRenderItemSize = CardRenderItemSize.SMALL): Builder {
     this._checkExistingItem();
     this._addSymbol(CardRenderSymbol.or(size));
     return this;
@@ -274,6 +274,12 @@ class Builder {
     return this;
   }
 
+  public colon(size: CardRenderItemSize = CardRenderItemSize.MEDIUM): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.colon(size));
+    return this;
+  }
+
   public empty(): Builder {
     this._checkExistingItem();
     this._addSymbol(CardRenderSymbol.empty());
@@ -300,6 +306,15 @@ class Builder {
   public get br(): Builder {
     const newRow: Array<ItemType> = [];
     this._data.push(newRow);
+    return this;
+  }
+
+  /**
+   * add non breakable space or simply empty space between items
+   */
+  public get nbsp(): Builder {
+    this._checkExistingItem();
+    this._addSymbol(CardRenderSymbol.nbsp());
     return this;
   }
 

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -220,6 +220,13 @@ class Builder {
     return this;
   }
 
+  public city(size: CardRenderItemSize = CardRenderItemSize.MEDIUM) {
+    const item = new CardRenderItem(CardRenderItemType.CITY);
+    item.size = size;
+    this._addRowItem(item);
+    return this;
+  }
+
   public description(description: string): Builder {
     this._checkExistingItem();
     this._addRowItem(description);

--- a/src/cards/turmoil/AerialLenses.ts
+++ b/src/cards/turmoil/AerialLenses.ts
@@ -8,7 +8,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {RemoveAnyPlants} from '../../deferredActions/RemoveAnyPlants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class AerialLenses implements IProjectCard {
   public cost = 2;

--- a/src/cards/turmoil/PublicCelebrations.ts
+++ b/src/cards/turmoil/PublicCelebrations.ts
@@ -3,8 +3,8 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
 
 export class PublicCelebrations implements IProjectCard {
     public cost = 8;

--- a/src/cards/venusNext/AerialMappers.ts
+++ b/src/cards/venusNext/AerialMappers.ts
@@ -10,9 +10,9 @@ import {SelectOption} from '../../inputs/SelectOption';
 import {SelectCard} from '../../inputs/SelectCard';
 import {CardName} from '../../CardName';
 import {LogHelper} from '../../components/LogHelper';
-import {CardMetadata} from './../CardMetadata';
-import {CardRenderer} from './../render/CardRenderer';
-import {CardRenderItemSize} from './../render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class AerialMappers implements IActionCard, IProjectCard, IResourceCard {
   public cost = 11;

--- a/src/cards/venusNext/AerosportTournament.ts
+++ b/src/cards/venusNext/AerosportTournament.ts
@@ -6,10 +6,10 @@ import {ResourceType} from '../../ResourceType';
 import {CardName} from '../../CardName';
 import {Resources} from '../../Resources';
 import {LogHelper} from '../../components/LogHelper';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
-import {CardRenderer} from '../../cards/render/CardRenderer';
-import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 
 export class AerosportTournament implements IProjectCard {

--- a/src/cards/venusNext/AerosportTournament.ts
+++ b/src/cards/venusNext/AerosportTournament.ts
@@ -7,23 +7,22 @@ import {CardName} from '../../CardName';
 import {Resources} from '../../Resources';
 import {LogHelper} from '../../components/LogHelper';
 
-
 export class AerosportTournament implements IProjectCard {
-    public cost = 7;
-    public tags = [];
-    public name = CardName.AEROSPORT_TOURNAMENT;
-    public cardType = CardType.EVENT;
-    public canPlay(player: Player): boolean {
-      return player.getResourceCount(ResourceType.FLOATER) >= 5;
-    }
-    public play(player: Player, game: Game) {
-      const amount = game.getCitiesInPlay();
-      player.megaCredits += amount;
-      LogHelper.logGainStandardResource(game, player, Resources.MEGACREDITS, amount);
-      return undefined;
-    }
+  public cost = 7;
+  public tags = [];
+  public name = CardName.AEROSPORT_TOURNAMENT;
+  public cardType = CardType.EVENT;
+  public canPlay(player: Player): boolean {
+    return player.getResourceCount(ResourceType.FLOATER) >= 5;
+  }
+  public play(player: Player, game: Game) {
+    const amount = game.getCitiesInPlay();
+    player.megaCredits += amount;
+    LogHelper.logGainStandardResource(game, player, Resources.MEGACREDITS, amount);
+    return undefined;
+  }
 
-    public getVictoryPoints() {
-      return 1;
-    }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/venusNext/AerosportTournament.ts
+++ b/src/cards/venusNext/AerosportTournament.ts
@@ -6,6 +6,11 @@ import {ResourceType} from '../../ResourceType';
 import {CardName} from '../../CardName';
 import {Resources} from '../../Resources';
 import {LogHelper} from '../../components/LogHelper';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRequirements} from '../../cards/CardRequirements';
+import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
+
 
 export class AerosportTournament implements IProjectCard {
   public cost = 7;
@@ -24,5 +29,15 @@ export class AerosportTournament implements IProjectCard {
 
   public getVictoryPoints() {
     return 1;
+  }
+
+  public metadata: CardMetadata = {
+    cardNumber: '214',
+    description: 'Requires that you have 5 Floaters. Gain 1 MC per each City tile in play',
+    requirements: CardRequirements.builder((b) => b.floaters(5)),
+    renderData: CardRenderer.builder((b) => {
+      b.megacredits(1).slash().city(CardRenderItemSize.SMALL).any;
+    }),
+    victoryPoints: 1,
   }
 }

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -10,8 +10,8 @@ import {Game} from '../../Game';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {REDS_RULING_POLICY_COST, MAX_VENUS_SCALE} from '../../constants';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class AirScrappingExpedition implements IProjectCard {
   public cost = 13;

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -10,6 +10,8 @@ import {Game} from '../../Game';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {REDS_RULING_POLICY_COST, MAX_VENUS_SCALE} from '../../constants';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRenderer} from '../../cards/render/CardRenderer';
 
 export class AirScrappingExpedition implements IProjectCard {
   public cost = 13;
@@ -39,5 +41,13 @@ export class AirScrappingExpedition implements IProjectCard {
       player.addResourceTo(foundCards[0], 3);
       return undefined;
     });
+  }
+
+  public metadata: CardMetadata = {
+    cardNumber: '215',
+    description: 'Raise Venus 1 step. Add 3 Floaters to ANY Venus CARD',
+    renderData: CardRenderer.builder((b) => {
+      b.venus(1).floaters(3).secondaryTag(Tags.VENUS);
+    }),
   }
 }

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -12,37 +12,32 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {REDS_RULING_POLICY_COST, MAX_VENUS_SCALE} from '../../constants';
 
 export class AirScrappingExpedition implements IProjectCard {
-    public cost = 13;
-    public tags = [Tags.VENUS];
-    public name = CardName.AIR_SCRAPPING_EXPEDITION;
-    public cardType = CardType.EVENT;
-    public hasRequirements = false;
+  public cost = 13;
+  public tags = [Tags.VENUS];
+  public name = CardName.AIR_SCRAPPING_EXPEDITION;
+  public cardType = CardType.EVENT;
+  public hasRequirements = false;
 
-    public canPlay(player: Player, game: Game): boolean {
-      const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
-        return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true);
-      }
-
-      return true;
+  public canPlay(player: Player, game: Game): boolean {
+    const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {
+      return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true);
     }
 
-    public play(player: Player, game: Game) {
-      game.increaseVenusScaleLevel(player, 1);
-      let floaterCards = player.getResourceCards(ResourceType.FLOATER);
-      floaterCards = floaterCards.filter((card) => card.tags.filter((cardTag) => cardTag === Tags.VENUS).length > 0 );
-      if (floaterCards.length === 0) {
-        return undefined;
-      }
+    return true;
+  }
 
-      return new SelectCard(
-          'Select card to add 3 floaters',
-          'Add floaters',
-          floaterCards,
-          (foundCards: Array<ICard>) => {
-            player.addResourceTo(foundCards[0], 3);
-            return undefined;
-          },
-      );
+  public play(player: Player, game: Game) {
+    game.increaseVenusScaleLevel(player, 1);
+    let floaterCards = player.getResourceCards(ResourceType.FLOATER);
+    floaterCards = floaterCards.filter((card) => card.tags.filter((cardTag) => cardTag === Tags.VENUS).length > 0);
+    if (floaterCards.length === 0) {
+      return undefined;
     }
+
+    return new SelectCard('Select card to add 3 floaters', 'Add floaters', floaterCards, (foundCards: Array<ICard>) => {
+      player.addResourceTo(foundCards[0], 3);
+      return undefined;
+    });
+  }
 }

--- a/src/cards/venusNext/AtalantaPlanitiaLab.ts
+++ b/src/cards/venusNext/AtalantaPlanitiaLab.ts
@@ -4,6 +4,9 @@ import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRequirements} from '../../cards/CardRequirements';
+import {CardRenderer} from '../../cards/render/CardRenderer';
 
 export class AtalantaPlanitiaLab implements IProjectCard {
   public cost = 10;
@@ -21,5 +24,12 @@ export class AtalantaPlanitiaLab implements IProjectCard {
 
   public getVictoryPoints() {
     return 2;
+  }
+  public metadata: CardMetadata = {
+    cardNumber: '216',
+    description: 'Requires 3 science tags. Draw 2 cards',
+    requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
+    renderData: CardRenderer.builder((b) => b.cards(2)),
+    victoryPoints: 2,
   }
 }

--- a/src/cards/venusNext/AtalantaPlanitiaLab.ts
+++ b/src/cards/venusNext/AtalantaPlanitiaLab.ts
@@ -6,20 +6,20 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 
 export class AtalantaPlanitiaLab implements IProjectCard {
-    public cost = 10;
-    public tags = [Tags.VENUS, Tags.SCIENCE];
-    public name = CardName.ATALANTA_PLANITIA_LAB;
-    public cardType = CardType.AUTOMATED;
-    public canPlay(player: Player): boolean {
-      return player.getTagCount(Tags.SCIENCE) >= 3;
-    }
-    public play(player: Player, game: Game) {
-      player.cardsInHand.push(game.dealer.dealCard());
-      player.cardsInHand.push(game.dealer.dealCard());
-      return undefined;
-    }
+  public cost = 10;
+  public tags = [Tags.VENUS, Tags.SCIENCE];
+  public name = CardName.ATALANTA_PLANITIA_LAB;
+  public cardType = CardType.AUTOMATED;
+  public canPlay(player: Player): boolean {
+    return player.getTagCount(Tags.SCIENCE) >= 3;
+  }
+  public play(player: Player, game: Game) {
+    player.cardsInHand.push(game.dealer.dealCard());
+    player.cardsInHand.push(game.dealer.dealCard());
+    return undefined;
+  }
 
-    public getVictoryPoints() {
-      return 2;
-    }
+  public getVictoryPoints() {
+    return 2;
+  }
 }

--- a/src/cards/venusNext/AtalantaPlanitiaLab.ts
+++ b/src/cards/venusNext/AtalantaPlanitiaLab.ts
@@ -4,9 +4,9 @@ import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
-import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
+import {CardRenderer} from '../render/CardRenderer';
 
 export class AtalantaPlanitiaLab implements IProjectCard {
   public cost = 10;

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -14,6 +14,10 @@ import {LogHelper} from '../../components/LogHelper';
 import * as constants from './../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
+import {CardMetadata} from '../../cards/CardMetadata';
+import {CardRequirements} from '../../cards/CardRequirements';
+import {CardRenderer} from '../../cards/render/CardRenderer';
+import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
 
 export class Atmoscoop implements IProjectCard {
   public cost = 22;
@@ -90,5 +94,15 @@ export class Atmoscoop implements IProjectCard {
 
   private venusIsMaxed(game: Game) {
     return game.getVenusScaleLevel() === constants.MAX_VENUS_SCALE;
+  }
+  public metadata: CardMetadata = {
+    cardNumber: '217',
+    description: 'Requires 3 Science tags. Either raise the temperature 2 steps, or raise Venus 2 steps. Add 2 Floaters to ANY card',
+    requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
+    renderData: CardRenderer.builder((b) => {
+      b.temperature(2).or(CardRenderItemSize.SMALL).venus(2).br;
+      b.floaters(2).asterix();
+    }),
+    victoryPoints: 1,
   }
 }

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -14,10 +14,10 @@ import {LogHelper} from '../../components/LogHelper';
 import * as constants from './../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
-import {CardRenderer} from '../../cards/render/CardRenderer';
-import {CardRenderItemSize} from '../../cards/render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class Atmoscoop implements IProjectCard {
   public cost = 22;

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -16,88 +16,79 @@ import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 
 export class Atmoscoop implements IProjectCard {
-    public cost = 22;
-    public tags = [Tags.JOVIAN, Tags.SPACE];
-    public name = CardName.ATMOSCOOP;
-    public cardType = CardType.AUTOMATED;
+  public cost = 22;
+  public tags = [Tags.JOVIAN, Tags.SPACE];
+  public name = CardName.ATMOSCOOP;
+  public cardType = CardType.AUTOMATED;
 
-    public canPlay(player: Player, game: Game): boolean {
-      const meetsTagRequirements = player.getTagCount(Tags.SCIENCE) >= 3;
-      const remainingTemperatureSteps = (constants.MAX_TEMPERATURE - game.getTemperature()) / 2;
-      const remainingVenusSteps = (constants.MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;
-      const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
+  public canPlay(player: Player, game: Game): boolean {
+    const meetsTagRequirements = player.getTagCount(Tags.SCIENCE) >= 3;
+    const remainingTemperatureSteps = (constants.MAX_TEMPERATURE - game.getTemperature()) / 2;
+    const remainingVenusSteps = (constants.MAX_VENUS_SCALE - game.getVenusScaleLevel()) / 2;
+    const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
 
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, game, false, true) && meetsTagRequirements;
-      }
-
-      return meetsTagRequirements;
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+      return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, game, false, true) && meetsTagRequirements;
     }
 
-    public play(player: Player, game: Game) {
-      const floaterCards = player.getResourceCards(ResourceType.FLOATER);
+    return meetsTagRequirements;
+  }
 
-      if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game) && floaterCards.length === 0) {
+  public play(player: Player, game: Game) {
+    const floaterCards = player.getResourceCards(ResourceType.FLOATER);
+
+    if (this.temperatureIsMaxed(game) && this.venusIsMaxed(game) && floaterCards.length === 0) {
+      return undefined;
+    }
+
+    const increaseTemp = new SelectOption('Raise temperature 2 steps', 'Raise temperature', () => {
+      game.increaseTemperature(player, 2);
+      return undefined;
+    });
+    const increaseVenus = new SelectOption('Raise Venus 2 steps', 'Raise venus', () => {
+      game.increaseVenusScaleLevel(player, 2);
+      return undefined;
+    });
+    const addFloaters = new SelectCard('Select card to add 2 floaters', 'Add floaters', floaterCards, (foundCards: Array<ICard>) => {
+      player.addResourceTo(foundCards[0], 2);
+      LogHelper.logAddResource(game, player, foundCards[0], 2);
+      return undefined;
+    });
+
+    if (!this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
+      game.increaseTemperature(player, 2);
+    } else if (this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
+      game.increaseVenusScaleLevel(player, 2);
+    }
+
+    switch (floaterCards.length) {
+      case 1:
+        player.addResourceTo(floaterCards[0], 2);
+        LogHelper.logAddResource(game, player, floaterCards[0], 2);
+
+      case 0:
+        if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
+          return new OrOptions(increaseTemp, increaseVenus);
+        }
         return undefined;
-      }
 
-      const increaseTemp = new SelectOption('Raise temperature 2 steps', 'Raise temperature', () => {
-        game.increaseTemperature(player, 2);
-        return undefined;
-      });
-      const increaseVenus = new SelectOption('Raise Venus 2 steps', 'Raise venus', () => {
-        game.increaseVenusScaleLevel(player, 2);
-        return undefined;
-      });
-      const addFloaters = new SelectCard(
-          'Select card to add 2 floaters',
-          'Add floaters',
-          floaterCards,
-          (foundCards: Array<ICard>) => {
-            player.addResourceTo(foundCards[0], 2);
-            LogHelper.logAddResource(game, player, foundCards[0], 2);
-            return undefined;
-          },
-      );
-
-      if (!this.temperatureIsMaxed(game) && this.venusIsMaxed(game)) {
-        game.increaseTemperature(player, 2);
-      } else if (this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
-        game.increaseVenusScaleLevel(player, 2);
-      }
-
-      switch (floaterCards.length) {
-        case 1:
-          player.addResourceTo(floaterCards[0], 2);
-          LogHelper.logAddResource(game, player, floaterCards[0], 2);
-
-        case 0:
-          if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
-            return new OrOptions(increaseTemp, increaseVenus);
-          }
-          return undefined;
-
-        default:
-          if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
-            return new AndOptions(
-                () => undefined,
-                new OrOptions(increaseTemp, increaseVenus),
-                addFloaters,
-            );
-          }
-          return addFloaters;
-      }
+      default:
+        if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
+          return new AndOptions(() => undefined, new OrOptions(increaseTemp, increaseVenus), addFloaters);
+        }
+        return addFloaters;
     }
+  }
 
-    public getVictoryPoints() {
-      return 1;
-    }
+  public getVictoryPoints() {
+    return 1;
+  }
 
-    private temperatureIsMaxed(game: Game) {
-      return game.getTemperature() === constants.MAX_TEMPERATURE;
-    }
+  private temperatureIsMaxed(game: Game) {
+    return game.getTemperature() === constants.MAX_TEMPERATURE;
+  }
 
-    private venusIsMaxed(game: Game) {
-      return game.getVenusScaleLevel() === constants.MAX_VENUS_SCALE;
-    }
+  private venusIsMaxed(game: Game) {
+    return game.getVenusScaleLevel() === constants.MAX_VENUS_SCALE;
+  }
 }

--- a/src/cards/venusNext/DeuteriumExport.ts
+++ b/src/cards/venusNext/DeuteriumExport.ts
@@ -8,9 +8,9 @@ import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from './../CardMetadata';
-import {CardRenderer} from './../render/CardRenderer';
-import {CardRenderItemSize} from './../render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class DeuteriumExport implements IActionCard, IProjectCard, IResourceCard {
   public cost = 11;

--- a/src/cards/venusNext/ExtractorBalloons.ts
+++ b/src/cards/venusNext/ExtractorBalloons.ts
@@ -12,9 +12,9 @@ import {MAX_VENUS_SCALE, REDS_RULING_POLICY_COST} from '../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {LogHelper} from '../../components/LogHelper';
-import {CardMetadata} from './../CardMetadata';
-import {CardRenderer} from './../render/CardRenderer';
-import {CardRenderItemSize} from './../render/CardRenderItemSize';
+import {CardMetadata} from '../CardMetadata';
+import {CardRenderer} from '../render/CardRenderer';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class ExtractorBalloons implements IActionCard, IProjectCard, IResourceCard {
   public cost = 21;

--- a/src/cards/venusNext/LuxuryFoods.ts
+++ b/src/cards/venusNext/LuxuryFoods.ts
@@ -3,8 +3,8 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../../cards/CardMetadata';
-import {CardRequirements} from '../../cards/CardRequirements';
+import {CardMetadata} from '../CardMetadata';
+import {CardRequirements} from '../CardRequirements';
 
 export class LuxuryFoods implements IProjectCard {
     public cost = 8;

--- a/src/components/card/CardContent.ts
+++ b/src/components/card/CardContent.ts
@@ -29,7 +29,7 @@ export const CardContent = Vue.component('CardContent', {
             <CardRequirementsComponent v-if="metadata.requirements !== undefined" :requirements="metadata.requirements"/>
             <CardRenderData v-if="metadata.renderData !== undefined" :renderData="metadata.renderData" />
             <CardDescription v-if="metadata.description !== undefined" :text="metadata.description" />
-            <CardVictoryPoints v-if="metadata.victoryPoints !== undefined" :amount="metadata.victoryPoints" />
+            <CardVictoryPoints v-if="metadata.victoryPoints !== undefined" :victoryPoints="metadata.victoryPoints" />
         </div>
     `,
 });

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -53,6 +53,9 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
       } else if (type === CardRenderItemType.FLOATERS) {
         classes.push('card-resource');
         classes.push('card-resource-floater');
+      } else if (type === CardRenderItemType.ASTEROIDS) {
+        classes.push('card-resource');
+        classes.push('card-resource-asteroid');
       } else if (type === CardRenderItemType.MICROBES) {
         classes.push('card-resource');
         classes.push('card-resource-microbe');

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import {generateClassString} from '../../utils/utils';
 import {CardRenderItem} from '../../cards/render/CardRenderItem';
 import {CardRenderItemType} from '../../cards/render/CardRenderItemType';
 import {CardRenderSymbol} from '../../cards/render/CardRenderSymbol';
@@ -92,7 +93,17 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
         classes.push('red-outline');
       }
 
-      return classes.join(' ');
+      // golden background
+      if (this.item.isPlate) {
+        classes.push('card-plate');
+      }
+
+      // size and text
+      if (this.item.text !== undefined) {
+        classes.push(`card-text-size--${this.item.size}`);
+      }
+
+      return generateClassString(classes);
     },
     getAmountAbs: function(): number {
       if (this.item.amountInside) return 1;
@@ -108,6 +119,7 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
     itemHtmlContent: function(): string {
       // in case of symbols inside
       if (this.item instanceof CardRenderItem && this.item.amountInside) return this.item.amount.toString();
+      if (this.item.isPlate || this.item.text !== undefined) return this.item.text || 'n/a';
       return '';
     },
   },

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -126,6 +126,11 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
       // in case of symbols inside
       if (this.item instanceof CardRenderItem && this.item.amountInside) return this.item.amount.toString();
       if (this.item.isPlate || this.item.text !== undefined) return this.item.text || 'n/a';
+      if (this.item.secondaryTag !== undefined) {
+        const classes: string[] = ['card-icon'];
+        classes.push(`tag-${this.item.secondaryTag}`);
+        return '<div class="' + generateClassString(classes) + '"/>';
+      }
       return '';
     },
   },

--- a/src/components/card/CardRenderItemComponent.ts
+++ b/src/components/card/CardRenderItemComponent.ts
@@ -78,6 +78,9 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
         classes.push('card-delegate');
       } else if (type === CardRenderItemType.INFLUENCE) {
         classes.push('card-influence');
+      } else if (type === CardRenderItemType.CITY) {
+        classes.push('card-tile');
+        classes.push(`city-tile--${this.item.size}`);
       } else if (type === CardRenderItemType.EVENT) {
         classes.push('card-tag-event');
       } else if (type === CardRenderItemType.SPACE) {
@@ -101,6 +104,9 @@ export const CardRenderItemComponent = Vue.component('CardRenderItemComponent', 
       // size and text
       if (this.item.text !== undefined) {
         classes.push(`card-text-size--${this.item.size}`);
+        if (this.item.isUppercase) {
+          classes.push('card-text-uppercase');
+        }
       }
 
       return generateClassString(classes);

--- a/src/components/card/CardRenderSymbolComponent.ts
+++ b/src/components/card/CardRenderSymbolComponent.ts
@@ -33,6 +33,9 @@ export const CardRenderSymbolComponent = Vue.component('CardRenderSymbolComponen
         classes.push('card-colon');
       } else if (type === CardRenderSymbolType.ARROW) {
         classes.push('card-red-arrow');
+      } else if (type === CardRenderSymbolType.NBSP) {
+        // TODO (chosta): add size
+        classes.push('card-nbsp');
       }
 
       return classes.join(' ');

--- a/src/components/card/CardVictoryPoints.ts
+++ b/src/components/card/CardVictoryPoints.ts
@@ -24,17 +24,6 @@ export const CardVictoryPoints = Vue.component('CardPoints', {
     isObject: function(): boolean {
       return this.victoryPoints instanceof CardRenderVictoryPoints;
     },
-    // getHtml: function(): string {
-    //   let result: string = '';
-    //   if (this.victoryPoints instanceof CardRenderVictoryPoints) {
-    //     result += this.victoryPoints.getPointsHtml();
-    //     result += '';
-    //   } else {
-    //     // assert type number
-    //     result = (<number> this.victoryPoints).toString();
-    //   }
-    //   return result;
-    // },
   },
   template: `
       <div v-if="isObject()" :class="getClasses()"><div>{{ this.victoryPoints.getPointsHtml() }}</div><CardRenderItemComponent :item="this.victoryPoints.item" /></div>

--- a/src/components/card/CardVictoryPoints.ts
+++ b/src/components/card/CardVictoryPoints.ts
@@ -1,20 +1,43 @@
 import Vue from 'vue';
-// TODO (chosta): implement points per tag
+import {CardRenderVictoryPoints} from '../../cards/render/CardRenderVictoryPoints';
+import {CardRenderItemComponent} from './CardRenderItemComponent';
+
 export const CardVictoryPoints = Vue.component('CardPoints', {
   props: {
-    amount: {
-      type: Number,
+    victoryPoints: {
       required: true,
     },
   },
+  components: {
+    CardRenderItemComponent,
+  },
   methods: {
     getClasses: function(): string {
-      const classes = ['card-points', 'points-big'];
-
+      const classes: string[] = ['card-points'];
+      if (this.isObject()) {
+        classes.push('card-points-normal');
+      } else {
+        classes.push('card-points-big');
+      }
       return classes.join(' ');
     },
+    isObject: function(): boolean {
+      return this.victoryPoints instanceof CardRenderVictoryPoints;
+    },
+    // getHtml: function(): string {
+    //   let result: string = '';
+    //   if (this.victoryPoints instanceof CardRenderVictoryPoints) {
+    //     result += this.victoryPoints.getPointsHtml();
+    //     result += '';
+    //   } else {
+    //     // assert type number
+    //     result = (<number> this.victoryPoints).toString();
+    //   }
+    //   return result;
+    // },
   },
   template: `
-        <div :class="getClasses()">{{ amount }}</div>
+      <div v-if="isObject()" :class="getClasses()"><div>{{ this.victoryPoints.getPointsHtml() }}</div><CardRenderItemComponent :item="this.victoryPoints.item" /></div>
+      <div v-else :class="getClasses()">{{ this.victoryPoints }}</div>
     `,
 });

--- a/src/components/card/CardVictoryPoints.ts
+++ b/src/components/card/CardVictoryPoints.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import {CardRenderVictoryPoints} from '../../cards/render/CardRenderVictoryPoints';
+import {CardRenderDynamicVictoryPoints} from '../../cards/render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemComponent} from './CardRenderItemComponent';
 
 export const CardVictoryPoints = Vue.component('CardPoints', {
@@ -22,7 +22,7 @@ export const CardVictoryPoints = Vue.component('CardPoints', {
       return classes.join(' ');
     },
     isObject: function(): boolean {
-      return this.victoryPoints instanceof CardRenderVictoryPoints;
+      return this.victoryPoints instanceof CardRenderDynamicVictoryPoints;
     },
   },
   template: `

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -459,6 +459,24 @@
             .card-text-size--L {
                 font-size: @font_size_big;
             }
+            .card-text-uppercase {
+                text-transform: uppercase;
+            }
+            /* tiles */
+            .card-tile {
+                margin-left: 4px;
+            }
+            .city-tile--M {
+                background-image: url(./assets/tiles/city.png);
+                filter: brightness(0.8) drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));
+            }
+            .city-tile--S {
+                background-image: url(./assets/tiles/city.png);
+                filter: brightness(0.8) drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));
+                width: 30px;
+                height: 32px;
+                background-size: 30px 32px;
+            }
         }
         .temporary-content-wrapper {
             position: relative;

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -435,6 +435,30 @@
                     margin-left: 4px;
                 }
             }
+            .card-plate {
+                width: 130px;
+                text-shadow: none;
+                font-size: 12px;
+                font-weight: bold;
+                line-height: 17px;
+                display: inline-block;
+                vertical-align: middle;
+                padding-top: 5px;
+                margin-right: 5px;
+                border-radius: 5px;
+                height: 20px;
+                background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
+                filter: drop-shadow(0px 0px 1px black);
+            }
+            .card-text-size--S {
+                font-size: @font_size_small;
+            }
+            .card-text-size--M {
+                font-size: @font_size_normal;
+            }
+            .card-text-size--L {
+                font-size: @font_size_big;
+            }
         }
         .temporary-content-wrapper {
             position: relative;

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -429,6 +429,7 @@
             }
             .card-points-normal {
                 display: flex;
+                justify-content: center;
                 font-size: 28px;
                 text-shadow: 0 0 2px darkorange;
                 >div{
@@ -450,6 +451,9 @@
                 background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
                 filter: drop-shadow(0px 0px 1px black);
             }
+            .card-text-size--XS {
+                font-size: @font_size_tiny;
+            }
             .card-text-size--S {
                 font-size: @font_size_small;
             }
@@ -461,6 +465,10 @@
             }
             .card-text-uppercase {
                 text-transform: uppercase;
+            }
+            .card-nbsp {
+                visibility: hidden;
+                width: 10px;
             }
             /* tiles */
             .card-tile {

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -409,6 +409,7 @@
                 right: 8px;
                 width: 80px;
                 height: 42px;
+                line-height: 42px;
                 text-align: center;
                 border-radius: 12px;
                 border-top: 2px solid #dddddd;
@@ -418,6 +419,21 @@
                 background-color: #cda282;
                 background: linear-gradient(#cc8b00, #805700, #805700);
                 box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.6), 0 0 0 2px rgba(0, 0, 0, 0.3);
+                .card-item-container{
+                    margin: 0px;
+                }
+            }
+            .card-points-big {
+                font-size: 36px;
+                text-shadow: 0 0 5px darkorange;
+            }
+            .card-points-normal {
+                display: flex;
+                font-size: 28px;
+                text-shadow: 0 0 2px darkorange;
+                >div{
+                    margin-left: 4px;
+                }
             }
         }
         .temporary-content-wrapper {

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -204,3 +204,4 @@ h2 {
 @import "./turmoil.less";
 @import "./ares.less";
 @import "./help-iconology.less";
+@import "./debug_ui.less";

--- a/src/styles/debug_ui.less
+++ b/src/styles/debug_ui.less
@@ -1,0 +1,10 @@
+.debug-ui-container {
+    .create-game-page-column {
+        display: flex;
+        flex-flow: row wrap !important;
+        padding: 20px 10px;
+        .expansion-button {
+            justify-content: center;
+        }
+    }
+}

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -24,5 +24,6 @@
 @font_size_big: 23px;
 @font_size_normal: 18px;
 @font_size_small: 14px;
+@font_size_tiny: 9px;
 //#TODO
 //shadows

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,4 @@
-export const playerColorClass = (
-    color: string,
-    type: 'shadow' | 'bg' | 'bg_transparent',
-): string => {
+export const playerColorClass = (color: string, type: 'shadow' | 'bg' | 'bg_transparent'): string => {
   const prefix = {
     shadow: 'player_shadow_color_',
     bg_transparent: 'player_translucent_bg_color_',
@@ -11,4 +8,5 @@ export const playerColorClass = (
   return `${prefix}${color}`;
 };
 
-export const range = (n: number): Array<Number> => Array.from(Array(n).keys());
+export const range = (n: number): Array<number> => Array.from(Array(n).keys());
+export const generateClassString = (classes: Array<string>): string => (classes.length > 1 ? classes.join(' ') : classes[0]);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,4 +9,4 @@ export const playerColorClass = (color: string, type: 'shadow' | 'bg' | 'bg_tran
 };
 
 export const range = (n: number): Array<number> => Array.from(Array(n).keys());
-export const generateClassString = (classes: Array<string>): string => (classes.length > 1 ? classes.join(' ') : classes[0]);
+export const generateClassString = (classes: Array<string>): string => classes.join(' ').trimStart();


### PR DESCRIPTION
The first PR handling all common cards starting with A. I'm doing it in this order so reviewers can easily pull and compare with the current cards (the best way to spot inaccuracies). Also, I want to finish this task until Christmas, so we have 25 more letters to go + Preludes and Corporations.
* Added CardsVictoryPoints component handling special points per amount cases
* Added secondary tag functionality
* Added text and special text functionality
* Several improvements, refactoring
* ~10 new cards