### PR TITLE
Remove unused field Player.generationPlayed.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -113,8 +113,6 @@ export class Player implements ISerializable<SerializedPlayer> {
     public playedCards: Array<IProjectCard> = [];
     public draftedCards: Array<IProjectCard> = [];
     public removedFromPlayCards: Array<IProjectCard> = [];
-    // TODO(kberg): Recast to Map<CardName, number>, make sure it survives JSONification.
-    private generationPlayed: Map<string, number> = new Map<string, number>();
     public cardCost: number = constants.CARD_COST;
     public needsToDraft: boolean | undefined = undefined;
     public cardDiscount: number = 0;
@@ -1092,7 +1090,6 @@ export class Player implements ISerializable<SerializedPlayer> {
       this.playedCards.push(card);
       game.log('${0} played ${1}', (b) => b.player(this).card(card));
       this.lastCardPlayed = card;
-      this.generationPlayed.set(card.name, game.generation);
 
       // Playwrights hook for Conscription and Indentured Workers
       this.removedFromPlayCards = this.removedFromPlayCards.filter((card) => card.getCardDiscount === undefined);
@@ -2316,7 +2313,6 @@ export class Player implements ISerializable<SerializedPlayer> {
         draftedCards: this.draftedCards.map((c) => c.name),
         removedFromPlayCards: this.removedFromPlayCards.map((c) => c.name),
         // TODO(kberg): Recast to Map<CardName, number>, make sure it survives JSONification.
-        generationPlayed: Array.from(this.generationPlayed),
         cardCost: this.cardCost,
         needsToDraft: this.needsToDraft,
         cardDiscount: this.cardDiscount,
@@ -2361,8 +2357,6 @@ export class Player implements ISerializable<SerializedPlayer> {
       // Assign each attributes
       Object.assign(player, d);
       const cardFinder = new CardFinder();
-      // Rebuild generation played map
-      player.generationPlayed = new Map<string, number>(d.generationPlayed);
 
       // action this generation set
       player.actionsThisGeneration = new Set<string>(d.actionsThisGeneration);

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -27,7 +27,6 @@ export interface SerializedPlayer {
     energy: number;
     energyProduction: number;
     fleetSize: number;
-    generationPlayed: Array<[string, number]>;
     handicap: number;
     hasIncreasedTerraformRatingThisGeneration: boolean;
     heat: number;


### PR DESCRIPTION
This seems like an acceptable change. I cannot find a single use for it.