### PR TITLE
Minor CSS fix for long player names

### DIFF
--- a/src/styles/players_overview.less
+++ b/src/styles/players_overview.less
@@ -83,6 +83,7 @@
                         max-width: 90px;
                         overflow: hidden;
                         text-overflow: ellipsis;
+                        white-space: nowrap;
                     }
                     .player-name--inactive {
                         cursor: default !important;


### PR DESCRIPTION
Current behaviour: Long player names will spill over into 2nd row or more, resulting in uneven heights for player bars.
<img width="146" alt="Screenshot 2020-12-04 at 10 46 33 PM" src="https://user-images.githubusercontent.com/2408094/101177530-e0cb4b80-3682-11eb-9352-8d4bf19f22f0.png">

Change: Add missing property so that `text-overflow: ellipsis` works correctly and keeps all heights constant
<img width="148" alt="Screenshot 2020-12-04 at 10 46 15 PM" src="https://user-images.githubusercontent.com/2408094/101177610-f8a2cf80-3682-11eb-9d9c-a4b3d4697531.png">
