### PR TITLE
Get rid of player.shouldTriggerCardEffect

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -127,11 +127,6 @@ export class Player implements ISerializable<SerializedPlayer> {
     // Turmoil
     public turmoilScientistsActionUsed: boolean = false;
 
-    // Controlled by cards with effects that might be called a second time recursively, I think.
-    // They set this to false in order to prevent card effects from triggering twice.
-    // Not sure this is clear.
-    public shouldTriggerCardEffect: boolean = true;
-
     public powerPlantCost: number = 11;
     public victoryPointsBreakdown = new VictoryPointsBreakdown();
     public oceanBonus: number = constants.OCEAN_BONUS;
@@ -2327,10 +2322,6 @@ export class Player implements ISerializable<SerializedPlayer> {
         colonyVictoryPoints: this.colonyVictoryPoints,
         // Turmoil
         turmoilScientistsActionUsed: this.turmoilScientistsActionUsed,
-        // Controlled by cards with effects that might be called a second time recursively, I think.
-        // They set this to false in order to prevent card effects from triggering twice.
-        // Not sure this is clear.
-        shouldTriggerCardEffect: this.shouldTriggerCardEffect,
         powerPlantCost: this.powerPlantCost,
         victoryPointsBreakdown: this.victoryPointsBreakdown,
         oceanBonus: this.oceanBonus,

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -48,7 +48,6 @@ export interface SerializedPlayer {
     removedFromPlayCards: Array<CardName>;
     removingPlayers: Array<PlayerId>;
     scienceTagCount: number;
-    shouldTriggerCardEffect: boolean;
     steel: number;
     steelProduction: number;
     steelValue: number;

--- a/src/cards/base/ImmigrantCity.ts
+++ b/src/cards/base/ImmigrantCity.ts
@@ -26,15 +26,11 @@ export class ImmigrantCity implements IProjectCard {
     }
     public onTilePlaced(player: Player, space: ISpace) {
       if (Board.isCitySpace(space)) {
-        if (player.shouldTriggerCardEffect) player.addProduction(Resources.MEGACREDITS);
-        if (!player.isCorporation(CardName.THARSIS_REPUBLIC)) player.shouldTriggerCardEffect = true; // reset value
+        player.addProduction(Resources.MEGACREDITS);
       }
     }
     public play(player: Player, game: Game) {
       return new SelectSpace('Select space for city tile', game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
-        const mcProductionAfterDecrease = player.getProduction(Resources.MEGACREDITS) - 2;
-        if (mcProductionAfterDecrease < -6) player.shouldTriggerCardEffect = false;
-
         game.addCityTile(player, space.id);
         player.addProduction(Resources.ENERGY, -1);
         player.addProduction(Resources.MEGACREDITS, -2);

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -31,8 +31,7 @@ export class TharsisRepublic implements CorporationCard {
           player.megaCredits += 3;
         }
         if (space.spaceType !== SpaceType.COLONY) {
-          if (player.shouldTriggerCardEffect) player.addProduction(Resources.MEGACREDITS);
-          player.shouldTriggerCardEffect = true; // reset value
+          player.addProduction(Resources.MEGACREDITS);
         }
       }
     }


### PR DESCRIPTION
This was only used by Immigrant City in case you either played it with **-4** MC production or with **-5** as Tharsis Republic.
Since the tile placement is the first effect of the card, the increases in MC production take place before the decrease so it works as intended, and we can remove that strange property :)