### PR TITLE
Make CardLoader.get...Cards() less convoluted

### DIFF
--- a/src/CardLoader.ts
+++ b/src/CardLoader.ts
@@ -59,21 +59,20 @@ export class CardLoader {
     deck.push(...cardInstances);
   }
 
-  public static getProjectCards(manifest: CardManifest) {
-    return manifest.projectCards;
+  public getProjectCards() {
+    return this.getCards((manifest) => manifest.projectCards);
   }
-  public static getStandardProjects(manifest: CardManifest) {
-    return manifest.standardProjects;
+  public getStandardProjects() {
+    return this.getCards((manifest) => manifest.standardProjects);
   }
-  public static getCorporationCards(manifest: CardManifest) {
-    return manifest.corporationCards;
+  public getCorporationCards() {
+    return this.getCards((manifest) => manifest.corporationCards);
   }
-  public static getPreludeCards(manifest: CardManifest) {
-    return manifest.preludeCards;
+  public getPreludeCards() {
+    return this.getCards((manifest) => manifest.preludeCards);
   }
 
-  // Should be called like this: getCards(CardLoader.getProjectCards())
-  public getCards<T extends CardTypes>(getDeck: (arg0: CardManifest) => Deck<T>) : Array<T> {
+  private getCards<T extends CardTypes>(getDeck: (arg0: CardManifest) => Deck<T>) : Array<T> {
     const deck: Array<T> = [];
     for (const manifest of this.manifests) {
       this.addToDeck(deck, getDeck(manifest));

--- a/src/Dealer.ts
+++ b/src/Dealer.ts
@@ -16,9 +16,9 @@ export class Dealer implements ISerializable<SerializedDealer> {
     public static newInstance(loader: CardLoader): Dealer {
       const dealer = new Dealer();
 
-      dealer.deck = dealer.shuffleCards(loader.getCards(CardLoader.getProjectCards));
-      dealer.preludeDeck = dealer.shuffleCards(loader.getCards(CardLoader.getPreludeCards));
-      dealer.corporationCards = loader.getCards(CardLoader.getCorporationCards);
+      dealer.deck = dealer.shuffleCards(loader.getProjectCards());
+      dealer.preludeDeck = dealer.shuffleCards(loader.getPreludeCards());
+      dealer.corporationCards = loader.getCorporationCards();
       return dealer;
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2190,7 +2190,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       'Standard projects',
       'Confirm',
       new CardLoader(game.gameOptions)
-        .getCards(CardLoader.getStandardProjects).sort((a, b) => a.cost - b.cost)
+        .getStandardProjects().sort((a, b) => a.cost - b.cost)
         .filter((card) => card.canAct(this, game)),
       (card) => card[0].action(this, game),
     );


### PR DESCRIPTION
Unless I missed something I think it makes more sense to keep the "complication" of the method inside the class itself.