### PR TITLE
separate teplate for v-else

### DIFF
--- a/src/components/overview/PlayerTags.ts
+++ b/src/components/overview/PlayerTags.ts
@@ -96,8 +96,12 @@ export const PlayerTags = Vue.component('player-tags', {
                 <tag-count :tag="'cards'" :count="getCardCount()" :size="'big'" :type="'main'"/>
             </div>
             <div class="player-tags-secondary">
-                <tag-count v-if="showShortTags()" v-for="tag in player.tags" :key="tag.tag" :tag="tag.tag" :count="tag.count" :size="'big'" :type="'secondary'"/>
-                <tag-count v-else v-for="tagName in getTagsPlaceholders()" :key="tagName" :tag="tagName" :count="getTagCount(tagName)" :size="'big'" :type="'secondary'"/>
+                <template v-if="showShortTags()">
+                    <tag-count v-for="tag in player.tags" :key="tag.tag" :tag="tag.tag" :count="tag.count" :size="'big'" :type="'secondary'"/>
+                </template>
+                <template v-else>
+                    <tag-count v-for="tagName in getTagsPlaceholders()" :key="tagName" :tag="tagName" :count="getTagCount(tagName)" :size="'big'" :type="'secondary'"/>
+                </template>
             </div>
         </div>
     `,


### PR DESCRIPTION
I moved the `v-else` onto an element with `v-for` and this seems to have indirectly attempted to run the `v-else` on each item in the array. I moved this to a template and that seems to have solved the problem.