### PR TITLE
Make GlobalEventDealer serializable on its own.

### DIFF
--- a/tests/GlobalEventsDealer.spec.ts
+++ b/tests/GlobalEventsDealer.spec.ts
@@ -1,0 +1,41 @@
+import {expect} from 'chai';
+import {GlobalDustStorm} from '../src/turmoil/globalEvents/GlobalDustStorm';
+import {GlobalEventDealer} from '../src/turmoil/globalEvents/GlobalEventDealer';
+import {GlobalEventName} from '../src/turmoil/globalEvents/GlobalEventName';
+import {IGlobalEvent} from '../src/turmoil/globalEvents/IGlobalEvent';
+import {ScientificCommunity} from '../src/turmoil/globalEvents/ScientificCommunity';
+import {SponsoredProjects} from '../src/turmoil/globalEvents/SponsoredProjects';
+import {SuccessfulOrganisms} from '../src/turmoil/globalEvents/SuccessfulOrganisms';
+import {WarOnEarth} from '../src/turmoil/globalEvents/WarOnEarth';
+
+describe('GlobalEventsDealer', () => {
+  it('serialize/deserialize - empty', () => {
+    const dealer = new GlobalEventDealer([], []);
+
+    const jsonString = JSON.stringify(dealer.serialize());
+    const json = JSON.parse(jsonString) as GlobalEventDealer;
+    const newDealer = GlobalEventDealer.deserialize(json);
+
+    expect(newDealer.globalEventsDeck).is.empty;
+    expect(newDealer.discardedGlobalEvents).is.empty;
+  });
+
+  it('serialize/deserialize - empty', () => {
+    const dealer = new GlobalEventDealer(
+      [new SponsoredProjects(), new SuccessfulOrganisms(), new ScientificCommunity()],
+      [new GlobalDustStorm(), new WarOnEarth()]);
+
+    const jsonString = JSON.stringify(dealer.serialize());
+    const json = JSON.parse(jsonString) as GlobalEventDealer;
+    const newDealer = GlobalEventDealer.deserialize(json);
+
+    const cardName = (e: IGlobalEvent) => e.name;
+    expect(newDealer.globalEventsDeck.map(cardName)).deep.eq([
+      GlobalEventName.SPONSORED_PROJECTS,
+      GlobalEventName.SUCCESSFUL_ORGANISMS,
+      GlobalEventName.SCIENTIFIC_COMMUNITY]);
+    expect(newDealer.discardedGlobalEvents.map(cardName)).deep.eq([
+      GlobalEventName.GLOBAL_DUST_STORM, GlobalEventName.WAR_ON_EARTH,
+    ]);
+  });
+});


### PR DESCRIPTION
This lets me put its behavior in one place. This is going to make it easier as I continue to adjust serialization behavior. Also added a sanity serialization/deserialization test, which will come in handle once I add a SerializedGlobalDealer.

@chstoa you asked why this style is better, and here's another example of why: first, by adding a fully-built dealer into Turmoil, Turmoil is no longer responsible for figuring out anything about how to make a deck. Second, Turmoil makes GlobalEventDealer readonly. Which meanse that I can't just do

turmoil.globalEventDealer = blah

once the object is constructed. So, fine, instead, just feed it into its constructor.