### PR TITLE
consolidate card finding to card component

### DIFF
--- a/src/CardFinder.ts
+++ b/src/CardFinder.ts
@@ -1,7 +1,6 @@
 import {ICard} from './cards/ICard';
 import {ICardFactory} from './cards/ICardFactory';
 import {IProjectCard} from './cards/IProjectCard';
-import {BeginnerCorporation} from './cards/corporation/BeginnerCorporation';
 import {CardManifest} from './cards/CardManifest';
 import {CardName} from './CardName';
 import {CorporationCard} from './cards/corporation/CorporationCard';
@@ -48,9 +47,6 @@ export class CardFinder {
     }
 
     public getCorporationCardByName(cardName: string): CorporationCard | undefined {
-      if (cardName === CardName.BEGINNER_CORPORATION) {
-        return new BeginnerCorporation();
-      }
       let found : (ICardFactory<CorporationCard> | undefined);
       CardFinder.getDecks().some((deck) => {
         found = deck.corporationCards.findByCardName(cardName);

--- a/src/CardLoader.ts
+++ b/src/CardLoader.ts
@@ -7,8 +7,10 @@ import {VENUS_CARD_MANIFEST} from './cards/venusNext/VenusCardManifest';
 import {COMMUNITY_CARD_MANIFEST} from './cards/community/CommunityCardManifest';
 import {ARES_CARD_MANIFEST} from './cards/ares/AresCardManifest';
 import {CardManifest} from './cards/CardManifest';
+import {CardName} from './CardName';
+import {ICard} from './cards/ICard';
 import {ICardFactory} from './cards/ICardFactory';
-import {CardTypes, Deck} from './Deck';
+import {Deck} from './Deck';
 import {GameModule} from './GameModule';
 import {GameOptions} from './Game';
 
@@ -35,7 +37,7 @@ export class CardLoader {
   }
 
   private static include(gameOptions: GameOptions) {
-    return function(cf: ICardFactory<CardTypes>): boolean {
+    return function(cf: ICardFactory<ICard>): boolean {
       const expansion = cf.compatibility;
       switch (expansion) {
       case undefined:
@@ -52,7 +54,7 @@ export class CardLoader {
     };
   }
 
-  private addToDeck<T extends CardTypes>(deck: Array<T>, cards: Deck<T>): void {
+  private addToDeck<T extends ICard>(deck: Array<T>, cards: Deck<T>): void {
     const cardInstances = cards.cards
       .filter(CardLoader.include(this.gameOptions))
       .map((cf) => new cf.Factory());
@@ -66,13 +68,14 @@ export class CardLoader {
     return this.getCards((manifest) => manifest.standardProjects);
   }
   public getCorporationCards() {
-    return this.getCards((manifest) => manifest.corporationCards);
+    return this.getCards((manifest) => manifest.corporationCards)
+      .filter((card) => card.name !== CardName.BEGINNER_CORPORATION);
   }
   public getPreludeCards() {
     return this.getCards((manifest) => manifest.preludeCards);
   }
 
-  private getCards<T extends CardTypes>(getDeck: (arg0: CardManifest) => Deck<T>) : Array<T> {
+  private getCards<T extends ICard>(getDeck: (arg0: CardManifest) => Deck<T>) : Array<T> {
     const deck: Array<T> = [];
     for (const manifest of this.manifests) {
       this.addToDeck(deck, getDeck(manifest));

--- a/src/Deck.ts
+++ b/src/Deck.ts
@@ -7,15 +7,4 @@ export class Deck<T extends ICard> {
   public findByCardName(name: string): ICardFactory<T> | undefined {
     return this.cards.find((cf) => cf.cardName === name);
   }
-
-  public shuffled(): Deck<T> {
-    const shuffled: Array<ICardFactory<T>> = [];
-    const copy = this.cards.slice();
-    while (copy.length) {
-      shuffled.push(
-        copy.splice(Math.floor(Math.random() * copy.length), 1)[0],
-      );
-    }
-    return new Deck(shuffled);
-  }
 }

--- a/src/Deck.ts
+++ b/src/Deck.ts
@@ -1,51 +1,21 @@
-import {CardName} from './CardName';
+import {ICard} from './cards/ICard';
 import {ICardFactory} from './cards/ICardFactory';
-import {CorporationCard} from './cards/corporation/CorporationCard';
-import {IProjectCard} from './cards/IProjectCard';
-import {PreludeCard} from './cards/prelude/PreludeCard';
-import {StandardProjectCard} from './cards/standardProjects/StandardProjectCard';
 
-export type CardTypes = IProjectCard | CorporationCard | PreludeCard | StandardProjectCard;
+export class Deck<T extends ICard> {
+  constructor(public cards: Array<ICardFactory<T>>) {}
 
-export class Deck<T extends CardTypes> {
-    cards: Array<ICardFactory<T>>;
-
-    constructor(cards: Array<ICardFactory<T>>) {
-      this.cards = cards;
-    }
-
-    public findByCardName(name: string): ICardFactory<T> | undefined {
-      return this.cards.find((cf) => cf.cardName === name);
-    }
-
-    public shuffled(): Deck<T> {
-      const shuffled: Array<ICardFactory<T>> = [];
-      const copy = this.cards.slice();
-      while (copy.length) {
-        shuffled.push(
-          copy.splice(Math.floor(Math.random() * copy.length), 1)[0],
-        );
-      }
-      return new Deck(shuffled);
-    }
-}
-
-export class Decks {
-  public static findByName<T extends CardTypes>(decks: Array<Deck<T>>, cardName: string): T | undefined {
-    let found : (ICardFactory<T> | undefined);
-    decks.some((deck) => {
-      found = deck.findByCardName(cardName);
-      return found !== undefined;
-    });
-    if (found !== undefined) {
-      return new found.Factory();
-    }
-    // currently flooding player's console. console.warn(`card not found ${cardName}`);
-    return undefined;
+  public findByCardName(name: string): ICardFactory<T> | undefined {
+    return this.cards.find((cf) => cf.cardName === name);
   }
 
-  public static allCardNames(decks: Array<Deck<CardTypes>>): Array<CardName> {
-    const arrays: Array<Array<CardName>> = decks.map((deck) => deck.cards.map((cf) => cf.cardName));
-    return ([] as Array<CardName>).concat(...arrays);
+  public shuffled(): Deck<T> {
+    const shuffled: Array<ICardFactory<T>> = [];
+    const copy = this.cards.slice();
+    while (copy.length) {
+      shuffled.push(
+        copy.splice(Math.floor(Math.random() * copy.length), 1)[0],
+      );
+    }
+    return new Deck(shuffled);
   }
 }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1,5 +1,4 @@
 import * as constants from './constants';
-import {ALL_CORPORATION_DECKS} from './cards/AllCards';
 import {AndOptions} from './inputs/AndOptions';
 import {BeginnerCorporation} from './cards/corporation/BeginnerCorporation';
 import {Board} from './boards/Board';
@@ -16,7 +15,6 @@ import {Color} from './Color';
 import {CorporationCard} from './cards/corporation/CorporationCard';
 import {Database} from './database/Database';
 import {Dealer} from './Dealer';
-import {Decks} from './Deck';
 import {ElysiumBoard} from './boards/ElysiumBoard';
 import {FundedAward} from './FundedAward';
 import {HellasBoard} from './boards/HellasBoard';
@@ -220,6 +218,7 @@ export class Game implements ISerializable<SerializedGame> {
     gameOptions: GameOptions = {...DEFAULT_GAME_OPTIONS}): Game {
     const seed = Math.random();
     const board = GameSetup.newBoard(gameOptions.boardName, gameOptions.shuffleMapOption, seed, gameOptions.venusNextExtension);
+    const cardFinder = new CardFinder();
     const cardLoader = new CardLoader(gameOptions);
     const dealer = Dealer.newInstance(cardLoader);
 
@@ -283,7 +282,7 @@ export class Game implements ISerializable<SerializedGame> {
     if (gameOptions.customCorporationsList && gameOptions.customCorporationsList.length >= minCorpsRequired) {
       const customCorporationCards: CorporationCard[] = [];
       for (const corp of gameOptions.customCorporationsList) {
-        const customCorp = Decks.findByName(ALL_CORPORATION_DECKS, corp);
+        const customCorp = cardFinder.getCorporationCardByName(corp);
         if (customCorp) customCorporationCards.push(customCorp);
       }
       corporationCards = customCorporationCards;

--- a/src/cards/AllCards.ts
+++ b/src/cards/AllCards.ts
@@ -1,9 +1,11 @@
-import {Decks} from '../Deck';
+import {CardName} from '../CardName';
+import {Deck} from '../Deck';
 import {ARES_CARD_MANIFEST} from './ares/AresCardManifest';
 import {GameModule} from '../GameModule';
 import {CardManifest} from './CardManifest';
 import {COLONIES_CARD_MANIFEST} from './colonies/ColoniesCardManifest';
 import {COMMUNITY_CARD_MANIFEST} from './community/CommunityCardManifest';
+import {ICard} from './ICard';
 import {PRELUDE_CARD_MANIFEST} from './prelude/PreludeCardManifest';
 import {PROMO_CARD_MANIFEST} from './promo/PromoCardManifest';
 import {
@@ -25,6 +27,11 @@ export const ALL_CARD_MANIFESTS: Array<CardManifest> = [
   ARES_CARD_MANIFEST,
 ];
 
+function allCardNames(decks: Array<Deck<ICard>>): Array<CardName> {
+  const arrays: Array<Array<CardName>> = decks.map((deck) => deck.cards.map((cf) => cf.cardName));
+  return ([] as Array<CardName>).concat(...arrays);
+}
+
 export const MANIFEST_BY_MODULE: Map<GameModule, CardManifest> =
     new Map(ALL_CARD_MANIFESTS.map((manifest) => [manifest.module, manifest]));
 
@@ -41,10 +48,10 @@ export const ALL_STANDARD_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
   (deck) => deck.standardProjects,
 );
 
-export const ALL_PROJECT_CARD_NAMES = Decks.allCardNames(ALL_PROJECT_DECKS);
-export const ALL_STANDARD_PROJECT_CARD_NAMES = Decks.allCardNames(ALL_STANDARD_PROJECT_DECKS);
+export const ALL_PROJECT_CARD_NAMES = allCardNames(ALL_PROJECT_DECKS);
+export const ALL_STANDARD_PROJECT_CARD_NAMES = allCardNames(ALL_STANDARD_PROJECT_DECKS);
 
-export const ALL_CORPORATION_CARD_NAMES = Decks.allCardNames(
+export const ALL_CORPORATION_CARD_NAMES = allCardNames(
   ALL_CORPORATION_DECKS,
 );
-export const ALL_PRELUDE_CARD_NAMES = Decks.allCardNames(ALL_PRELUDE_DECKS);
+export const ALL_PRELUDE_CARD_NAMES = allCardNames(ALL_PRELUDE_DECKS);

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -1,15 +1,11 @@
-import {CardType} from './CardType';
 import {ICard} from './ICard';
 import {Player} from '../Player';
 import {Game} from '../Game';
-import {ResourceType} from '../ResourceType';
 import {Resources} from '../Resources';
 
 export interface IProjectCard extends ICard {
     canPlay?: (player: Player, game: Game) => boolean;
-    cardType: CardType;
     cost: number;
-    resourceType?: ResourceType;
     hasRequirements?: boolean;
     bonusResource?: Resources | undefined;
 }

--- a/src/cards/StandardCardManifests.ts
+++ b/src/cards/StandardCardManifests.ts
@@ -19,6 +19,7 @@ import {Asteroid} from './base/Asteroid';
 import {AsteroidMining} from './base/AsteroidMining';
 import {AsteroidMiningConsortium} from './base/AsteroidMiningConsortium';
 import {BeamFromAThoriumAsteroid} from './base/BeamFromAThoriumAsteroid';
+import {BeginnerCorporation} from './corporation/BeginnerCorporation';
 import {BigAsteroid} from './base/BigAsteroid';
 import {BiomassCombustors} from './base/BiomassCombustors';
 import {Birds} from './base/Birds';
@@ -371,6 +372,7 @@ export const BASE_CARD_MANIFEST = new CardManifest({
     {cardName: CardName.ZEPPELINS, Factory: Zeppelins},
   ],
   corporationCards: [
+    {cardName: CardName.BEGINNER_CORPORATION, Factory: BeginnerCorporation},
     {cardName: CardName.CREDICOR, Factory: CrediCor},
     {cardName: CardName.ECOLINE, Factory: EcoLine},
     {cardName: CardName.HELION, Factory: Helion},

--- a/src/cards/community/AerospaceMission.ts
+++ b/src/cards/community/AerospaceMission.ts
@@ -1,14 +1,13 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from '../prelude/PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {BuildColony} from '../../deferredActions/BuildColony';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class AerospaceMission extends PreludeCard implements IProjectCard {
+export class AerospaceMission extends PreludeCard {
     public tags = [Tags.SPACE];
     public name = CardName.AEROSPACE_MISSION;
 

--- a/src/cards/corporation/CorporationCard.ts
+++ b/src/cards/corporation/CorporationCard.ts
@@ -3,38 +3,17 @@ import {ICard} from '../ICard';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
 import {OrOptions} from '../../inputs/OrOptions';
-import {SelectCard} from '../../inputs/SelectCard';
-import {IProjectCard} from '../IProjectCard';
-import {ResourceType} from '../../ResourceType';
-import {SelectOption} from '../../inputs/SelectOption';
-import {SelectSpace} from '../../inputs/SelectSpace';
-import {CardType} from '../CardType';
 
 export interface CorporationCard extends ICard {
     initialActionText?: string;
     initialAction?: (player: Player, game: Game) => PlayerInput | undefined;
     startingMegaCredits: number;
     cardCost?: number;
-    play: (
-        player: Player,
-        game: Game
-    ) => SelectCard<ICard> | OrOptions | undefined;
-    action?: (
-        player: Player,
-        game: Game
-    ) => OrOptions | SelectCard<ICard> | SelectOption | SelectSpace | undefined;
-    onCardPlayed?: (
-        player: Player,
-        game: Game,
-        card: IProjectCard
-    ) => OrOptions | void;
     onCorpCardPlayed?: (
         player: Player,
         game: Game,
         card: CorporationCard
     ) => OrOptions | void;
-    resourceType?: ResourceType;
     onProductionPhase?: (player: Player) => undefined;
     isDisabled?: boolean;
-    cardType: CardType;
 }

--- a/src/cards/prelude/AcquiredSpaceAgency.ts
+++ b/src/cards/prelude/AcquiredSpaceAgency.ts
@@ -2,13 +2,12 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class AcquiredSpaceAgency extends PreludeCard implements IProjectCard {
+export class AcquiredSpaceAgency extends PreludeCard {
     public tags = [];
     public name = CardName.ACQUIRED_SPACE_AGENCY;
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -1,13 +1,12 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class AlliedBanks extends PreludeCard implements IProjectCard {
+export class AlliedBanks extends PreludeCard {
     public tags = [Tags.EARTH];
     public name = CardName.ALLIED_BANKS;
 

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -2,7 +2,6 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
@@ -10,7 +9,7 @@ import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferr
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class AquiferTurbines extends PreludeCard implements IProjectCard {
+export class AquiferTurbines extends PreludeCard {
     public tags = [Tags.ENERGY];
     public name = CardName.AQUIFER_TURBINES;
     public canPlay(player: Player, _game: Game) {

--- a/src/cards/prelude/Biofuels.ts
+++ b/src/cards/prelude/Biofuels.ts
@@ -1,13 +1,12 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Biofuels extends PreludeCard implements IProjectCard {
+export class Biofuels extends PreludeCard {
     public tags = [Tags.MICROBE];
     public name = CardName.BIOFUELS;
     public play(player: Player) {

--- a/src/cards/prelude/Biolab.ts
+++ b/src/cards/prelude/Biolab.ts
@@ -2,14 +2,13 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Biolab extends PreludeCard implements IProjectCard {
+export class Biolab extends PreludeCard {
     public tags = [Tags.SCIENCE];
     public name = CardName.BIOLAB;
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/BiosphereSupport.ts
+++ b/src/cards/prelude/BiosphereSupport.ts
@@ -1,13 +1,12 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class BiosphereSupport extends PreludeCard implements IProjectCard {
+export class BiosphereSupport extends PreludeCard {
     public tags = [Tags.PLANT];
     public name = CardName.BIOSPHERE_SUPPORT;
     public hasRequirements = false;

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -1,7 +1,6 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
@@ -9,7 +8,7 @@ import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferr
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class BusinessEmpire extends PreludeCard implements IProjectCard {
+export class BusinessEmpire extends PreludeCard {
     public tags = [Tags.EARTH];
     public name = CardName.BUSINESS_EMPIRE;
     public canPlay(player: Player, _game: Game) {

--- a/src/cards/prelude/DomeFarming.ts
+++ b/src/cards/prelude/DomeFarming.ts
@@ -1,13 +1,12 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class DomeFarming extends PreludeCard implements IProjectCard {
+export class DomeFarming extends PreludeCard {
     public tags = [Tags.PLANT, Tags.BUILDING];
     public name = CardName.DOME_FARMING;
     public play(player: Player) {

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -1,11 +1,10 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Donation extends PreludeCard implements IProjectCard {
+export class Donation extends PreludeCard {
     public tags = [];
     public name = CardName.DONATION;
 

--- a/src/cards/prelude/EarlySettlement.ts
+++ b/src/cards/prelude/EarlySettlement.ts
@@ -2,14 +2,13 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class EarlySettlement extends PreludeCard implements IProjectCard {
+export class EarlySettlement extends PreludeCard {
     public tags = [Tags.BUILDING, Tags.CITY];
     public name = CardName.EARLY_SETTLEMENT;
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/EccentricSponsor.ts
+++ b/src/cards/prelude/EccentricSponsor.ts
@@ -2,12 +2,11 @@ import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {PlayProjectCard} from '../../deferredActions/PlayProjectCard';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class EccentricSponsor extends PreludeCard implements IProjectCard {
+export class EccentricSponsor extends PreludeCard {
     public tags = [];
     public name = CardName.ECCENTRIC_SPONSOR;
 

--- a/src/cards/prelude/EcologyExperts.ts
+++ b/src/cards/prelude/EcologyExperts.ts
@@ -2,14 +2,13 @@ import {Tags} from '../Tags';
 import {CardName} from '../../CardName';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 import {PlayProjectCard} from '../../deferredActions/PlayProjectCard';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class EcologyExperts extends PreludeCard implements IProjectCard {
+export class EcologyExperts extends PreludeCard {
     public tags = [Tags.PLANT, Tags.MICROBE];
     public name = CardName.ECOLOGY_EXPERTS;
     public getRequirementBonus(player: Player): number {

--- a/src/cards/prelude/ExperimentalForest.ts
+++ b/src/cards/prelude/ExperimentalForest.ts
@@ -2,14 +2,13 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {PlaceGreeneryTile} from '../../deferredActions/PlaceGreeneryTile';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class ExperimentalForest extends PreludeCard implements IProjectCard {
+export class ExperimentalForest extends PreludeCard {
     public tags = [Tags.PLANT];
     public name = CardName.EXPERIMENTAL_FOREST
 

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -1,7 +1,6 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
@@ -9,7 +8,7 @@ import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferr
 import {CardMetadata} from '../../cards/CardMetadata';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-export class GalileanMining extends PreludeCard implements IProjectCard {
+export class GalileanMining extends PreludeCard {
     public tags = [Tags.JOVIAN];
     public name = CardName.GALILEAN_MINING;
     public canPlay(player: Player, _game: Game) {

--- a/src/cards/prelude/GreatAquifer.ts
+++ b/src/cards/prelude/GreatAquifer.ts
@@ -1,13 +1,12 @@
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class GreatAquifer extends PreludeCard implements IProjectCard {
+export class GreatAquifer extends PreludeCard {
     public tags = [];
     public name = CardName.GREAT_AQUIFER;
 

--- a/src/cards/prelude/HousePrinting.ts
+++ b/src/cards/prelude/HousePrinting.ts
@@ -1,4 +1,3 @@
-import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
@@ -7,7 +6,7 @@ import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class HousePrinting implements IProjectCard {
+export class HousePrinting {
     public cost = 10;
     public tags = [Tags.BUILDING];
     public name = CardName.HOUSE_PRINTING;

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -1,13 +1,12 @@
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class HugeAsteroid extends PreludeCard implements IProjectCard {
+export class HugeAsteroid extends PreludeCard {
     public tags = [];
     public name = CardName.HUGE_ASTEROID;
     public canPlay(player: Player, _game: Game) {

--- a/src/cards/prelude/IoResearchOutpost.ts
+++ b/src/cards/prelude/IoResearchOutpost.ts
@@ -2,14 +2,13 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class IoResearchOutpost extends PreludeCard implements IProjectCard {
+export class IoResearchOutpost extends PreludeCard {
     public tags = [Tags.JOVIAN, Tags.SCIENCE];
     public name = CardName.IO_RESEARCH_OUTPOST;
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -1,12 +1,17 @@
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
+import {PlayerInput} from '../../PlayerInput';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
+import {Tags} from '../Tags';
+import {IProjectCard} from '../IProjectCard';
 
-export abstract class PreludeCard {
+export abstract class PreludeCard implements IProjectCard {
     public cost = 0;
     public cardType = CardType.PRELUDE;
     public abstract name: CardName;
+    public abstract tags: Array<Tags>;
+    public abstract play(player: Player, game: Game): PlayerInput | undefined;
     public hasRequirements = false;
     public canPlay(_player: Player, _game: Game): boolean {
       return true;

--- a/src/cards/prelude/SmeltingPlant.ts
+++ b/src/cards/prelude/SmeltingPlant.ts
@@ -2,12 +2,11 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SmeltingPlant extends PreludeCard implements IProjectCard {
+export class SmeltingPlant extends PreludeCard {
     public tags = [Tags.BUILDING];
     public name = CardName.SMELTING_PLANT;
     public play(player: Player, game: Game) {

--- a/src/cards/prelude/SocietySupport.ts
+++ b/src/cards/prelude/SocietySupport.ts
@@ -1,12 +1,11 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SocietySupport extends PreludeCard implements IProjectCard {
+export class SocietySupport extends PreludeCard {
     public tags = [];
     public name = CardName.SOCIETY_SUPPORT;
     public play(player: Player) {

--- a/src/cards/prelude/Supplier.ts
+++ b/src/cards/prelude/Supplier.ts
@@ -1,13 +1,12 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Supplier extends PreludeCard implements IProjectCard {
+export class Supplier extends PreludeCard {
     public tags = [Tags.ENERGY];
     public name = CardName.SUPPLIER;
 

--- a/src/cards/prelude/SupplyDrop.ts
+++ b/src/cards/prelude/SupplyDrop.ts
@@ -1,11 +1,10 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SupplyDrop extends PreludeCard implements IProjectCard {
+export class SupplyDrop extends PreludeCard {
     public tags = [];
     public name = CardName.SUPPLY_DROP;
 

--- a/src/cards/prelude/UNMIContractor.ts
+++ b/src/cards/prelude/UNMIContractor.ts
@@ -2,13 +2,12 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
-import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class UNMIContractor extends PreludeCard implements IProjectCard {
+export class UNMIContractor extends PreludeCard {
     public tags = [Tags.EARTH];
     public name = CardName.UNMI_CONTRACTOR;
 

--- a/src/components/SelectHowToPayForCard.ts
+++ b/src/components/SelectHowToPayForCard.ts
@@ -19,7 +19,8 @@ interface SelectHowToPayForCardModel {
 }
 
 import {HowToPay} from '../inputs/HowToPay';
-import {getProjectCardByName, Card} from './card/Card';
+import {Card} from './card/Card';
+import {CardFinder} from '../CardFinder';
 import {Tags} from '../cards/Tags';
 import {CardModel} from '../models/CardModel';
 import {CardOrderStorage} from './CardOrderStorage';
@@ -106,7 +107,7 @@ export const SelectHowToPayForCard = Vue.component('select-how-to-pay-for-card',
       return card;
     },
     getCardTags: function() {
-      const card = getProjectCardByName(this.cardName);
+      const card = new CardFinder().getProjectCardByName(this.cardName);
       if (card === undefined) {
         throw new Error(`card not found ${this.cardName}`);
       }

--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 
 import {ICard} from '../../cards/ICard';
-// import {BeginnerCorporation} from '../../cards/corporation/BeginnerCorporation';
 import {CardModel} from '../../models/CardModel';
 import {CardTitle} from './CardTitle';
 import {CardNumber} from './CardNumber';

--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -1,8 +1,7 @@
 import Vue from 'vue';
 
-import {IProjectCard} from '../../cards/IProjectCard';
 import {ICard} from '../../cards/ICard';
-import {BeginnerCorporation} from '../../cards/corporation/BeginnerCorporation';
+// import {BeginnerCorporation} from '../../cards/corporation/BeginnerCorporation';
 import {CardModel} from '../../models/CardModel';
 import {CardTitle} from './CardTitle';
 import {CardNumber} from './CardNumber';
@@ -15,47 +14,8 @@ import {CardType} from '../../cards/CardType';
 import {CardContent} from './CardContent';
 import {CardMetadata} from '../../cards/CardMetadata';
 import {Tags} from '../../cards/Tags';
-import {
-  ALL_CARD_MANIFESTS,
-  ALL_CORPORATION_DECKS,
-  ALL_PRELUDE_DECKS,
-  ALL_PROJECT_DECKS,
-  ALL_STANDARD_PROJECT_DECKS,
-} from '../../cards/AllCards';
-import {CardTypes, Deck, Decks} from '../../Deck';
+import {ALL_CARD_MANIFESTS} from '../../cards/AllCards';
 import {GameModule} from '../../GameModule';
-
-function getCorporationCardByName(cardName: string): ICard | undefined {
-  if (cardName === new BeginnerCorporation().name) {
-    return new BeginnerCorporation();
-  }
-  return Decks.findByName(ALL_CORPORATION_DECKS, cardName);
-}
-
-export function getProjectCardByName(cardName: string): IProjectCard | undefined {
-  return Decks.findByName(ALL_PROJECT_DECKS.concat(ALL_PRELUDE_DECKS), cardName);
-}
-
-function getStandardProjectCardByName(cardName: string): ICard | undefined {
-  return Decks.findByName(ALL_STANDARD_PROJECT_DECKS, cardName);
-}
-
-export function getCardExpansionByName(cardName: string): GameModule {
-  const manifest = ALL_CARD_MANIFESTS.find((manifest) => {
-    const decks: Array<Deck<CardTypes>> = [
-      manifest.corporationCards,
-      manifest.projectCards,
-      manifest.preludeCards,
-      manifest.standardProjects,
-    ];
-    return Decks.findByName(decks, cardName);
-  });
-
-  if (manifest === undefined) {
-    throw new Error(`Can't find card ${cardName}`);
-  }
-  return manifest.module;
-}
 
 export const Card = Vue.component('card', {
   components: {
@@ -77,12 +37,39 @@ export const Card = Vue.component('card', {
       type: Boolean,
     },
   },
+  data: function() {
+    let cardInstance: ICard | undefined;
+    const cardName = this.card.name;
+    let expansion: GameModule | undefined;
+    for (const manifest of ALL_CARD_MANIFESTS) {
+      for (const deck of [manifest.corporationCards, manifest.projectCards, manifest.preludeCards, manifest.standardProjects]) {
+        const factory = deck.findByCardName(cardName);
+        if (factory !== undefined) {
+          cardInstance = new factory.Factory();
+          expansion = manifest.module;
+          break;
+        }
+      }
+      if (expansion !== undefined) {
+        break;
+      }
+    }
+
+    if (cardInstance === undefined || expansion === undefined) {
+      throw new Error(`Can't find card ${cardName}`);
+    }
+
+    return {
+      cardInstance,
+      expansion,
+    };
+  },
   methods: {
     getCardExpansion: function(): string {
-      return getCardExpansionByName(this.card.name);
+      return this.expansion;
     },
     getCard: function(): ICard | undefined {
-      return getProjectCardByName(this.card.name) || getCorporationCardByName(this.card.name) || getStandardProjectCardByName(this.card.name);
+      return this.cardInstance;
     },
     getTags: function(): Array<string> {
       let result: Array<string> = [];
@@ -127,10 +114,10 @@ export const Card = Vue.component('card', {
       return card.resources !== undefined ? card.resources : 0;
     },
     isCorporationCard: function() : boolean {
-      return getCorporationCardByName(this.card.name) !== undefined;
+      return this.getCardType() === CardType.CORPORATION;
     },
     isStandardProject: function() : boolean {
-      return getStandardProjectCardByName(this.card.name) !== undefined;
+      return this.getCardType() === CardType.STANDARD_PROJECT;
     },
   },
   template: `

--- a/tests/Deck.spec.ts
+++ b/tests/Deck.spec.ts
@@ -21,7 +21,4 @@ describe('Deck', function() {
   it('findCardByName: failure', function() {
     expect(deck.findByCardName('Ecological Zone')).is.undefined;
   });
-  it('shuffle', function() {
-    expect(deck.shuffled().cards).to.have.members(cards);
-  });
 });

--- a/tests/Deck.spec.ts
+++ b/tests/Deck.spec.ts
@@ -1,5 +1,4 @@
 import {Deck} from '../src/Deck';
-import {Decks} from '../src/Deck';
 import {IProjectCard} from '../src/cards/IProjectCard';
 import {ICardFactory} from '../src/cards/ICardFactory';
 import {CardName} from '../src/CardName';
@@ -7,9 +6,6 @@ import {expect} from 'chai';
 import {AcquiredCompany} from '../src/cards/base/AcquiredCompany';
 import {BannedDelegate} from '../src/cards/turmoil/BannedDelegate';
 import {CallistoPenalMines} from '../src/cards/base/CallistoPenalMines';
-import {Decomposers} from '../src/cards/base/Decomposers';
-import {EcologicalZone} from '../src/cards/base/EcologicalZone';
-import {FuelFactory} from '../src/cards/base/FuelFactory';
 
 describe('Deck', function() {
   const cards: Array<ICardFactory<IProjectCard>> = [
@@ -19,13 +15,6 @@ describe('Deck', function() {
   ];
   const deck: Deck<IProjectCard> = new Deck(cards);
 
-  const secondCards: Array<ICardFactory<IProjectCard>> = [
-    {cardName: CardName.DECOMPOSERS, Factory: Decomposers},
-    {cardName: CardName.ECOLOGICAL_ZONE, Factory: EcologicalZone},
-    {cardName: CardName.FUEL_FACTORY, Factory: FuelFactory},
-  ];
-  const secondDeck: Deck<IProjectCard> = new Deck(secondCards);
-
   it('findCardByName: success', function() {
     expect(deck.findByCardName('Acquired Company')).is.not.undefined;
   });
@@ -34,21 +23,5 @@ describe('Deck', function() {
   });
   it('shuffle', function() {
     expect(deck.shuffled().cards).to.have.members(cards);
-  });
-  it('Decks.findCardByName: success', function() {
-    expect(Decks.findByName([deck, secondDeck], 'Ecological Zone')).is.not.undefined;
-  });
-  it('Decks.findCardByName: failure', function() {
-    expect(Decks.findByName([deck, secondDeck], 'Eggylogical Zone')).is.undefined;
-  });
-  it('Decks.allCardNames', function() {
-    expect(Decks.allCardNames([deck, secondDeck])).to.have.members([
-      'Acquired Company',
-      'Banned Delegate',
-      'Callisto Penal Mines',
-      'Decomposers',
-      'Ecological Zone',
-      'Fuel Factory',
-    ]);
   });
 });


### PR DESCRIPTION
First part of a two part series for #2215 . This part removes `Decks` and the find card operations to the card component where they are used. It simplifies some of the `Deck` by leveraging `ICard` directly as well. Also moves `BeginnerCorporation` to the base manifest so that it doesn't always need to be considered separately. It is filtered out from the dealer as the dealer should never deal it.