### PR TITLE
set properties without Object.assign

### DIFF
--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -368,10 +368,12 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     // Function used to rebuild each objects
     public static deserialize(d: SerializedTurmoil): Turmoil {
       const turmoil = new Turmoil(d.rulingParty.name, d.dominantParty.name);
-      // Assign each attributes
-      const o = Object.assign(turmoil, d);
 
+      turmoil.chairman = d.chairman;
+      turmoil.rulingParty = d.rulingParty;
+      turmoil.dominantParty = d.dominantParty;
       turmoil.lobby = new Set(d.lobby);
+      turmoil.delegate_reserve = d.delegate_reserve;
 
       turmoil.playersInfluenceBonus = new Map<string, number>(d.playersInfluenceBonus);
 
@@ -394,6 +396,6 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
         turmoil.currentGlobalEvent = getGlobalEventByName(d.currentGlobalEvent.name);
       }
 
-      return o;
+      return turmoil;
     }
 }

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -217,4 +217,10 @@ describe('Turmoil', function() {
     turmoilKeys.sort();
     expect(serializedKeys).to.deep.eq(turmoilKeys);
   });
+
+  it('serializes and deserializes keeping players', function() {
+    const serialized = JSON.parse(JSON.stringify(turmoil.serialize()));
+    const deserialized = Turmoil.deserialize(serialized);
+    expect(deserialized.parties[0].getPresentPlayers().length).to.eq(0);
+  });
 });


### PR DESCRIPTION
Added regression test. when deserializing a `Turmoil` the usage of `Object.assign` we setting `players` to a type we aren't enforcing with typescript!