### PR TITLE
Fix first cards pick when an error occur

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -312,7 +312,7 @@ export class Game implements ISerializable<SerializedGame, Game> {
           }
         } else {
           this.setStartingProductions(player);
-          this.playerHasPickedCorporationCard(player, new BeginnerCorporation() );
+          this.playerHasPickedCorporationCard(player, new BeginnerCorporation());
         }
       }
 
@@ -687,24 +687,14 @@ export class Game implements ISerializable<SerializedGame, Game> {
     private playCorporationCard(
       player: Player, corporationCard: CorporationCard,
     ): void {
-      // Check for negative M€
-      let cardCost = player.cardCost;
-      if (corporationCard.name === CardName.TERRALABS_RESEARCH) {
-        cardCost = 1;
-      } else if (corporationCard.name === CardName.POLYPHEMOS) {
-        cardCost = 5;
-      }
-      if (corporationCard.name !== new BeginnerCorporation().name && player.cardsInHand.length * cardCost > corporationCard.startingMegaCredits) {
-        player.cardsInHand = [];
-        player.preludeCardsInHand = [];
-        throw new Error('Too many cards selected');
-      }
-
       player.corporationCard = corporationCard;
       player.megaCredits = corporationCard.startingMegaCredits;
-      if (corporationCard.name !== new BeginnerCorporation().name) {
-        const cardsToPayFor: number = player.cardsInHand.length;
-        player.megaCredits -= cardsToPayFor * cardCost;
+      if (corporationCard.cardCost !== undefined) {
+        player.cardCost = corporationCard.cardCost;
+      }
+
+      if (corporationCard.name !== CardName.BEGINNER_CORPORATION) {
+        player.megaCredits -= player.cardsInHand.length * player.cardCost;
       }
       corporationCard.play(player, this);
       this.log('${0} played ${1}', (b) => b.player(player).card(corporationCard));
@@ -743,6 +733,18 @@ export class Game implements ISerializable<SerializedGame, Game> {
     private pickCorporationCard(player: Player): PlayerInput {
       let corporation: CorporationCard;
       const result: AndOptions = new AndOptions(() => {
+        // Check for negative M€
+        const cardCost = corporation.cardCost !== undefined ? corporation.cardCost : player.cardCost;
+        if (corporation.name !== CardName.BEGINNER_CORPORATION && player.cardsInHand.length * cardCost > corporation.startingMegaCredits) {
+          player.cardsInHand = [];
+          player.preludeCardsInHand = [];
+          throw new Error('Too many cards selected');
+        }
+        // discard all unpurchased cards
+        player.dealtProjectCards
+          .filter((card) => player.cardsInHand.includes(card))
+          .forEach((card) => this.dealer.discard(card));
+
         this.playerHasPickedCorporationCard(player, corporation); return undefined;
       });
 
@@ -764,7 +766,7 @@ export class Game implements ISerializable<SerializedGame, Game> {
           new SelectCard(
             'Select 2 Prelude cards', undefined, player.dealtPreludeCards,
             (preludeCards: Array<IProjectCard>) => {
-              player.preludeCardsInHand.push(preludeCards[0], preludeCards[1]);
+              player.preludeCardsInHand.push(...preludeCards);
               return undefined;
             }, 2, 2,
           ),
@@ -775,17 +777,7 @@ export class Game implements ISerializable<SerializedGame, Game> {
         new SelectCard(
           'Select initial cards to buy', undefined, player.dealtProjectCards,
           (foundCards: Array<IProjectCard>) => {
-            for (const dealt of foundCards) {
-              if (foundCards.find((foundCard) => foundCard.name === dealt.name)) {
-                player.cardsInHand.push(dealt);
-              }
-            }
-
-            // discard all unpurchased cards
-            player.dealtProjectCards
-              .filter((card) => !foundCards.includes(card))
-              .forEach((card) => this.dealer.discard(card));
-
+            player.cardsInHand.push(...foundCards);
             return undefined;
           }, 10, 0,
         ),

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -742,7 +742,7 @@ export class Game implements ISerializable<SerializedGame, Game> {
         }
         // discard all unpurchased cards
         player.dealtProjectCards
-          .filter((card) => player.cardsInHand.includes(card))
+          .filter((card) => player.cardsInHand.includes(card) === false)
           .forEach((card) => this.dealer.discard(card));
 
         this.playerHasPickedCorporationCard(player, corporation); return undefined;

--- a/src/cards/colonies/Polyphemos.ts
+++ b/src/cards/colonies/Polyphemos.ts
@@ -9,12 +9,12 @@ export class Polyphemos implements CorporationCard {
     public tags = [];
     public startingMegaCredits: number = 50;
     public cardType = CardType.CORPORATION;
+    public cardCost = 5;
 
 
     public play(player: Player) {
       player.addProduction(Resources.MEGACREDITS, 5);
       player.titanium = 5;
-      player.cardCost = 5;
       return undefined;
     }
 }

--- a/src/cards/corporation/CorporationCard.ts
+++ b/src/cards/corporation/CorporationCard.ts
@@ -14,6 +14,7 @@ export interface CorporationCard extends ICard {
     initialActionText?: string;
     initialAction?: (player: Player, game: Game) => PlayerInput | undefined;
     startingMegaCredits: number;
+    cardCost?: number;
     play: (
         player: Player,
         game: Game

--- a/src/cards/turmoil/TerralabsResearch.ts
+++ b/src/cards/turmoil/TerralabsResearch.ts
@@ -9,10 +9,10 @@ export class TerralabsResearch implements CorporationCard {
     public tags = [Tags.SCIENCE, Tags.EARTH];
     public startingMegaCredits: number = 14;
     public cardType = CardType.CORPORATION;
+    public cardCost = 1;
 
     public play(player: Player) {
       player.decreaseTerraformRating();
-      player.cardCost = 1;
       return undefined;
     }
 }


### PR DESCRIPTION
The issue it fixes has a couple of ways to be exploited. I'll give one example below.

**Steps to reproduce the issue:**
 - Create a 2 players game
 - Make sure one of the player has Phobolog
 - Select 8+ cards with Phobolog player and confirm the selection [_No error_]
 - Confirm the other player selection, you get an error saying you took too many cards [_But that's really for Phobolog_]
 - Change the other player selection (or not) and validate again

**Consequences:**
 - The other player has more/duplicated cards [_You get cards from the first and the second selections you made_]
 - Phobolog player has no cards [_Yay_]
 - If the other player is the first in turn order, its corporation is played twice
 - All cards not selected during other player both elections were added to the discard pile, so there's most likely duplicates there as well

**Solution:**
 - Move initial cards buying checks into the `AndOptions` callback to be returned directly to the correct player
 - Discard cards after the checks passed instead of when the selection is made