### PR TITLE
Ability to set static pass phrase for admin routes via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A [.env](https://www.npmjs.com/package/dotenv) file allows you to store environm
 * MAX_GAME_DAYS: How many days to keep unfinished games before deleting them
 * WAITING_FOR_TIMEOUT: (default 5000) How many milliseconds to check for game update on multi-player games
 * ASSET_CACHE_MAX_AGE: (default 0) How many seconds should assets (fonts, stylesheets, images) be cached by browsers
+* SERVER_ID: (default random) Static pass phrase to restrict access to /games-overview and /api/games endpoints
 
 ### Deployment
 

--- a/server.ts
+++ b/server.ts
@@ -53,7 +53,7 @@ import {SelectColony} from './src/inputs/SelectColony';
 import {SelectProductionToLose} from './src/inputs/SelectProductionToLose';
 import {ShiftAresGlobalParameters} from './src/inputs/ShiftAresGlobalParameters';
 
-const serverId = generateRandomServerId();
+const serverId = process.env.SERVER_ID || generateRandomServerId();
 const styles = fs.readFileSync('styles.css');
 let compressedStyles: undefined | Buffer = undefined;
 const gameLoader = new GameLoader();


### PR DESCRIPTION
I am always losing that random pass phrase for /games-overview?serverId=**90bff6c48f8c**
This PR allows to set it to fixed value