### PR TITLE
rearrange more often used actions

### DIFF
--- a/src/cards/promo/AsteroidRights.ts
+++ b/src/cards/promo/AsteroidRights.ts
@@ -41,14 +41,14 @@ export class AsteroidRights implements IActionCard, IProjectCard, IResourceCard 
       this.resourceCount--;
 
       return new OrOptions(
-        new SelectOption('Increase MC production 1 step', 'Select', () => {
-          player.addProduction(Resources.MEGACREDITS);
-          LogHelper.logRemoveResource(game, player, this, 1, 'increase MC production 1 step');
-          return undefined;
-        }),
         new SelectOption('Gain 2 titanium', 'Select', () => {
           player.titanium += 2;
           LogHelper.logRemoveResource(game, player, this, 1, 'gain 2 titanium');
+          return undefined;
+        }),
+        new SelectOption('Increase MC production 1 step', 'Select', () => {
+          player.addProduction(Resources.MEGACREDITS);
+          LogHelper.logRemoveResource(game, player, this, 1, 'increase MC production 1 step');
           return undefined;
         }),
       );

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -37,13 +37,13 @@ export class SulphurEatingBacteria implements IActionCard, IProjectCard, IResour
       const addResource = new SelectOption('Add 1 microbe to this card', 'Add microbe', () => this.addResource(player, game));
       const spendResource = new SelectAmount('Remove any number of microbes to gain 3 MC per microbe removed', 'Remove microbes', (amount: number) => this.spendResource(player, game, amount), 1, this.resourceCount);
 
+      opts.push(addResource);
+
       if (this.resourceCount > 0) {
         opts.push(spendResource);
       } else {
         return this.addResource(player, game);
       }
-
-      opts.push(addResource);
 
       return new OrOptions(...opts);
     }

--- a/tests/cards/promo/AsteroidRights.spec.ts
+++ b/tests/cards/promo/AsteroidRights.spec.ts
@@ -38,11 +38,11 @@ describe('AsteroidRights', function() {
     const action = card.action(player, game) as OrOptions;
 
     // Gain 1 MC prod
-    action.options[0].cb();
+    action.options[1].cb();
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);
 
     // Gain 2 titanium
-    action.options[1].cb();
+    action.options[0].cb();
     expect(player.titanium).to.eq(2);
   });
 

--- a/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
+++ b/tests/cards/venusNext/SulphurEatingBacteria.spec.ts
@@ -31,7 +31,7 @@ describe('SulphurEatingBacteria', function() {
     player.addResourceTo(card, 5);
 
     const action = card.action(player, game) as OrOptions;
-    action.options[0].cb(3);
+    action.options[1].cb(3);
     expect(player.megaCredits).to.eq(9);
     expect(card.resourceCount).to.eq(2);
   });


### PR DESCRIPTION
For Sulphur-eating bacteria, I put add microbe on top as a default action. Players will more often add microbes instead of removing it.

For Asteroid Right, I put remove asteroid for 2 Ti on top as a default action. Any sane person would do that instead of 1 mc production.