### PR TITLE
Flaky timer test

### DIFF
--- a/tests/Timer.spec.ts
+++ b/tests/Timer.spec.ts
@@ -18,16 +18,24 @@ describe('Timer', function() {
     expect(timer.serialize().running).eq(true);
   });
 
-  it('shows 00:00:01 after 1 sec', function(done) {
+  it('shows 00:00:01 after 1 sec', function() {
     const timer = Timer.newInstance();
     timer.start(); // Skipping first action
+    let callCount = 0;
+    const originalNow = Date.now;
+    const start = originalNow();
+    Date.now = function () {
+      callCount++;
+      if (callCount === 1) {
+        return start;
+      }
+      return start + 1000;
+    }
     timer.stop();
     timer.start();
-    setTimeout(() => {
-      expect(Timer.toString(timer.serialize())).eq('00:00:01');
-      timer.stop();
-      expect(Timer.toString(timer.serialize())).eq('00:00:01');
-      done();
-    }, 1000);
+    expect(Timer.toString(timer.serialize())).eq('00:00:01');
+    timer.stop();
+    expect(Timer.toString(timer.serialize())).eq('00:00:01');
+    Date.now = originalNow;
   });
 });

--- a/tests/Timer.spec.ts
+++ b/tests/Timer.spec.ts
@@ -24,13 +24,13 @@ describe('Timer', function() {
     let callCount = 0;
     const originalNow = Date.now;
     const start = originalNow();
-    Date.now = function () {
+    Date.now = function() {
       callCount++;
       if (callCount === 1) {
         return start;
       }
       return start + 1000;
-    }
+    };
     timer.stop();
     timer.start();
     expect(Timer.toString(timer.serialize())).eq('00:00:01');


### PR DESCRIPTION
Noticed today a new unit test for `Timer` was taking a second to run and relying on `setTimeout` to take a second. I had this test fail on me. The `setTimeout` function can not guarantee that the callback will be called at exactly 1000ms. When it is called too late this unit tests fails. I modified the unit test to manually provide a time and run without using `setTimeout`.