### PR TITLE
Include `Player.spendableMegacredits`, which takes heat into account.

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -983,7 +983,7 @@ export class Player implements ISerializable<SerializedPlayer> {
 
   /**
    * @return {number} the number of avaialble megacredits. Which is just a shorthand for megacredits,
-   * plus any units of heat available thanks to Thorgate.
+   * plus any units of heat available thanks to Helion.
    */
   public spendableMegacredits(): number {
     return (this.canUseHeatAsMegaCredits) ? (this.heat + this.megaCredits) : this.megaCredits;

--- a/src/cards/promo/EnergyMarket.ts
+++ b/src/cards/promo/EnergyMarket.ts
@@ -56,7 +56,7 @@ export class EnergyMarket implements IProjectCard {
   }
 
   public action(player: Player, game: Game) {
-    const availableMC = (player.canUseHeatAsMegaCredits) ? player.getResource(Resources.MEGACREDITS) + player.getResource(Resources.HEAT) : player.getResource(Resources.MEGACREDITS);
+    const availableMC = player.spendableMegacredits();
     if (availableMC >= 2 && player.getProduction(Resources.ENERGY) >= 1) {
       return new OrOptions(
         new SelectOption('Spend 2X MC to gain X energy', 'Spend MC', () => {


### PR DESCRIPTION
Is this a good idea? It reduces some use, and I'd use it at least twice.