### PR TITLE
Rewrite Imported Nitrogen

### DIFF
--- a/src/cards/ImportedNitrogen.ts
+++ b/src/cards/ImportedNitrogen.ts
@@ -1,14 +1,11 @@
-import {ICard} from './ICard';
 import {IProjectCard} from './IProjectCard';
 import {Tags} from './Tags';
 import {CardType} from './CardType';
 import {Player} from '../Player';
-import {AndOptions} from '../inputs/AndOptions';
-import {SelectCard} from '../inputs/SelectCard';
 import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
 import {Game} from '../Game';
-import {LogHelper} from '../components/LogHelper';
+import {AddResourcesToCard} from '../deferredActions/AddResourcesToCard';
 import {PartyHooks} from '../turmoil/parties/PartyHooks';
 import {PartyName} from '../turmoil/parties/PartyName';
 import {REDS_RULING_POLICY_COST} from '../constants';
@@ -28,56 +25,11 @@ export class ImportedNitrogen implements IProjectCard {
       return true;
     }
 
-    private giveResources(player: Player, game: Game): undefined {
-      player.increaseTerraformRating(game);
-      player.plants += 4;
-      return undefined;
-    }
-
     public play(player: Player, game: Game) {
-      const otherAnimalCards = player.getResourceCards(ResourceType.ANIMAL);
-      const otherMicrobeCards = player.getResourceCards(ResourceType.MICROBE);
-
-      let microbesAdded : boolean = false;
-      let animalsAdded : boolean = false;
-
-      if (otherAnimalCards.length === 0 && otherMicrobeCards.length === 0) {
-        return this.giveResources(player, game);
-      } else if (otherAnimalCards.length > 0 && otherMicrobeCards.length > 0) {
-        return new AndOptions(
-          () => this.giveResources(player, game),
-          new SelectCard('Select card to add 3 microbes',
-            'Add microbes', otherMicrobeCards, (foundCards: Array<ICard>) => {
-              if (!microbesAdded) {
-                microbesAdded = true;
-                player.addResourceTo(foundCards[0], 3);
-                LogHelper.logAddResource(game, player, foundCards[0], 3);
-              }
-
-              return undefined;
-            }),
-          new SelectCard('Select card to add 2 animals',
-            'Add animals', otherAnimalCards, (foundCards: Array<ICard>) => {
-              if (!animalsAdded) {
-                animalsAdded = true;
-                player.addResourceTo(foundCards[0], 2);
-                LogHelper.logAddResource(game, player, foundCards[0], 2);
-              }
-
-              return undefined;
-            }),
-        );
-      } else if (otherAnimalCards.length > 0) {
-        return new SelectCard('Select card to add 2 animals', 'Add animals', otherAnimalCards, (foundCards: Array<ICard>) => {
-          player.addResourceTo(foundCards[0], 2);
-          LogHelper.logAddResource(game, player, foundCards[0], 2);
-          return this.giveResources(player, game);
-        });
-      }
-      return new SelectCard('Select card to add 3 microbes', 'Add microbes', otherMicrobeCards, (foundCards: Array<ICard>) => {
-        player.addResourceTo(foundCards[0], 3);
-        LogHelper.logAddResource(game, player, foundCards[0], 3);
-        return this.giveResources(player, game);
-      });
+      player.plants += 4;
+      player.increaseTerraformRating(game);
+      game.defer(new AddResourcesToCard(player, game, ResourceType.MICROBE, 3));
+      game.defer(new AddResourcesToCard(player, game, ResourceType.ANIMAL, 2));
+      return undefined;
     }
 }

--- a/tests/cards/ImportedNitrogen.spec.ts
+++ b/tests/cards/ImportedNitrogen.spec.ts
@@ -2,10 +2,11 @@ import {expect} from 'chai';
 import {ImportedNitrogen} from '../../src/cards/ImportedNitrogen';
 import {Color} from '../../src/Color';
 import {Player} from '../../src/Player';
-import {AndOptions} from '../../src/inputs/AndOptions';
 import {SelectCard} from '../../src/inputs/SelectCard';
 import {Tardigrades} from '../../src/cards/Tardigrades';
+import {Ants} from '../../src/cards/Ants';
 import {Pets} from '../../src/cards/Pets';
+import {Birds} from '../../src/cards/Birds';
 import {ICard} from '../../src/cards/ICard';
 import {Game} from '../../src/Game';
 
@@ -26,45 +27,55 @@ describe('ImportedNitrogen', function() {
 
   it('Should play with only animals', function() {
     const pets = new Pets();
-    player.playedCards.push(pets);
-    const action = card.play(player, game);
-    expect(action instanceof SelectCard).is.true;
+    const birds = new Birds();
+    player.playedCards.push(pets, birds);
+    card.play(player, game);
 
-    const andAction = action as SelectCard<ICard>;
-    andAction.cb([pets]);
+    const addMicrobes = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    expect(addMicrobes).is.undefined;
+
+    const addAnimals = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    addAnimals.cb([pets]);
+    expect(player.getResourcesOnCard(pets)).to.eq(2);
+
     expect(player.getTerraformRating()).to.eq(21);
     expect(player.plants).to.eq(4);
-    expect(player.getResourcesOnCard(pets)).to.eq(2);
   });
 
   it('Should play with only microbes', function() {
     const tardigrades = new Tardigrades();
-    player.playedCards.push(tardigrades);
-    const action = card.play(player, game);
-    expect(action instanceof SelectCard).is.true;
+    const ants = new Ants();
+    player.playedCards.push(tardigrades, ants);
+    card.play(player, game);
 
-    const andAction = action as SelectCard<ICard>;
-    andAction.cb([tardigrades]);
+    const addMicrobes = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    addMicrobes.cb([tardigrades]);
+    expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
+
+    const addAnimals = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    expect(addAnimals).is.undefined;
+
     expect(player.getTerraformRating()).to.eq(21);
     expect(player.plants).to.eq(4);
-    expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
   });
 
   it('Should play with animals and microbes', function() {
     const pets = new Pets();
+    const birds = new Birds();
     const tardigrades = new Tardigrades();
-    player.playedCards.push(pets, tardigrades);
-    const action = card.play(player, game);
-    expect(action instanceof AndOptions).is.true;
+    const ants = new Ants();
+    player.playedCards.push(pets, tardigrades, birds, ants);
+    card.play(player, game);
 
-    const andAction = action as AndOptions;
-    andAction.cb();
+    const addMicrobes = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    addMicrobes.cb([tardigrades]);
+    expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
+
+    const addAnimals = game.deferredActions.shift()!.execute() as SelectCard<ICard>;
+    addAnimals.cb([pets]);
+    expect(player.getResourcesOnCard(pets)).to.eq(2);
+
     expect(player.getTerraformRating()).to.eq(21);
     expect(player.plants).to.eq(4);
-
-    andAction.options[0].cb([tardigrades]);
-    expect(player.getResourcesOnCard(tardigrades)).to.eq(3);
-    andAction.options[1].cb([pets]);
-    expect(player.getResourcesOnCard(pets)).to.eq(2);
   });
 });


### PR DESCRIPTION
Reduce code duplication and split the action in two. Add microbes to card, then add animals.
Here's the reason for that choice:

Because of how `AndOptions` is implemented, a failsafe (using microbesAdded and animalsAdded) had to be implemented to prevent adding multiple microbes if an error occured (if you didn't select an animal card for example).
But because of that failsafe, it also means that, in case of an error, you cannot change your mind and select another microbe card, as microbes were already added to the card you previously selected.