### PR TITLE
hide code for corporation cards

### DIFF
--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -86,7 +86,7 @@ export const Card = Vue.component('card', {
     getCost: function(): number | undefined {
       const cost = this.getCard()?.cost;
       const type = this.getCardType();
-      return cost === undefined || type === CardType.PRELUDE ? undefined : cost;
+      return cost === undefined || type === CardType.PRELUDE || type === CardType.CORPORATION ? undefined : cost;
     },
     getCardType: function(): CardType | undefined {
       return this.getCard()?.cardType;


### PR DESCRIPTION
With the update for corporation cards to extend the base card class the cost is defaulting to zero. This makes the client side logic more robust to never display the cost for corporation cards as they don't have a cost.