### PR TITLE
Requirements to unity

### DIFF
--- a/src/cards/CardRequirements.ts
+++ b/src/cards/CardRequirements.ts
@@ -105,6 +105,13 @@ class Builder {
     return this;
   }
 
+  public unity(): Builder {
+    this.reqs.push(new TagCardRequirement(Tags.VENUS, -1));
+    this.reqs.push(new TagCardRequirement(Tags.EARTH, -1));
+    this.reqs.push(new TagCardRequirement(Tags.JOVIAN, -1));
+    return this;
+  }
+
   public production(resource: Resources, amount: number = -1): Builder {
     this.reqs.push(new ProductionCardRequirement(resource, amount));
     return this;

--- a/src/cards/venusNext/LuxuryFoods.ts
+++ b/src/cards/venusNext/LuxuryFoods.ts
@@ -27,9 +27,7 @@ export class LuxuryFoods implements IProjectCard {
     public metadata: CardMetadata = {
       description: 'Requires that you have a Venus tag, an Earth tag and a Jovian tag.',
       cardNumber: 'T10',
-      requirements: CardRequirements.builder((b) =>
-        b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN),
-      ),
+      requirements: CardRequirements.builder((b) => b.unity()),
       victoryPoints: 2,
     };
 }

--- a/src/cards/venusNext/MiningQuota.ts
+++ b/src/cards/venusNext/MiningQuota.ts
@@ -24,7 +24,7 @@ export class MiningQuota implements IProjectCard {
     }
     public metadata: CardMetadata = {
       cardNumber: '239',
-      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
+      requirements: CardRequirements.builder((b) => b.unity()),
       renderData: CardRenderer.builder((b) => {
         b.productionBox((pb) => pb.steel(2));
       }),

--- a/src/cards/venusNext/Omnicourt.ts
+++ b/src/cards/venusNext/Omnicourt.ts
@@ -33,7 +33,7 @@ export class Omnicourt implements IProjectCard {
 
     public metadata: CardMetadata = {
       cardNumber: '241',
-      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
+      requirements: CardRequirements.builder((b) => b.unity()),
       renderData: CardRenderer.builder((b) => {
         b.tr(2);
       }),

--- a/src/cards/venusNext/Solarnet.ts
+++ b/src/cards/venusNext/Solarnet.ts
@@ -25,7 +25,7 @@ export class Solarnet implements IProjectCard {
     }
     public metadata: CardMetadata = {
       cardNumber: '245',
-      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
+      requirements: CardRequirements.builder((b) => b.unity()),
       renderData: CardRenderer.builder((b) => {
         b.cards(2);
       }),

--- a/tests/metadata/CardRequirements.spec.ts
+++ b/tests/metadata/CardRequirements.spec.ts
@@ -201,6 +201,11 @@ describe('CardRequirement', function() {
       'Party leader',
     );
   });
+  it('unity', function() {
+    expect(CardRequirements.builder((b) => b.unity()).getRequirementsText()).to.equal(
+      'Venus Earth Jovian',
+    );
+  });
   it('Throws error on max w/o requirement', function() {
     expect(() => {
       CardRequirements.builder((b) => b.max());


### PR DESCRIPTION
Added a shorthand to requirements:
`b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)` becomes `unity()`