### PR TITLE
Added checkMinRequirements and checkMaxRequirements

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1269,9 +1269,12 @@ export class Game implements ISerializable<SerializedGame> {
     } else if (parameter === GlobalParameter.TEMPERATURE) {
       currentLevel = this.getTemperature();
       playerRequirementsBonus *= 2;
-    } else { // parameter === GlobalParameter.VENUS
+    } else if (parameter === GlobalParameter.VENUS) {
       currentLevel = this.getVenusScaleLevel();
       playerRequirementsBonus *= 2;
+    } else {
+      console.warn(`Unknown GlobalParameter provided: ${parameter}`);
+      return false;
     }
 
     if (max) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -59,6 +59,7 @@ import {IAresData} from './ares/IAresData';
 import {Multiset} from './utils/Multiset';
 import {GameSetup} from './GameSetup';
 import {CardLoader} from './CardLoader';
+import {GlobalParameter} from './GlobalParameter';
 
 export type GameId = string;
 
@@ -1247,6 +1248,37 @@ export class Game implements ISerializable<SerializedGame> {
 
   public getTemperature(): number {
     return this.temperature;
+  }
+
+  public checkMinRequirements(player: Player, parameter: GlobalParameter, level: number): boolean {
+    return this.checkRequirements(player, parameter, level);
+  }
+
+  public checkMaxRequirements(player: Player, parameter: GlobalParameter, level: number): boolean {
+    return this.checkRequirements(player, parameter, level, true);
+  }
+
+  private checkRequirements(player: Player, parameter: GlobalParameter, level: number, max: boolean = false): boolean {
+    let currentLevel: number;
+    let playerRequirementsBonus: number = player.getRequirementsBonus(this, parameter === GlobalParameter.VENUS);
+
+    if (parameter === GlobalParameter.OCEANS) {
+      currentLevel = this.board.getOceansOnBoard();
+    } else if (parameter === GlobalParameter.OXYGEN) {
+      currentLevel = this.getOxygenLevel();
+    } else if (parameter === GlobalParameter.TEMPERATURE) {
+      currentLevel = this.getTemperature();
+      playerRequirementsBonus *= 2;
+    } else { // parameter === GlobalParameter.VENUS
+      currentLevel = this.getVenusScaleLevel();
+      playerRequirementsBonus *= 2;
+    }
+
+    if (max) {
+      return currentLevel <= level + playerRequirementsBonus;
+    } else {
+      return currentLevel >= level - playerRequirementsBonus;
+    }
   }
 
   public getGeneration(): number {

--- a/src/GlobalParameter.ts
+++ b/src/GlobalParameter.ts
@@ -1,0 +1,6 @@
+export enum GlobalParameter {
+  OCEANS,
+  OXYGEN,
+  TEMPERATURE,
+  VENUS,
+}

--- a/src/cards/ares/OceanCity.ts
+++ b/src/cards/ares/OceanCity.ts
@@ -11,6 +11,7 @@ import {Tags} from './../Tags';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class OceanCity implements IProjectCard {
   public cost = 18;
@@ -20,7 +21,7 @@ export class OceanCity implements IProjectCard {
 
   public canPlay(player: Player, game: Game): boolean {
     return (player.getProduction(Resources.ENERGY) > 0) &&
-        (game.board.getOceansOnBoard() >= 6 - player.getRequirementsBonus(game));
+      game.checkMinRequirements(player, GlobalParameter.OCEANS, 6);
   }
 
   public play(player: Player, game: Game) {

--- a/src/cards/ares/OceanFarm.ts
+++ b/src/cards/ares/OceanFarm.ts
@@ -12,6 +12,7 @@ import {Tags} from './../Tags';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class OceanFarm implements IProjectCard {
   public cost = 15;
@@ -20,7 +21,7 @@ export class OceanFarm implements IProjectCard {
   public name = CardName.OCEAN_FARM;
 
   public canPlay(player: Player, game: Game): boolean {
-    return game.board.getOceansOnBoard() >= 4 - player.getRequirementsBonus(game);
+    return game.checkMinRequirements(player, GlobalParameter.OCEANS, 4);
   }
 
   public play(player: Player, game: Game) {

--- a/src/cards/ares/OceanSanctuary.ts
+++ b/src/cards/ares/OceanSanctuary.ts
@@ -14,6 +14,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class OceanSanctuary implements IResourceCard {
   public cost = 9;
@@ -24,7 +25,7 @@ export class OceanSanctuary implements IResourceCard {
   public name = CardName.OCEAN_SANCTUARY;
 
   public canPlay(player: Player, game: Game): boolean {
-    return game.board.getOceansOnBoard() >= 5 - player.getRequirementsBonus(game);
+    return game.checkMinRequirements(player, GlobalParameter.OCEANS, 5);
   }
 
   public getVictoryPoints(): number {

--- a/src/cards/base/Algae.ts
+++ b/src/cards/base/Algae.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Algae implements IProjectCard {
   public cost = 10;
@@ -15,7 +16,7 @@ export class Algae implements IProjectCard {
   public name = CardName.ALGAE;
   public cardType = CardType.AUTOMATED;
   public canPlay(player: Player, game: Game): boolean {
-    return game.board.getOceansOnBoard() >= 5 - player.getRequirementsBonus(game);
+    return game.checkMinRequirements(player, GlobalParameter.OCEANS, 5);
   }
   public play(player: Player) {
     player.plants++;

--- a/src/cards/base/Ants.ts
+++ b/src/cards/base/Ants.ts
@@ -12,6 +12,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Ants implements IActionCard, IProjectCard, IResourceCard {
   public cost = 9;
@@ -22,7 +23,7 @@ export class Ants implements IActionCard, IProjectCard, IResourceCard {
   public cardType = CardType.ACTIVE;
 
   public canPlay(player: Player, game: Game): boolean {
-    return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
+    return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 4);
   }
 
   public getVictoryPoints(): number {

--- a/src/cards/base/ArchaeBacteria.ts
+++ b/src/cards/base/ArchaeBacteria.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ArchaeBacteria implements IProjectCard {
   public cost = 6;
@@ -15,7 +16,7 @@ export class ArchaeBacteria implements IProjectCard {
   public name = CardName.ARCHAEBACTERIA;
   public cardType = CardType.AUTOMATED;
   public canPlay(player: Player, game: Game): boolean {
-    return game.getTemperature() <= -18 + player.getRequirementsBonus(game) * 2;
+    return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -18);
   }
   public play(player: Player) {
     player.addProduction(Resources.PLANTS);

--- a/src/cards/base/ArcticAlgae.ts
+++ b/src/cards/base/ArcticAlgae.ts
@@ -9,6 +9,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ArcticAlgae implements IProjectCard {
   public cost = 12;
@@ -16,7 +17,7 @@ export class ArcticAlgae implements IProjectCard {
   public name = CardName.ARCTIC_ALGAE;
   public cardType = CardType.ACTIVE;
   public canPlay(player: Player, game: Game): boolean {
-    return game.getTemperature() <= -12 + player.getRequirementsBonus(game) * 2;
+    return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -12);
   }
   public onTilePlaced(player: Player, space: ISpace) {
     if (space.tile !== undefined && space.tile.tileType === TileType.OCEAN) {

--- a/src/cards/base/ArtificialLake.ts
+++ b/src/cards/base/ArtificialLake.ts
@@ -13,6 +13,7 @@ import {MAX_OCEAN_TILES, REDS_RULING_POLICY_COST} from '../../constants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ArtificialLake implements IProjectCard {
   public cost = 15;
@@ -20,7 +21,7 @@ export class ArtificialLake implements IProjectCard {
   public name = CardName.ARTIFICIAL_LAKE;
   public cardType = CardType.AUTOMATED;
   public canPlay(player: Player, game: Game): boolean {
-    const meetsTemperatureRequirements = game.getTemperature() >= -6 - player.getRequirementsBonus(game) * 2;
+    const meetsTemperatureRequirements = game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -6);
     const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
     if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {

--- a/src/cards/base/BiomassCombustors.ts
+++ b/src/cards/base/BiomassCombustors.ts
@@ -9,6 +9,7 @@ import {DecreaseAnyProduction} from '../../deferredActions/DecreaseAnyProduction
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class BiomassCombustors implements IProjectCard {
   public cost = 4;
@@ -16,7 +17,7 @@ export class BiomassCombustors implements IProjectCard {
   public tags = [Tags.ENERGY, Tags.BUILDING];
   public name = CardName.BIOMASS_COMBUSTORS;
   public canPlay(player: Player, game: Game): boolean {
-    return game.getOxygenLevel() >= 6 - player.getRequirementsBonus(game) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
+    return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 6) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
   }
 
   public play(player: Player, game: Game) {

--- a/src/cards/base/Birds.ts
+++ b/src/cards/base/Birds.ts
@@ -12,6 +12,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Birds implements IActionCard, IProjectCard, IResourceCard {
     public cost = 10;
@@ -22,7 +23,7 @@ export class Birds implements IActionCard, IProjectCard, IResourceCard {
     public cardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 13 - player.getRequirementsBonus(game) && game.someoneHasResourceProduction(Resources.PLANTS, 2);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 13);
     }
     public getVictoryPoints(): number {
       return this.resourceCount;

--- a/src/cards/base/BreathingFilters.ts
+++ b/src/cards/base/BreathingFilters.ts
@@ -6,6 +6,7 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class BreathingFilters implements IProjectCard {
   public cost = 11;
@@ -13,7 +14,7 @@ export class BreathingFilters implements IProjectCard {
   public name = CardName.BREATHING_FILTERS;
   public cardType = CardType.AUTOMATED;
   public canPlay(player: Player, game: Game): boolean {
-    return game.getOxygenLevel() >= 7 - player.getRequirementsBonus(game);
+    return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 7);
   }
   public play() {
     return undefined;

--- a/src/cards/base/Bushes.ts
+++ b/src/cards/base/Bushes.ts
@@ -9,6 +9,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Bushes implements IProjectCard {
     public cost = 10;
@@ -16,9 +17,7 @@ export class Bushes implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.BUSHES;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -10 - (
-        2 * player.getRequirementsBonus(game)
-      );
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -10);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS, 2);

--- a/src/cards/base/Capital.ts
+++ b/src/cards/base/Capital.ts
@@ -16,6 +16,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Capital implements IProjectCard {
     public cost = 26;
@@ -26,7 +27,7 @@ export class Capital implements IProjectCard {
 
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 2 &&
-        game.board.getOceansOnBoard() >= 4 - player.getRequirementsBonus(game) &&
+        game.checkMinRequirements(player, GlobalParameter.OCEANS, 4) &&
         game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public getVictoryPoints(_player: Player, game: Game) {

--- a/src/cards/base/CaretakerContract.ts
+++ b/src/cards/base/CaretakerContract.ts
@@ -12,6 +12,7 @@ import {REDS_RULING_POLICY_COST} from '../../constants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class CaretakerContract implements IActionCard, IProjectCard {
     public cost = 3;
@@ -19,9 +20,7 @@ export class CaretakerContract implements IActionCard, IProjectCard {
     public cardType = CardType.ACTIVE;
     public name = CardName.CARETAKER_CONTRACT;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= 0 - (
-        2 * player.getRequirementsBonus(game)
-      );
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 0);
     }
     public play() {
       return undefined;

--- a/src/cards/base/CloudSeeding.ts
+++ b/src/cards/base/CloudSeeding.ts
@@ -8,6 +8,7 @@ import {DecreaseAnyProduction} from '../../deferredActions/DecreaseAnyProduction
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class CloudSeeding implements IProjectCard {
     public cost = 11;
@@ -17,7 +18,7 @@ export class CloudSeeding implements IProjectCard {
 
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.MEGACREDITS) > -5 &&
-        game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game) &&
+        game.checkMinRequirements(player, GlobalParameter.OCEANS, 3) &&
         game.someoneHasResourceProduction(Resources.HEAT, 1);
     }
 

--- a/src/cards/base/ColonizerTrainingCamp.ts
+++ b/src/cards/base/ColonizerTrainingCamp.ts
@@ -6,6 +6,7 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ColonizerTrainingCamp implements IProjectCard {
     public cost = 8;
@@ -13,7 +14,7 @@ export class ColonizerTrainingCamp implements IProjectCard {
     public name = CardName.COLONIZER_TRAINING_CAMP;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() <= 5 + player.getRequirementsBonus(game);
+      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 5);
     }
     public play() {
       return undefined;

--- a/src/cards/base/CupolaCity.ts
+++ b/src/cards/base/CupolaCity.ts
@@ -11,6 +11,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class CupolaCity implements IProjectCard {
     public cost = 16;
@@ -18,7 +19,7 @@ export class CupolaCity implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.CUPOLA_CITY;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() <= 9 + player.getRequirementsBonus(game) &&
+      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 9) &&
         player.getProduction(Resources.ENERGY) >= 1 &&
         game.board.getAvailableSpacesForCity(player).length > 0;
     }

--- a/src/cards/base/Decomposers.ts
+++ b/src/cards/base/Decomposers.ts
@@ -10,6 +10,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Decomposers implements IProjectCard, IResourceCard {
     public cost = 5;
@@ -19,7 +20,7 @@ export class Decomposers implements IProjectCard, IResourceCard {
     public cardType = CardType.ACTIVE;
     public name = CardName.DECOMPOSERS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 3 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 3);
     }
     public onCardPlayed(player: Player, _game: Game, card: IProjectCard): void {
       player.addResourceTo(this, card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT || tag === Tags.MICROBE).length);

--- a/src/cards/base/DesignedMicroOrganisms.ts
+++ b/src/cards/base/DesignedMicroOrganisms.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class DesignedMicroOrganisms implements IProjectCard {
     public cost = 16;
@@ -15,9 +16,7 @@ export class DesignedMicroOrganisms implements IProjectCard {
     public name = CardName.DESIGNED_MICRO_ORGANISMS;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() <= -14 + (
-        2 * player.getRequirementsBonus(game)
-      );
+      return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -14);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS, 2);

--- a/src/cards/base/DomedCrater.ts
+++ b/src/cards/base/DomedCrater.ts
@@ -11,6 +11,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class DomedCrater implements IProjectCard {
     public cost = 24;
@@ -19,7 +20,7 @@ export class DomedCrater implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 1 &&
-        game.getOxygenLevel() <= 7 + player.getRequirementsBonus(game) &&
+        game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 7) &&
         game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {

--- a/src/cards/base/DustSeals.ts
+++ b/src/cards/base/DustSeals.ts
@@ -5,6 +5,7 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class DustSeals implements IProjectCard {
     public cost = 2;
@@ -12,7 +13,7 @@ export class DustSeals implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.DUST_SEALS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() <= 3 + player.getRequirementsBonus(game);
+      return game.checkMaxRequirements(player, GlobalParameter.OCEANS, 3);
     }
     public play() {
       return undefined;

--- a/src/cards/base/EOSChasmaNationalPark.ts
+++ b/src/cards/base/EOSChasmaNationalPark.ts
@@ -12,6 +12,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class EosChasmaNationalPark implements IProjectCard {
   public cost = 16;
@@ -21,9 +22,7 @@ export class EosChasmaNationalPark implements IProjectCard {
   public cardType = CardType.AUTOMATED;
 
   public canPlay(player: Player, game: Game): boolean {
-    return game.getTemperature() >= -12 - (
-      2 * player.getRequirementsBonus(game)
-    );
+    return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -12);
   }
 
   public play(player: Player, game: Game) {

--- a/src/cards/base/ElectroCatapult.ts
+++ b/src/cards/base/ElectroCatapult.ts
@@ -11,6 +11,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ElectroCatapult implements IActionCard, IProjectCard {
     public cost = 17;
@@ -19,7 +20,7 @@ export class ElectroCatapult implements IActionCard, IProjectCard {
     public cardType = CardType.ACTIVE;
     public canPlay(player: Player, game: Game): boolean {
       return player.getProduction(Resources.ENERGY) >= 1 &&
-        game.getOxygenLevel() <= 8 + player.getRequirementsBonus(game);
+        game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 8);
     }
     public canAct(player: Player): boolean {
       return player.plants > 0 || player.steel > 0;

--- a/src/cards/base/ExtremeColdFungus.ts
+++ b/src/cards/base/ExtremeColdFungus.ts
@@ -14,6 +14,7 @@ import {Resources} from '../../Resources';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class ExtremeColdFungus implements IActionCard, IProjectCard {
     public cost = 13;
@@ -21,9 +22,7 @@ export class ExtremeColdFungus implements IActionCard, IProjectCard {
     public cardType = CardType.ACTIVE;
     public name = CardName.EXTREME_COLD_FUNGUS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() <= -10 + (
-        2 * player.getRequirementsBonus(game)
-      );
+      return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -10);
     }
     public play() {
       return undefined;

--- a/src/cards/base/Farming.ts
+++ b/src/cards/base/Farming.ts
@@ -9,6 +9,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Farming implements IProjectCard {
   public cost = 16;
@@ -16,7 +17,7 @@ export class Farming implements IProjectCard {
   public name = CardName.FARMING;
   public cardType = CardType.AUTOMATED;
   public canPlay(player: Player, game: Game): boolean {
-    return game.getTemperature() >= 4 - (2 * player.getRequirementsBonus(game));
+    return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 4);
   }
   public play(player: Player) {
     player.addProduction(Resources.MEGACREDITS, 2);

--- a/src/cards/base/Fish.ts
+++ b/src/cards/base/Fish.ts
@@ -13,6 +13,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Fish implements IActionCard, IProjectCard, IResourceCard {
     public cost = 9;
@@ -23,7 +24,7 @@ export class Fish implements IActionCard, IProjectCard, IResourceCard {
     public cardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= 2 - (player.getRequirementsBonus(game) * 2) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 2) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
     public getVictoryPoints(): number {
       return this.resourceCount;

--- a/src/cards/base/GHGProducingBacteria.ts
+++ b/src/cards/base/GHGProducingBacteria.ts
@@ -14,6 +14,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 import {REDS_RULING_POLICY_COST} from '../../constants';
 
 export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourceCard {
@@ -24,7 +25,7 @@ export class GHGProducingBacteria implements IActionCard, IProjectCard, IResourc
     public resourceType = ResourceType.MICROBE;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 4);
     }
     public play() {
       return undefined;

--- a/src/cards/base/Grass.ts
+++ b/src/cards/base/Grass.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Grass implements IProjectCard {
     public cost = 11;
@@ -15,7 +16,7 @@ export class Grass implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.GRASS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -16 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -16);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS);

--- a/src/cards/base/GreatDam.ts
+++ b/src/cards/base/GreatDam.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class GreatDam implements IProjectCard {
     public cost = 12;
@@ -15,7 +16,7 @@ export class GreatDam implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.GREAT_DAM;
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 4 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 4);
     }
     public play(player: Player) {
       player.addProduction(Resources.ENERGY, 2);

--- a/src/cards/base/Heather.ts
+++ b/src/cards/base/Heather.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Heather implements IProjectCard {
     public cost = 6;
@@ -15,7 +16,7 @@ export class Heather implements IProjectCard {
     public name = CardName.HEATHER;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -14 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -14);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS);

--- a/src/cards/base/Herbivores.ts
+++ b/src/cards/base/Herbivores.ts
@@ -15,6 +15,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Herbivores implements IProjectCard, IResourceCard {
     public cost = 12;
@@ -25,7 +26,7 @@ export class Herbivores implements IProjectCard, IResourceCard {
     public resourceCount: number = 0;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 8 - player.getRequirementsBonus(game) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 8) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
 
     public getVictoryPoints(): number {

--- a/src/cards/base/IceCapMelting.ts
+++ b/src/cards/base/IceCapMelting.ts
@@ -10,6 +10,7 @@ import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class IceCapMelting implements IProjectCard {
     public cost = 5;
@@ -17,7 +18,7 @@ export class IceCapMelting implements IProjectCard {
     public tags = [];
     public name = CardName.ICE_CAP_MELTING;
     public canPlay(player: Player, game: Game): boolean {
-      const meetsTemperatureRequirements = game.getTemperature() >= 2 - (2 * player.getRequirementsBonus(game));
+      const meetsTemperatureRequirements = game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 2);
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {

--- a/src/cards/base/Insects.ts
+++ b/src/cards/base/Insects.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Insects implements IProjectCard {
     public cost = 9;
@@ -15,7 +16,7 @@ export class Insects implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.INSECTS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 6 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 6);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS, player.getTagCount(Tags.PLANT));

--- a/src/cards/base/KelpFarming.ts
+++ b/src/cards/base/KelpFarming.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class KelpFarming implements IProjectCard {
     public cost = 17;
@@ -15,7 +16,7 @@ export class KelpFarming implements IProjectCard {
     public name = CardName.KELP_FARMING;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 6 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 6);
     }
     public play(player: Player) {
       player.addProduction(Resources.MEGACREDITS, 2);

--- a/src/cards/base/LakeMarineris.ts
+++ b/src/cards/base/LakeMarineris.ts
@@ -10,7 +10,7 @@ import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class LakeMarineris implements IProjectCard {
     public cost = 18;
@@ -18,7 +18,7 @@ export class LakeMarineris implements IProjectCard {
     public name = CardName.LAKE_MARINERIS;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      const meetsTemperatureRequirements = game.getTemperature() >= 0 - (2 * player.getRequirementsBonus(game));
+      const meetsTemperatureRequirements = game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 0);
       const remainingOceans = MAX_OCEAN_TILES - game.board.getOceansOnBoard();
       const oceansPlaced = Math.min(remainingOceans, 2);
 

--- a/src/cards/base/Lichen.ts
+++ b/src/cards/base/Lichen.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Lichen implements IProjectCard {
     public cost = 7;
@@ -15,7 +16,7 @@ export class Lichen implements IProjectCard {
     public name = CardName.LICHEN;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -24 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -24);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS);

--- a/src/cards/base/Livestock.ts
+++ b/src/cards/base/Livestock.ts
@@ -12,6 +12,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Livestock implements IActionCard, IProjectCard, IResourceCard {
     public cost = 13;
@@ -21,7 +22,7 @@ export class Livestock implements IActionCard, IProjectCard, IResourceCard {
     public tags = [Tags.ANIMAL];
     public name = CardName.LIVESTOCK;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 9 - player.getRequirementsBonus(game) && player.getProduction(Resources.PLANTS) >= 1;
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 9) && player.getProduction(Resources.PLANTS) >= 1;
     }
     public getVictoryPoints(): number {
       return this.resourceCount;

--- a/src/cards/base/Mangrove.ts
+++ b/src/cards/base/Mangrove.ts
@@ -14,6 +14,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Mangrove implements IProjectCard {
     public cost = 12;
@@ -22,7 +23,7 @@ export class Mangrove implements IProjectCard {
     public cardType = CardType.AUTOMATED;
 
     public canPlay(player: Player, game: Game): boolean {
-      const meetsTemperatureRequirements = game.getTemperature() >= 4 - (2 * player.getRequirementsBonus(game));
+      const meetsTemperatureRequirements = game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, 4);
       const oxygenMaxed = game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oxygenMaxed) {

--- a/src/cards/base/MethaneFromTitan.ts
+++ b/src/cards/base/MethaneFromTitan.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class MethaneFromTitan implements IProjectCard {
     public cost = 28;
@@ -15,7 +16,7 @@ export class MethaneFromTitan implements IProjectCard {
     public name = CardName.METHANE_FROM_TITAN;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 2 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 2);
     }
     public play(player: Player) {
       player.addProduction(Resources.HEAT, 2);

--- a/src/cards/base/Moss.ts
+++ b/src/cards/base/Moss.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Moss implements IProjectCard {
     public cost = 4;
@@ -15,7 +16,7 @@ export class Moss implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.MOSS;
     public canPlay(player: Player, game: Game): boolean {
-      const meetsOceanRequirements = game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game);
+      const meetsOceanRequirements = game.checkMinRequirements(player, GlobalParameter.OCEANS, 3);
       const hasViralEnhancers = player.playedCards.find((card) => card.name === CardName.VIRAL_ENHANCERS);
       const hasEnoughPlants = player.plants >= 1 || hasViralEnhancers !== undefined || player.isCorporation(CardName.MANUTECH);
 

--- a/src/cards/base/NaturalPreserve.ts
+++ b/src/cards/base/NaturalPreserve.ts
@@ -12,6 +12,7 @@ import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class NaturalPreserve implements IProjectCard {
     public cost = 9;
@@ -22,10 +23,10 @@ export class NaturalPreserve implements IProjectCard {
 
     private getAvailableSpaces(player: Player, game: Game): Array<ISpace> {
       return game.board.getAvailableSpacesOnLand(player)
-        .filter((space) => game.board.getAdjacentSpaces(space).filter((adjacentSpace) => adjacentSpace.tile !== undefined).length === 0);
+        .filter((space) => game.board.getAdjacentSpaces(space).some((adjacentSpace) => adjacentSpace.tile !== undefined) === false);
     }
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() <= 4 + player.getRequirementsBonus(game) && this.getAvailableSpaces(player, game).length > 0;
+      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 4) && this.getAvailableSpaces(player, game).length > 0;
     }
     public play(player: Player, game: Game) {
       return new SelectSpace('Select space for special tile next to no other tile', this.getAvailableSpaces(player, game), (foundSpace: ISpace) => {

--- a/src/cards/base/NitrophilicMoss.ts
+++ b/src/cards/base/NitrophilicMoss.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class NitrophilicMoss implements IProjectCard {
     public cost = 8;
@@ -15,7 +16,7 @@ export class NitrophilicMoss implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.NITROPHILIC_MOSS;
     public canPlay(player: Player, game: Game): boolean {
-      const meetsOceanRequirements = game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game);
+      const meetsOceanRequirements = game.checkMinRequirements(player, GlobalParameter.OCEANS, 3);
       const hasViralEnhancers = player.playedCards.find((card) => card.name === CardName.VIRAL_ENHANCERS);
       const hasEnoughPlants = player.plants >= 2 || player.isCorporation(CardName.MANUTECH) || player.plants >= 1 && hasViralEnhancers !== undefined;
 

--- a/src/cards/base/NoctisFarming.ts
+++ b/src/cards/base/NoctisFarming.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class NoctisFarming implements IProjectCard {
     public cost = 10;
@@ -15,7 +16,7 @@ export class NoctisFarming implements IProjectCard {
     public name = CardName.NOCTIS_FARMING;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -20 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -20);
     }
     public play(player: Player) {
       player.addProduction(Resources.MEGACREDITS);

--- a/src/cards/base/OpenCity.ts
+++ b/src/cards/base/OpenCity.ts
@@ -10,6 +10,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class OpenCity implements IProjectCard {
     public cost = 23;
@@ -17,7 +18,7 @@ export class OpenCity implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.OPEN_CITY;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 12 - player.getRequirementsBonus(game) && player.getProduction(Resources.ENERGY) >= 1 && game.board.getAvailableSpacesForCity(player).length > 0;
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 12) && player.getProduction(Resources.ENERGY) >= 1 && game.board.getAvailableSpacesForCity(player).length > 0;
     }
     public play(player: Player, game: Game) {
       return new SelectSpace('Select space for city tile', game.board.getAvailableSpacesForCity(player), (space: ISpace) => {

--- a/src/cards/base/PermafrostExtraction.ts
+++ b/src/cards/base/PermafrostExtraction.ts
@@ -11,6 +11,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class PermafrostExtraction implements IProjectCard {
     public cardType = CardType.EVENT;
@@ -19,7 +20,7 @@ export class PermafrostExtraction implements IProjectCard {
     public name = CardName.PERMAFROST_EXTRACTION;
 
     public canPlay(player: Player, game: Game): boolean {
-      const meetsTemperatureRequirements = game.getTemperature() >= -8 - (2 * player.getRequirementsBonus(game));
+      const meetsTemperatureRequirements = game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -8);
       const oceansMaxed = game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !oceansMaxed) {

--- a/src/cards/base/Predators.ts
+++ b/src/cards/base/Predators.ts
@@ -13,6 +13,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Predators implements IProjectCard, IActionCard, IResourceCard {
     public cost = 14;
@@ -23,7 +24,7 @@ export class Predators implements IProjectCard, IActionCard, IResourceCard {
     public resourceCount: number = 0;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 11 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 11);
     }
 
     public getVictoryPoints(): number {

--- a/src/cards/base/SearchForLife.ts
+++ b/src/cards/base/SearchForLife.ts
@@ -12,6 +12,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SearchForLife implements IActionCard, IProjectCard, IResourceCard {
     public cost = 3;
@@ -21,7 +22,7 @@ export class SearchForLife implements IActionCard, IProjectCard, IResourceCard {
     public resourceCount: number = 0;
     public name = CardName.SEARCH_FOR_LIFE;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() <= 6 + player.getRequirementsBonus(game);
+      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 6);
     }
 
     public getVictoryPoints() {

--- a/src/cards/base/Shuttles.ts
+++ b/src/cards/base/Shuttles.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Shuttles implements IProjectCard {
     public cost = 10;
@@ -15,7 +16,7 @@ export class Shuttles implements IProjectCard {
     public cardType = CardType.ACTIVE;
     public name = CardName.SHUTTLES;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 5 - player.getRequirementsBonus(game) && player.getProduction(Resources.ENERGY) >= 1;
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 5) && player.getProduction(Resources.ENERGY) >= 1;
     }
     public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
       if (card.tags.indexOf(Tags.SPACE) !== -1) {

--- a/src/cards/base/SmallAnimals.ts
+++ b/src/cards/base/SmallAnimals.ts
@@ -13,6 +13,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SmallAnimals implements IActionCard, IProjectCard, IResourceCard {
     public cost = 6;
@@ -22,7 +23,7 @@ export class SmallAnimals implements IActionCard, IProjectCard, IResourceCard {
     public resourceType = ResourceType.ANIMAL;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 6 - player.getRequirementsBonus(game) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 6) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
     public getVictoryPoints(): number {
       return Math.floor(this.resourceCount / 2);

--- a/src/cards/base/SymbioticFungus.ts
+++ b/src/cards/base/SymbioticFungus.ts
@@ -11,6 +11,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SymbioticFungus implements IActionCard, IProjectCard {
     public cost = 4;
@@ -18,7 +19,7 @@ export class SymbioticFungus implements IActionCard, IProjectCard {
     public cardType = CardType.ACTIVE;
     public name = CardName.SYMBIOTIC_FUNGUS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -14 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -14);
     }
     public play() {
       return undefined;

--- a/src/cards/base/Trees.ts
+++ b/src/cards/base/Trees.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Trees implements IProjectCard {
     public cost = 13;
@@ -15,7 +16,7 @@ export class Trees implements IProjectCard {
     public name = CardName.TREES;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -4 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -4);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS, 3);

--- a/src/cards/base/TundraFarming.ts
+++ b/src/cards/base/TundraFarming.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class TundraFarming implements IProjectCard {
     public cost = 16;
@@ -15,7 +16,7 @@ export class TundraFarming implements IProjectCard {
     public tags = [Tags.PLANT];
     public name = CardName.TUNDRA_FARMING;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -6 - (2 * player.getRequirementsBonus(game));
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -6);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS);

--- a/src/cards/base/WaterSplittingPlant.ts
+++ b/src/cards/base/WaterSplittingPlant.ts
@@ -10,6 +10,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class WaterSplittingPlant implements IProjectCard {
     public cost = 12;
@@ -17,7 +18,7 @@ export class WaterSplittingPlant implements IProjectCard {
     public name = CardName.WATER_SPLITTING_PLANT;
     public cardType = CardType.ACTIVE;
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 2 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 2);
     }
     public play() {
       return undefined;

--- a/src/cards/base/WavePower.ts
+++ b/src/cards/base/WavePower.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class WavePower implements IProjectCard {
     public tags = [Tags.ENERGY];
@@ -15,7 +16,7 @@ export class WavePower implements IProjectCard {
     public name = CardName.WAVE_POWER;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 3 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 3);
     }
     public play(player: Player) {
       player.addProduction(Resources.ENERGY);

--- a/src/cards/base/Windmills.ts
+++ b/src/cards/base/Windmills.ts
@@ -9,6 +9,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Windmills implements IProjectCard {
     public cost = 6;
@@ -16,7 +17,7 @@ export class Windmills implements IProjectCard {
     public name = CardName.WINDMILLS;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 7 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 7);
     }
     public play(player: Player): PlayerInput | undefined {
       player.addProduction(Resources.ENERGY);

--- a/src/cards/base/Worms.ts
+++ b/src/cards/base/Worms.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Worms implements IProjectCard {
     public cost = 8;
@@ -15,7 +16,7 @@ export class Worms implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.WORMS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 4 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 4);
     }
     public play(player: Player) {
       player.addProduction(Resources.PLANTS, Math.floor((player.getTagCount(Tags.MICROBE) + 1) / 2));

--- a/src/cards/base/Zeppelins.ts
+++ b/src/cards/base/Zeppelins.ts
@@ -8,6 +8,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Zeppelins implements IProjectCard {
     public cost = 13;
@@ -15,7 +16,7 @@ export class Zeppelins implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.ZEPPELINS;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() >= 5 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OXYGEN, 5);
     }
     public play(player: Player, game: Game) {
       player.addProduction(Resources.MEGACREDITS, game.getCitiesInPlayOnMars());

--- a/src/cards/colonies/SubZeroSaltFish.ts
+++ b/src/cards/colonies/SubZeroSaltFish.ts
@@ -13,6 +13,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SubZeroSaltFish implements IProjectCard, IResourceCard {
     public cost = 5;
@@ -27,7 +28,7 @@ export class SubZeroSaltFish implements IProjectCard, IResourceCard {
     }
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() >= -6 - (player.getRequirementsBonus(game) * 2) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return game.checkMinRequirements(player, GlobalParameter.TEMPERATURE, -6) && game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
 
     public action(player: Player) {

--- a/src/cards/prelude/MartianSurvey.ts
+++ b/src/cards/prelude/MartianSurvey.ts
@@ -8,6 +8,7 @@ import {DrawCards} from '../../deferredActions/DrawCards';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class MartianSurvey implements IProjectCard {
     public cost = 9;
@@ -16,7 +17,7 @@ export class MartianSurvey implements IProjectCard {
     public cardType = CardType.EVENT;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getOxygenLevel() <= 4 + player.getRequirementsBonus(game);
+      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 4);
     }
 
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/Psychrophiles.ts
+++ b/src/cards/prelude/Psychrophiles.ts
@@ -9,6 +9,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Psychrophiles implements IActionCard, IProjectCard, IResourceCard {
     public cost = 2;
@@ -19,7 +20,7 @@ export class Psychrophiles implements IActionCard, IProjectCard, IResourceCard {
     public cardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getTemperature() <= -20 + (player.getRequirementsBonus(game) * 2);
+      return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -20);
     }
 
     public play() {

--- a/src/cards/promo/GreatDamPromo.ts
+++ b/src/cards/promo/GreatDamPromo.ts
@@ -12,6 +12,7 @@ import {Board} from '../../boards/Board';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class GreatDamPromo implements IProjectCard {
     public cost = 15;
@@ -19,7 +20,7 @@ export class GreatDamPromo implements IProjectCard {
     public cardType = CardType.AUTOMATED;
     public name = CardName.GREAT_DAM_PROMO;
     public canPlay(player: Player, game: Game): boolean {
-      const meetsOceanRequirements = game.board.getOceansOnBoard() >= 4 - player.getRequirementsBonus(game);
+      const meetsOceanRequirements = game.checkMinRequirements(player, GlobalParameter.OCEANS, 4);
       const canPlaceTile = this.getAvailableSpaces(player, game).length > 0;
 
       return meetsOceanRequirements && canPlaceTile;

--- a/src/cards/promo/Penguins.ts
+++ b/src/cards/promo/Penguins.ts
@@ -11,6 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Penguins implements IActionCard, IProjectCard, IResourceCard {
     public name = CardName.PENGUINS;
@@ -21,7 +22,7 @@ export class Penguins implements IActionCard, IProjectCard, IResourceCard {
     public cardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 8 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 8);
     }
 
     public play() {

--- a/src/cards/promo/SnowAlgae.ts
+++ b/src/cards/promo/SnowAlgae.ts
@@ -8,6 +8,7 @@ import {Resources} from '../../Resources';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SnowAlgae implements IProjectCard {
     public name = CardName.SNOW_ALGAE;
@@ -16,7 +17,7 @@ export class SnowAlgae implements IProjectCard {
     public cardType = CardType.AUTOMATED;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.board.getOceansOnBoard() >= 2 - player.getRequirementsBonus(game);
+      return game.checkMinRequirements(player, GlobalParameter.OCEANS, 2);
     }
 
     public play(player: Player) {

--- a/src/cards/venusNext/FreyjaBiodomes.ts
+++ b/src/cards/venusNext/FreyjaBiodomes.ts
@@ -12,6 +12,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class FreyjaBiodomes implements IProjectCard {
     public cost = 14;
@@ -19,7 +20,7 @@ export class FreyjaBiodomes implements IProjectCard {
     public name = CardName.FREYJA_BIODOMES;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1 && game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
+      return player.getProduction(Resources.ENERGY) >= 1 && game.checkMinRequirements(player, GlobalParameter.VENUS, 10);
     }
     public getResCards(player: Player): ICard[] {
       let resourceCards = player.getResourceCards(ResourceType.ANIMAL);

--- a/src/cards/venusNext/IshtarMining.ts
+++ b/src/cards/venusNext/IshtarMining.ts
@@ -8,6 +8,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class IshtarMining implements IProjectCard {
     public cost = 5;
@@ -15,7 +16,7 @@ export class IshtarMining implements IProjectCard {
     public name = CardName.ISHTAR_MINING;
     public cardType = CardType.AUTOMATED;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 8 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 8);
     }
     public play(player: Player) {
       player.addProduction(Resources.TITANIUM);

--- a/src/cards/venusNext/MaxwellBase.ts
+++ b/src/cards/venusNext/MaxwellBase.ts
@@ -14,6 +14,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class MaxwellBase implements IActionCard, IProjectCard {
     public cost = 18;
@@ -21,7 +22,7 @@ export class MaxwellBase implements IActionCard, IProjectCard {
     public name = CardName.MAXWELL_BASE;
     public cardType = CardType.ACTIVE;
     public canPlay(player: Player, game: Game): boolean {
-      return player.getProduction(Resources.ENERGY) >= 1 && game.getVenusScaleLevel() >= 12 - (2 * player.getRequirementsBonus(game, true));
+      return player.getProduction(Resources.ENERGY) >= 1 && game.checkMinRequirements(player, GlobalParameter.VENUS, 12);
     }
     public play(player: Player, game: Game) {
       player.addProduction(Resources.ENERGY, -1);

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -10,6 +10,7 @@ import {REDS_RULING_POLICY_COST} from '../../constants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class NeutralizerFactory implements IProjectCard {
     public cost = 7;
@@ -18,7 +19,7 @@ export class NeutralizerFactory implements IProjectCard {
     public cardType = CardType.AUTOMATED;
 
     public canPlay(player: Player, game: Game): boolean {
-      const venusRequirementMet = game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
+      const venusRequirementMet = game.checkMinRequirements(player, GlobalParameter.VENUS, 10);
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
         return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST, game, false, false, true) && venusRequirementMet;
       }

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -16,6 +16,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class RotatorImpacts implements IActionCard, IProjectCard, IResourceCard {
     public cost = 6;
@@ -25,7 +26,7 @@ export class RotatorImpacts implements IActionCard, IProjectCard, IResourceCard 
     public resourceType = ResourceType.ASTEROID;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() - (2 * player.getRequirementsBonus(game, true)) <= 14;
+      return game.checkMaxRequirements(player, GlobalParameter.VENUS, 14);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -10,6 +10,7 @@ import {REDS_RULING_POLICY_COST} from '../../constants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SpinInducingAsteroid implements IProjectCard {
     public cost = 16;
@@ -18,7 +19,7 @@ export class SpinInducingAsteroid implements IProjectCard {
     public cardType = CardType.EVENT;
 
     public canPlay(player: Player, game: Game): boolean {
-      const meetsVenusRequirements = game.getVenusScaleLevel() - (2 * player.getRequirementsBonus(game, true)) <= 10;
+      const meetsVenusRequirements = game.checkMaxRequirements(player, GlobalParameter.VENUS, 10);
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
         return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * 2, game, false, true) && meetsVenusRequirements;

--- a/src/cards/venusNext/StratosphericBirds.ts
+++ b/src/cards/venusNext/StratosphericBirds.ts
@@ -12,6 +12,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class StratosphericBirds implements IActionCard, IProjectCard, IResourceCard {
     public cost = 12;
@@ -24,7 +25,7 @@ export class StratosphericBirds implements IActionCard, IProjectCard, IResourceC
       const cardsWithFloater = player.getCardsWithResources().filter((card) => card.resourceType === ResourceType.FLOATER);
       if (cardsWithFloater.length === 0) return false;
 
-      const meetsVenusRequirements = game.getVenusScaleLevel() >= 12 - (2 * player.getRequirementsBonus(game, true));
+      const meetsVenusRequirements = game.checkMinRequirements(player, GlobalParameter.VENUS, 12);
 
       if (cardsWithFloater.length > 1) {
         return meetsVenusRequirements;

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -13,6 +13,7 @@ import {LogHelper} from '../../LogHelper';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class SulphurEatingBacteria implements IActionCard, IProjectCard, IResourceCard {
     public cost = 6;
@@ -22,7 +23,7 @@ export class SulphurEatingBacteria implements IActionCard, IProjectCard, IResour
     public resourceType = ResourceType.MICROBE;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 6 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 6);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/Thermophiles.ts
+++ b/src/cards/venusNext/Thermophiles.ts
@@ -16,6 +16,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class Thermophiles implements IActionCard, IProjectCard, IResourceCard {
     public cost = 9;
@@ -25,7 +26,7 @@ export class Thermophiles implements IActionCard, IProjectCard, IResourceCard {
     public resourceType = ResourceType.MICROBE;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 6 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 6);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -12,6 +12,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class VenusMagnetizer implements IActionCard, IProjectCard {
     public cost = 7;
@@ -20,7 +21,7 @@ export class VenusMagnetizer implements IActionCard, IProjectCard {
     public cardType = CardType.ACTIVE;
 
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 10 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 10);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/VenusianAnimals.ts
+++ b/src/cards/venusNext/VenusianAnimals.ts
@@ -11,6 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class VenusianAnimals implements IProjectCard, IResourceCard {
     public cost = 15;
@@ -20,7 +21,7 @@ export class VenusianAnimals implements IProjectCard, IResourceCard {
     public resourceType = ResourceType.ANIMAL;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 18 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 18);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/VenusianInsects.ts
+++ b/src/cards/venusNext/VenusianInsects.ts
@@ -11,6 +11,7 @@ import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class VenusianInsects implements IActionCard, IProjectCard, IResourceCard {
     public cost = 5;
@@ -20,7 +21,7 @@ export class VenusianInsects implements IActionCard, IProjectCard, IResourceCard
     public resourceType = ResourceType.MICROBE;
     public resourceCount: number = 0;
     public canPlay(player: Player, game: Game): boolean {
-      return game.getVenusScaleLevel() >= 12 - (2 * player.getRequirementsBonus(game, true));
+      return game.checkMinRequirements(player, GlobalParameter.VENUS, 12);
     }
     public play() {
       return undefined;

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -14,6 +14,7 @@ import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {GlobalParameter} from '../../GlobalParameter';
 
 export class VenusianPlants implements IProjectCard {
     public cost = 13;
@@ -22,7 +23,7 @@ export class VenusianPlants implements IProjectCard {
     public cardType = CardType.AUTOMATED;
 
     public canPlay(player: Player, game: Game): boolean {
-      const meetsVenusRequirements = game.getVenusScaleLevel() >= 16 - (2 * player.getRequirementsBonus(game, true));
+      const meetsVenusRequirements = game.checkMinRequirements(player, GlobalParameter.VENUS, 16);
       const venusMaxed = game.getVenusScaleLevel() === MAX_VENUS_SCALE;
 
       if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS) && !venusMaxed) {


### PR DESCRIPTION
It's pretty easy to forget to add/substract `player.getRequirementsBonus()` when checking for global requirements or to forget that you need to multiply Venus and Temperature by 2.

Anyway, less random comparisons, 2 new methods to take care of that.

All tests pass properly but, when reviewing, please make sure once more that I didn't invert a Min/Max somewhere (should be fine, but who knows).