### PR TITLE
more lenient on game id check

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -316,7 +316,7 @@ function loadGame(req: http.IncomingMessage, res: http.ServerResponse): void {
 }
 
 function apiGetGame(req: http.IncomingMessage, res: http.ServerResponse): void {
-  const routeRegExp: RegExp = /^\/api\/game\?id\=([0-9abcdef]+)$/i;
+  const routeRegExp: RegExp = /^\/api\/game\?id\=([0-9a-z_]+)$/i;
 
   if (req.url === undefined) {
     console.warn('url not defined');


### PR DESCRIPTION
This will fix #1941 . The unit tests create games that were at one point inadvertently saved to the sqlite database. Users of that database will have these games listed. These games aren't using the generated game id. This change makes the check for game id more lenient as it isn't crucial that this game id matches the generated format.