### PR TITLE
Add the ability for a card to need to be compatible with more than one other module.

### DIFF
--- a/src/CardLoader.ts
+++ b/src/CardLoader.ts
@@ -38,19 +38,27 @@ export class CardLoader {
 
   private static include(gameOptions: GameOptions) {
     return function(cf: ICardFactory<ICard>): boolean {
-      const expansion = cf.compatibility;
-      switch (expansion) {
-      case undefined:
+      if (cf.compatibility === undefined) {
         return true;
-      case GameModule.Venus:
-        return gameOptions.venusNextExtension;
-      case GameModule.Colonies:
-        return gameOptions.coloniesExtension;
-      case GameModule.Turmoil:
-        return gameOptions.turmoilExtension;
-      default:
-        throw ('Unhandled expansion type: ' + expansion);
       }
+      const expansions: Array<GameModule> = Array.isArray(cf.compatibility) ? cf.compatibility : [cf.compatibility];
+      let meets = true;
+      expansions.forEach((expansion) => {
+        switch (expansion) {
+        case GameModule.Venus:
+          meets = meets && gameOptions.venusNextExtension;
+          break;
+        case GameModule.Colonies:
+          meets = meets && gameOptions.coloniesExtension;
+          break;
+        case GameModule.Turmoil:
+          meets = meets && gameOptions.turmoilExtension;
+          break;
+        default:
+          throw new Error(`Unhandled expansion type ${expansion} for card ${cf.cardName}`);
+        }
+      });
+      return meets;
     };
   }
 

--- a/src/CardLoader.ts
+++ b/src/CardLoader.ts
@@ -42,23 +42,18 @@ export class CardLoader {
         return true;
       }
       const expansions: Array<GameModule> = Array.isArray(cf.compatibility) ? cf.compatibility : [cf.compatibility];
-      let meets = true;
-      expansions.forEach((expansion) => {
+      return expansions.every((expansion) => {
         switch (expansion) {
         case GameModule.Venus:
-          meets = meets && gameOptions.venusNextExtension;
-          break;
+          return gameOptions.venusNextExtension;
         case GameModule.Colonies:
-          meets = meets && gameOptions.coloniesExtension;
-          break;
+          return gameOptions.coloniesExtension;
         case GameModule.Turmoil:
-          meets = meets && gameOptions.turmoilExtension;
-          break;
+          return gameOptions.turmoilExtension;
         default:
           throw new Error(`Unhandled expansion type ${expansion} for card ${cf.cardName}`);
         }
       });
-      return meets;
     };
   }
 

--- a/src/cards/ICardFactory.ts
+++ b/src/cards/ICardFactory.ts
@@ -4,5 +4,5 @@ import {GameModule} from '../GameModule';
 export interface ICardFactory<T> {
     cardName: CardName;
     Factory: new () => T;
-    compatibility ?: GameModule ;
+    compatibility ?: GameModule | Array<GameModule>;
 }


### PR DESCRIPTION
I had hoped not to start putting behavior specific to the moon yet, but this has been overwritten once already (as code moved from Dealer to CardLoader so I thought I'd get it in now.