### PR TITLE
Game may no longer have multiple players with the same player ID, and `firstPlayer` must be in the list of players.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -189,7 +189,7 @@ export class Game implements ISerializable<SerializedGame> {
       public gameOptions: GameOptions = {...DEFAULT_GAME_OPTIONS}) {
       {
         const _playerIds = players.map((p) => p.id);
-        if (_playerIds.find((pid) => pid === first.id) === undefined) {
+        if (_playerIds.includes(first.id) === false) {
           throw new Error('Cannot find first player ' + first.id + ' in ' + _playerIds);
         }
         if (new Set(_playerIds).size !== players.length) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -190,10 +190,10 @@ export class Game implements ISerializable<SerializedGame> {
       {
         const _playerIds = players.map((p) => p.id);
         if (_playerIds.find((pid) => pid === first.id) === undefined) {
-          throw new Error('Cannot find first player ' + first + ' in ' + _playerIds);
+          throw new Error('Cannot find first player ' + first.id + ' in ' + _playerIds);
         }
         if (new Set(_playerIds).size !== players.length) {
-          throw new Error('duplicate player found: ' + _playerIds);
+          throw new Error('Duplicate player found: ' + _playerIds);
         }
       }
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -184,8 +184,17 @@ export class Game implements ISerializable<SerializedGame> {
       public id: string,
       private players: Array<Player>,
       private first: Player,
-      // ... creates a shallow copy.
       public gameOptions: GameOptions = {...DEFAULT_GAME_OPTIONS}) {
+      {
+        const _playerIds = players.map((p) => p.id);
+        if (_playerIds.find((pid) => pid === first.id) === undefined) {
+          throw new Error('Cannot find first player ' + first + ' in ' + _playerIds);
+        }
+        if (new Set(_playerIds).size !== players.length) {
+          throw new Error('duplicate player found: ' + _playerIds);
+        }
+      }
+
       // Initialize Ares data
       if (gameOptions.aresExtension) {
         this.aresData = AresHandler.initialData(gameOptions.aresExtension, gameOptions.aresHazards, players);

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -34,6 +34,7 @@ describe('Game', function() {
 
   it('sets starting production if corporate era not selected', function() {
     const player = TestPlayers.BLUE.newPlayer();
+
     const gameOptions = setCustomGameOptions({corporateEra: false});
 
     new Game('foobar', [player], player, gameOptions);
@@ -253,6 +254,7 @@ describe('Game', function() {
 
   it('Should not finish solo game before last generation if Mars is already terraformed', function() {
     const player = TestPlayers.BLUE.newPlayer();
+
     const game = new Game('solo2', [player], player);
     game.generation = 10;
 
@@ -272,7 +274,9 @@ describe('Game', function() {
 
   it('Should not give TR or raise oxygen for final greenery placements', function() {
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+
+    const game = new Game('foobar', [player, redPlayer], player);
     game.generation = 14;
 
     // Terraform
@@ -369,6 +373,7 @@ describe('Game', function() {
 
   it('Removes Hellas bonus ocean space if player cannot pay', function() {
     const player = TestPlayers.BLUE.newPlayer();
+
     // NOTE: By setting up the two-player game, instead of a solo game as we regularly do
     // the neutral player can't claim the bonus ocean space before our player has a
     // chance.

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -465,6 +465,20 @@ describe('Game', function() {
     expect(corpsAssignedToPlayers).has.members(corpsFromTurmoil);
   });
 
+  it('fails when the same id appears in two players', () => {
+    const player1 = new Player('name', Color.BLUE, false, 0, 'id3');
+    const player2 = new Player('name', Color.RED, false, 0, 'id3');
+    expect(
+      () => new Game('id', [player1, player2], player1))
+      .to.throw(Error, /Duplicate player found: id3,id3/);
+  });
+
+  it('fails when first player is absent from the list of players.', () => {
+    expect(
+      () => new Game('id', [TestPlayers.RED.newPlayer(), TestPlayers.BLUE.newPlayer()], TestPlayers.YELLOW.newPlayer()))
+      .to.throw(Error, /Cannot find first player/);
+  });
+
   /**
    * ensure as we modify properties we consider
    * serialization. if this fails update SerializedGame

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -44,10 +44,12 @@ describe('Player', function() {
   it('Should error with input for run select player for PowerSupplyConsortium', function() {
     const card = new PowerSupplyConsortium();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+
     const game = new Game('foobar', [player], player);
     player.playedCards.push(new LunarBeam());
     player.playedCards.push(new LunarBeam());
-    const action = card.play(player, new Game('foobar', [player, player], player));
+    const action = card.play(player, new Game('foobar', [player, redPlayer], player));
     if (action !== undefined) {
       player.setWaitingFor(action, () => undefined);
       expect(player.getWaitingFor()).is.not.undefined;
@@ -65,9 +67,11 @@ describe('Player', function() {
   it('Should run select amount for Insulation', function() {
     const card = new Insulation();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+
     player.addProduction(Resources.HEAT, 2);
-    const game = new Game('foobar', [player], player);
-    const action = card.play(player, new Game('foobar', [player, player], player));
+    const game = new Game('foobar', [player, redPlayer], player);
+    const action = card.play(player, new Game('foobar', [player, redPlayer], player));
     expect(action).is.not.undefined;
     if (action === undefined) return;
     player.setWaitingFor(action, () => undefined);

--- a/tests/cards/ares/BioengineeringEnclosure.spec.ts
+++ b/tests/cards/ares/BioengineeringEnclosure.spec.ts
@@ -34,7 +34,8 @@ describe('BioengineeringEnclosure', function() {
   beforeEach(function() {
     card = new BioengineeringEnclosure();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Can\'t play without a science tag', () => {

--- a/tests/cards/ares/BiofertilizerFacility.spec.ts
+++ b/tests/cards/ares/BiofertilizerFacility.spec.ts
@@ -37,7 +37,8 @@ describe('BiofertilizerFacility', function() {
   beforeEach(function() {
     card = new BiofertilizerFacility();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Can\'t play without a science tag', function() {

--- a/tests/cards/ares/ButterflyEffect.spec.ts
+++ b/tests/cards/ares/ButterflyEffect.spec.ts
@@ -12,7 +12,8 @@ describe('ButterflyEffect', function() {
   beforeEach(function() {
     card = new ButterflyEffect();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_WITH_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_WITH_HAZARDS);
   });
 
   it('play', function() {

--- a/tests/cards/ares/CapitalAres.spec.ts
+++ b/tests/cards/ares/CapitalAres.spec.ts
@@ -16,7 +16,8 @@ describe('CapitalAres', function() {
   beforeEach(function() {
     card = new CapitalAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/CommercialDistrictAres.spec.ts
+++ b/tests/cards/ares/CommercialDistrictAres.spec.ts
@@ -14,7 +14,8 @@ describe('CommercialDistrictAres', function() {
   beforeEach(function() {
     card = new CommercialDistrictAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/DesperateMeasures.spec.ts
+++ b/tests/cards/ares/DesperateMeasures.spec.ts
@@ -12,7 +12,8 @@ describe('DesperateMeasures', function() {
   beforeEach(function() {
     card = new DesperateMeasures();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_WITH_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_WITH_HAZARDS);
   });
 
   it('play on top of dust storm', function() {

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -16,7 +16,8 @@ describe('EcologicalSurvey', function() {
   beforeEach(function() {
     card = new EcologicalSurvey();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     game.board = new EmptyBoard();
   });
 

--- a/tests/cards/ares/EcologicalZoneAres.spec.ts
+++ b/tests/cards/ares/EcologicalZoneAres.spec.ts
@@ -14,7 +14,8 @@ describe('EcologicalZoneAres', function() {
   beforeEach(function() {
     card = new EcologicalZoneAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -17,7 +17,8 @@ describe('GeologicalSurvey', function() {
   beforeEach(function() {
     card = new GeologicalSurvey();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     game.board = new EmptyBoard();
   });
 

--- a/tests/cards/ares/IndustrialCenterAres.spec.ts
+++ b/tests/cards/ares/IndustrialCenterAres.spec.ts
@@ -13,7 +13,8 @@ describe('IndustrialCenterAres', function() {
   beforeEach(function() {
     card = new IndustrialCenterAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/LavaFlowsAres.spec.ts
+++ b/tests/cards/ares/LavaFlowsAres.spec.ts
@@ -13,7 +13,8 @@ describe('LavaFlowsAres', function() {
   beforeEach(function() {
     card = new LavaFlowsAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     resetBoard(game);
   });
 

--- a/tests/cards/ares/MiningAreaAres.spec.ts
+++ b/tests/cards/ares/MiningAreaAres.spec.ts
@@ -15,7 +15,8 @@ describe('MiningAreaAres', function() {
   beforeEach(function() {
     card = new MiningAreaAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/MiningRightsAres.spec.ts
+++ b/tests/cards/ares/MiningRightsAres.spec.ts
@@ -15,7 +15,8 @@ describe('MiningRightsAres', function() {
   beforeEach(function() {
     card = new MiningRightsAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/MoholeAreaAres.spec.ts
+++ b/tests/cards/ares/MoholeAreaAres.spec.ts
@@ -11,7 +11,9 @@ describe('MoholeAreaAres', function() {
   it('Should play', function() {
     const card = new MoholeAreaAres();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+
+    const game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     const action = card.play(player, game);
 
     expect(action).is.not.undefined;

--- a/tests/cards/ares/NaturalPreserveAres.spec.ts
+++ b/tests/cards/ares/NaturalPreserveAres.spec.ts
@@ -14,7 +14,8 @@ describe('NaturalPreserveAres', function() {
   beforeEach(function() {
     card = new NaturalPreserveAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/NuclearZoneAres.spec.ts
+++ b/tests/cards/ares/NuclearZoneAres.spec.ts
@@ -9,7 +9,9 @@ describe('NuclearZoneAres', function() {
   it('Should play', function() {
     const card = new NuclearZoneAres();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+
+    const game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
 
     const action = card.play(player, game);
     if (action !== undefined) {

--- a/tests/cards/ares/OceanCity.spec.ts
+++ b/tests/cards/ares/OceanCity.spec.ts
@@ -15,7 +15,8 @@ describe('OceanCity', function() {
   beforeEach(function() {
     card = new OceanCity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Can play', function() {

--- a/tests/cards/ares/RestrictedAreaAres.spec.ts
+++ b/tests/cards/ares/RestrictedAreaAres.spec.ts
@@ -13,7 +13,8 @@ describe('RestrictedAreaAres', function() {
   beforeEach(function() {
     card = new RestrictedAreaAres();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
   it('Should play', function() {

--- a/tests/cards/ares/SolarFarm.spec.ts
+++ b/tests/cards/ares/SolarFarm.spec.ts
@@ -16,7 +16,8 @@ describe('SolarFarm', function() {
   beforeEach(function() {
     card = new SolarFarm();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_WITH_HAZARDS);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_WITH_HAZARDS);
   });
 
   it('Play', function() {

--- a/tests/cards/base/AICentral.spec.ts
+++ b/tests/cards/base/AICentral.spec.ts
@@ -11,7 +11,8 @@ describe('AICentral', function() {
   beforeEach(function() {
     card = new AICentral();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if not enough science tags to play', function() {

--- a/tests/cards/base/AcquiredCompany.spec.ts
+++ b/tests/cards/base/AcquiredCompany.spec.ts
@@ -8,6 +8,7 @@ describe('AcquiredCompany', function() {
   it('Should play', function() {
     const card = new AcquiredCompany();
     const player = TestPlayers.BLUE.newPlayer();
+
     card.play(player);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
   });

--- a/tests/cards/base/AdaptationTechnology.spec.ts
+++ b/tests/cards/base/AdaptationTechnology.spec.ts
@@ -7,6 +7,7 @@ describe('AdaptationTechnology', function() {
   it('Should play', function() {
     const card = new AdaptationTechnology();
     const player = TestPlayers.BLUE.newPlayer();
+
     card.play();
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
     expect(player.victoryPointsBreakdown.victoryPoints).to.eq(1);

--- a/tests/cards/base/AdaptedLichen.spec.ts
+++ b/tests/cards/base/AdaptedLichen.spec.ts
@@ -8,6 +8,7 @@ describe('AdaptedLichen', function() {
   it('Should play', function() {
     const card = new AdaptedLichen();
     const player = TestPlayers.BLUE.newPlayer();
+
     card.play(player);
     expect(player.getProduction(Resources.PLANTS)).to.eq(1);
   });

--- a/tests/cards/base/AdvancedAlloys.spec.ts
+++ b/tests/cards/base/AdvancedAlloys.spec.ts
@@ -7,7 +7,8 @@ describe('AdvancedAlloys', function() {
   it('Should play', function() {
     const card = new AdvancedAlloys();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     card.play(player);
     expect(player.getTitaniumValue(game)).to.eq(4);
     expect(player.getSteelValue()).to.eq(3);

--- a/tests/cards/base/AerobrakedAmmoniaAsteroid.spec.ts
+++ b/tests/cards/base/AerobrakedAmmoniaAsteroid.spec.ts
@@ -13,7 +13,8 @@ describe('AerobrakedAmmoniaAsteroid', function() {
   beforeEach(function() {
     card = new AerobrakedAmmoniaAsteroid();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play without microbe cards', function() {

--- a/tests/cards/base/Algae.spec.ts
+++ b/tests/cards/base/Algae.spec.ts
@@ -12,7 +12,8 @@ describe('Algae', function() {
   beforeEach(function() {
     card = new Algae();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/AquiferPumping.spec.ts
+++ b/tests/cards/base/AquiferPumping.spec.ts
@@ -10,7 +10,8 @@ describe('AquiferPumping', function() {
   beforeEach(function() {
     card = new AquiferPumping();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/ArchaeBacteria.spec.ts
+++ b/tests/cards/base/ArchaeBacteria.spec.ts
@@ -11,7 +11,8 @@ describe('ArchaeBacteria', function() {
   beforeEach(function() {
     card = new ArchaeBacteria();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -14,7 +14,8 @@ describe('ArtificialLake', function() {
   beforeEach(function() {
     card = new ArtificialLake();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/BlackPolarDust.spec.ts
+++ b/tests/cards/base/BlackPolarDust.spec.ts
@@ -12,7 +12,8 @@ describe('BlackPolarDust', function() {
   beforeEach(function() {
     card = new BlackPolarDust();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/BreathingFilters.spec.ts
+++ b/tests/cards/base/BreathingFilters.spec.ts
@@ -10,7 +10,8 @@ describe('BreathingFilters', function() {
   beforeEach(function() {
     card = new BreathingFilters();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/BribedCommittee.spec.ts
+++ b/tests/cards/base/BribedCommittee.spec.ts
@@ -7,7 +7,8 @@ describe('BribedCommittee', function() {
   it('Should play', function() {
     const card = new BribedCommittee();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     card.play(player, game);
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());
     expect(player.victoryPointsBreakdown.victoryPoints).to.eq(-2);

--- a/tests/cards/base/Bushes.spec.ts
+++ b/tests/cards/base/Bushes.spec.ts
@@ -11,7 +11,8 @@ describe('Bushes', function() {
   beforeEach(function() {
     card = new Bushes();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/BusinessContacts.spec.ts
+++ b/tests/cards/base/BusinessContacts.spec.ts
@@ -9,7 +9,8 @@ describe('BusinessContacts', function() {
   it('Should play', function() {
     const card = new BusinessContacts();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.not.undefined;
     expect(action instanceof SelectCard).is.true;

--- a/tests/cards/base/BusinessNetwork.spec.ts
+++ b/tests/cards/base/BusinessNetwork.spec.ts
@@ -13,7 +13,8 @@ describe('BusinessNetwork', function() {
   beforeEach(function() {
     card = new BusinessNetwork();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/CEOsFavoriteProject.spec.ts
+++ b/tests/cards/base/CEOsFavoriteProject.spec.ts
@@ -15,7 +15,8 @@ describe('CEOsFavoriteProject', function() {
   beforeEach(function() {
     card = new CEOsFavoriteProject();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Capital.spec.ts
+++ b/tests/cards/base/Capital.spec.ts
@@ -15,7 +15,8 @@ describe('Capital', function() {
   beforeEach(function() {
     card = new Capital();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/CaretakerContract.spec.ts
+++ b/tests/cards/base/CaretakerContract.spec.ts
@@ -10,7 +10,8 @@ describe('CaretakerContract', function() {
   beforeEach(function() {
     card = new CaretakerContract();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play or act', function() {

--- a/tests/cards/base/ColonizerTrainingCamp.spec.ts
+++ b/tests/cards/base/ColonizerTrainingCamp.spec.ts
@@ -10,7 +10,8 @@ describe('ColonizerTrainingCamp', function() {
   beforeEach(function() {
     card = new ColonizerTrainingCamp();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/CommercialDistrict.spec.ts
+++ b/tests/cards/base/CommercialDistrict.spec.ts
@@ -13,7 +13,8 @@ describe('CommercialDistrict', function() {
   beforeEach(function() {
     card = new CommercialDistrict();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/ConvoyFromEuropa.spec.ts
+++ b/tests/cards/base/ConvoyFromEuropa.spec.ts
@@ -7,7 +7,8 @@ describe('ConvoyFromEuropa', function() {
   it('Should play', function() {
     const card = new ConvoyFromEuropa();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     card.play(player, game);
     expect(player.cardsInHand).has.lengthOf(1);
   });

--- a/tests/cards/base/CorporateStronghold.spec.ts
+++ b/tests/cards/base/CorporateStronghold.spec.ts
@@ -13,7 +13,8 @@ describe('CorporateStronghold', function() {
   beforeEach(function() {
     card = new CorporateStronghold();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/CupolaCity.spec.ts
+++ b/tests/cards/base/CupolaCity.spec.ts
@@ -13,7 +13,8 @@ describe('CupolaCity', function() {
   beforeEach(function() {
     card = new CupolaCity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/Decomposers.spec.ts
+++ b/tests/cards/base/Decomposers.spec.ts
@@ -12,7 +12,8 @@ describe('Decomposers', function() {
   beforeEach(function() {
     card = new Decomposers();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/DeepWellHeating.spec.ts
+++ b/tests/cards/base/DeepWellHeating.spec.ts
@@ -8,7 +8,8 @@ describe('DeepWellHeating', function() {
   it('Should play', function() {
     const card = new DeepWellHeating();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);

--- a/tests/cards/base/DesignedMicroOrganisms.spec.ts
+++ b/tests/cards/base/DesignedMicroOrganisms.spec.ts
@@ -11,7 +11,8 @@ describe('DesignedMicroOrganisms', function() {
   beforeEach(function() {
     card = new DesignedMicroOrganisms();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/DevelopmentCenter.spec.ts
+++ b/tests/cards/base/DevelopmentCenter.spec.ts
@@ -10,7 +10,8 @@ describe('DevelopmentCenter', function() {
   beforeEach(function() {
     card = new DevelopmentCenter();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/DomedCrater.spec.ts
+++ b/tests/cards/base/DomedCrater.spec.ts
@@ -13,7 +13,8 @@ describe('DomedCrater', function() {
   beforeEach(function() {
     card = new DomedCrater();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/DustSeals.spec.ts
+++ b/tests/cards/base/DustSeals.spec.ts
@@ -10,7 +10,8 @@ describe('DustSeals', function() {
   beforeEach(function() {
     card = new DustSeals();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/base/EOSChasmaNationalPark.spec.ts
@@ -14,7 +14,8 @@ describe('EosChasmaNationalPark', function() {
   beforeEach(function() {
     card = new EosChasmaNationalPark();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/EarthCatapult.spec.ts
+++ b/tests/cards/base/EarthCatapult.spec.ts
@@ -6,6 +6,7 @@ describe('EarthCatapult', function() {
   it('Should play', function() {
     const card = new EarthCatapult();
     const player = TestPlayers.BLUE.newPlayer();
+
     const action = card.play();
     expect(action).is.undefined;
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/base/EarthOffice.spec.ts
+++ b/tests/cards/base/EarthOffice.spec.ts
@@ -12,7 +12,8 @@ describe('EarthOffice', function() {
   beforeEach(function() {
     card = new EarthOffice();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play();
     expect(action).is.undefined;

--- a/tests/cards/base/EcologicalZone.spec.ts
+++ b/tests/cards/base/EcologicalZone.spec.ts
@@ -12,7 +12,8 @@ describe('EcologicalZone', function() {
   beforeEach(function() {
     card = new EcologicalZone();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/ElectroCatapult.spec.ts
+++ b/tests/cards/base/ElectroCatapult.spec.ts
@@ -12,7 +12,8 @@ describe('ElectroCatapult', function() {
   beforeEach(function() {
     card = new ElectroCatapult();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/EnergySaving.spec.ts
+++ b/tests/cards/base/EnergySaving.spec.ts
@@ -8,7 +8,8 @@ describe('EnergySaving', function() {
   it('Should play', function() {
     const card = new EnergySaving();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(action).is.undefined;

--- a/tests/cards/base/EquatorialMagnetizer.spec.ts
+++ b/tests/cards/base/EquatorialMagnetizer.spec.ts
@@ -11,7 +11,8 @@ describe('EquatorialMagnetizer', function() {
   beforeEach(function() {
     card = new EquatorialMagnetizer();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/Farming.spec.ts
+++ b/tests/cards/base/Farming.spec.ts
@@ -11,7 +11,8 @@ describe('Farming', function() {
   beforeEach(function() {
     card = new Farming();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/FueledGenerators.spec.ts
+++ b/tests/cards/base/FueledGenerators.spec.ts
@@ -7,6 +7,7 @@ describe('FueledGenerators', function() {
   it('Should play', function() {
     const card = new FueledGenerators();
     const player = TestPlayers.BLUE.newPlayer();
+
     player.addProduction(Resources.PLANTS);
     card.play(player);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);

--- a/tests/cards/base/GHGProducingBacteria.spec.ts
+++ b/tests/cards/base/GHGProducingBacteria.spec.ts
@@ -11,7 +11,8 @@ describe('GHGProducingBacteria', function() {
   beforeEach(function() {
     card = new GHGProducingBacteria();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/GanymedeColony.spec.ts
+++ b/tests/cards/base/GanymedeColony.spec.ts
@@ -7,7 +7,8 @@ describe('GanymedeColony', function() {
   it('Should play', function() {
     const card = new GanymedeColony();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     player.playedCards.push(card);

--- a/tests/cards/base/GeneRepair.spec.ts
+++ b/tests/cards/base/GeneRepair.spec.ts
@@ -11,7 +11,8 @@ describe('GeneRepair', function() {
   beforeEach(function() {
     card = new GeneRepair();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Grass.spec.ts
+++ b/tests/cards/base/Grass.spec.ts
@@ -11,7 +11,8 @@ describe('Grass', function() {
   beforeEach(function() {
     card = new Grass();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/GreatDam.spec.ts
+++ b/tests/cards/base/GreatDam.spec.ts
@@ -11,7 +11,8 @@ describe('GreatDam', function() {
   beforeEach(function() {
     card = new GreatDam();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Greenhouses.spec.ts
+++ b/tests/cards/base/Greenhouses.spec.ts
@@ -7,7 +7,8 @@ describe('Greenhouses', function() {
   it('Should play', function() {
     const card = new Greenhouses();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.plants).to.eq(0);

--- a/tests/cards/base/Heather.spec.ts
+++ b/tests/cards/base/Heather.spec.ts
@@ -11,7 +11,8 @@ describe('Heather', function() {
   beforeEach(function() {
     card = new Heather();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/IceAsteroid.spec.ts
+++ b/tests/cards/base/IceAsteroid.spec.ts
@@ -7,7 +7,8 @@ describe('IceAsteroid', function() {
   it('Should play', function() {
     const card = new IceAsteroid();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
   });

--- a/tests/cards/base/IceCapMelting.spec.ts
+++ b/tests/cards/base/IceCapMelting.spec.ts
@@ -10,7 +10,8 @@ describe('IceCapMelting', function() {
   beforeEach(function() {
     card = new IceCapMelting();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/ImmigrationShuttles.spec.ts
+++ b/tests/cards/base/ImmigrationShuttles.spec.ts
@@ -8,7 +8,8 @@ describe('ImmigrationShuttles', function() {
   it('Should play', function() {
     const card = new ImmigrationShuttles();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(5);

--- a/tests/cards/base/ImportOfAdvancedGHG.spec.ts
+++ b/tests/cards/base/ImportOfAdvancedGHG.spec.ts
@@ -8,7 +8,8 @@ describe('ImportOfAdvancedGHG', function() {
   it('Should play', function() {
     const card = new ImportOfAdvancedGHG();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.HEAT)).to.eq(2);

--- a/tests/cards/base/ImportedGHG.spec.ts
+++ b/tests/cards/base/ImportedGHG.spec.ts
@@ -8,7 +8,8 @@ describe('ImportedGHG', function() {
   it('Should play', function() {
     const card = new ImportedGHG();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.HEAT)).to.eq(1);

--- a/tests/cards/base/ImportedHydrogen.spec.ts
+++ b/tests/cards/base/ImportedHydrogen.spec.ts
@@ -16,7 +16,8 @@ describe('ImportedHydrogen', function() {
   beforeEach(function() {
     card = new ImportedHydrogen();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/ImportedNitrogen.spec.ts
+++ b/tests/cards/base/ImportedNitrogen.spec.ts
@@ -16,7 +16,8 @@ describe('ImportedNitrogen', function() {
   beforeEach(function() {
     card = new ImportedNitrogen();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play without animals and microbes', function() {

--- a/tests/cards/base/IndenturedWorkers.spec.ts
+++ b/tests/cards/base/IndenturedWorkers.spec.ts
@@ -7,7 +7,8 @@ describe('IndenturedWorkers', function() {
   it('Should apply card discount until next card played', function() {
     const card = new IndenturedWorkers();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play();
     expect(action).is.undefined;
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/base/IndustrialCenter.spec.ts
+++ b/tests/cards/base/IndustrialCenter.spec.ts
@@ -12,7 +12,8 @@ describe('IndustrialCenter', function() {
   beforeEach(function() {
     card = new IndustrialCenter();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play or act', function() {

--- a/tests/cards/base/IndustrialMicrobes.spec.ts
+++ b/tests/cards/base/IndustrialMicrobes.spec.ts
@@ -8,7 +8,8 @@ describe('IndustrialMicrobes', function() {
   it('Should play', function() {
     const card = new IndustrialMicrobes();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);

--- a/tests/cards/base/Insects.spec.ts
+++ b/tests/cards/base/Insects.spec.ts
@@ -12,7 +12,8 @@ describe('Insects', function() {
   beforeEach(function() {
     card = new Insects();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Insulation.spec.ts
+++ b/tests/cards/base/Insulation.spec.ts
@@ -9,7 +9,8 @@ describe('Insulation', function() {
   it('Should play', function() {
     const card = new Insulation();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     expect(card.canPlay(player)).is.false;
     player.addProduction(Resources.HEAT);

--- a/tests/cards/base/InterstellarColonyShip.spec.ts
+++ b/tests/cards/base/InterstellarColonyShip.spec.ts
@@ -12,7 +12,8 @@ describe('InterstellarColonyShip', function() {
   beforeEach(function() {
     card = new InterstellarColonyShip();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/InventionContest.spec.ts
+++ b/tests/cards/base/InventionContest.spec.ts
@@ -7,7 +7,8 @@ describe('InventionContest', function() {
   it('Should play', function() {
     const card = new InventionContest();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.not.undefined;
     action.cb([action.cards[0]]);

--- a/tests/cards/base/InventorsGuild.spec.ts
+++ b/tests/cards/base/InventorsGuild.spec.ts
@@ -12,7 +12,8 @@ describe('InventorsGuild', function() {
   beforeEach(function() {
     card = new InventorsGuild();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/InvestmentLoan.spec.ts
+++ b/tests/cards/base/InvestmentLoan.spec.ts
@@ -8,7 +8,8 @@ describe('InvestmentLoan', function() {
   it('Should play', function() {
     const card = new InvestmentLoan();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);

--- a/tests/cards/base/Ironworks.spec.ts
+++ b/tests/cards/base/Ironworks.spec.ts
@@ -10,7 +10,8 @@ describe('Ironworks', function() {
   beforeEach(function() {
     card = new Ironworks();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act without enough energy', function() {

--- a/tests/cards/base/KelpFarming.spec.ts
+++ b/tests/cards/base/KelpFarming.spec.ts
@@ -11,7 +11,8 @@ describe('KelpFarming', function() {
   beforeEach(function() {
     card = new KelpFarming();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/LagrangeObservatory.spec.ts
+++ b/tests/cards/base/LagrangeObservatory.spec.ts
@@ -7,7 +7,8 @@ describe('LagrangeObservatory', function() {
   it('Should play', function() {
     const card = new LagrangeObservatory();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.cardsInHand).has.lengthOf(1);

--- a/tests/cards/base/LakeMarineris.spec.ts
+++ b/tests/cards/base/LakeMarineris.spec.ts
@@ -11,7 +11,8 @@ describe('LakeMarineris', function() {
   beforeEach(function() {
     card = new LakeMarineris();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/LandClaim.spec.ts
+++ b/tests/cards/base/LandClaim.spec.ts
@@ -11,7 +11,8 @@ describe('LandClaim', function() {
   it('Should play', function() {
     const card = new LandClaim();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.not.undefined;
     const landSpace = game.board.getAvailableSpacesOnLand(player)[0];

--- a/tests/cards/base/LargeConvoy.spec.ts
+++ b/tests/cards/base/LargeConvoy.spec.ts
@@ -13,7 +13,8 @@ describe('LargeConvoy', function() {
   beforeEach(function() {
     card = new LargeConvoy();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play without animal cards', function() {

--- a/tests/cards/base/LavaFlows.spec.ts
+++ b/tests/cards/base/LavaFlows.spec.ts
@@ -13,7 +13,8 @@ describe('LavaFlows', function() {
   beforeEach(function() {
     card = new LavaFlows();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     resetBoard(game);
   });
 

--- a/tests/cards/base/Lichen.spec.ts
+++ b/tests/cards/base/Lichen.spec.ts
@@ -11,7 +11,8 @@ describe('Lichen', function() {
   beforeEach(function() {
     card = new Lichen();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/LightningHarvest.spec.ts
+++ b/tests/cards/base/LightningHarvest.spec.ts
@@ -12,7 +12,8 @@ describe('LightningHarvest', function() {
   beforeEach(function() {
     card = new LightningHarvest();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Livestock.spec.ts
+++ b/tests/cards/base/Livestock.spec.ts
@@ -11,7 +11,8 @@ describe('Livestock', function() {
   beforeEach(function() {
     card = new Livestock();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without plant production', function() {

--- a/tests/cards/base/LocalHeatTrapping.spec.ts
+++ b/tests/cards/base/LocalHeatTrapping.spec.ts
@@ -14,7 +14,8 @@ describe('LocalHeatTrapping', function() {
   beforeEach(function() {
     card = new LocalHeatTrapping();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without 5 heat', function() {

--- a/tests/cards/base/MagneticFieldDome.spec.ts
+++ b/tests/cards/base/MagneticFieldDome.spec.ts
@@ -11,7 +11,8 @@ describe('MagneticFieldDome', function() {
   beforeEach(function() {
     card = new MagneticFieldDome();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/base/MagneticFieldGenerators.spec.ts
@@ -11,7 +11,8 @@ describe('MagneticFieldGenerators', function() {
   beforeEach(function() {
     card = new MagneticFieldGenerators();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Mangrove.spec.ts
+++ b/tests/cards/base/Mangrove.spec.ts
@@ -11,7 +11,8 @@ describe('Mangrove', function() {
   beforeEach(function() {
     card = new Mangrove();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/MarsUniversity.spec.ts
+++ b/tests/cards/base/MarsUniversity.spec.ts
@@ -13,7 +13,8 @@ describe('MarsUniversity', function() {
   beforeEach(function() {
     card = new MarsUniversity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/MartianRails.spec.ts
+++ b/tests/cards/base/MartianRails.spec.ts
@@ -10,7 +10,8 @@ describe('MartianRails', function() {
   beforeEach(function() {
     card = new MartianRails();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act without energy', function() {

--- a/tests/cards/base/MassConverter.spec.ts
+++ b/tests/cards/base/MassConverter.spec.ts
@@ -12,7 +12,8 @@ describe('MassConverter', function() {
   beforeEach(function() {
     card = new MassConverter();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/MediaGroup.spec.ts
+++ b/tests/cards/base/MediaGroup.spec.ts
@@ -8,7 +8,8 @@ describe('MediaGroup', function() {
   it('Should play', function() {
     const card = new MediaGroup();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play();
     expect(action).is.undefined;
     card.onCardPlayed(player, game, new Virus());

--- a/tests/cards/base/MethaneFromTitan.spec.ts
+++ b/tests/cards/base/MethaneFromTitan.spec.ts
@@ -11,7 +11,8 @@ describe('MethaneFromTitan', function() {
   beforeEach(function() {
     card = new MethaneFromTitan();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/MicroMills.spec.ts
+++ b/tests/cards/base/MicroMills.spec.ts
@@ -8,7 +8,8 @@ describe('MicroMills', function() {
   it('Should play', function() {
     const card = new MicroMills();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.HEAT)).to.eq(1);

--- a/tests/cards/base/MineralDeposit.spec.ts
+++ b/tests/cards/base/MineralDeposit.spec.ts
@@ -7,7 +7,8 @@ describe('MineralDeposit', function() {
   it('Should play', function() {
     const card = new MineralDeposit();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.steel).to.eq(5);

--- a/tests/cards/base/MiningArea.spec.ts
+++ b/tests/cards/base/MiningArea.spec.ts
@@ -14,7 +14,8 @@ describe('MiningArea', function() {
   beforeEach(function() {
     card = new MiningArea();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/MiningRights.spec.ts
+++ b/tests/cards/base/MiningRights.spec.ts
@@ -14,7 +14,8 @@ describe('MiningRights', function() {
   beforeEach(function() {
     card = new MiningRights();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if no available spaces', function() {

--- a/tests/cards/base/MoholeArea.spec.ts
+++ b/tests/cards/base/MoholeArea.spec.ts
@@ -10,7 +10,8 @@ describe('MoholeArea', function() {
   it('Should play', function() {
     const card = new MoholeArea();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
 
     expect(action).is.not.undefined;

--- a/tests/cards/base/Moss.spec.ts
+++ b/tests/cards/base/Moss.spec.ts
@@ -12,7 +12,8 @@ describe('Moss', function() {
   beforeEach(function() {
     card = new Moss();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without enough oceans', function() {

--- a/tests/cards/base/NaturalPreserve.spec.ts
+++ b/tests/cards/base/NaturalPreserve.spec.ts
@@ -13,7 +13,8 @@ describe('NaturalPreserve', function() {
   beforeEach(function() {
     card = new NaturalPreserve();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if no spaces available', function() {

--- a/tests/cards/base/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/base/NitriteReducingBacteria.spec.ts
@@ -11,7 +11,8 @@ describe('NitriteReducingBacteria', function() {
   beforeEach(function() {
     card = new NitriteReducingBacteria();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/NitrogenRichAsteroid.spec.ts
+++ b/tests/cards/base/NitrogenRichAsteroid.spec.ts
@@ -9,7 +9,8 @@ describe('NitrogenRichAsteroid', function() {
   it('Should play', function() {
     const card = new NitrogenRichAsteroid();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getTerraformRating()).to.eq(23);

--- a/tests/cards/base/NitrophilicMoss.spec.ts
+++ b/tests/cards/base/NitrophilicMoss.spec.ts
@@ -13,7 +13,8 @@ describe('NitrophilicMoss', function() {
   beforeEach(function() {
     card = new NitrophilicMoss();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without enough oceans', function() {

--- a/tests/cards/base/NoctisCity.spec.ts
+++ b/tests/cards/base/NoctisCity.spec.ts
@@ -13,7 +13,8 @@ describe('NoctisCity', function() {
   beforeEach(function() {
     card = new NoctisCity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/NoctisFarming.spec.ts
+++ b/tests/cards/base/NoctisFarming.spec.ts
@@ -11,7 +11,8 @@ describe('NoctisFarming', function() {
   beforeEach(function() {
     card = new NoctisFarming();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/NuclearPower.spec.ts
+++ b/tests/cards/base/NuclearPower.spec.ts
@@ -11,7 +11,8 @@ describe('NuclearPower', function() {
   beforeEach(function() {
     card = new NuclearPower();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/NuclearZone.spec.ts
+++ b/tests/cards/base/NuclearZone.spec.ts
@@ -8,7 +8,8 @@ describe('NuclearZone', function() {
   it('Should play', function() {
     const card = new NuclearZone();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     if (action !== undefined) {
       const space = action.availableSpaces[0];

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -16,7 +16,8 @@ describe('OlympusConference', function() {
   beforeEach(function() {
     card = new OlympusConference();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/OpenCity.spec.ts
+++ b/tests/cards/base/OpenCity.spec.ts
@@ -11,7 +11,8 @@ describe('OpenCity', function() {
   beforeEach(function() {
     card = new OpenCity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/OptimalAerobraking.spec.ts
+++ b/tests/cards/base/OptimalAerobraking.spec.ts
@@ -8,7 +8,8 @@ describe('OptimalAerobraking', function() {
   it('Should play', function() {
     const card = new OptimalAerobraking();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play();
     expect(action).is.undefined;
     expect(card.onCardPlayed(player, game, card)).is.undefined;

--- a/tests/cards/base/OreProcessor.spec.ts
+++ b/tests/cards/base/OreProcessor.spec.ts
@@ -10,7 +10,8 @@ describe('OreProcessor', function() {
   beforeEach(function() {
     card = new OreProcessor();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/PermafrostExtraction.spec.ts
+++ b/tests/cards/base/PermafrostExtraction.spec.ts
@@ -10,7 +10,8 @@ describe('PermafrostExtraction', function() {
   beforeEach(function() {
     card = new PermafrostExtraction();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/PhobosSpaceHaven.spec.ts
+++ b/tests/cards/base/PhobosSpaceHaven.spec.ts
@@ -8,7 +8,8 @@ describe('PhobosSpaceHaven', function() {
   it('Should play', function() {
     const card = new PhobosSpaceHaven();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/base/Plantation.spec.ts
+++ b/tests/cards/base/Plantation.spec.ts
@@ -11,7 +11,8 @@ describe('Plantation', function() {
   beforeEach(function() {
     card = new Plantation();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/PowerInfrastructure.spec.ts
+++ b/tests/cards/base/PowerInfrastructure.spec.ts
@@ -10,7 +10,8 @@ describe('PowerInfrastructure', function() {
   beforeEach(function() {
     card = new PowerInfrastructure();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/ProtectedHabitats.spec.ts
+++ b/tests/cards/base/ProtectedHabitats.spec.ts
@@ -7,7 +7,8 @@ describe('ProtectedHabitats', function() {
   it('Should play', function() {
     const card = new ProtectedHabitats();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.play(player, game)).is.undefined;
   });
 });

--- a/tests/cards/base/ProtectedValley.spec.ts
+++ b/tests/cards/base/ProtectedValley.spec.ts
@@ -9,7 +9,8 @@ describe('ProtectedValley', function() {
   it('Should play', function() {
     const card = new ProtectedValley();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.not.undefined;
     action.cb(action.availableSpaces[0]);

--- a/tests/cards/base/QuantumExtractor.spec.ts
+++ b/tests/cards/base/QuantumExtractor.spec.ts
@@ -12,7 +12,8 @@ describe('QuantumExtractor', function() {
   beforeEach(function() {
     card = new QuantumExtractor();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/RadChemFactory.spec.ts
+++ b/tests/cards/base/RadChemFactory.spec.ts
@@ -11,7 +11,8 @@ describe('RadChemFactory', function() {
   beforeEach(function() {
     card = new RadChemFactory();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/RadSuits.spec.ts
+++ b/tests/cards/base/RadSuits.spec.ts
@@ -11,7 +11,8 @@ describe('RadSuits', function() {
   beforeEach(function() {
     card = new RadSuits();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/RegolithEaters.spec.ts
+++ b/tests/cards/base/RegolithEaters.spec.ts
@@ -11,7 +11,8 @@ describe('RegolithEaters', function() {
   beforeEach(function() {
     card = new RegolithEaters();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should act', function() {

--- a/tests/cards/base/ReleaseOfInertGases.spec.ts
+++ b/tests/cards/base/ReleaseOfInertGases.spec.ts
@@ -7,7 +7,8 @@ describe('ReleaseOfInertGases', function() {
   it('Should play', function() {
     const card = new ReleaseOfInertGases();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getTerraformRating()).to.eq(22);

--- a/tests/cards/base/Research.spec.ts
+++ b/tests/cards/base/Research.spec.ts
@@ -7,7 +7,8 @@ describe('Research', function() {
   it('Should play', function() {
     const card = new Research();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/base/ResearchOutpost.spec.ts
+++ b/tests/cards/base/ResearchOutpost.spec.ts
@@ -11,7 +11,8 @@ describe('ResearchOutpost', function() {
   beforeEach(function() {
     card = new ResearchOutpost();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/RestrictedArea.spec.ts
+++ b/tests/cards/base/RestrictedArea.spec.ts
@@ -11,7 +11,8 @@ describe('RestrictedArea', function() {
   beforeEach(function() {
     card = new RestrictedArea();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act if not enough MC', function() {

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -22,11 +22,13 @@ import {resetBoard, setCustomGameOptions, TestPlayers} from '../../TestingUtils'
 
 describe('RoboticWorkforce', function() {
   let card : RoboticWorkforce; let player : Player; let game : Game;
+  let redPlayer: Player;
 
   beforeEach(function() {
     card = new RoboticWorkforce();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if no building cards to copy', function() {
@@ -66,7 +68,7 @@ describe('RoboticWorkforce', function() {
   });
 
   it('Should work with Capital (Ares expansion)', function() {
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     const capitalAres = new CapitalAres();
     player.playedCards.push(capitalAres);
 
@@ -82,7 +84,7 @@ describe('RoboticWorkforce', function() {
   });
 
   it('Should work with Solar Farm (Ares expansion)', function() {
-    game = new Game('foobar', [player, player], player, ARES_OPTIONS_NO_HAZARDS);
+    game = new Game('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     const solarFarm = new SolarFarm();
 
     // This space should have 2 plants bonus on default map
@@ -132,9 +134,10 @@ describe('RoboticWorkforce', function() {
             return;
           }
 
-          // Create a new player, set all productions to 2 and place some tiles
+          // Create new players, set all productions to 2 and place some tiles
           player = TestPlayers.BLUE.newPlayer();
-          game = new Game('foobar', [player, player], player, gameOptions);
+          redPlayer = TestPlayers.RED.newPlayer();
+          game = new Game('foobar', [player, redPlayer], player, gameOptions);
           resetBoard(game);
           game.addCityTile(player, '17');
           game.addCityTile(player, '19');

--- a/tests/cards/base/SearchForLife.spec.ts
+++ b/tests/cards/base/SearchForLife.spec.ts
@@ -11,7 +11,8 @@ describe('SearchForLife', function() {
   beforeEach(function() {
     card = new SearchForLife();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act if no MC', function() {

--- a/tests/cards/base/Shuttles.spec.ts
+++ b/tests/cards/base/Shuttles.spec.ts
@@ -13,7 +13,8 @@ describe('Shuttles', function() {
   beforeEach(function() {
     card = new Shuttles();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/base/Soletta.spec.ts
+++ b/tests/cards/base/Soletta.spec.ts
@@ -9,7 +9,8 @@ describe('Soletta', function() {
   it('Should play', function() {
     const card = new Soletta();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.HEAT)).to.eq(7);

--- a/tests/cards/base/SpaceElevator.spec.ts
+++ b/tests/cards/base/SpaceElevator.spec.ts
@@ -11,7 +11,8 @@ describe('SpaceElevator', function() {
   beforeEach(function() {
     card = new SpaceElevator();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act if no steel', function() {

--- a/tests/cards/base/SpaceMirrors.spec.ts
+++ b/tests/cards/base/SpaceMirrors.spec.ts
@@ -11,7 +11,8 @@ describe('SpaceMirrors', function() {
   beforeEach(function() {
     card = new SpaceMirrors();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/SpaceStation.spec.ts
+++ b/tests/cards/base/SpaceStation.spec.ts
@@ -9,7 +9,8 @@ describe('SpaceStation', function() {
   it('Should play', function() {
     const card = new SpaceStation();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play();
     expect(action).is.undefined;
     player.victoryPointsBreakdown.setVictoryPoints('victoryPoints', card.getVictoryPoints());

--- a/tests/cards/base/SpecialDesign.spec.ts
+++ b/tests/cards/base/SpecialDesign.spec.ts
@@ -8,7 +8,8 @@ describe('SpecialDesign', function() {
   it('Should play', function() {
     const card = new SpecialDesign();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play();
     expect(action).is.undefined;
     expect(card.getRequirementBonus(player, game)).to.eq(0);

--- a/tests/cards/base/Steelworks.spec.ts
+++ b/tests/cards/base/Steelworks.spec.ts
@@ -10,7 +10,8 @@ describe('Steelworks', function() {
   beforeEach(function() {
     card = new Steelworks();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/StripMine.spec.ts
+++ b/tests/cards/base/StripMine.spec.ts
@@ -11,7 +11,8 @@ describe('StripMine', function() {
   beforeEach(function() {
     card = new StripMine();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/SubterraneanReservoir.spec.ts
+++ b/tests/cards/base/SubterraneanReservoir.spec.ts
@@ -8,7 +8,8 @@ describe('SubterraneanReservoir', function() {
   it('Should play', function() {
     const card = new SubterraneanReservoir();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
   });

--- a/tests/cards/base/SymbioticFungus.spec.ts
+++ b/tests/cards/base/SymbioticFungus.spec.ts
@@ -12,7 +12,8 @@ describe('SymbioticFungus', function() {
   beforeEach(function() {
     card = new SymbioticFungus();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/TechnologyDemonstration.spec.ts
+++ b/tests/cards/base/TechnologyDemonstration.spec.ts
@@ -7,7 +7,8 @@ describe('TechnologyDemonstration', function() {
   it('Should play', function() {
     const card = new TechnologyDemonstration();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.cardsInHand).has.lengthOf(2);

--- a/tests/cards/base/TitaniumMine.spec.ts
+++ b/tests/cards/base/TitaniumMine.spec.ts
@@ -8,7 +8,8 @@ describe('TitaniumMine', function() {
   it('Should play', function() {
     const card = new TitaniumMine();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/base/TowingAComet.spec.ts
+++ b/tests/cards/base/TowingAComet.spec.ts
@@ -8,7 +8,8 @@ describe('TowingAComet', function() {
   it('Should play', function() {
     const card = new TowingAComet();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     card.play(player, game);
     expect(player.plants).to.eq(2);
     expect(game.getOxygenLevel()).to.eq(1);

--- a/tests/cards/base/Trees.spec.ts
+++ b/tests/cards/base/Trees.spec.ts
@@ -11,7 +11,8 @@ describe('Trees', function() {
   beforeEach(function() {
     card = new Trees();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/TundraFarming.spec.ts
+++ b/tests/cards/base/TundraFarming.spec.ts
@@ -11,7 +11,8 @@ describe('TundraFarming', function() {
   beforeEach(function() {
     card = new TundraFarming();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/UndergroundCity.spec.ts
+++ b/tests/cards/base/UndergroundCity.spec.ts
@@ -11,7 +11,8 @@ describe('UndergroundCity', function() {
   beforeEach(function() {
     card = new UndergroundCity();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/UndergroundDetonations.spec.ts
+++ b/tests/cards/base/UndergroundDetonations.spec.ts
@@ -11,7 +11,8 @@ describe('UndergroundDetonations', function() {
   beforeEach(function() {
     card = new UndergroundDetonations();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/UrbanizedArea.spec.ts
+++ b/tests/cards/base/UrbanizedArea.spec.ts
@@ -14,7 +14,8 @@ describe('UrbanizedArea', function() {
   beforeEach(function() {
     card = new UrbanizedArea();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     const tharsisTholus = game.getSpace(SpaceName.THARSIS_THOLUS);
     lands = game.board.getAdjacentSpaces(tharsisTholus).filter((space) => space.spaceType === SpaceType.LAND);

--- a/tests/cards/base/VestaShipyard.spec.ts
+++ b/tests/cards/base/VestaShipyard.spec.ts
@@ -8,7 +8,8 @@ describe('VestaShipyard', function() {
   it('Should play', function() {
     const card = new VestaShipyard();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     card.play(player, game);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/base/ViralEnhancers.spec.ts
+++ b/tests/cards/base/ViralEnhancers.spec.ts
@@ -15,7 +15,8 @@ describe('ViralEnhancers', function() {
   beforeEach(function() {
     card = new ViralEnhancers();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/base/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/base/WaterImportFromEuropa.spec.ts
@@ -11,7 +11,8 @@ describe('WaterImportFromEuropa', function() {
   beforeEach(function() {
     card = new WaterImportFromEuropa();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/base/WaterSplittingPlant.spec.ts
+++ b/tests/cards/base/WaterSplittingPlant.spec.ts
@@ -10,7 +10,8 @@ describe('WaterSplittingPlant', function() {
   beforeEach(function() {
     card = new WaterSplittingPlant();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/WavePower.spec.ts
+++ b/tests/cards/base/WavePower.spec.ts
@@ -11,7 +11,8 @@ describe('WavePower', function() {
   beforeEach(function() {
     card = new WavePower();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Windmills.spec.ts
+++ b/tests/cards/base/Windmills.spec.ts
@@ -11,7 +11,8 @@ describe('Windmills', function() {
   beforeEach(function() {
     card = new Windmills();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Worms.spec.ts
+++ b/tests/cards/base/Worms.spec.ts
@@ -11,7 +11,8 @@ describe('Worms', function() {
   beforeEach(function() {
     card = new Worms();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/base/Zeppelins.spec.ts
+++ b/tests/cards/base/Zeppelins.spec.ts
@@ -11,7 +11,8 @@ describe('Zeppelins', function() {
   beforeEach(function() {
     card = new Zeppelins();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/colonies/AtmoCollectors.spec.ts
+++ b/tests/cards/colonies/AtmoCollectors.spec.ts
@@ -11,7 +11,8 @@ describe('AtmoCollectors', function() {
   beforeEach(function() {
     card = new AtmoCollectors();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/colonies/Conscription.spec.ts
+++ b/tests/cards/colonies/Conscription.spec.ts
@@ -8,7 +8,8 @@ describe('Conscription', function() {
   it('Should apply card discount until next card played', function() {
     const card = new Conscription();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.canPlay(player)).is.not.true;
     const action = card.play();
     expect(action).is.undefined;

--- a/tests/cards/colonies/EcologyResearch.spec.ts
+++ b/tests/cards/colonies/EcologyResearch.spec.ts
@@ -17,8 +17,9 @@ describe('EcologyResearch', function() {
   beforeEach(function() {
     card = new EcologyResearch();
     player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions({coloniesExtension: true});
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
 
     colony1 = new Luna();
     colony1.colonies.push(player.id);

--- a/tests/cards/colonies/FloaterTechnology.spec.ts
+++ b/tests/cards/colonies/FloaterTechnology.spec.ts
@@ -14,7 +14,8 @@ describe('FloaterTechnology', function() {
   beforeEach(function() {
     card = new FloaterTechnology();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can play', function() {

--- a/tests/cards/colonies/JovianLanterns.spec.ts
+++ b/tests/cards/colonies/JovianLanterns.spec.ts
@@ -10,7 +10,8 @@ describe('JovianLanterns', function() {
   beforeEach(function() {
     card = new JovianLanterns();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/colonies/JupiterFloatingStation.spec.ts
+++ b/tests/cards/colonies/JupiterFloatingStation.spec.ts
@@ -11,7 +11,8 @@ describe('JupiterFloatingStation', function() {
   beforeEach(function() {
     card = new JupiterFloatingStation();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/colonies/MartianZoo.spec.ts
+++ b/tests/cards/colonies/MartianZoo.spec.ts
@@ -11,7 +11,8 @@ describe('MartianZoo', function() {
   beforeEach(function() {
     card = new MartianZoo();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -14,7 +14,8 @@ describe('NitrogenFromTitan', function() {
   beforeEach(function() {
     card = new NitrogenFromTitan();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can play without floaters', function() {

--- a/tests/cards/colonies/RedSpotObservatory.spec.ts
+++ b/tests/cards/colonies/RedSpotObservatory.spec.ts
@@ -11,7 +11,8 @@ describe('RedSpotObservatory', function() {
   beforeEach(function() {
     card = new RedSpotObservatory();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/colonies/RimFreighters.spec.ts
+++ b/tests/cards/colonies/RimFreighters.spec.ts
@@ -8,7 +8,8 @@ describe('RimFreighters', function() {
   it('Should play', function() {
     const card = new RimFreighters();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player);
     expect(action).is.undefined;
     const ceres = new Ceres();

--- a/tests/cards/colonies/SpacePort.spec.ts
+++ b/tests/cards/colonies/SpacePort.spec.ts
@@ -13,7 +13,8 @@ describe('SpacePort', function() {
   beforeEach(function() {
     card = new SpacePort();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without colony', function() {

--- a/tests/cards/colonies/StormCraftIncorporated.spec.ts
+++ b/tests/cards/colonies/StormCraftIncorporated.spec.ts
@@ -13,7 +13,8 @@ describe('StormCraftIncorporated', function() {
   beforeEach(function() {
     card = new StormCraftIncorporated();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     player.corporationCard = card;
   });

--- a/tests/cards/colonies/TitanAirScrapping.spec.ts
+++ b/tests/cards/colonies/TitanAirScrapping.spec.ts
@@ -11,7 +11,8 @@ describe('TitanAirScrapping', function() {
   beforeEach(function() {
     card = new TitanAirScrapping();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act', function() {

--- a/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
+++ b/tests/cards/colonies/TitanFloatingLaunchPad.spec.ts
@@ -18,7 +18,8 @@ describe('TitanFloatingLaunchPad', function() {
   beforeEach(function() {
     card = new TitanFloatingLaunchPad();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should act', function() {

--- a/tests/cards/colonies/TitanShuttles.spec.ts
+++ b/tests/cards/colonies/TitanShuttles.spec.ts
@@ -14,7 +14,8 @@ describe('TitanShuttles', function() {
   beforeEach(function() {
     card = new TitanShuttles();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     player.playedCards.push(card);
   });

--- a/tests/cards/colonies/TradeEnvoys.spec.ts
+++ b/tests/cards/colonies/TradeEnvoys.spec.ts
@@ -8,7 +8,8 @@ describe('TradeEnvoys', function() {
   it('Should play', function() {
     const card = new TradeEnvoys();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player);
     expect(action).is.undefined;
     const ceres = new Ceres();

--- a/tests/cards/colonies/UrbanDecomposers.spec.ts
+++ b/tests/cards/colonies/UrbanDecomposers.spec.ts
@@ -17,7 +17,8 @@ describe('UrbanDecomposers', function() {
   beforeEach(function() {
     card = new UrbanDecomposers();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if player has no city', function() {

--- a/tests/cards/community/AerospaceMission.spec.ts
+++ b/tests/cards/community/AerospaceMission.spec.ts
@@ -12,9 +12,9 @@ describe('AerospaceMission', function() {
   beforeEach(function() {
     card = new AerospaceMission();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions({coloniesExtension: true});
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Should play', function() {

--- a/tests/cards/community/AgricolaInc.spec.ts
+++ b/tests/cards/community/AgricolaInc.spec.ts
@@ -14,7 +14,8 @@ describe('AgricolaInc', function() {
   beforeEach(function() {
     card = new AgricolaInc();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     card.play(player);
     player.corporationCard = card;

--- a/tests/cards/community/ByElection.spec.ts
+++ b/tests/cards/community/ByElection.spec.ts
@@ -13,9 +13,9 @@ describe('ByElection', function() {
   beforeEach(function() {
     card = new ByElection();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Should play', function() {

--- a/tests/cards/community/PoliticalUprising.spec.ts
+++ b/tests/cards/community/PoliticalUprising.spec.ts
@@ -13,9 +13,9 @@ describe('PoliticalUprising', function() {
   beforeEach(function() {
     card = new PoliticalUprising();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Should play', function() {

--- a/tests/cards/community/ProjectWorkshop.spec.ts
+++ b/tests/cards/community/ProjectWorkshop.spec.ts
@@ -18,7 +18,8 @@ describe('ProjectWorkshop', function() {
   beforeEach(function() {
     card = new ProjectWorkshop();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     advancedAlloys = new AdvancedAlloys();
 
     card.play(player);

--- a/tests/cards/community/TradeAdvance.spec.ts
+++ b/tests/cards/community/TradeAdvance.spec.ts
@@ -12,12 +12,12 @@ describe('TradeAdvance', function() {
   beforeEach(function() {
     card = new TradeAdvance();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions({
       coloniesExtension: true,
       customColoniesList: [ColonyName.LUNA, ColonyName.CALLISTO, ColonyName.CERES, ColonyName.IO, ColonyName.TITAN],
     });
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Should play', function() {

--- a/tests/cards/community/ValuableGases.spec.ts
+++ b/tests/cards/community/ValuableGases.spec.ts
@@ -10,7 +10,8 @@ describe('ValuableGases', function() {
   beforeEach(function() {
     card = new ValuableGases();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/community/VenusFirst.spec.ts
+++ b/tests/cards/community/VenusFirst.spec.ts
@@ -12,9 +12,9 @@ describe('VenusFirst', function() {
   beforeEach(function() {
     card = new VenusFirst();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/BeginnerCorporation.spec.ts
+++ b/tests/cards/corporation/BeginnerCorporation.spec.ts
@@ -8,7 +8,8 @@ describe('BeginnerCorporation', function() {
   it('Should play', function() {
     const card = new BeginnerCorporation();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
   });

--- a/tests/cards/corporation/CrediCor.spec.ts
+++ b/tests/cards/corporation/CrediCor.spec.ts
@@ -13,7 +13,8 @@ describe('CrediCor', function() {
   beforeEach(function() {
     card = new CrediCor();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/InterplanetaryCinematics.spec.ts
+++ b/tests/cards/corporation/InterplanetaryCinematics.spec.ts
@@ -12,7 +12,8 @@ describe('InterplanetaryCinematics', function() {
   beforeEach(function() {
     card = new InterplanetaryCinematics();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/Inventrix.spec.ts
+++ b/tests/cards/corporation/Inventrix.spec.ts
@@ -10,7 +10,8 @@ describe('Inventrix', function() {
   beforeEach(function() {
     card = new Inventrix();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/MiningGuild.spec.ts
+++ b/tests/cards/corporation/MiningGuild.spec.ts
@@ -16,7 +16,7 @@ describe('MiningGuild', function() {
     card = new MiningGuild();
     player = TestPlayers.BLUE.newPlayer();
     player2 = TestPlayers.RED.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    game = new Game('foobar', [player, player2], player);
 
     player.corporationCard = card;
   });
@@ -42,7 +42,12 @@ describe('MiningGuild', function() {
   });
 
   it('Gives steel production bonus when placing ocean tile', function() {
-    maxOutOceans(player, game); // 1 ocean with titanium and 1 with steel
+    game.board.getSpaces(SpaceType.OCEAN, player).forEach((space) => {
+      if (space.bonus.includes(SpaceBonus.TITANIUM) || space.bonus.includes(SpaceBonus.STEEL)) {
+        game.addOceanTile(player, space.id);
+      }
+    });
+    // There are two spaces on the main board that grant titanium or steel.
     expect(player.getProduction(Resources.STEEL)).to.eq(2);
   });
 

--- a/tests/cards/corporation/PhoboLog.spec.ts
+++ b/tests/cards/corporation/PhoboLog.spec.ts
@@ -7,7 +7,8 @@ describe('PhoboLog', function() {
   it('Should play', function() {
     const card = new PhoboLog();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.titanium).to.eq(10);

--- a/tests/cards/corporation/SaturnSystems.spec.ts
+++ b/tests/cards/corporation/SaturnSystems.spec.ts
@@ -12,7 +12,8 @@ describe('SaturnSystems', function() {
   beforeEach(function() {
     card = new SaturnSystems();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/corporation/Teractor.spec.ts
+++ b/tests/cards/corporation/Teractor.spec.ts
@@ -13,7 +13,8 @@ describe('Teractor', function() {
   beforeEach(function() {
     card = new Teractor();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play();
     expect(action).is.undefined;

--- a/tests/cards/corporation/Thorgate.spec.ts
+++ b/tests/cards/corporation/Thorgate.spec.ts
@@ -10,7 +10,8 @@ describe('Thorgate', function() {
   it('Should play', function() {
     const card = new Thorgate();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.powerPlantCost).to.eq(8);

--- a/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
+++ b/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
@@ -10,7 +10,8 @@ describe('UnitedNationsMarsInitiative', function() {
   beforeEach(function() {
     card = new UnitedNationsMarsInitiative();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t act if TR was not raised', function() {

--- a/tests/cards/prelude/GreatAquifer.spec.ts
+++ b/tests/cards/prelude/GreatAquifer.spec.ts
@@ -7,7 +7,8 @@ describe('GreatAquifer', function() {
   it('Should play', function() {
     const card = new GreatAquifer();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
   });

--- a/tests/cards/prelude/NitrogenDelivery.spec.ts
+++ b/tests/cards/prelude/NitrogenDelivery.spec.ts
@@ -8,7 +8,8 @@ describe('NitrogenDelivery', function() {
   it('Should play', function() {
     const card = new NitrogenDelivery();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/prelude/Vitor.spec.ts
+++ b/tests/cards/prelude/Vitor.spec.ts
@@ -13,7 +13,8 @@ describe('Vitor', function() {
   beforeEach(function() {
     card = new Vitor();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/AsteroidDeflectionSystem.spec.ts
+++ b/tests/cards/promo/AsteroidDeflectionSystem.spec.ts
@@ -12,7 +12,8 @@ describe('AsteroidDeflectionSystem', function() {
   beforeEach(function() {
     card = new AsteroidDeflectionSystem();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/promo/AsteroidHollowing.spec.ts
+++ b/tests/cards/promo/AsteroidHollowing.spec.ts
@@ -11,7 +11,8 @@ describe('AsteroidHollowing', function() {
   beforeEach(function() {
     card = new AsteroidHollowing();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/AsteroidRights.spec.ts
+++ b/tests/cards/promo/AsteroidRights.spec.ts
@@ -16,7 +16,8 @@ describe('AsteroidRights', function() {
   beforeEach(function() {
     card = new AsteroidRights();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     player.playedCards.push(card);
     card.play();

--- a/tests/cards/promo/Astrodrill.spec.ts
+++ b/tests/cards/promo/Astrodrill.spec.ts
@@ -14,7 +14,8 @@ describe('Astrodrill', function() {
   beforeEach(function() {
     card = new Astrodrill();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
 
     card.play();
     player.corporationCard = card;

--- a/tests/cards/promo/CometAiming.spec.ts
+++ b/tests/cards/promo/CometAiming.spec.ts
@@ -14,7 +14,8 @@ describe('CometAiming', function() {
   beforeEach(function() {
     card = new CometAiming();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/CrashSiteCleanup.spec.ts
+++ b/tests/cards/promo/CrashSiteCleanup.spec.ts
@@ -12,7 +12,8 @@ describe('CrashSiteCleanup', function() {
   beforeEach(function() {
     card = new CrashSiteCleanup();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/promo/CuttingEdgeTechnology.spec.ts
+++ b/tests/cards/promo/CuttingEdgeTechnology.spec.ts
@@ -10,7 +10,8 @@ describe('CuttingEdgeTechnology', function() {
   it('Should play', function() {
     const card = new CuttingEdgeTechnology();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     card.play();
 
     const discountedCard = new DustSeals();

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -15,7 +15,8 @@ describe('DirectedImpactors', function() {
   beforeEach(function() {
     card = new DirectedImpactors();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/DiversitySupport.spec.ts
+++ b/tests/cards/promo/DiversitySupport.spec.ts
@@ -13,7 +13,8 @@ describe('DiversitySupport', function() {
   beforeEach(function() {
     card = new DiversitySupport();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/promo/Factorum.spec.ts
+++ b/tests/cards/promo/Factorum.spec.ts
@@ -9,7 +9,8 @@ describe('Factorum', function() {
   it('Should play', function() {
     const card = new Factorum();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const play = card.play(player);
     expect(play).is.undefined;
     expect(player.getProduction(Resources.STEEL)).to.eq(1);

--- a/tests/cards/promo/FieldCappedCity.spec.ts
+++ b/tests/cards/promo/FieldCappedCity.spec.ts
@@ -10,7 +10,8 @@ describe('FieldCappedCity', function() {
   it('Should play', function() {
     const card = new FieldCappedCity();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.not.undefined;
     expect(action instanceof SelectSpace).is.true;

--- a/tests/cards/promo/GreatDamPromo.spec.ts
+++ b/tests/cards/promo/GreatDamPromo.spec.ts
@@ -14,7 +14,8 @@ describe('GreatDamPromo', function() {
   beforeEach(function() {
     card = new GreatDamPromo();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without meeting requirements', function() {

--- a/tests/cards/promo/JovianEmbassy.spec.ts
+++ b/tests/cards/promo/JovianEmbassy.spec.ts
@@ -7,7 +7,9 @@ describe('JovianEmbassy', function() {
   it('Should play', function() {
     const card = new JovianEmbassy();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+
+    const game = new Game('foobar', [player, redPlayer], player);
 
     card.play(player, game);
     expect(player.getTerraformRating()).to.eq(21);

--- a/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
+++ b/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
@@ -12,7 +12,8 @@ describe('MagneticFieldGeneratorsPromo', function() {
   beforeEach(function() {
     card = new MagneticFieldGeneratorsPromo();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Cannot play without enough energy production', function() {

--- a/tests/cards/promo/MagneticShield.spec.ts
+++ b/tests/cards/promo/MagneticShield.spec.ts
@@ -11,7 +11,8 @@ describe('MagneticShield', function() {
   beforeEach(function() {
     card = new MagneticShield();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if not enough power tags available', function() {

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -15,7 +15,8 @@ describe('MoholeLake', function() {
   beforeEach(function() {
     card = new MoholeLake();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can play', function() {

--- a/tests/cards/promo/StanfordTorus.spec.ts
+++ b/tests/cards/promo/StanfordTorus.spec.ts
@@ -10,7 +10,8 @@ describe('StanfordTorus', function() {
   beforeEach(function() {
     card = new StanfordTorus();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/promo/SubCrustMeasurements.spec.ts
+++ b/tests/cards/promo/SubCrustMeasurements.spec.ts
@@ -11,7 +11,8 @@ describe('SubCrustMeasurements', function() {
   beforeEach(function() {
     card = new SubCrustMeasurements();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play if not enough science tags', function() {

--- a/tests/cards/turmoil/PoliticalAlliance.spec.ts
+++ b/tests/cards/turmoil/PoliticalAlliance.spec.ts
@@ -12,9 +12,9 @@ describe('PoliticalAlliance', function() {
   beforeEach(function() {
     card = new PoliticalAlliance();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
     turmoil = game.turmoil!;
   });
 

--- a/tests/cards/turmoil/Pristar.spec.ts
+++ b/tests/cards/turmoil/Pristar.spec.ts
@@ -7,7 +7,8 @@ describe('Pristar', function() {
   it('Should play', function() {
     const card = new Pristar();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const play = card.play(player);
     player.corporationCard = card;
     expect(play).is.undefined;

--- a/tests/cards/turmoil/RedTourismWave.spec.ts
+++ b/tests/cards/turmoil/RedTourismWave.spec.ts
@@ -11,9 +11,9 @@ describe('RedTourismWave', function() {
   it('Should play', function() {
     const card = new RedTourismWave();
     const player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
     expect(card.canPlay(player, game)).is.not.true;
 
     const reds = game.turmoil!.getPartyByName(PartyName.REDS)!;

--- a/tests/cards/turmoil/SponsoredMohole.spec.ts
+++ b/tests/cards/turmoil/SponsoredMohole.spec.ts
@@ -9,9 +9,9 @@ describe('SponsoredMohole', function() {
   it('Should play', function() {
     const card = new SponsoredMohole();
     const player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
     expect(card.canPlay(player, game)).is.not.true;
 
     const kelvinists = game.turmoil!.getPartyByName(PartyName.KELVINISTS)!;

--- a/tests/cards/turmoil/SupportedResearch.spec.ts
+++ b/tests/cards/turmoil/SupportedResearch.spec.ts
@@ -8,9 +8,9 @@ describe('SupportedResearch', function() {
   it('Should play', function() {
     const card = new SupportedResearch();
     const player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
     expect(card.canPlay(player, game)).is.not.true;
 
     const scientists = game.turmoil!.getPartyByName(PartyName.SCIENTISTS)!;

--- a/tests/cards/turmoil/UtopiaInvest.spec.ts
+++ b/tests/cards/turmoil/UtopiaInvest.spec.ts
@@ -9,7 +9,8 @@ describe('UtopiaInvest', function() {
   it('Should play', function() {
     const card = new UtopiaInvest();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('id', [player, player], player, setCustomGameOptions());
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('id', [player, redPlayer], player, setCustomGameOptions());
     const play = card.play(player);
     expect(play).is.undefined;
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);

--- a/tests/cards/turmoil/WildlifeDome.spec.ts
+++ b/tests/cards/turmoil/WildlifeDome.spec.ts
@@ -8,9 +8,9 @@ describe('WildlifeDome', function() {
   it('Should play', function() {
     const card = new WildlifeDome();
     const player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
 
         game.turmoil!.rulingParty = game.turmoil!.getPartyByName(PartyName.REDS)!;
         expect(card.canPlay(player, game)).is.not.true;

--- a/tests/cards/venusNext/AerialMappers.spec.ts
+++ b/tests/cards/venusNext/AerialMappers.spec.ts
@@ -14,7 +14,8 @@ describe('AerialMappers', function() {
   beforeEach(function() {
     card = new AerialMappers();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     player.playedCards.push(card);
   });
 

--- a/tests/cards/venusNext/AerosportTournament.spec.ts
+++ b/tests/cards/venusNext/AerosportTournament.spec.ts
@@ -9,7 +9,8 @@ describe('AerosportTournament', function() {
     const card = new AerosportTournament();
     const corp = new Celestic();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     player.corporationCard = corp;
     corp.action(player, game);
     corp.action(player, game);

--- a/tests/cards/venusNext/AirScrappingExpedition.spec.ts
+++ b/tests/cards/venusNext/AirScrappingExpedition.spec.ts
@@ -11,7 +11,8 @@ describe('AirScrappingExpedition', function() {
     const card = new AirScrappingExpedition();
     const corp = new Celestic();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     player.corporationCard = corp;
 
 

--- a/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
+++ b/tests/cards/venusNext/AtalantaPlanitiaLab.spec.ts
@@ -7,7 +7,8 @@ describe('AtalantaPlanitiaLab', function() {
   it('Should play', function() {
     const card = new AtalantaPlanitiaLab();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.canPlay(player)).is.not.true;
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/Atmoscoop.spec.ts
+++ b/tests/cards/venusNext/Atmoscoop.spec.ts
@@ -18,7 +18,8 @@ describe('Atmoscoop', function() {
   beforeEach(function() {
     card = new Atmoscoop();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     dirigibles = new Dirigibles();
     floatingHabs = new FloatingHabs();
   });

--- a/tests/cards/venusNext/Celestic.spec.ts
+++ b/tests/cards/venusNext/Celestic.spec.ts
@@ -7,7 +7,8 @@ describe('Celestic', function() {
   it('Should play', function() {
     const card = new Celestic();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const play = card.play();
     expect(play).is.undefined;
 

--- a/tests/cards/venusNext/CorroderSuits.spec.ts
+++ b/tests/cards/venusNext/CorroderSuits.spec.ts
@@ -14,7 +14,8 @@ describe('CorroderSuits', function() {
   beforeEach(function() {
     card = new CorroderSuits();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play - no targets', function() {

--- a/tests/cards/venusNext/DawnCity.spec.ts
+++ b/tests/cards/venusNext/DawnCity.spec.ts
@@ -8,9 +8,9 @@ describe('DawnCity', function() {
   it('Should play', function() {
     const card = new DawnCity();
     const player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
     player.addProduction(Resources.ENERGY);
     expect(card.canPlay(player)).is.not.true;
 

--- a/tests/cards/venusNext/Dirigibles.spec.ts
+++ b/tests/cards/venusNext/Dirigibles.spec.ts
@@ -12,7 +12,8 @@ describe('Dirigibles', function() {
   beforeEach(function() {
     card = new Dirigibles();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     player.playedCards.push(card);
   });
 

--- a/tests/cards/venusNext/ExtractorBalloons.spec.ts
+++ b/tests/cards/venusNext/ExtractorBalloons.spec.ts
@@ -11,7 +11,8 @@ describe('ExtractorBalloons', function() {
   beforeEach(function() {
     card = new ExtractorBalloons();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/venusNext/Extremophiles.spec.ts
+++ b/tests/cards/venusNext/Extremophiles.spec.ts
@@ -13,7 +13,8 @@ describe('Extremophiles', function() {
   beforeEach(function() {
     card = new Extremophiles();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -14,7 +14,8 @@ describe('FloatingHabs', function() {
   beforeEach(function() {
     card = new FloatingHabs();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -11,7 +11,8 @@ describe('ForcedPrecipitation', function() {
   beforeEach(function() {
     card = new ForcedPrecipitation();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/venusNext/FreyjaBiodomes.spec.ts
+++ b/tests/cards/venusNext/FreyjaBiodomes.spec.ts
@@ -15,7 +15,8 @@ describe('FreyjaBiodomes', function() {
   beforeEach(function() {
     card = new FreyjaBiodomes();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/venusNext/GHGImportFromVenus.spec.ts
+++ b/tests/cards/venusNext/GHGImportFromVenus.spec.ts
@@ -8,7 +8,8 @@ describe('GHGImportFromVenus', function() {
   it('Should play', function() {
     const card = new GHGImportFromVenus();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/GiantSolarShade.spec.ts
+++ b/tests/cards/venusNext/GiantSolarShade.spec.ts
@@ -9,7 +9,8 @@ describe('GiantSolarShade', function() {
   it('Should play', function() {
     const card = new GiantSolarShade();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const action = card.play(player, game);
     expect(action).is.undefined;
     expect(game.getVenusScaleLevel()).to.eq(6);

--- a/tests/cards/venusNext/Gyropolis.spec.ts
+++ b/tests/cards/venusNext/Gyropolis.spec.ts
@@ -12,7 +12,8 @@ describe('Gyropolis', function() {
   it('Should play', function() {
     const card = new Gyropolis();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     const card1 = new ResearchNetwork();
     const card2 = new LunaGovernor();
 

--- a/tests/cards/venusNext/HydrogenToVenus.spec.ts
+++ b/tests/cards/venusNext/HydrogenToVenus.spec.ts
@@ -15,7 +15,8 @@ describe('HydrogenToVenus', function() {
   beforeEach(function() {
     card = new HydrogenToVenus();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play with multiple venus cards', function() {

--- a/tests/cards/venusNext/IoSulphurResearch.spec.ts
+++ b/tests/cards/venusNext/IoSulphurResearch.spec.ts
@@ -7,7 +7,8 @@ describe('IoSulphurResearch', function() {
   it('Should play', function() {
     const card = new IoSulphurResearch();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/IshtarMining.spec.ts
+++ b/tests/cards/venusNext/IshtarMining.spec.ts
@@ -8,7 +8,8 @@ describe('IshtarMining', function() {
   it('Should play', function() {
     const card = new IshtarMining();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     game.increaseVenusScaleLevel(player, 3);
     expect(card.canPlay(player, game)).is.not.true;
     game.increaseVenusScaleLevel(player, 3);

--- a/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
+++ b/tests/cards/venusNext/JetStreamMicroscrappers.spec.ts
@@ -11,7 +11,8 @@ describe('JetStreamMicroscrappers', function() {
   beforeEach(function() {
     card = new JetStreamMicroscrappers();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {

--- a/tests/cards/venusNext/LunaMetropolis.spec.ts
+++ b/tests/cards/venusNext/LunaMetropolis.spec.ts
@@ -8,8 +8,9 @@ describe('LunaMetropolis', function() {
   it('Should play', function() {
     const card = new LunaMetropolis();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    const game = new Game('foobar', [player, player], player, gameOptions);
+    const game = new Game('foobar', [player, redPlayer], player, gameOptions);
 
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/Manutech.spec.ts
+++ b/tests/cards/venusNext/Manutech.spec.ts
@@ -11,7 +11,8 @@ describe('Manutech', function() {
   beforeEach(function() {
     card = new Manutech();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     player.corporationCard = card;
   });
 

--- a/tests/cards/venusNext/MaxwellBase.spec.ts
+++ b/tests/cards/venusNext/MaxwellBase.spec.ts
@@ -16,9 +16,9 @@ describe('MaxwellBase', function() {
   beforeEach(function() {
     card = new MaxwellBase();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Can\'t play without energy production', function() {

--- a/tests/cards/venusNext/MorningStarInc.spec.ts
+++ b/tests/cards/venusNext/MorningStarInc.spec.ts
@@ -9,7 +9,8 @@ describe('MorningStarInc', function() {
     const corp = new MorningStarInc();
     const card = new IshtarMining();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     player.corporationCard = corp;
     game.increaseVenusScaleLevel(player, 3);
     expect(card.canPlay(player, game)).is.true;

--- a/tests/cards/venusNext/NeutralizerFactory.spec.ts
+++ b/tests/cards/venusNext/NeutralizerFactory.spec.ts
@@ -7,7 +7,8 @@ describe('NeutralizerFactory', function() {
   it('Should play', function() {
     const card = new NeutralizerFactory();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.canPlay(player, game)).is.not.true;
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/Omnicourt.spec.ts
+++ b/tests/cards/venusNext/Omnicourt.spec.ts
@@ -7,7 +7,8 @@ describe('Omnicourt', function() {
   it('Should play', function() {
     const card = new Omnicourt();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.canPlay(player, game)).is.not.true;
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/OrbitalReflectors.spec.ts
+++ b/tests/cards/venusNext/OrbitalReflectors.spec.ts
@@ -8,7 +8,8 @@ describe('OrbitalReflectors', function() {
   it('Should play', function() {
     const card = new OrbitalReflectors();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -13,7 +13,8 @@ describe('RotatorImpacts', function() {
   beforeEach(function() {
     card = new RotatorImpacts();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/Solarnet.spec.ts
+++ b/tests/cards/venusNext/Solarnet.spec.ts
@@ -7,7 +7,8 @@ describe('Solarnet', function() {
   it('Should play', function() {
     const card = new Solarnet();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
     expect(card.canPlay(player)).is.not.true;
     const action = card.play(player, game);
     expect(action).is.undefined;

--- a/tests/cards/venusNext/SpinInducingAsteroid.spec.ts
+++ b/tests/cards/venusNext/SpinInducingAsteroid.spec.ts
@@ -11,7 +11,8 @@ describe('SpinInducingAsteroid', function() {
   beforeEach(function() {
     card = new SpinInducingAsteroid();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/Stratopolis.spec.ts
+++ b/tests/cards/venusNext/Stratopolis.spec.ts
@@ -14,9 +14,9 @@ describe('Stratopolis', function() {
   beforeEach(function() {
     card = new Stratopolis();
     player = TestPlayers.BLUE.newPlayer();
-
+    const redPlayer = TestPlayers.RED.newPlayer();
     const gameOptions = setCustomGameOptions();
-    game = new Game('foobar', [player, player], player, gameOptions);
+    game = new Game('foobar', [player, redPlayer], player, gameOptions);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/StratosphericBirds.spec.ts
+++ b/tests/cards/venusNext/StratosphericBirds.spec.ts
@@ -15,7 +15,8 @@ describe('StratosphericBirds', function() {
   beforeEach(function() {
     card = new StratosphericBirds();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
     deuteriumExport = new DeuteriumExport();
   });
 

--- a/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
+++ b/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
@@ -11,7 +11,8 @@ describe('SulphurEatingBacteria', function() {
   beforeEach(function() {
     card = new SulphurEatingBacteria();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/SulphurExports.spec.ts
+++ b/tests/cards/venusNext/SulphurExports.spec.ts
@@ -8,7 +8,8 @@ describe('SulphurExports', function() {
   it('Should play', function() {
     const card = new SulphurExports();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     card.play(player, game);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);

--- a/tests/cards/venusNext/Thermophiles.spec.ts
+++ b/tests/cards/venusNext/Thermophiles.spec.ts
@@ -13,7 +13,8 @@ describe('Thermophiles', function() {
   beforeEach(function() {
     card = new Thermophiles();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/VenusMagnetizer.spec.ts
+++ b/tests/cards/venusNext/VenusMagnetizer.spec.ts
@@ -11,7 +11,8 @@ describe('VenusMagnetizer', function() {
   beforeEach(function() {
     card = new VenusMagnetizer();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/VenusSoils.spec.ts
+++ b/tests/cards/venusNext/VenusSoils.spec.ts
@@ -14,7 +14,8 @@ describe('VenusSoils', function() {
   beforeEach(function() {
     card = new VenusSoils();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Should play - single target', function() {

--- a/tests/cards/venusNext/VenusWaystation.spec.ts
+++ b/tests/cards/venusNext/VenusWaystation.spec.ts
@@ -11,7 +11,8 @@ describe('VenusWaystation', function() {
     const card2 = new LocalShading();
     const card3 = new VenusGovernor();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     const action = card.play();
     expect(action).is.undefined;

--- a/tests/cards/venusNext/VenusianAnimals.spec.ts
+++ b/tests/cards/venusNext/VenusianAnimals.spec.ts
@@ -11,7 +11,8 @@ describe('VenusianAnimals', function() {
   beforeEach(function() {
     card = new VenusianAnimals();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/VenusianInsects.spec.ts
+++ b/tests/cards/venusNext/VenusianInsects.spec.ts
@@ -10,7 +10,8 @@ describe('VenusianInsects', function() {
   beforeEach(function() {
     card = new VenusianInsects();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/VenusianPlants.spec.ts
+++ b/tests/cards/venusNext/VenusianPlants.spec.ts
@@ -13,7 +13,8 @@ describe('VenusianPlants', function() {
   beforeEach(function() {
     card = new VenusianPlants();
     player = TestPlayers.BLUE.newPlayer();
-    game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = new Game('foobar', [player, redPlayer], player);
   });
 
   it('Can\'t play', function() {

--- a/tests/cards/venusNext/WaterToVenus.spec.ts
+++ b/tests/cards/venusNext/WaterToVenus.spec.ts
@@ -7,7 +7,8 @@ describe('WaterToVenus', function() {
   it('Should play', function() {
     const card = new WaterToVenus();
     const player = TestPlayers.BLUE.newPlayer();
-    const game = new Game('foobar', [player, player], player);
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = new Game('foobar', [player, redPlayer], player);
 
     const play = card.play(player, game);
     expect(play).is.undefined;

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -8,10 +8,11 @@ describe('GameLoader', function() {
   let expectedGameIds: Array<string> = [];
   const originalGenerateId = (Player as any).prototype.generateId;
   const originalGetInstance = (Database as any).getInstance;
+  let playerIdIndex = 0;
 
   before(function() {
     (Player as any).prototype.generateId = function() {
-      return 'bar';
+      return 'bar-' + (playerIdIndex++);
     };
     (Database as any).getInstance = function() {
       return {
@@ -62,7 +63,7 @@ describe('GameLoader', function() {
 
   it('loads player after loaded from database', function() {
     const expectedGameId = 'foo';
-    const expectedPlayerId = 'bar';
+    const expectedPlayerId = 'bar-' + playerIdIndex;
     expectedGameIds = [expectedGameId];
     const loader = new GameLoader();
     let actual: Game | undefined;
@@ -71,13 +72,14 @@ describe('GameLoader', function() {
     });
     expect(actual).to.be.undefined;
     loader.start();
+    console.log(actual!.getPlayers());
     expect(actual).not.to.be.undefined;
     expect(actual?.id).to.eq(expectedGameId);
   });
 
   it('loads player already loaded from database', function() {
     const expectedGameId = 'foo';
-    const expectedPlayerId = 'bar';
+    const expectedPlayerId = 'bar-' + playerIdIndex;
     expectedGameIds = [expectedGameId];
     const loader = new GameLoader();
     loader.start();

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -72,7 +72,6 @@ describe('GameLoader', function() {
     });
     expect(actual).to.be.undefined;
     loader.start();
-    console.log(actual!.getPlayers());
     expect(actual).not.to.be.undefined;
     expect(actual?.id).to.eq(expectedGameId);
   });


### PR DESCRIPTION
This only happens in tests, and as you can see by this change, it's *a lot* of tests, which casually use `[player, player]` as their list of players in a game. This causes some super-weird test failures when a player receives both ends of an action. We shouldn't be doing it anyway.

There were surprisingly few tests that didn't like this: MiningGuild and GameLoader. Both were easy enough to fix, ... no actually MiningGuild was a pain in the butt. Mining Guild's issue was that that it used maxOutOceans, which by default stops when it places 9 oceans -- but there are 12 ocean spaces! So I switched to a more direct space filter.

GameLoader just needed dedicated Player IDs. Also a bit of a pain trying to manage the sheer volume of callbacks between GameLoader and tests.

**What do you need, reviewer?**

It's a lot of files. Do you want me to split it out? No problem. Almost all the changes are dead simple to understand (except MiningGuild and GameLoader, but I've discussed that.) Also, do you want me to rename `redPlayer`? I am not terribly fond of `player2` - you tell me.