### PR TITLE
Search for cards in the debug-ui using the description as a filter.

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -77,7 +77,7 @@ checkComponent(
 checkComponent(
     'src/components/DebugUI',
     require('./build/src/components/DebugUI').DebugUI,
-    ['filterText', 'base', 'corporateEra', 'prelude', 'venusNext', 'colonies', 'turmoil', 'community', 'ares', 'promo'],
+    ['filterText', 'filterDescription', 'base', 'corporateEra', 'prelude', 'venusNext', 'colonies', 'turmoil', 'community', 'ares', 'promo'],
 );
 checkComponent(
     'src/components/GameHome',


### PR DESCRIPTION
To make this work I pre-fetch all the cards, and store data in memory.
This turns out to make searching MUCH faster!

Incidentally, most of the cards do not have text, so while this will seem broken, it surely isn't.