### PR TITLE
Rewrite Turmoil serialization.

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -917,12 +917,12 @@ function getTurmoil(game: Game): TurmoilModel | undefined {
     }
 
     let coming;
-    if (game.turmoil.commingGlobalEvent) {
+    if (game.turmoil.comingGlobalEvent) {
       coming = {
-        name: game.turmoil.commingGlobalEvent.name,
-        description: game.turmoil.commingGlobalEvent.description,
-        revealed: game.turmoil.commingGlobalEvent.revealedDelegate,
-        current: game.turmoil.commingGlobalEvent.currentDelegate,
+        name: game.turmoil.comingGlobalEvent.name,
+        description: game.turmoil.comingGlobalEvent.description,
+        revealed: game.turmoil.comingGlobalEvent.revealedDelegate,
+        current: game.turmoil.comingGlobalEvent.currentDelegate,
       };
     }
 

--- a/server.ts
+++ b/server.ts
@@ -916,9 +916,9 @@ function getTurmoil(game: Game): TurmoilModel | undefined {
       };
     }
 
-    let comming;
+    let coming;
     if (game.turmoil.commingGlobalEvent) {
-      comming = {
+      coming = {
         name: game.turmoil.commingGlobalEvent.name,
         description: game.turmoil.commingGlobalEvent.description,
         revealed: game.turmoil.commingGlobalEvent.revealedDelegate,
@@ -944,7 +944,7 @@ function getTurmoil(game: Game): TurmoilModel | undefined {
       lobby: lobby,
       reserve: reserve,
       distant: distant,
-      comming: comming,
+      coming: coming,
       current: current,
     };
   } else {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -245,7 +245,8 @@ export class Game implements ISerializable<SerializedGame, Game> {
 
       // Add Turmoil stuff
       if (gameOptions.turmoilExtension) {
-        this.turmoil = new Turmoil(this);
+        this.turmoil = new Turmoil();
+        this.turmoil.loadFromGame(this);
       }
 
       // Setup Ares hazards
@@ -535,17 +536,17 @@ export class Game implements ISerializable<SerializedGame, Game> {
         // Recreate turmoil lobby and reserve (Turmoil stores some players ids)
         if (gameToRebuild.gameOptions.turmoilExtension && game.turmoil !== undefined) {
           game.turmoil.lobby.clear();
-          game.turmoil.delegate_reserve = [];
+          game.turmoil.delegateReserve = [];
           game.getPlayers().forEach((player) => {
             if (game.turmoil !== undefined) {
               game.turmoil.lobby.add(player.id);
               for (let i = 0; i < 6; i++) {
-                game.turmoil.delegate_reserve.push(player.id);
+                game.turmoil.delegateReserve.push(player.id);
               }
             }
           });
           for (let i = 0; i < 13; i++) {
-            game.turmoil.delegate_reserve.push('NEUTRAL');
+            game.turmoil.delegateReserve.push('NEUTRAL');
           }
         }
 
@@ -1796,7 +1797,7 @@ export class Game implements ISerializable<SerializedGame, Game> {
 
       // Reload turmoil elements if needed
       if (d.turmoil && this.gameOptions.turmoilExtension) {
-        const turmoil = new Turmoil(this);
+        const turmoil = new Turmoil();
         this.turmoil = turmoil.loadFromJSON(d.turmoil);
 
         // Rebuild lobby

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -33,9 +33,9 @@ export class VoteOfNoConfidence implements IProjectCard {
     public play(player: Player, game: Game) {
       if (game.turmoil !== undefined) {
             game.turmoil.chairman! = player.id;
-            const index = game.turmoil.delegate_reserve.indexOf(player.id);
+            const index = game.turmoil.delegateReserve.indexOf(player.id);
             if (index > -1) {
-              game.turmoil.delegate_reserve.splice(index, 1);
+              game.turmoil.delegateReserve.splice(index, 1);
             }
             player.increaseTerraformRating(game);
       }

--- a/src/components/Turmoil.ts
+++ b/src/components/Turmoil.ts
@@ -98,10 +98,10 @@ export const Turmoil = Vue.component('turmoil', {
             <div class="event-party event-party--bottom" :class="'event-party--'+partyNameToCss(turmoil.distant.current)" v-i18n>{{ turmoil.distant.current }}</div>
             <div class="event-content"><div class="event-text" v-i18n>{{ turmoil.distant.description }}</div></div>
           </div>
-          <div v-if="turmoil.comming" class="global-event global-event--comming">
-            <div class="event-party event-party--top" :class="'event-party--'+partyNameToCss(turmoil.comming.revealed)" v-i18n>{{ turmoil.comming.revealed }}</div>
-            <div class="event-party event-party--bottom" :class="'event-party--'+partyNameToCss(turmoil.comming.current)" v-i18n>{{ turmoil.comming.current }}</div>
-            <div class="event-content" v-i18n>{{ turmoil.comming.description }}</div>
+          <div v-if="turmoil.coming" class="global-event global-event--coming">
+            <div class="event-party event-party--top" :class="'event-party--'+partyNameToCss(turmoil.coming.revealed)" v-i18n>{{ turmoil.coming.revealed }}</div>
+            <div class="event-party event-party--bottom" :class="'event-party--'+partyNameToCss(turmoil.coming.current)" v-i18n>{{ turmoil.coming.current }}</div>
+            <div class="event-content" v-i18n>{{ turmoil.coming.description }}</div>
           </div>
           <div v-if="turmoil.current" class="global-event global-event--current">
             <div class="event-party event-party--top" :class="'event-party--'+partyNameToCss(turmoil.current.revealed)" v-i18n>{{ turmoil.current.revealed }}</div>

--- a/src/models/TurmoilModel.ts
+++ b/src/models/TurmoilModel.ts
@@ -11,7 +11,7 @@ export interface TurmoilModel {
     lobby: Array<Color>;
     reserve: Array<DelegatesModel>;
     distant: GlobalEventModel | undefined;
-    comming: GlobalEventModel | undefined;
+    coming: GlobalEventModel | undefined;
     current: GlobalEventModel | undefined;
 }
 

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -100,7 +100,7 @@
     background-position: -727px -172px;
 }
 
-.global-event--comming {
+.global-event--comin {
     background-position: -375px -172px;
 }
   
@@ -158,7 +158,7 @@
     }
 }
 
-.global-event--comming .event-party--bottom {
+.global-event--comin .event-party--bottom {
     margin-left: 123px
 }
 

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -100,7 +100,7 @@
     background-position: -727px -172px;
 }
 
-.global-event--comin {
+.global-event--coming {
     background-position: -375px -172px;
 }
   

--- a/src/turmoil/SerializedTurmoil.ts
+++ b/src/turmoil/SerializedTurmoil.ts
@@ -2,17 +2,26 @@ import {IParty} from './parties/IParty';
 import {GlobalEventDealer} from './globalEvents/GlobalEventDealer';
 import {IGlobalEvent} from './globalEvents/IGlobalEvent';
 import {PlayerId} from '../Player';
+import {PartyName} from './parties/PartyName';
 
 export interface SerializedTurmoil {
     chairman: undefined | PlayerId | 'NEUTRAL';
+    // TODO(kberg): Remove by end of year.
     rulingParty: undefined | IParty;
+    rulingPartyName: undefined | PartyName;
+    // TODO(kberg): Remove by end of year.
     dominantParty: undefined | IParty;
-    lobby: Array<string>;
+    dominantPartyName: undefined | PartyName;
+    lobby: Array<PlayerId>;
+    // TODO(kberg): Remove by end of year.
     delegate_reserve: Array<PlayerId | 'NEUTRAL'>; // eslint-disable-line camelcase
+    delegateReserve: Array<PlayerId | 'NEUTRAL'> | undefined;
     parties: Array<IParty>;
     playersInfluenceBonus: Array<[string, number]>;
     globalEventDealer: GlobalEventDealer;
     distantGlobalEvent: IGlobalEvent | undefined;
+    comingGlobalEvent: IGlobalEvent | undefined;
+    // TODO(kberg): Remove by end of year.
     commingGlobalEvent: IGlobalEvent | undefined;
     currentGlobalEvent?: IGlobalEvent;
 }

--- a/src/turmoil/globalEvents/GlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/GlobalEventDealer.ts
@@ -102,19 +102,19 @@ export const NEGATIVE_GLOBAL_EVENTS: Array<IGlobalEventFactory<IGlobalEvent>> = 
   {globalEventName: GlobalEventName.SOLAR_FLARE, Factory: SolarFlare},
 ];
 
+const ALL_EVENTS = [
+  ...POSITIVE_GLOBAL_EVENTS,
+  ...NEGATIVE_GLOBAL_EVENTS,
+  ...COLONY_ONLY_POSITIVE_GLOBAL_EVENTS,
+  ...COLONY_ONLY_NEGATIVE_GLOBAL_EVENTS,
+  ...VENUS_COLONY_POSITIVE_GLOBAL_EVENTS,
+  ...VENUS_COLONY_NEGATIVE_GLOBAL_EVENTS,
+  ...VENUS_POSITIVE_GLOBAL_EVENTS,
+];
+
 // Function to return a global event object by its name
 export function getGlobalEventByName(globalEventName: string): IGlobalEvent | undefined {
-  const allEvents = [
-    ...POSITIVE_GLOBAL_EVENTS,
-    ...NEGATIVE_GLOBAL_EVENTS,
-    ...COLONY_ONLY_POSITIVE_GLOBAL_EVENTS,
-    ...COLONY_ONLY_NEGATIVE_GLOBAL_EVENTS,
-    ...VENUS_COLONY_POSITIVE_GLOBAL_EVENTS,
-    ...VENUS_COLONY_NEGATIVE_GLOBAL_EVENTS,
-    ...VENUS_POSITIVE_GLOBAL_EVENTS,
-  ];
-
-  const globalEventFactory = allEvents.find((globalEventFactory) => globalEventFactory.globalEventName === globalEventName);
+  const globalEventFactory = ALL_EVENTS.find((globalEventFactory) => globalEventFactory.globalEventName === globalEventName);
 
   if (globalEventFactory !== undefined) return new globalEventFactory.Factory();
   return undefined;

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -211,10 +211,9 @@ describe('Turmoil', function() {
 
   it('serializes all properties', function() {
     const serialized = turmoil.serialize();
-    const serializedKeys = Object.keys(serialized);
-    const turmoilKeys = Object.keys(turmoil);
-    serializedKeys.sort();
-    turmoilKeys.sort();
-    expect(serializedKeys).to.deep.eq(turmoilKeys);
+    const turmoil2 = new Turmoil();
+    turmoil2.loadFromJSON(serialized);
+    const serialized2 = turmoil2.serialize();
+    expect(serialized2).to.deep.eq(serialized);
   });
 });


### PR DESCRIPTION
This is a series of small changes that grew into something a bit larger, but I think cleaner. It removes Object.assign, for instance, which means serialization and deserialization are far more explicit.

While making this change I also changed the way Turmoil instances are constructed. If you're going to make a Turmoil from a Game, you can use loadFromGame(), which  works great for first-time set-up. But when you want to load from JSON, you no longer need a Game instance, which makes sense, doesn't it? Why create a vestigial game just to create a new instance? I hope that we can propagate this up to the Game and Player instances, and get rid of the need for vestigial players just to, load a Game from the database, or to clone one.

While at it, I made a backwards-compatible change to the save format with the intent to remove the older ways.

This removes references to (most) non-serializable objects in Turmoil - instead storing well-known indexes. It also makes a breaking change away from a couple of typos in field names that can at least be removed now.

Testing was great at finding the bugs in my serialization, but I would like to hear feedback on serialization test requests before you felt comfortable making a change like this, especially because I would like to propagate this to Player and Game.