### PR TITLE
add gitattributes file for windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ts text eol=lf
+*.js text eol=lf


### PR DESCRIPTION
I don't use windows but I believe this will address issue reported in #2062 . New linting rule is checking for lines ending in LF.
