### PR TITLE
new version of metal bonus indicator

### DIFF
--- a/src/components/overview/PlayerResource.ts
+++ b/src/components/overview/PlayerResource.ts
@@ -53,16 +53,14 @@ export const PlayerResource = Vue.component('player-resource', {
     displayPlantsProtectedIcon: function(): boolean {
       return this.type === Resources.PLANTS && this.plantsAreProtected;
     },
-    isMetal: function(): boolean {
-      return (this.type === Resources.STEEL || this.type === Resources.TITANIUM);
+    isMetalUpgraded: function(): boolean {
+      return (this.type === Resources.STEEL && this.steelValue > DEFAULT_STEEL_VALUE) || (this.type === Resources.TITANIUM && this.titaniumValue > DEFAULT_TITANIUM_VALUE);
     },
     getMetalBonus: function(): string {
       if (this.type === Resources.STEEL) {
-        const steelBonus: number = this.steelValue-DEFAULT_STEEL_VALUE;
-        return '&#9679;'.repeat(steelBonus);
+        return `${this.steelValue}`;
       } else if (this.type === Resources.TITANIUM) {
-        const titaniumBonus: number = this.titaniumValue-DEFAULT_TITANIUM_VALUE;
-        return titaniumBonus <= 2 ? '&#9679;'.repeat(titaniumBonus) : '&#9679;&#9679;<br>'+'&#9679;'.repeat(titaniumBonus-2);
+        return `${this.titaniumValue}`;
       } else {
         return '';
       }
@@ -77,7 +75,7 @@ export const PlayerResource = Vue.component('player-resource', {
             <div class="resource_item_prod">
                 <span class="resource_item_prod_count">{{ productionSign() }}{{ production }}</span>
                 <div v-if="displayPlantsProtectedIcon()" class="shield_icon"></div>
-                <div v-if="isMetal()" class="alloys" v-html="getMetalBonus()"></div>
+                <div v-if="isMetalUpgraded()" class="resource_icon--metalbonus" v-html="getMetalBonus()"></div>
             </div>
         </div>
     `,

--- a/src/styles/resources.less
+++ b/src/styles/resources.less
@@ -81,14 +81,15 @@
     background-size: 20px 20px;
     width: 20px;
     height: 20px;
-    color: rgba(0, 0, 0);
+    color: black;
     font-size: 15px;
     font-style: normal;
-    font-family: Arial;
+    font-family: Prototype;
     text-align: center;
     line-height: 21px;
-    margin-left: -15px;
+    margin-left: -14px;
     margin-top: -37px;
+    text-align: center;
 }
 
 .resource_icon--microbe {

--- a/src/styles/resources.less
+++ b/src/styles/resources.less
@@ -76,6 +76,21 @@
     line-height: 36px;
 }
 
+.resource_icon--metalbonus {
+    background-image: url(assets/resources/megacredit.png);
+    background-size: 20px 20px;
+    width: 20px;
+    height: 20px;
+    color: rgba(0, 0, 0);
+    font-size: 15px;
+    font-style: normal;
+    font-family: Arial;
+    text-align: center;
+    line-height: 21px;
+    margin-left: -15px;
+    margin-top: -37px;
+}
+
 .resource_icon--microbe {
     background-image: url(assets/resources/microbe.png);
 }


### PR DESCRIPTION
New version of the metal bonus indicator as proposed by @ssimeonoff .

Show the value of the metal as a superscript next to the metal icon. Only show the value that is above 2 for steel or above 3 for Ti

Before Unity round. 
![image](https://user-images.githubusercontent.com/14239220/103920295-1d092600-50df-11eb-9698-b4244da20084.png)

During Unity round.
![image](https://user-images.githubusercontent.com/14239220/103920325-25f9f780-50df-11eb-8419-a84b8d15c38e.png)
