### PR TITLE
Atmoscoop: Heat/Venus increase before adding floaters

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -748,6 +748,7 @@ export class Player implements ISerializable<SerializedPlayer, Player> {
           remainingInput.push(input[i].slice());
         }
         this.runInput(game, remainingInput, waiting.options[optionIndex]);
+        this.runInputCb(game, pi.cb());
       } else if (pi instanceof SelectHowToPayForCard) {
         if (input.length !== 1 || input[0].length !== 2) {
           throw new Error('Incorrect options provided');

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -3,7 +3,6 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
-import {AndOptions} from '../../inputs/AndOptions';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {ResourceType} from '../../ResourceType';
@@ -53,6 +52,9 @@ export class Atmoscoop implements IProjectCard {
       game.increaseVenusScaleLevel(player, 2);
       return undefined;
     });
+    const increaseTempOrVenus = new OrOptions(increaseTemp, increaseVenus);
+    increaseTempOrVenus.title = 'Choose global parameter to raise';
+
     const addFloaters = new SelectCard(
       'Select card to add 2 floaters',
       'Add floaters',
@@ -77,17 +79,14 @@ export class Atmoscoop implements IProjectCard {
 
     case 0:
       if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
-        return new OrOptions(increaseTemp, increaseVenus);
+        return increaseTempOrVenus;
       }
       return undefined;
 
     default:
       if (!this.temperatureIsMaxed(game) && !this.venusIsMaxed(game)) {
-        return new AndOptions(
-          () => undefined,
-          new OrOptions(increaseTemp, increaseVenus),
-          addFloaters,
-        );
+        increaseTempOrVenus.cb = () => addFloaters;
+        return increaseTempOrVenus;
       }
       return addFloaters;
     }

--- a/src/inputs/OrOptions.ts
+++ b/src/inputs/OrOptions.ts
@@ -12,7 +12,7 @@ import {SelectDelegate} from './SelectDelegate';
 import {SelectColony} from './SelectColony';
 
 export class OrOptions implements PlayerInput {
-  public cb(): undefined {
+  public cb(): PlayerInput | undefined {
     return undefined;
   }
     public title: string = 'Select one option';

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -3,7 +3,6 @@ import {Atmoscoop} from '../../../src/cards/venusNext/Atmoscoop';
 import {Color} from '../../../src/Color';
 import {Player} from '../../../src/Player';
 import {Game} from '../../../src/Game';
-import {AndOptions} from '../../../src/inputs/AndOptions';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Dirigibles} from '../../../src/cards/venusNext/Dirigibles';
 import {FloatingHabs} from '../../../src/cards/venusNext/FloatingHabs';
@@ -58,15 +57,16 @@ describe('Atmoscoop', function() {
   it('Should play - multiple targets', function() {
     player.playedCards.push(dirigibles, floatingHabs);
 
-    const action = card.play(player, game) as AndOptions;
-    const orOptions = action.options[0] as OrOptions;
-    const selectCard = action.options[1] as SelectCard<ICard>;
+    const orOptions = card.play(player, game) as OrOptions;
 
+    // First the global parameter
     orOptions.options[0].cb();
     expect(game.getTemperature()).to.eq(-26);
     orOptions.options[1].cb();
     expect(game.getVenusScaleLevel()).to.eq(4);
 
+    // Then the floaters
+    const selectCard = orOptions.cb() as SelectCard<ICard>;
     selectCard.cb([dirigibles]);
     expect(dirigibles.resourceCount).to.eq(2);
     selectCard.cb([floatingHabs]);


### PR DESCRIPTION
Couldn't reproduce the issue mentioned on Discord but this will hopefully reduce user mistake to have Heat/Venus increase uncoupled from the floaters addition (and may help debugging said bugs).

Also made it so that when a OrOptions has a callback, it will be run after the selected option's callback.