### PR TITLE
use Map for efficient card finding

### DIFF
--- a/src/CardFinder.ts
+++ b/src/CardFinder.ts
@@ -36,7 +36,7 @@ export class CardFinder {
     public getStandardProjectCardByName(cardName: string): StandardProjectCard | undefined {
       let found : (ICardFactory<StandardProjectCard> | undefined);
       CardFinder.getDecks().some((deck) => {
-        found = deck.standardProjects.findByCardName(cardName);
+        found = deck.standardProjects.findByCardName(cardName as CardName);
         return found !== undefined;
       });
       if (found !== undefined) {
@@ -49,7 +49,7 @@ export class CardFinder {
     public getCorporationCardByName(cardName: string): CorporationCard | undefined {
       let found : (ICardFactory<CorporationCard> | undefined);
       CardFinder.getDecks().some((deck) => {
-        found = deck.corporationCards.findByCardName(cardName);
+        found = deck.corporationCards.findByCardName(cardName as CardName);
         return found !== undefined;
       });
       if (found !== undefined) {
@@ -66,9 +66,9 @@ export class CardFinder {
     public getProjectCardByName(cardName: string): IProjectCard | undefined {
       let found : (ICardFactory<IProjectCard> | undefined);
       CardFinder.getDecks().some((deck) => {
-        found = deck.projectCards.findByCardName(cardName);
+        found = deck.projectCards.findByCardName(cardName as CardName);
         if (found === undefined) {
-          found = deck.preludeCards.findByCardName(cardName);
+          found = deck.preludeCards.findByCardName(cardName as CardName);
         }
         return found !== undefined;
       });

--- a/src/Deck.ts
+++ b/src/Deck.ts
@@ -1,10 +1,14 @@
+import {CardName} from './CardName';
 import {ICard} from './cards/ICard';
 import {ICardFactory} from './cards/ICardFactory';
 
 export class Deck<T extends ICard> {
-  constructor(public cards: Array<ICardFactory<T>>) {}
+  public readonly factories: Map<CardName, ICardFactory<T>>;
+  constructor(cards: Array<ICardFactory<T>>) {
+    this.factories = new Map(cards.map((cf) => [cf.cardName, cf]));
+  }
 
-  public findByCardName(name: string): ICardFactory<T> | undefined {
-    return this.cards.find((cf) => cf.cardName === name);
+  public findByCardName(name: CardName): ICardFactory<T> | undefined {
+    return this.factories.get(name);
   }
 }

--- a/src/cards/AllCards.ts
+++ b/src/cards/AllCards.ts
@@ -28,8 +28,11 @@ export const ALL_CARD_MANIFESTS: Array<CardManifest> = [
 ];
 
 function allCardNames(decks: Array<Deck<ICard>>): Array<CardName> {
-  const arrays: Array<Array<CardName>> = decks.map((deck) => deck.cards.map((cf) => cf.cardName));
-  return ([] as Array<CardName>).concat(...arrays);
+  const cardNames: Array<CardName> = [];
+  for (const deck of decks) {
+    deck.factories.forEach((cf) => cardNames.push(cf.cardName));
+  }
+  return cardNames;
 }
 
 export const MANIFEST_BY_MODULE: Map<GameModule, CardManifest> =
@@ -38,7 +41,7 @@ export const MANIFEST_BY_MODULE: Map<GameModule, CardManifest> =
 export const ALL_PROJECT_DECKS = ALL_CARD_MANIFESTS.map(
   (deck) => deck.projectCards,
 );
-export const ALL_CORPORATION_DECKS = ALL_CARD_MANIFESTS.map(
+const ALL_CORPORATION_DECKS = ALL_CARD_MANIFESTS.map(
   (deck) => deck.corporationCards,
 );
 export const ALL_PRELUDE_DECKS = ALL_CARD_MANIFESTS.map(

--- a/src/cards/CardManifest.ts
+++ b/src/cards/CardManifest.ts
@@ -1,3 +1,4 @@
+import {CardName} from '../CardName';
 import {Deck} from '../Deck';
 import {GameModule} from '../GameModule';
 import {CorporationCard} from './corporation/CorporationCard';
@@ -8,21 +9,21 @@ import {StandardProjectCard} from './standardProjects/StandardProjectCard';
 export class CardManifest {
     module: GameModule;
     projectCards : Deck<IProjectCard>;
-    cardsToRemove: Array<String>;
+    cardsToRemove: Set<CardName>;
     corporationCards : Deck<CorporationCard>;
     preludeCards : Deck<IProjectCard>;
     standardProjects : Deck<StandardProjectCard>;
     constructor(arg: {
          module: GameModule,
          projectCards?: Array<ICardFactory<IProjectCard>>,
-         cardsToRemove?: Array<String>,
+         cardsToRemove?: Array<CardName>,
          corporationCards?: Array<ICardFactory<CorporationCard>>,
          preludeCards?: Array<ICardFactory<IProjectCard>>,
          standardProjects?: Array<ICardFactory<StandardProjectCard>>,
          }) {
       this.module = arg.module;
       this.projectCards = new Deck<IProjectCard>(arg.projectCards || []);
-      this.cardsToRemove = arg.cardsToRemove || [];
+      this.cardsToRemove = new Set(arg.cardsToRemove || []);
       this.corporationCards = new Deck<CorporationCard>(arg.corporationCards || []);
       this.preludeCards = new Deck<IProjectCard>(arg.preludeCards || []);
       this.standardProjects = new Deck<StandardProjectCard>(arg.standardProjects || []);

--- a/src/cards/community/PoliticalUprising.ts
+++ b/src/cards/community/PoliticalUprising.ts
@@ -24,7 +24,8 @@ export class PoliticalUprising extends PreludeCard implements IProjectCard {
     }
 
     private drawTurmoilCard(player: Player, game: Game) {
-      const turmoilCards = TURMOIL_CARD_MANIFEST.projectCards.cards.map((c) => c.cardName);
+      const turmoilCards: Array<CardName> = [];
+      TURMOIL_CARD_MANIFEST.projectCards.factories.forEach((cf) => turmoilCards.push(cf.cardName));
       const drawnCard = game.dealer.deck.find((card) => turmoilCards.includes(card.name));
 
       if (drawnCard) {

--- a/src/components/CorporationsFilter.ts
+++ b/src/components/CorporationsFilter.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 
 import {CardName} from '../CardName';
-import {ALL_CARD_MANIFESTS, ALL_CORPORATION_DECKS, MANIFEST_BY_MODULE} from '../cards/AllCards';
+import {ALL_CARD_MANIFESTS, MANIFEST_BY_MODULE} from '../cards/AllCards';
 import {GameModule} from '../GameModule';
 
 function corpCardNames(module: GameModule): Array<CardName> {
@@ -10,15 +10,22 @@ function corpCardNames(module: GameModule): Array<CardName> {
     console.log('manifest %s not found', manifest);
     return [];
   } else {
-    return manifest.corporationCards.cards.map((cf) => cf.cardName)
-      .filter((cardName) => cardName !== CardName.BEGINNER_CORPORATION);
+    const cards: Array<CardName> = [];
+    manifest.corporationCards.factories.forEach((cf) => {
+      if (cf.cardName !== CardName.BEGINNER_CORPORATION) {
+        cards.push(cf.cardName);
+      }
+    });
+    return cards;
   }
 }
 
-// TODO(kberg): no need for both ALL_CORPORATION_DECKS and MANIFEST_BY_MODULE
-const allItems: Array<CardName> =
-    ALL_CORPORATION_DECKS.map((deck) => deck.cards.map((cf) => cf.cardName))
-      .reduce((accumulator, cards) => accumulator.concat(cards));
+const allItems: Array<CardName> = [];
+ALL_CARD_MANIFESTS.forEach((manifest) => {
+  manifest.corporationCards.factories.forEach((cf) => {
+    allItems.push(cf.cardName);
+  });
+});
 
 export const CorporationsFilter = Vue.component('corporations-filter', {
   props: {

--- a/src/components/DebugUI.ts
+++ b/src/components/DebugUI.ts
@@ -22,7 +22,7 @@ ALL_CARD_MANIFESTS.forEach((manifest) => {
     manifest.corporationCards,
     manifest.preludeCards,
     manifest.standardProjects].forEach((deck) => {
-    deck.cards.forEach((cf: ICardFactory<ICard>) => {
+    deck.factories.forEach((cf: ICardFactory<ICard>) => {
       const card: ICard = new cf.Factory();
       const cardNumber = card.metadata.cardNumber;
       cards.set(card.name, {card, module, cardNumber});

--- a/tests/CardLoader.spec.ts
+++ b/tests/CardLoader.spec.ts
@@ -58,7 +58,8 @@ describe('CardLoader', function() {
 
     const preludeDeck = new CardLoader(gameOptions).getPreludeCards();
 
-    const turmoilPreludes = COMMUNITY_CARD_MANIFEST.preludeCards.cards.map((c) => c.cardName);
+    const turmoilPreludes: Array<CardName> = [];
+    COMMUNITY_CARD_MANIFEST.preludeCards.factories.forEach((cf) => turmoilPreludes.push(cf.cardName));
     turmoilPreludes.forEach((preludeName) => {
       const preludeCard = new CardFinder().getProjectCardByName(preludeName)!;
       expect(preludeDeck.includes(preludeCard)).is.not.true;

--- a/tests/Deck.spec.ts
+++ b/tests/Deck.spec.ts
@@ -16,9 +16,9 @@ describe('Deck', function() {
   const deck: Deck<IProjectCard> = new Deck(cards);
 
   it('findCardByName: success', function() {
-    expect(deck.findByCardName('Acquired Company')).is.not.undefined;
+    expect(deck.findByCardName(CardName.ACQUIRED_COMPANY)).is.not.undefined;
   });
   it('findCardByName: failure', function() {
-    expect(deck.findByCardName('Ecological Zone')).is.undefined;
+    expect(deck.findByCardName(CardName.ECOLOGICAL_ZONE)).is.undefined;
   });
 });

--- a/tests/cards/CardMetadata.spec.ts
+++ b/tests/cards/CardMetadata.spec.ts
@@ -15,7 +15,7 @@ describe('CardMetadata', function() {
 
   it('should have a VP icon', function() {
     ALL_CARD_MANIFESTS.forEach((manifest) => {
-      manifest.projectCards.cards.forEach((c) => {
+      manifest.projectCards.factories.forEach((c) => {
         const card = new c.Factory();
         if (card.metadata !== undefined && card.getVictoryPoints !== undefined) {
           expect(card.metadata.victoryPoints, card.name + ' is missing VP metadata').is.not.undefined;

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -126,7 +126,7 @@ describe('RoboticWorkforce', function() {
     const gameOptions = setCustomGameOptions();
     const productions = [Resources.MEGACREDITS, Resources.STEEL, Resources.TITANIUM, Resources.PLANTS, Resources.ENERGY, Resources.HEAT];
     ALL_CARD_MANIFESTS.forEach((manifest) => {
-      manifest.projectCards.cards.forEach((c) => {
+      manifest.projectCards.factories.forEach((c) => {
         const card = new c.Factory();
         if (card.tags.includes(Tags.BUILDING) && card.play !== undefined) {
           // Solar Farm is a pain to test so let's just say it's fine


### PR DESCRIPTION
Finish the work for #2215 . Uses a `Map` and `Set` within `CardManifest` and `Deck` to make the look-up more efficient.