### PR TITLE
hide Beginner Corporation from custom corporations list

### DIFF
--- a/src/components/CorporationsFilter.ts
+++ b/src/components/CorporationsFilter.ts
@@ -10,7 +10,8 @@ function corpCardNames(module: GameModule): Array<CardName> {
     console.log('manifest %s not found', manifest);
     return [];
   } else {
-    return manifest.corporationCards.cards.map((cf) => cf.cardName);
+    return manifest.corporationCards.cards.map((cf) => cf.cardName)
+      .filter((cardName) => cardName !== CardName.BEGINNER_CORPORATION);
   }
 }
 


### PR DESCRIPTION
A recent change moved the beginner corporation into a manifest so that it's name can be pulled without needing to specify it wherever we pull the cards by their manifest. This had a side effect of now requiring us to hide the corporation whenever we don't want it displayed. This change hides it from the custom corporations list as it was not showing previously.