### PR TITLE
Turmoil serialization updated.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -248,7 +248,7 @@ export class Game implements ISerializable<SerializedGame> {
 
       // Add Turmoil stuff
       if (gameOptions.turmoilExtension) {
-        this.turmoil = new Turmoil(this);
+        this.turmoil = Turmoil.newInstance(this);
       }
 
       // Setup Ares hazards
@@ -1799,8 +1799,7 @@ export class Game implements ISerializable<SerializedGame> {
 
       // Reload turmoil elements if needed
       if (d.turmoil && this.gameOptions.turmoilExtension) {
-        const turmoil = new Turmoil(this);
-        this.turmoil = turmoil.loadFromJSON(d.turmoil);
+        this.turmoil = Turmoil.deserialize(d.turmoil);
 
         // Rebuild lobby
         this.turmoil.lobby = new Set<string>(d.turmoil.lobby);

--- a/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
+++ b/tests/globalEvents/AquiferReleasedByPublicCouncil.spec.ts
@@ -12,7 +12,7 @@ describe('AquiferReleasedByPublicCouncil', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/AsteroidMining.spec.ts
+++ b/tests/globalEvents/AsteroidMining.spec.ts
@@ -13,7 +13,7 @@ describe('AsteroidMining', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new MethaneFromTitan());

--- a/tests/globalEvents/CelebrityLeaders.spec.ts
+++ b/tests/globalEvents/CelebrityLeaders.spec.ts
@@ -13,7 +13,7 @@ describe('CelebrityLeaders', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new Virus());

--- a/tests/globalEvents/CloudSocieties.spec.ts
+++ b/tests/globalEvents/CloudSocieties.spec.ts
@@ -11,7 +11,7 @@ describe('CloudSocieties', function() {
     const card = new CloudSocieties();
     const player = TestPlayers.BLUE.newPlayer();
     const game = new Game('foobar', [player], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     player.playedCards.push(new FloatingHabs());
     turmoil.chairman = player.id;
     turmoil.dominantParty = new Kelvinists();

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -11,7 +11,7 @@ describe('CorrosiveRain', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.chairman = player2.id;
     turmoil.dominantParty = new Kelvinists();

--- a/tests/globalEvents/Diversity.spec.ts
+++ b/tests/globalEvents/Diversity.spec.ts
@@ -15,7 +15,7 @@ describe('Diversity', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player2.playedCards.push(new AdvancedEcosystems());
     player2.playedCards.push(new EarlySettlement());

--- a/tests/globalEvents/EcoSabotage.spec.ts
+++ b/tests/globalEvents/EcoSabotage.spec.ts
@@ -12,7 +12,7 @@ describe('EcoSabotage', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;
     turmoil.dominantParty = new Kelvinists();

--- a/tests/globalEvents/Election.spec.ts
+++ b/tests/globalEvents/Election.spec.ts
@@ -13,7 +13,7 @@ describe('Election', function() {
     const player2 = TestPlayers.RED.newPlayer();
     const player3 = TestPlayers.GREEN.newPlayer();
     const game = new Game('foobar', [player, player2, player3], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());

--- a/tests/globalEvents/GenerousFunding.spec.ts
+++ b/tests/globalEvents/GenerousFunding.spec.ts
@@ -12,7 +12,7 @@ describe('GenerousFunding', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/GlobalDustStorm.spec.ts
+++ b/tests/globalEvents/GlobalDustStorm.spec.ts
@@ -13,7 +13,7 @@ describe('GlobalDustStorm', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());

--- a/tests/globalEvents/HomeworldSupport.spec.ts
+++ b/tests/globalEvents/HomeworldSupport.spec.ts
@@ -13,7 +13,7 @@ describe('HomeworldSupport', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new Sponsors());

--- a/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
+++ b/tests/globalEvents/ImprovedEnergyTemplates.spec.ts
@@ -13,7 +13,7 @@ describe('ImprovedEnergyTemplates', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new SolarWindPower());
     player2.playedCards.push(new SolarWindPower());

--- a/tests/globalEvents/InterplanetaryTrade.spec.ts
+++ b/tests/globalEvents/InterplanetaryTrade.spec.ts
@@ -13,7 +13,7 @@ describe('InterplanetaryTrade', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new MethaneFromTitan());

--- a/tests/globalEvents/JovianTaxRights.spec.ts
+++ b/tests/globalEvents/JovianTaxRights.spec.ts
@@ -14,7 +14,7 @@ describe('JovianTaxRights', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     const colony1 = new Luna();
     const colony2 = new Triton();

--- a/tests/globalEvents/MicrogravityHealthProblems.spec.ts
+++ b/tests/globalEvents/MicrogravityHealthProblems.spec.ts
@@ -13,7 +13,7 @@ describe('MicrogravityHealthProblems', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     const colony1 = new Luna();
     const colony2 = new Triton();
     colony1.colonies.push(player.id);

--- a/tests/globalEvents/MinersOnStrike.spec.ts
+++ b/tests/globalEvents/MinersOnStrike.spec.ts
@@ -13,7 +13,7 @@ describe('MinersOnStrike', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player.setResource(Resources.TITANIUM, 5);
     player2.setResource(Resources.TITANIUM, 5);

--- a/tests/globalEvents/MudSlides.spec.ts
+++ b/tests/globalEvents/MudSlides.spec.ts
@@ -11,7 +11,7 @@ describe('MudSlides', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     const oceanTile = game.board.getAvailableSpacesForOcean(player)[0];
     game.addCityTile(player, game.board.getAdjacentSpaces(oceanTile)[0].id);

--- a/tests/globalEvents/Pandemic.spec.ts
+++ b/tests/globalEvents/Pandemic.spec.ts
@@ -13,7 +13,7 @@ describe('Pandemic', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new StripMine());
     player2.playedCards.push(new StripMine());

--- a/tests/globalEvents/ParadigmBreakdown.spec.ts
+++ b/tests/globalEvents/ParadigmBreakdown.spec.ts
@@ -16,7 +16,7 @@ describe('ParadigmBreakdown', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/Productivity.spec.ts
+++ b/tests/globalEvents/Productivity.spec.ts
@@ -12,7 +12,7 @@ describe('Productivity', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/RedInfluence.spec.ts
+++ b/tests/globalEvents/RedInfluence.spec.ts
@@ -12,7 +12,7 @@ describe('RedInfluence', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.setTerraformRating(23);
     player.megaCredits = 10;

--- a/tests/globalEvents/Revolution.spec.ts
+++ b/tests/globalEvents/Revolution.spec.ts
@@ -16,7 +16,7 @@ describe('Revolution', function() {
     player2 = TestPlayers.RED.newPlayer();
 
     game = new Game('foobar', [player, player2], player);
-    turmoil = new Turmoil(game);
+    turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/Riots.spec.ts
+++ b/tests/globalEvents/Riots.spec.ts
@@ -10,7 +10,7 @@ describe('Riots', function() {
     const card = new Riots();
     const player = TestPlayers.BLUE.newPlayer();
     const game = new Game('foobar', [player], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
     turmoil.initGlobalEvent(game);
     game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
     player.setResource(Resources.MEGACREDITS, 10);

--- a/tests/globalEvents/Sabotage.spec.ts
+++ b/tests/globalEvents/Sabotage.spec.ts
@@ -12,7 +12,7 @@ describe('Sabotage', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.addProduction(Resources.ENERGY, 1);

--- a/tests/globalEvents/ScientificCommunity.spec.ts
+++ b/tests/globalEvents/ScientificCommunity.spec.ts
@@ -14,7 +14,7 @@ describe('ScientificCommunity', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.cardsInHand.push(new Ants());
     player2.cardsInHand.push(new SecurityFleet(), new Ants());

--- a/tests/globalEvents/SnowCover.spec.ts
+++ b/tests/globalEvents/SnowCover.spec.ts
@@ -16,7 +16,7 @@ describe('SnowCover', function() {
     player2 = TestPlayers.RED.newPlayer();
     game = new Game('foobar', [player, player2], player);
 
-    turmoil = new Turmoil(game);
+    turmoil = Turmoil.newInstance(game);
     turmoil.chairman = player2.id;
     turmoil.dominantParty = new Kelvinists();
     turmoil.dominantParty.partyLeader = player2.id;

--- a/tests/globalEvents/SolarFlare.spec.ts
+++ b/tests/globalEvents/SolarFlare.spec.ts
@@ -13,7 +13,7 @@ describe('SolarFlare', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.playedCards.push(new SpaceStation());
     player2.playedCards.push(new SpaceStation(), new SpaceStation(), new SpaceStation());

--- a/tests/globalEvents/SolarnetShutdown.spec.ts
+++ b/tests/globalEvents/SolarnetShutdown.spec.ts
@@ -14,7 +14,7 @@ describe('SolarnetShutdown', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.playedCards.push(new InventorsGuild());
     player.playedCards.push(new ColonizerTrainingCamp());

--- a/tests/globalEvents/SpinoffProducts.spec.ts
+++ b/tests/globalEvents/SpinoffProducts.spec.ts
@@ -13,7 +13,7 @@ describe('SpinoffProducts', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     player.playedCards.push(new Research());

--- a/tests/globalEvents/SponsoredProjects.spec.ts
+++ b/tests/globalEvents/SponsoredProjects.spec.ts
@@ -14,7 +14,7 @@ describe('SponsoredProjects', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.playedCards.push(new Ants());
     if (player.playedCards[0].resourceCount !== undefined) {

--- a/tests/globalEvents/StrongSociety.spec.ts
+++ b/tests/globalEvents/StrongSociety.spec.ts
@@ -12,7 +12,7 @@ describe('StrongSociety', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     game.addCityTile(player, game.board.getAvailableSpacesOnLand(player)[0].id);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/SuccessfulOrganisms.spec.ts
+++ b/tests/globalEvents/SuccessfulOrganisms.spec.ts
@@ -12,7 +12,7 @@ describe('SuccessfulOrganisms', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/VenusInfrastructure.spec.ts
+++ b/tests/globalEvents/VenusInfrastructure.spec.ts
@@ -13,7 +13,7 @@ describe('VenusInfrastructure', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     player.playedCards.push(new CorroderSuits());
     player2.playedCards.push(new CorroderSuits(), new CorroderSuits(), new CorroderSuits());

--- a/tests/globalEvents/VolcanicEruptions.spec.ts
+++ b/tests/globalEvents/VolcanicEruptions.spec.ts
@@ -12,7 +12,7 @@ describe('VolcanicEruptions', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;

--- a/tests/globalEvents/WarOnEarth.spec.ts
+++ b/tests/globalEvents/WarOnEarth.spec.ts
@@ -11,7 +11,7 @@ describe('WarOnEarth', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = new Game('foobar', [player, player2], player);
-    const turmoil = new Turmoil(game);
+    const turmoil = Turmoil.newInstance(game);
 
     turmoil.initGlobalEvent(game);
     turmoil.chairman = player2.id;


### PR DESCRIPTION
This is the first in a series of updates that will adopt the same behavior: no direct access to constructors allowed, it will be private. Deserialization will be renamed to, hey, `deserialize.`

This works just fine with `Turmoil`, `Dealer` and `Player` but once you apply the same thing to `Game` you see just how tightly coupled the current structure for serialization/deserialization is tied to existing behavior. It won't be hard to fix, but it's clear that the whole thing has to be done in a series of small PRs. Hence, the easy one first.