### PR TITLE
use key when iterating cards

### DIFF
--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -83,7 +83,7 @@ export const SelectCard = Vue.component('select-card', {
   },
   template: `<div class="wf-component wf-component--select-card">
         <div v-if="showtitle === true" class="nofloat wf-component-title">{{ translate(playerinput.title) }}</div>
-        <label v-for="card in getOrderedCards()" class="cardbox">
+        <label v-for="card in getOrderedCards()" :key="card.name" class="cardbox">
             <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" type="radio" v-model="cards" :value="card" />
             <input v-else type="checkbox" v-model="cards" :value="card" :disabled="playerinput.maxCardsToSelect !== undefined && Array.isArray(cards) && cards.length >= playerinput.maxCardsToSelect && cards.indexOf(card) === -1" />
             <Card :card="card" />


### PR DESCRIPTION
This should resolve the issue in #2274 . I can't seem to recreate the issue with this in place. Without looking into vue source I would think that it is somehow creating a key based off of something since we didn't provide one. With the recent card change most cards could look the same.