### PR TITLE
let MoholeLake always take action

### DIFF
--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -41,14 +41,17 @@ export class MoholeLake implements IActionCard, IProjectCard {
       return undefined;
     }
 
-    public canAct(player: Player): boolean {
-      const microbeCards = player.getResourceCards(ResourceType.MICROBE);
-      const animalCards = player.getResourceCards(ResourceType.ANIMAL);
-      return microbeCards.length > 0 || animalCards.length > 0;
+    public canAct(): boolean {
+      return true;
     }
 
     public action(player: Player, game: Game) {
       const availableCards = player.getResourceCards(ResourceType.MICROBE).concat(player.getResourceCards(ResourceType.ANIMAL));
+
+      if (availableCards.length === 0) {
+        return undefined;
+      }
+
       if (availableCards.length === 1) {
         player.addResourceTo(availableCards[0]);
         LogHelper.logAddResource(game, player, availableCards[0], 1);

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -32,9 +32,9 @@ describe('MoholeLake', function() {
     expect(player.plants).to.eq(3);
   });
 
-  it('Can\'t act', function() {
-    card.play(player, game);
-    expect(card.canAct(player)).is.not.true;
+  it('Can act - no target', function() {
+    expect(card.canAct()).is.true;
+    card.action(player, game);
   });
 
   it('Can act - single target', function() {
@@ -42,7 +42,7 @@ describe('MoholeLake', function() {
     player.playedCards.push(fish);
 
     card.play(player, game);
-    expect(card.canAct(player)).is.true;
+    expect(card.canAct()).is.true;
     card.action(player, game);
     expect(fish.resourceCount).to.eq(1);
   });
@@ -53,7 +53,7 @@ describe('MoholeLake', function() {
     player.playedCards.push(fish, ants);
 
     card.play(player, game);
-    expect(card.canAct(player)).is.true;
+    expect(card.canAct()).is.true;
     const action = card.action(player, game) as SelectCard<ICard>;
 
     action.cb([ants]);

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -34,7 +34,7 @@ describe('MoholeLake', function() {
 
   it('Can act - no target', function() {
     expect(card.canAct()).is.true;
-    card.action(player, game);
+    expect(card.action(player, game)).is.undefined;
   });
 
   it('Can act - single target', function() {


### PR DESCRIPTION
Scheduling is difficult for humans and computers. There is some strategy that if a task will not take long to do it right away. This change allows MoholeLake to do nothing with an action which is the precedent we have started with other cards.