### PR TITLE
Restore previous option order where Sell patents is always last option

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1659,11 +1659,6 @@ export class Player implements ISerializable<SerializedPlayer> {
     if (standardProjects.cards.length >= 1) {
       options.push(standardProjects);
     }
-
-    const sellPatents = new SellPatents();
-    if (sellPatents.canAct(this)) {
-      options.push(sellPatents.action(this, game));
-    }
   }
 
   public takeAction(game: Game): void {
@@ -1886,6 +1881,12 @@ export class Player implements ISerializable<SerializedPlayer> {
     action.options.push(
       this.passOption(game),
     );
+
+    // Sell patents
+    const sellPatents = new SellPatents();
+    if (sellPatents.canAct(this)) {
+      action.options.push(sellPatents.action(this, game));
+    }
 
     // Propose undo action only if you have done one action this turn
     if (this.actionsTakenThisRound > 0 && game.gameOptions.undoOption) {


### PR DESCRIPTION
This change moves Sell Patents to where it was before. This option is always the last one as in most cases players prefer to pass than actively sell patents. It also avoids auto expanding the cards unless the player deliberately clicked to sell (e.g. https://github.com/bafolts/terraforming-mars/issues/749#issue-627949117)

<img width="527" alt="Screenshot 2021-01-05 at 12 17 05 PM" src="https://user-images.githubusercontent.com/2408094/103605937-23b56300-4f50-11eb-9c55-be0314edb53e.png">
