### PR TITLE
use getters for corporation cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2085,7 +2085,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     player.actionsThisGeneration = new Set<CardName>(d.actionsThisGeneration);
 
     if (d.pickedCorporationCard !== undefined) {
-      player.pickedCorporationCard = cardFinder.getCorporationCardByName(typeof d.pickedCorporationCard === 'string' ? d.pickedCorporationCard : d.pickedCorporationCard.name);
+      player.pickedCorporationCard = cardFinder.getCorporationCardByName(d.pickedCorporationCard);
     }
 
     // Rebuild corporation card

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -4,9 +4,7 @@ import {Color} from './Color';
 import {SerializedCard} from './SerializedCard';
 import {VictoryPointsBreakdown} from './VictoryPointsBreakdown';
 import {SerializedTimer} from './SerializedTimer';
-import {CorporationCard} from './cards/corporation/CorporationCard';
 
-// TODO(kberg): remove reference to CorporationCard by 2021-01-15
 export interface SerializedPlayer {
     actionsTakenThisRound: number;
     actionsThisGeneration: Array<CardName>;
@@ -39,7 +37,7 @@ export interface SerializedPlayer {
     name: string;
     needsToDraft: boolean | undefined;
     oceanBonus: number;
-    pickedCorporationCard: CardName | CorporationCard | undefined;
+    pickedCorporationCard: CardName | undefined;
     plantProduction: number;
     plants: number;
     plantsNeededForGreenery: number;

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -1,0 +1,51 @@
+
+import {CardMetadata} from './CardMetadata';
+import {CardName} from '../CardName';
+import {CardType} from './CardType';
+import {Tags} from './Tags';
+
+/**
+ * Utility function to pull the static instance
+ * of a class.
+ * @param {Card} instance of a card
+ * @return {Object} static instance of card
+ */
+function staticInstance(instance: Card) {
+  return Object.getPrototypeOf(instance).constructor;
+}
+
+interface StaticCardProperties {
+  cardType: CardType;
+  initialActionText?: string;
+  metadata: CardMetadata;
+  name: CardName;
+  startingMegaCredits?: number;
+  tags?: Array<Tags>;
+}
+
+export abstract class Card {
+  constructor(properties: StaticCardProperties) {
+    const instance = staticInstance(this);
+    if (instance.properties === undefined) {
+      instance.properties = properties;
+    }
+  }
+  public get cardType() {
+    return staticInstance(this).properties.cardType;
+  }
+  public get initialActionText() {
+    return staticInstance(this).properties.initialActionText;
+  }
+  public get metadata() {
+    return staticInstance(this).properties.metadata;
+  }
+  public get name() {
+    return staticInstance(this).properties.name;
+  }
+  public get startingMegaCredits() {
+    return staticInstance(this).properties.startingMegaCredits;
+  }
+  public get tags() {
+    return staticInstance(this).properties.tags;
+  }
+}

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -38,9 +38,9 @@ export abstract class Card {
     return this.properties.name;
   }
   public get startingMegaCredits() {
-    return this.properties.startingMegaCredits || 0;
+    return this.properties.startingMegaCredits === undefined ? 0 : this.properties.startingMegaCredits;
   }
   public get tags() {
-    return this.properties.tags || [];
+    return this.properties.tags === undefined ? [] : this.properties.tags;
   }
 }

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -4,16 +4,6 @@ import {CardName} from '../CardName';
 import {CardType} from './CardType';
 import {Tags} from './Tags';
 
-/**
- * Utility function to pull the static instance
- * of a class.
- * @param {Card} instance of a card
- * @return {Object} static instance of card
- */
-function staticInstance(instance: Card) {
-  return Object.getPrototypeOf(instance).constructor;
-}
-
 interface StaticCardProperties {
   cardType: CardType;
   initialActionText?: string;
@@ -24,28 +14,33 @@ interface StaticCardProperties {
 }
 
 export abstract class Card {
+  private readonly properties: StaticCardProperties;
   constructor(properties: StaticCardProperties) {
-    const instance = staticInstance(this);
-    if (instance.properties === undefined) {
-      instance.properties = properties;
+    const staticInstance = Object.getPrototypeOf(this).constructor;
+    if (staticInstance.properties === undefined) {
+      if (properties.cardType === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
+        throw new Error('must define startingMegaCredits for corporation cards');
+      }
+      staticInstance.properties = properties;
     }
+    this.properties = staticInstance.properties;
   }
   public get cardType() {
-    return staticInstance(this).properties.cardType;
+    return this.properties.cardType;
   }
   public get initialActionText() {
-    return staticInstance(this).properties.initialActionText;
+    return this.properties.initialActionText;
   }
   public get metadata() {
-    return staticInstance(this).properties.metadata;
+    return this.properties.metadata;
   }
   public get name() {
-    return staticInstance(this).properties.name;
+    return this.properties.name;
   }
   public get startingMegaCredits() {
-    return staticInstance(this).properties.startingMegaCredits;
+    return this.properties.startingMegaCredits || 0;
   }
   public get tags() {
-    return staticInstance(this).properties.tags;
+    return this.properties.tags || [];
   }
 }

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -46,6 +46,6 @@ export interface ICard {
     resourceCount?: number;
     cost?: number;
     cardType: CardType;
-    metadata?: CardMetadata;
+    metadata: CardMetadata;
     warning?: string | Message;
 }

--- a/src/cards/base/MiningCard.ts
+++ b/src/cards/base/MiningCard.ts
@@ -1,4 +1,5 @@
 
+import {CardMetadata} from '../CardMetadata';
 import {CardName} from '../../CardName';
 import {CardType} from '../../cards/CardType';
 import {Game} from '../../Game';
@@ -16,6 +17,7 @@ import {TileType} from '../../TileType';
 export abstract class MiningCard implements IProjectCard {
     public abstract cost: number;
     public abstract name: CardName;
+    public abstract metadata: CardMetadata;
     public readonly tags: Array<Tags> = [Tags.BUILDING];
     public readonly cardType: CardType = CardType.AUTOMATED;
     public hasRequirements = false;

--- a/src/cards/community/ScienceTagCard.ts
+++ b/src/cards/community/ScienceTagCard.ts
@@ -18,7 +18,7 @@ export class ScienceTagCard implements IProjectCard {
     return CardType.PROXY;
   }
   public get metadata(): CardMetadata {
-    throw new Error('proxy card should not render');
+    throw new Error('ScienceTagCard is a proxy card, not a real card. Should not render');
   }
   public play() {
     return undefined;

--- a/src/cards/community/ScienceTagCard.ts
+++ b/src/cards/community/ScienceTagCard.ts
@@ -2,14 +2,25 @@ import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {CardName} from '../../CardName';
+import {CardMetadata} from '../CardMetadata';
 
 export class ScienceTagCard implements IProjectCard {
-    public cost = 0;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.SCIENCE_TAG_BLANK_CARD;
-    public cardType = CardType.PROXY;
-
-    public play() {
-      return undefined;
-    }
+  public get cost() {
+    return 0;
+  }
+  public get tags() {
+    return [Tags.SCIENCE];
+  }
+  public get name() {
+    return CardName.SCIENCE_TAG_BLANK_CARD;
+  }
+  public get cardType() {
+    return CardType.PROXY;
+  }
+  public get metadata(): CardMetadata {
+    throw new Error('proxy card should not render');
+  }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/corporation/BeginnerCorporation.ts
+++ b/src/cards/corporation/BeginnerCorporation.ts
@@ -4,26 +4,35 @@ import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class BeginnerCorporation implements CorporationCard {
-    public tags = [];
-    public startingMegaCredits: number = 42;
-    public name = CardName.BEGINNER_CORPORATION;
-    public cardType = CardType.CORPORATION;
-    public play(player: Player, game: Game) {
-      for (let i = 0; i < 10; i++) {
-        player.cardsInHand.push(game.dealer.dealCard());
-      }
-      return undefined;
+  public get tags() {
+    return [];
+  }
+  public get startingMegaCredits() {
+    return 42;
+  }
+  public get name() {
+    return CardName.BEGINNER_CORPORATION;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
+  public play(player: Player, game: Game) {
+    for (let i = 0; i < 10; i++) {
+      player.cardsInHand.push(game.dealer.dealCard());
     }
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R00',
       description: 'You start with 42 MC. Instead of choosing from 10 cards during setup, you get 10 cards for free.',
       renderData: CardRenderer.builder((b) => {
         b.megacredits(42).nbsp.cards(10).digit;
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/BeginnerCorporation.ts
+++ b/src/cards/corporation/BeginnerCorporation.ts
@@ -2,37 +2,30 @@
 import {CorporationCard} from './CorporationCard';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class BeginnerCorporation implements CorporationCard {
-  public get tags() {
-    return [];
-  }
-  public get startingMegaCredits() {
-    return 42;
-  }
-  public get name() {
-    return CardName.BEGINNER_CORPORATION;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
+export class BeginnerCorporation extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.BEGINNER_CORPORATION,
+      metadata: {
+        cardNumber: 'R00',
+        description: 'You start with 42 MC. Instead of choosing from 10 cards during setup, you get 10 cards for free.',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(42).nbsp.cards(10).digit;
+        }),
+      },
+      startingMegaCredits: 42,
+    });
   }
   public play(player: Player, game: Game) {
     for (let i = 0; i < 10; i++) {
       player.cardsInHand.push(game.dealer.dealCard());
     }
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R00',
-      description: 'You start with 42 MC. Instead of choosing from 10 cards during setup, you get 10 cards for free.',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(42).nbsp.cards(10).digit;
-      }),
-    };
   }
 }

--- a/src/cards/corporation/BeginnerCorporation.ts
+++ b/src/cards/corporation/BeginnerCorporation.ts
@@ -12,6 +12,7 @@ export class BeginnerCorporation extends Card implements CorporationCard {
     super({
       cardType: CardType.CORPORATION,
       name: CardName.BEGINNER_CORPORATION,
+
       metadata: {
         cardNumber: 'R00',
         description: 'You start with 42 MC. Instead of choosing from 10 cards during setup, you get 10 cards for free.',

--- a/src/cards/corporation/CrediCor.ts
+++ b/src/cards/corporation/CrediCor.ts
@@ -4,30 +4,37 @@ import {Game} from '../../Game';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {StandardProjectCard} from '../standardProjects/StandardProjectCard';
 
 export class CrediCor implements CorporationCard {
-    public name = CardName.CREDICOR;
-    public tags = [];
-    public startingMegaCredits: number = 57;
-    public cardType = CardType.CORPORATION;
-    public requirements: undefined;
-    public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
-      if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cost >= 20) {
-        player.megaCredits += 4;
-      }
+  public get name() {
+    return CardName.CREDICOR;
+  }
+  public get tags() {
+    return [];
+  }
+  public get startingMegaCredits() {
+    return 57;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
+  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+    if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cost >= 20) {
+      player.megaCredits += 4;
     }
-    public onStandardProject(player: Player, project: StandardProjectCard) {
-      if (project.cost >= 20) {
-        player.megaCredits += 4;
-      }
+  }
+  public onStandardProject(player: Player, project: StandardProjectCard) {
+    if (project.cost >= 20) {
+      player.megaCredits += 4;
     }
-    public play() {
-      return undefined;
-    }
-    public metadata: CardMetadata = {
+  }
+  public play() {
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R08',
       description: 'You start with 57 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -40,5 +47,6 @@ export class CrediCor implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/CrediCor.ts
+++ b/src/cards/corporation/CrediCor.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
@@ -7,18 +8,27 @@ import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {StandardProjectCard} from '../standardProjects/StandardProjectCard';
 
-export class CrediCor implements CorporationCard {
-  public get name() {
-    return CardName.CREDICOR;
-  }
-  public get tags() {
-    return [];
-  }
-  public get startingMegaCredits() {
-    return 57;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
+export class CrediCor extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.CREDICOR,
+      startingMegaCredits: 57,
+      metadata: {
+        cardNumber: 'R08',
+        description: 'You start with 57 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br.br;
+          b.megacredits(57);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.minus().megacredits(20).startEffect.megacredits(4);
+              eb.description('Effect: After you pay for a card or standard project with a basic cost of 20MC or more, you gain 4MC.');
+            });
+          });
+        }),
+      },
+    });
   }
   public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
     if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cost >= 20) {
@@ -32,21 +42,5 @@ export class CrediCor implements CorporationCard {
   }
   public play() {
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R08',
-      description: 'You start with 57 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br.br;
-        b.megacredits(57);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.minus().megacredits(20).startEffect.megacredits(4);
-            eb.description('Effect: After you pay for a card or standard project with a basic cost of 20MC or more, you gain 4MC.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/CrediCor.ts
+++ b/src/cards/corporation/CrediCor.ts
@@ -14,6 +14,7 @@ export class CrediCor extends Card implements CorporationCard {
       cardType: CardType.CORPORATION,
       name: CardName.CREDICOR,
       startingMegaCredits: 57,
+
       metadata: {
         cardNumber: 'R08',
         description: 'You start with 57 MC.',
@@ -30,15 +31,16 @@ export class CrediCor extends Card implements CorporationCard {
       },
     });
   }
-  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+  private effect(player: Player, card: IProjectCard | StandardProjectCard): void {
     if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cost >= 20) {
       player.megaCredits += 4;
     }
   }
+  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+    this.effect(player, card);
+  }
   public onStandardProject(player: Player, project: StandardProjectCard) {
-    if (project.cost >= 20) {
-      player.megaCredits += 4;
-    }
+    this.effect(player, project);
   }
   public play() {
     return undefined;

--- a/src/cards/corporation/EcoLine.ts
+++ b/src/cards/corporation/EcoLine.ts
@@ -4,22 +4,30 @@ import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class EcoLine implements CorporationCard {
-    public name = CardName.ECOLINE;
-    public tags = [Tags.PLANT];
-    public startingMegaCredits: number = 36;
-    public cardType = CardType.CORPORATION;
-    public play(player: Player) {
-      player.addProduction(Resources.PLANTS, 2);
-      player.plants = 3;
-      player.plantsNeededForGreenery = 7;
-      return undefined;
-    }
+  public get name() {
+    return CardName.ECOLINE;
+  }
+  public get tags() {
+    return [Tags.PLANT];
+  }
+  public get startingMegaCredits() {
+    return 36;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.PLANTS, 2);
+    player.plants = 3;
+    player.plantsNeededForGreenery = 7;
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R17',
       description: 'You start with 2 plant production, 3 plants, and 36 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -32,5 +40,6 @@ export class EcoLine implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/EcoLine.ts
+++ b/src/cards/corporation/EcoLine.ts
@@ -10,10 +10,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class EcoLine extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.ECOLINE,
       tags: [Tags.PLANT],
       startingMegaCredits: 36,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R17',
         description: 'You start with 2 plant production, 3 plants, and 36 MC.',

--- a/src/cards/corporation/EcoLine.ts
+++ b/src/cards/corporation/EcoLine.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
@@ -6,40 +7,33 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class EcoLine implements CorporationCard {
-  public get name() {
-    return CardName.ECOLINE;
-  }
-  public get tags() {
-    return [Tags.PLANT];
-  }
-  public get startingMegaCredits() {
-    return 36;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
+export class EcoLine extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.ECOLINE,
+      tags: [Tags.PLANT],
+      startingMegaCredits: 36,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R17',
+        description: 'You start with 2 plant production, 3 plants, and 36 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.productionBox((pb) => pb.plants(2)).nbsp.megacredits(36).plants(3).digit;
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.plants(7).digit.startAction.greenery();
+              eb.description('Effect: You may always pay 7 plants, instead of 8, to place greenery.');
+            });
+          });
+        }),
+      },
+    });
   }
   public play(player: Player) {
     player.addProduction(Resources.PLANTS, 2);
     player.plants = 3;
     player.plantsNeededForGreenery = 7;
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R17',
-      description: 'You start with 2 plant production, 3 plants, and 36 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.productionBox((pb) => pb.plants(2)).nbsp.megacredits(36).plants(3).digit;
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.plants(7).digit.startAction.greenery();
-            eb.description('Effect: You may always pay 7 plants, instead of 8, to place greenery.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/Helion.ts
+++ b/src/cards/corporation/Helion.ts
@@ -10,10 +10,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class Helion extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.HELION,
       tags: [Tags.SPACE],
       startingMegaCredits: 42,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R18',
         description: 'You start with 3 heat production and 42 MC.',

--- a/src/cards/corporation/Helion.ts
+++ b/src/cards/corporation/Helion.ts
@@ -4,22 +4,30 @@ import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Helion implements CorporationCard {
-    public name = CardName.HELION;
-    public tags = [Tags.SPACE];
-    public startingMegaCredits: number = 42;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.HELION;
+  }
+  public get tags() {
+    return [Tags.SPACE];
+  }
+  public get startingMegaCredits() {
+    return 42;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public play(player: Player) {
-      player.canUseHeatAsMegaCredits = true;
-      player.addProduction(Resources.HEAT, 3);
-      return undefined;
-    }
+  public play(player: Player) {
+    player.canUseHeatAsMegaCredits = true;
+    player.addProduction(Resources.HEAT, 3);
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R18',
       description: 'You start with 3 heat production and 42 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -32,5 +40,6 @@ export class Helion implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/Helion.ts
+++ b/src/cards/corporation/Helion.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
@@ -6,40 +7,32 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Helion implements CorporationCard {
-  public get name() {
-    return CardName.HELION;
+export class Helion extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.HELION,
+      tags: [Tags.SPACE],
+      startingMegaCredits: 42,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R18',
+        description: 'You start with 3 heat production and 42 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.productionBox((pb) => pb.heat(3)).nbsp.megacredits(42);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.text('x').heat(1).startEffect.megacredits(0).multiplier;
+              eb.description('Effect: You may use heat as MC. You may not use MC as heat.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.SPACE];
-  }
-  public get startingMegaCredits() {
-    return 42;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public play(player: Player) {
     player.canUseHeatAsMegaCredits = true;
     player.addProduction(Resources.HEAT, 3);
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R18',
-      description: 'You start with 3 heat production and 42 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.productionBox((pb) => pb.heat(3)).nbsp.megacredits(42);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.text('x').heat(1).startEffect.megacredits(0).multiplier;
-            eb.description('Effect: You may use heat as MC. You may not use MC as heat.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/InterplanetaryCinematics.ts
+++ b/src/cards/corporation/InterplanetaryCinematics.ts
@@ -11,10 +11,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class InterplanetaryCinematics extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.INTERPLANETARY_CINEMATICS,
       tags: [Tags.BUILDING],
       startingMegaCredits: 30,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R19',
         description: 'You start with 20 steel and 30 MC.',

--- a/src/cards/corporation/InterplanetaryCinematics.ts
+++ b/src/cards/corporation/InterplanetaryCinematics.ts
@@ -5,25 +5,33 @@ import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardType} from '../CardType';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class InterplanetaryCinematics implements CorporationCard {
-    public name = CardName.INTERPLANETARY_CINEMATICS;
-    public tags = [Tags.BUILDING];
-    public startingMegaCredits: number = 30;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.INTERPLANETARY_CINEMATICS;
+  }
+  public get tags() {
+    return [Tags.BUILDING];
+  }
+  public get startingMegaCredits() {
+    return 30;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
-      if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cardType === CardType.EVENT) {
-        player.megaCredits += 2;
-      }
+  public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
+    if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cardType === CardType.EVENT) {
+      player.megaCredits += 2;
     }
-    public play(player: Player) {
-      player.steel = 20;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
+  }
+  public play(player: Player) {
+    player.steel = 20;
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R19',
       description: 'You start with 20 steel and 30 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -36,5 +44,6 @@ export class InterplanetaryCinematics implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/InterplanetaryCinematics.ts
+++ b/src/cards/corporation/InterplanetaryCinematics.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Tags} from '../Tags';
 import {IProjectCard} from '../IProjectCard';
@@ -7,20 +8,29 @@ import {CardType} from '../CardType';
 import {CardName} from '../../CardName';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class InterplanetaryCinematics implements CorporationCard {
-  public get name() {
-    return CardName.INTERPLANETARY_CINEMATICS;
+export class InterplanetaryCinematics extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.INTERPLANETARY_CINEMATICS,
+      tags: [Tags.BUILDING],
+      startingMegaCredits: 30,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R19',
+        description: 'You start with 20 steel and 30 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br.br;
+          b.megacredits(30).nbsp.steel(20).digit;
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.event().played.startEffect.megacredits(2);
+              eb.description('Effect: Each time you play an event, you gain 2 MC.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.BUILDING];
-  }
-  public get startingMegaCredits() {
-    return 30;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public onCardPlayed(player: Player, _game: Game, card: IProjectCard) {
     if (player.corporationCard !== undefined && player.corporationCard.name === this.name && card.cardType === CardType.EVENT) {
       player.megaCredits += 2;
@@ -29,21 +39,5 @@ export class InterplanetaryCinematics implements CorporationCard {
   public play(player: Player) {
     player.steel = 20;
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R19',
-      description: 'You start with 20 steel and 30 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br.br;
-        b.megacredits(30).nbsp.steel(20).digit;
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.event().played.startEffect.megacredits(2);
-            eb.description('Effect: Each time you play an event, you gain 2 MC.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -11,11 +11,12 @@ import {CardRenderer} from '../render/CardRenderer';
 export class Inventrix extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.INVENTRIX,
       tags: [Tags.SCIENCE],
       initialActionText: 'Draw 3 cards',
       startingMegaCredits: 45,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R43',
         description: 'As you first action in the game, draw 3 cards. Start with 45MC.',

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -5,35 +5,45 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {LogHelper} from '../../LogHelper';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Inventrix implements CorporationCard {
-    public name = CardName.INVENTRIX;
-    public tags = [Tags.SCIENCE];
-    public startingMegaCredits: number = 45;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.INVENTRIX;
+  }
+  public get tags() {
+    return [Tags.SCIENCE];
+  }
+  public get startingMegaCredits() {
+    return 45;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public initialActionText: string = 'Draw 3 cards';
-    public initialAction(player: Player, game: Game) {
-      player.cardsInHand.push(
-        game.dealer.dealCard(),
-        game.dealer.dealCard(),
-        game.dealer.dealCard(),
-      );
+  public get initialActionText() {
+    return 'Draw 3 cards';
+  }
+  public initialAction(player: Player, game: Game) {
+    player.cardsInHand.push(
+      game.dealer.dealCard(),
+      game.dealer.dealCard(),
+      game.dealer.dealCard(),
+    );
 
-      LogHelper.logCardChange(game, player, 'drew', 3);
+    LogHelper.logCardChange(game, player, 'drew', 3);
 
-      return undefined;
-    }
-    public getRequirementBonus(_player: Player, _game: Game): number {
-      return 2;
-    }
-    public play() {
-      return undefined;
-    }
+    return undefined;
+  }
+  public getRequirementBonus(_player: Player, _game: Game): number {
+    return 2;
+  }
+  public play() {
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R43',
       description: 'As you first action in the game, draw 3 cards. Start with 45MC.',
       renderData: CardRenderer.builder((b) => {
@@ -46,6 +56,7 @@ export class Inventrix implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }
 

--- a/src/cards/corporation/Inventrix.ts
+++ b/src/cards/corporation/Inventrix.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
@@ -7,22 +8,29 @@ import {LogHelper} from '../../LogHelper';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Inventrix implements CorporationCard {
-  public get name() {
-    return CardName.INVENTRIX;
-  }
-  public get tags() {
-    return [Tags.SCIENCE];
-  }
-  public get startingMegaCredits() {
-    return 45;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
-  public get initialActionText() {
-    return 'Draw 3 cards';
+export class Inventrix extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.INVENTRIX,
+      tags: [Tags.SCIENCE],
+      initialActionText: 'Draw 3 cards',
+      startingMegaCredits: 45,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R43',
+        description: 'As you first action in the game, draw 3 cards. Start with 45MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.megacredits(45).nbsp.cards(3);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.plate('Global requirements').startEffect.text('+/- 2');
+              eb.description('Effect: Your temperature, oxygen, ocean, and Venus requirements are +2 or -2 steps, your choice in each case.');
+            });
+          });
+        }),
+      },
+    });
   }
   public initialAction(player: Player, game: Game) {
     player.cardsInHand.push(
@@ -40,23 +48,6 @@ export class Inventrix implements CorporationCard {
   }
   public play() {
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R43',
-      description: 'As you first action in the game, draw 3 cards. Start with 45MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.megacredits(45).nbsp.cards(3);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.plate('Global requirements').startEffect.text('+/- 2');
-            eb.description('Effect: Your temperature, oxygen, ocean, and Venus requirements are +2 or -2 steps, your choice in each case.');
-          });
-        });
-      }),
-    };
   }
 }
 

--- a/src/cards/corporation/MiningGuild.ts
+++ b/src/cards/corporation/MiningGuild.ts
@@ -12,10 +12,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class MiningGuild extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.MINING_GUILD,
       tags: [Tags.BUILDING, Tags.BUILDING],
       startingMegaCredits: 30,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R24',
         description: 'You start with 30 MC, 5 steel and 1 steel production.',

--- a/src/cards/corporation/MiningGuild.ts
+++ b/src/cards/corporation/MiningGuild.ts
@@ -6,29 +6,37 @@ import {SpaceBonus} from '../../SpaceBonus';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MiningGuild implements CorporationCard {
-    public name = CardName.MINING_GUILD;
-    public tags = [Tags.BUILDING, Tags.BUILDING];
-    public startingMegaCredits: number = 30;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.MINING_GUILD;
+  }
+  public get tags() {
+    return [Tags.BUILDING, Tags.BUILDING];
+  }
+  public get startingMegaCredits() {
+    return 30;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public onTilePlaced(player: Player, space: ISpace) {
-      if (
-        player.isCorporation(this.name) &&
+  public onTilePlaced(player: Player, space: ISpace) {
+    if (
+      player.isCorporation(this.name) &&
             space.player === player &&
             (space.bonus.indexOf(SpaceBonus.STEEL) !== -1 || space.bonus.indexOf(SpaceBonus.TITANIUM) !== -1)) {
-        player.addProduction(Resources.STEEL);
-      }
-    }
-    public play(player: Player) {
-      player.steel = 5;
       player.addProduction(Resources.STEEL);
-      return undefined;
     }
-    public metadata: CardMetadata = {
+  }
+  public play(player: Player) {
+    player.steel = 5;
+    player.addProduction(Resources.STEEL);
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R24',
       description: 'You start with 30 MC, 5 steel and 1 steel production.',
       renderData: CardRenderer.builder((b) => {
@@ -41,5 +49,6 @@ export class MiningGuild implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/MiningGuild.ts
+++ b/src/cards/corporation/MiningGuild.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {CorporationCard} from './CorporationCard';
@@ -8,20 +9,29 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class MiningGuild implements CorporationCard {
-  public get name() {
-    return CardName.MINING_GUILD;
+export class MiningGuild extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.MINING_GUILD,
+      tags: [Tags.BUILDING, Tags.BUILDING],
+      startingMegaCredits: 30,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R24',
+        description: 'You start with 30 MC, 5 steel and 1 steel production.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(30).nbsp.steel(5).digit.nbsp.productionBox((pb) => pb.steel(1));
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.steel(1).slash().titanium(1).startEffect.productionBox((pb) => pb.steel(1));
+              eb.description('Effect: Each time you get any steel or titanium as a placement bonus on the map, increase your steel production 1 step.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.BUILDING, Tags.BUILDING];
-  }
-  public get startingMegaCredits() {
-    return 30;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public onTilePlaced(player: Player, space: ISpace) {
     if (
       player.isCorporation(this.name) &&
@@ -34,21 +44,5 @@ export class MiningGuild implements CorporationCard {
     player.steel = 5;
     player.addProduction(Resources.STEEL);
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R24',
-      description: 'You start with 30 MC, 5 steel and 1 steel production.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(30).nbsp.steel(5).digit.nbsp.productionBox((pb) => pb.steel(1));
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.steel(1).slash().titanium(1).startEffect.productionBox((pb) => pb.steel(1));
-            eb.description('Effect: Each time you get any steel or titanium as a placement bonus on the map, increase your steel production 1 step.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/PhoboLog.ts
+++ b/src/cards/corporation/PhoboLog.ts
@@ -4,23 +4,30 @@ import {Game} from '../../Game';
 import {CorporationCard} from './CorporationCard';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class PhoboLog implements CorporationCard {
-    public name = CardName.PHOBOLOG;
-    public tags = [Tags.SPACE];
-    public startingMegaCredits: number = 23;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.PHOBOLOG;
+  }
+  public get tags() {
+    return [Tags.SPACE];
+  }
+  public get startingMegaCredits() {
+    return 23;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
+  public play(player: Player, _game: Game) {
+    player.titanium = 10;
+    player.increaseTitaniumValue();
+    return undefined;
+  }
 
-    public play(player: Player, _game: Game) {
-      player.titanium = 10;
-      player.increaseTitaniumValue();
-      return undefined;
-    }
-
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R09',
       description: 'You start with 10 titanium and 23 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -33,5 +40,6 @@ export class PhoboLog implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/PhoboLog.ts
+++ b/src/cards/corporation/PhoboLog.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
@@ -7,39 +8,32 @@ import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
-export class PhoboLog implements CorporationCard {
-  public get name() {
-    return CardName.PHOBOLOG;
-  }
-  public get tags() {
-    return [Tags.SPACE];
-  }
-  public get startingMegaCredits() {
-    return 23;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
+export class PhoboLog extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.PHOBOLOG,
+      tags: [Tags.SPACE],
+      startingMegaCredits: 23,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R09',
+        description: 'You start with 10 titanium and 23 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(23).nbsp.titanium(10).digit;
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.titanium(1).startEffect.plus(CardRenderItemSize.SMALL).megacredits(1);
+              eb.description('Effect: Your titanium resources are each worth 1 MC extra.');
+            });
+          });
+        }),
+      },
+    });
   }
   public play(player: Player, _game: Game) {
     player.titanium = 10;
     player.increaseTitaniumValue();
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R09',
-      description: 'You start with 10 titanium and 23 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(23).nbsp.titanium(10).digit;
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.titanium(1).startEffect.plus(CardRenderItemSize.SMALL).megacredits(1);
-            eb.description('Effect: Your titanium resources are each worth 1 MC extra.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/PhoboLog.ts
+++ b/src/cards/corporation/PhoboLog.ts
@@ -11,10 +11,11 @@ import {CardRenderItemSize} from '../render/CardRenderItemSize';
 export class PhoboLog extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.PHOBOLOG,
       tags: [Tags.SPACE],
       startingMegaCredits: 23,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R09',
         description: 'You start with 10 titanium and 23 MC.',

--- a/src/cards/corporation/SaturnSystems.ts
+++ b/src/cards/corporation/SaturnSystems.ts
@@ -13,10 +13,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class SaturnSystems extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.SATURN_SYSTEMS,
       tags: [Tags.JOVIAN],
       startingMegaCredits: 42,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R03',
         description: 'You start with 1 titanium production and 42 MC.',

--- a/src/cards/corporation/SaturnSystems.ts
+++ b/src/cards/corporation/SaturnSystems.ts
@@ -7,34 +7,42 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {ICard} from '../ICard';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class SaturnSystems implements CorporationCard {
-    public name = CardName.SATURN_SYSTEMS;
-    public tags = [Tags.JOVIAN];
-    public startingMegaCredits: number = 42;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.SATURN_SYSTEMS;
+  }
+  public get tags() {
+    return [Tags.JOVIAN];
+  }
+  public get startingMegaCredits() {
+    return 42;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public onCardPlayed(_player: Player, game: Game, card: IProjectCard) {
-      for (const tag of card.tags) {
-        if (tag === Tags.JOVIAN) {
-          game.getCardPlayer(this.name).addProduction(Resources.MEGACREDITS);
-        }
+  public onCardPlayed(_player: Player, game: Game, card: IProjectCard) {
+    for (const tag of card.tags) {
+      if (tag === Tags.JOVIAN) {
+        game.getCardPlayer(this.name).addProduction(Resources.MEGACREDITS);
       }
     }
+  }
 
-    public onCorpCardPlayed(_player: Player, game: Game, card: CorporationCard) {
-      return this.onCardPlayed(_player, game, card as ICard as IProjectCard);
-    }
+  public onCorpCardPlayed(_player: Player, game: Game, card: CorporationCard) {
+    return this.onCardPlayed(_player, game, card as ICard as IProjectCard);
+  }
 
-    public play(player: Player) {
-      player.addProduction(Resources.TITANIUM);
-      player.addProduction(Resources.MEGACREDITS);
-      return undefined;
-    }
+  public play(player: Player) {
+    player.addProduction(Resources.TITANIUM);
+    player.addProduction(Resources.MEGACREDITS);
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R03',
       description: 'You start with 1 titanium production and 42 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -47,5 +55,6 @@ export class SaturnSystems implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/SaturnSystems.ts
+++ b/src/cards/corporation/SaturnSystems.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
@@ -9,18 +10,28 @@ import {ICard} from '../ICard';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SaturnSystems implements CorporationCard {
-  public get name() {
-    return CardName.SATURN_SYSTEMS;
-  }
-  public get tags() {
-    return [Tags.JOVIAN];
-  }
-  public get startingMegaCredits() {
-    return 42;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
+export class SaturnSystems extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.SATURN_SYSTEMS,
+      tags: [Tags.JOVIAN],
+      startingMegaCredits: 42,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R03',
+        description: 'You start with 1 titanium production and 42 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.productionBox((pb) => pb.titanium(1)).nbsp.megacredits(42);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.jovian().played.any.startEffect.productionBox((pb) => pb.megacredits(1));
+              eb.description('Effect: Each time any Jovian tag is put into play, including this, increase your MC production 1 step.');
+            });
+          });
+        }),
+      },
+    });
   }
 
   public onCardPlayed(_player: Player, game: Game, card: IProjectCard) {
@@ -39,22 +50,5 @@ export class SaturnSystems implements CorporationCard {
     player.addProduction(Resources.TITANIUM);
     player.addProduction(Resources.MEGACREDITS);
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R03',
-      description: 'You start with 1 titanium production and 42 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.productionBox((pb) => pb.titanium(1)).nbsp.megacredits(42);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.jovian().played.any.startEffect.productionBox((pb) => pb.megacredits(1));
-            eb.description('Effect: Each time any Jovian tag is put into play, including this, increase your MC production 1 step.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/Teractor.ts
+++ b/src/cards/corporation/Teractor.ts
@@ -5,23 +5,31 @@ import {Game} from '../../Game';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Teractor implements CorporationCard {
-    public name = CardName.TERACTOR;
-    public tags = [Tags.EARTH];
-    public startingMegaCredits: number = 60;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.TERACTOR;
+  }
+  public get tags() {
+    return [Tags.EARTH];
+  }
+  public get startingMegaCredits() {
+    return 60;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-      return card.tags.filter((tag) => tag === Tags.EARTH).length * 3;
-    }
-    public play() {
-      return undefined;
-    }
+  public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
+    return card.tags.filter((tag) => tag === Tags.EARTH).length * 3;
+  }
+  public play() {
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
+  public get metadata() {
+    return {
       cardNumber: 'R30',
       description: 'You start with 60 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -34,5 +42,6 @@ export class Teractor implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/Teractor.ts
+++ b/src/cards/corporation/Teractor.ts
@@ -11,10 +11,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class Teractor extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.TERACTOR,
       tags: [Tags.EARTH],
       startingMegaCredits: 60,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R30',
         description: 'You start with 60 MC.',

--- a/src/cards/corporation/Teractor.ts
+++ b/src/cards/corporation/Teractor.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {Tags} from '../Tags';
 import {CorporationCard} from './CorporationCard';
 import {Player} from '../../Player';
@@ -7,41 +8,33 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Teractor implements CorporationCard {
-  public get name() {
-    return CardName.TERACTOR;
+export class Teractor extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.TERACTOR,
+      tags: [Tags.EARTH],
+      startingMegaCredits: 60,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R30',
+        description: 'You start with 60 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(60);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.earth(1).played.startEffect.megacredits(-3);
+              eb.description('Effect: When you play an Earth tag, you pay 3 MC less for it.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.EARTH];
-  }
-  public get startingMegaCredits() {
-    return 60;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
     return card.tags.filter((tag) => tag === Tags.EARTH).length * 3;
   }
   public play() {
     return undefined;
-  }
-
-  public get metadata() {
-    return {
-      cardNumber: 'R30',
-      description: 'You start with 60 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(60);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.earth(1).played.startEffect.megacredits(-3);
-            eb.description('Effect: When you play an Earth tag, you pay 3 MC less for it.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -16,11 +16,12 @@ import {CardRenderItemSize} from '../render/CardRenderItemSize';
 export class TharsisRepublic extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.THARSIS_REPUBLIC,
       tags: [Tags.BUILDING],
-      startingMegaCredits: 40,
-      cardType: CardType.CORPORATION,
       initialActionText: 'Place a city tile',
+      startingMegaCredits: 40,
+
       metadata: {
         cardNumber: 'R31',
         description: 'You start with 40 MC. As your first action in the game,place a city tile.',

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -9,42 +9,52 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Board} from '../../boards/Board';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class TharsisRepublic implements CorporationCard {
-    public name = CardName.THARSIS_REPUBLIC;
-    public tags = [Tags.BUILDING];
-    public startingMegaCredits: number = 40;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.THARSIS_REPUBLIC;
+  }
+  public get tags() {
+    return [Tags.BUILDING];
+  }
+  public get startingMegaCredits() {
+    return 40;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public initialActionText: string = 'Place a city tile';
-    public initialAction(player: Player, game: Game) {
-      return new SelectSpace('Select space on mars for city tile', game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
-        game.addCityTile(player, space.id);
-        game.log('${0} placed a City tile', (b) => b.player(player));
-        return undefined;
-      });
-    }
-    public onTilePlaced(player: Player, space: ISpace) {
-      if (Board.isCitySpace(space)) {
-        if (space.player === player) {
-          player.megaCredits += 3;
-        }
-        if (space.spaceType !== SpaceType.COLONY) {
-          player.addProduction(Resources.MEGACREDITS);
-        }
-      }
-    }
-    public play(player: Player, game: Game) {
-      if (game.getPlayers().length === 1) {
-        // Get bonus for 2 neutral cities
-        player.addProduction(Resources.MEGACREDITS, 2);
-      }
+  public get initialActionText() {
+    return 'Place a city tile';
+  }
+  public initialAction(player: Player, game: Game) {
+    return new SelectSpace('Select space on mars for city tile', game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
+      game.addCityTile(player, space.id);
+      game.log('${0} placed a City tile', (b) => b.player(player));
       return undefined;
+    });
+  }
+  public onTilePlaced(player: Player, space: ISpace) {
+    if (Board.isCitySpace(space)) {
+      if (space.player === player) {
+        player.megaCredits += 3;
+      }
+      if (space.spaceType !== SpaceType.COLONY) {
+        player.addProduction(Resources.MEGACREDITS);
+      }
     }
-    public metadata: CardMetadata = {
+  }
+  public play(player: Player, game: Game) {
+    if (game.getPlayers().length === 1) {
+      // Get bonus for 2 neutral cities
+      player.addProduction(Resources.MEGACREDITS, 2);
+    }
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R31',
       description: 'You start with 40 MC. As your first action in the game,place a city tile.',
       renderData: CardRenderer.builder((b) => {
@@ -59,5 +69,6 @@ export class TharsisRepublic implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/corporation/TharsisRepublic.ts
+++ b/src/cards/corporation/TharsisRepublic.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CorporationCard} from './CorporationCard';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
@@ -12,22 +13,31 @@ import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
-export class TharsisRepublic implements CorporationCard {
-  public get name() {
-    return CardName.THARSIS_REPUBLIC;
-  }
-  public get tags() {
-    return [Tags.BUILDING];
-  }
-  public get startingMegaCredits() {
-    return 40;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
-  public get initialActionText() {
-    return 'Place a city tile';
+export class TharsisRepublic extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.THARSIS_REPUBLIC,
+      tags: [Tags.BUILDING],
+      startingMegaCredits: 40,
+      cardType: CardType.CORPORATION,
+      initialActionText: 'Place a city tile',
+      metadata: {
+        cardNumber: 'R31',
+        description: 'You start with 40 MC. As your first action in the game,place a city tile.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(40).nbsp.city();
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              eb.city(CardRenderItemSize.SMALL).any.asterix().colon();
+              eb.productionBox((pb) => pb.megacredits(1)).nbsp;
+              eb.city(CardRenderItemSize.SMALL).startEffect.megacredits(3);
+              eb.description('Effect: When any city tile is placed ON MARS, increase your MC production 1 step. When you place a city tile, gain 3 MC.');
+            });
+          });
+        }),
+      },
+    });
   }
   public initialAction(player: Player, game: Game) {
     return new SelectSpace('Select space on mars for city tile', game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
@@ -52,23 +62,5 @@ export class TharsisRepublic implements CorporationCard {
       player.addProduction(Resources.MEGACREDITS, 2);
     }
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R31',
-      description: 'You start with 40 MC. As your first action in the game,place a city tile.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(40).nbsp.city();
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            eb.city(CardRenderItemSize.SMALL).any.asterix().colon();
-            eb.productionBox((pb) => pb.megacredits(1)).nbsp;
-            eb.city(CardRenderItemSize.SMALL).startEffect.megacredits(3);
-            eb.description('Effect: When any city tile is placed ON MARS, increase your MC production 1 step. When you place a city tile, gain 3 MC.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/Thorgate.ts
+++ b/src/cards/corporation/Thorgate.ts
@@ -12,10 +12,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class Thorgate extends Card implements CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.THORGATE,
       tags: [Tags.ENERGY],
       startingMegaCredits: 48,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R13',
         description: 'You start with 1 energy production and 48 MC.',

--- a/src/cards/corporation/Thorgate.ts
+++ b/src/cards/corporation/Thorgate.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
@@ -8,20 +9,30 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Thorgate implements CorporationCard {
-  public get name() {
-    return CardName.THORGATE;
+export class Thorgate extends Card implements CorporationCard {
+  constructor() {
+    super({
+      name: CardName.THORGATE,
+      tags: [Tags.ENERGY],
+      startingMegaCredits: 48,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R13',
+        description: 'You start with 1 energy production and 48 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.productionBox((pb) => pb.energy(1)).nbsp.megacredits(48);
+          b.corpBox('effect', (ce) => {
+            ce.effectBox((eb) => {
+              // TODO(chosta): energy().played needs to be power() [same for space()]
+              eb.energy(1).played.asterix().startEffect.megacredits(-3);
+              eb.description('Effect: When playing a power card OR THE STANDARD PROJECT POWER PLANT, you pay 3 MC less for it.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.ENERGY];
-  }
-  public get startingMegaCredits() {
-    return 48;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
     if (card.tags.indexOf(Tags.ENERGY) !== -1) {
       return 3;
@@ -31,23 +42,6 @@ export class Thorgate implements CorporationCard {
   public play(player: Player, _game: Game) {
     player.addProduction(Resources.ENERGY);
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R13',
-      description: 'You start with 1 energy production and 48 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.productionBox((pb) => pb.energy(1)).nbsp.megacredits(48);
-        b.corpBox('effect', (ce) => {
-          ce.effectBox((eb) => {
-            // TODO(chosta): energy().played needs to be power() [same for space()]
-            eb.energy(1).played.asterix().startEffect.megacredits(-3);
-            eb.description('Effect: When playing a power card OR THE STANDARD PROJECT POWER PLANT, you pay 3 MC less for it.');
-          });
-        });
-      }),
-    };
   }
 }
 

--- a/src/cards/corporation/Thorgate.ts
+++ b/src/cards/corporation/Thorgate.ts
@@ -6,26 +6,34 @@ import {CorporationCard} from './CorporationCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Thorgate implements CorporationCard {
-    public name = CardName.THORGATE;
-    public tags = [Tags.ENERGY];
-    public startingMegaCredits: number = 48;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.THORGATE;
+  }
+  public get tags() {
+    return [Tags.ENERGY];
+  }
+  public get startingMegaCredits() {
+    return 48;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-      if (card.tags.indexOf(Tags.ENERGY) !== -1) {
-        return 3;
-      }
-      return 0;
+  public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
+    if (card.tags.indexOf(Tags.ENERGY) !== -1) {
+      return 3;
     }
-    public play(player: Player, _game: Game) {
-      player.addProduction(Resources.ENERGY);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
+    return 0;
+  }
+  public play(player: Player, _game: Game) {
+    player.addProduction(Resources.ENERGY);
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R13',
       description: 'You start with 1 energy production and 48 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -39,6 +47,7 @@ export class Thorgate implements CorporationCard {
           });
         });
       }),
-    }
+    };
+  }
 }
 

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -14,10 +14,11 @@ import {CardRenderer} from '../render/CardRenderer';
 export class UnitedNationsMarsInitiative extends Card implements IActionCard, CorporationCard {
   constructor() {
     super({
+      cardType: CardType.CORPORATION,
       name: CardName.UNITED_NATIONS_MARS_INITIATIVE,
       tags: [Tags.EARTH],
       startingMegaCredits: 40,
-      cardType: CardType.CORPORATION,
+
       metadata: {
         cardNumber: 'R32',
         description: 'You start with 40 MC.',

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {IActionCard} from '../ICard';
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
@@ -10,20 +11,30 @@ import {REDS_RULING_POLICY_COST} from '../../constants';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard {
-  public get name() {
-    return CardName.UNITED_NATIONS_MARS_INITIATIVE;
+export class UnitedNationsMarsInitiative extends Card implements IActionCard, CorporationCard {
+  constructor() {
+    super({
+      name: CardName.UNITED_NATIONS_MARS_INITIATIVE,
+      tags: [Tags.EARTH],
+      startingMegaCredits: 40,
+      cardType: CardType.CORPORATION,
+      metadata: {
+        cardNumber: 'R32',
+        description: 'You start with 40 MC.',
+        renderData: CardRenderer.builder((b) => {
+          // TODO(chosta): find a not so hacky solutions to spacing
+          b.br.br.br;
+          b.empty().nbsp.nbsp.nbsp.nbsp.megacredits(40);
+          b.corpBox('action', (ce) => {
+            ce.effectBox((eb) => {
+              eb.megacredits(3).startAction.tr(1).asterix();
+              eb.description('Action: If your Terraform Rating was raised this generation, you may pay 3 MC to raise it 1 step more.');
+            });
+          });
+        }),
+      },
+    });
   }
-  public get tags() {
-    return [Tags.EARTH];
-  }
-  public get startingMegaCredits() {
-    return 40;
-  }
-  public get cardType() {
-    return CardType.CORPORATION;
-  }
-
   public play() {
     return undefined;
   }
@@ -41,22 +52,5 @@ export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard
     player.megaCredits -= 3;
     player.increaseTerraformRating(game);
     return undefined;
-  }
-  public get metadata() {
-    return {
-      cardNumber: 'R32',
-      description: 'You start with 40 MC.',
-      renderData: CardRenderer.builder((b) => {
-        // TODO(chosta): find a not so hacky solutions to spacing
-        b.br.br.br;
-        b.empty().nbsp.nbsp.nbsp.nbsp.megacredits(40);
-        b.corpBox('action', (ce) => {
-          ce.effectBox((eb) => {
-            eb.megacredits(3).startAction.tr(1).asterix();
-            eb.description('Action: If your Terraform Rating was raised this generation, you may pay 3 MC to raise it 1 step more.');
-          });
-        });
-      }),
-    };
   }
 }

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -8,35 +8,42 @@ import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {REDS_RULING_POLICY_COST} from '../../constants';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-
 export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard {
-    public name = CardName.UNITED_NATIONS_MARS_INITIATIVE;
-    public tags = [Tags.EARTH];
-    public startingMegaCredits: number = 40;
-    public cardType = CardType.CORPORATION;
+  public get name() {
+    return CardName.UNITED_NATIONS_MARS_INITIATIVE;
+  }
+  public get tags() {
+    return [Tags.EARTH];
+  }
+  public get startingMegaCredits() {
+    return 40;
+  }
+  public get cardType() {
+    return CardType.CORPORATION;
+  }
 
-    public play() {
-      return undefined;
-    }
-    public canAct(player: Player, game: Game): boolean {
-      const hasIncreasedTR = player.hasIncreasedTerraformRatingThisGeneration;
-      const actionCost = 3;
+  public play() {
+    return undefined;
+  }
+  public canAct(player: Player, game: Game): boolean {
+    const hasIncreasedTR = player.hasIncreasedTerraformRatingThisGeneration;
+    const actionCost = 3;
 
-      if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-        return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + actionCost);
-      }
+    if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
+      return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + actionCost);
+    }
 
-      return hasIncreasedTR && player.canAfford(actionCost);
-    }
-    public action(player: Player, game: Game) {
-      player.megaCredits -= 3;
-      player.increaseTerraformRating(game);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
+    return hasIncreasedTR && player.canAfford(actionCost);
+  }
+  public action(player: Player, game: Game) {
+    player.megaCredits -= 3;
+    player.increaseTerraformRating(game);
+    return undefined;
+  }
+  public get metadata() {
+    return {
       cardNumber: 'R32',
       description: 'You start with 40 MC.',
       renderData: CardRenderer.builder((b) => {
@@ -50,5 +57,6 @@ export class UnitedNationsMarsInitiative implements IActionCard, CorporationCard
           });
         });
       }),
-    }
+    };
+  }
 }

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -2,6 +2,7 @@ import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
 import {Game} from '../../Game';
+import {CardMetadata} from '../CardMetadata';
 import {CardName} from '../../CardName';
 import {Tags} from '../Tags';
 import {IProjectCard} from '../IProjectCard';
@@ -9,6 +10,7 @@ import {IProjectCard} from '../IProjectCard';
 export abstract class PreludeCard implements IProjectCard {
     public cost = 0;
     public cardType = CardType.PRELUDE;
+    public abstract metadata: CardMetadata;
     public abstract name: CardName;
     public abstract tags: Array<Tags>;
     public abstract play(player: Player, game: Game): PlayerInput | undefined;

--- a/src/cards/standardProjects/StandardProjectCard.ts
+++ b/src/cards/standardProjects/StandardProjectCard.ts
@@ -11,6 +11,7 @@ import {SelectPlayer} from '../../inputs/SelectPlayer';
 import {AndOptions} from '../../inputs/AndOptions';
 import {SelectCard} from '../../inputs/SelectCard';
 import {SelectSpace} from '../../inputs/SelectSpace';
+import {CardMetadata} from '../CardMetadata';
 import {CardName} from '../../CardName';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 
@@ -20,6 +21,7 @@ export abstract class StandardProjectCard implements IActionCard, ICard {
     public tags = [];
     public abstract name: CardName;
     public abstract cost: number;
+    public abstract metadata: CardMetadata;
     protected discount(_player: Player) {
       return 0;
     }

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -135,15 +135,6 @@ describe('Player', function() {
     playerKeys.sort();
     expect(serializedKeys).to.deep.eq(playerKeys);
   });
-  it('backward compatible deserialization for pickedCorporationCard', () => {
-    const player = TestPlayers.BLUE.newPlayer();
-    const json = player.serialize();
-    json.pickedCorporationCard = new SaturnSystems();
-    const s: SerializedPlayer = JSON.parse(JSON.stringify(json));
-    expect(s.pickedCorporationCard).to.deep.eq(JSON.parse(JSON.stringify(new SaturnSystems())));
-    const p = Player.deserialize(s);
-    expect(p.pickedCorporationCard?.name).eq('Saturn Systems');
-  });
   it('forward serialization for pickedCorporationCard', () => {
     const player = TestPlayers.BLUE.newPlayer();
     player.pickedCorporationCard = new SaturnSystems();

--- a/tests/cards/Card.spec.ts
+++ b/tests/cards/Card.spec.ts
@@ -1,0 +1,23 @@
+import {expect} from 'chai';
+
+import {CardName} from '../../src/CardName';
+import {CardType} from '../../src/cards/CardType';
+import {Helion} from '../../src/cards/corporation/Helion';
+import {Inventrix} from '../../src/cards/corporation/Inventrix';
+import {Tags} from '../../src/cards/Tags';
+
+describe('Card', function() {
+  it('pulls values for typical corporation', function() {
+    const card = new Helion();
+    expect(card.cardType).to.eq(CardType.CORPORATION);
+    expect(card.initialActionText).is.undefined;
+    expect(card.startingMegaCredits).to.eq(42);
+    expect(card.metadata).not.is.undefined;
+    expect(card.name).to.eq(CardName.HELION);
+    expect(card.tags).to.deep.eq([Tags.SPACE]);
+  });
+  it('pulls initialActionText', function() {
+    const card = new Inventrix();
+    expect(card.initialActionText).to.eq('Draw 3 cards');
+  });
+});

--- a/tests/cards/ares/BioengineeringEnclosure.spec.ts
+++ b/tests/cards/ares/BioengineeringEnclosure.spec.ts
@@ -1,37 +1,19 @@
+import {AICentral} from '../../../src/cards/base/AICentral';
 import {BioengineeringEnclosure} from '../../../src/cards/ares/BioengineeringEnclosure';
+import {Birds} from '../../../src/cards/base/Birds';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {CardName} from '../../../src/CardName';
-import {Tags} from '../../../src/cards/Tags';
-import {CardType} from '../../../src/cards/CardType';
-import {ResourceType} from '../../../src/ResourceType';
 import {expect} from 'chai';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {TestPlayers} from '../../TestingUtils';
 
 describe('BioengineeringEnclosure', function() {
   let card : BioengineeringEnclosure; let player : Player; let game : Game;
-
-  const scienceTagCard: IProjectCard = {
-    name: CardName.ACQUIRED_COMPANY,
-    cardType: CardType.ACTIVE,
-    cost: 0,
-    tags: [Tags.SCIENCE],
-    play: () => undefined,
-  };
-
-  const animalHost: IProjectCard = {
-    name: CardName.ACQUIRED_SPACE_AGENCY,
-    cardType: CardType.ACTIVE,
-    cost: 0,
-    tags: [],
-    resourceType: ResourceType.ANIMAL,
-    resourceCount: 0,
-    play: () => undefined,
-  };
+  let animalHost: IProjectCard = new Birds();
 
   beforeEach(function() {
+    animalHost = new Birds();
     card = new BioengineeringEnclosure();
     player = TestPlayers.BLUE.newPlayer();
     const redPlayer = TestPlayers.RED.newPlayer();
@@ -40,7 +22,7 @@ describe('BioengineeringEnclosure', function() {
 
   it('Can\'t play without a science tag', () => {
     expect(card.canPlay(player, game)).is.false;
-    player.playCard(game, scienceTagCard);
+    player.playCard(game, new AICentral());
     expect(card.canPlay(player, game)).is.true;
   });
 
@@ -65,6 +47,7 @@ describe('BioengineeringEnclosure', function() {
   it('Move animal', () => {
     // Set up the cards.
     player.playCard(game, animalHost);
+    game.deferredActions.shift();
     player.playCard(game, card);
 
     // Initial expectations that will change after playing the card.

--- a/tests/cards/ares/BiofertilizerFacility.spec.ts
+++ b/tests/cards/ares/BiofertilizerFacility.spec.ts
@@ -1,13 +1,11 @@
 import {expect} from 'chai';
-import {CardName} from '../../../src/CardName';
+import {AICentral} from '../../../src/cards/base/AICentral';
+import {Ants} from '../../../src/cards/base/Ants';
 import {BiofertilizerFacility} from '../../../src/cards/ares/BiofertilizerFacility';
-import {CardType} from '../../../src/cards/CardType';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {Tags} from '../../../src/cards/Tags';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {ResourceType} from '../../../src/ResourceType';
 import {SpaceBonus} from '../../../src/SpaceBonus';
 import {TileType} from '../../../src/TileType';
 import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
@@ -16,29 +14,16 @@ import {TestPlayers} from '../../TestingUtils';
 describe('BiofertilizerFacility', function() {
   let card : BiofertilizerFacility; let player : Player; let game : Game;
 
-  const scienceTagCard: IProjectCard = {
-    name: CardName.ACQUIRED_COMPANY,
-    cardType: CardType.ACTIVE,
-    cost: 0,
-    tags: [Tags.SCIENCE],
-    play: () => undefined,
-  };
-
-  const microbeHost: IProjectCard = {
-    name: CardName.ACQUIRED_SPACE_AGENCY,
-    cardType: CardType.ACTIVE,
-    cost: 0,
-    tags: [],
-    resourceType: ResourceType.MICROBE,
-    resourceCount: 0,
-    play: () => undefined,
-  };
+  let scienceTagCard: IProjectCard = new AICentral();
+  let microbeHost: IProjectCard = new Ants();
 
   beforeEach(function() {
     card = new BiofertilizerFacility();
     player = TestPlayers.BLUE.newPlayer();
     const redPlayer = TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
+    scienceTagCard = new AICentral();
+    microbeHost = new Ants();
   });
 
   it('Can\'t play without a science tag', function() {

--- a/tests/cards/corporation/CrediCor.spec.ts
+++ b/tests/cards/corporation/CrediCor.spec.ts
@@ -22,7 +22,7 @@ describe('CrediCor', function() {
   it('Should play', function() {
     const action = card.play();
     expect(action).is.undefined;
-
+    player.corporationCard = card;
     card.onStandardProject(player, new AsteroidStandard());
     card.onStandardProject(player, new City());
     card.onStandardProject(player, new Greenery());


### PR DESCRIPTION
Been trying to work around a problem a few other ways in regards to all of our cards creating new values for their properties. With a moment of inspiration when @Lynesth mentioned creating a separate interface for dynamic properties I remembered that when using a `get` for a property we don't have to store these values. With this change the values which are static such as `name`, `tags`, `cost`, and `metadata` wont store a new value on each instance but will instead provide the value at runtime.

The trade off here is the generated javascript will be slightly larger per card and some operations will run marginally slower as the value will be calculated when it is needed versus stored in memory. As a dealer creates an instance of most cards per game I think this trade off is well worth it.

I will do this roll out in batches. This starts with the corporation cards.