### PR TITLE
Fix: Missing property for colony placement cards

### DIFF
--- a/src/cards/colonies/IceMoonColony.ts
+++ b/src/cards/colonies/IceMoonColony.ts
@@ -15,6 +15,7 @@ export class IceMoonColony implements IProjectCard {
     public tags = [Tags.SPACE];
     public name = CardName.ICE_MOON_COLONY;
     public cardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;

--- a/src/cards/colonies/InterplanetaryColonyShip.ts
+++ b/src/cards/colonies/InterplanetaryColonyShip.ts
@@ -11,6 +11,7 @@ export class InterplanetaryColonyShip implements IProjectCard {
     public tags = [Tags.SPACE, Tags.EARTH];
     public name = CardName.INTERPLANETARY_COLONY_SHIP;
     public cardType = CardType.EVENT;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       return player.canPlayColonyPlacementCard(game);

--- a/src/cards/colonies/MiningColony.ts
+++ b/src/cards/colonies/MiningColony.ts
@@ -12,6 +12,7 @@ export class MiningColony implements IProjectCard {
     public tags = [Tags.SPACE];
     public name = CardName.MINING_COLONY;
     public cardType = CardType.AUTOMATED;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       return player.canPlayColonyPlacementCard(game);

--- a/src/cards/colonies/TradingColony.ts
+++ b/src/cards/colonies/TradingColony.ts
@@ -11,6 +11,7 @@ export class TradingColony implements IProjectCard {
     public tags = [Tags.SPACE];
     public name = CardName.TRADING_COLONY;
     public cardType = CardType.ACTIVE;
+    public hasRequirements = false;
 
     public canPlay(player: Player, game: Game): boolean {
       return player.canPlayColonyPlacementCard(game);


### PR DESCRIPTION
Bug reported by Simon. 4 of the colony cards incorrectly count as cards with requirements