### PR TITLE
add basic support for watching changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "templates": "node compile-vue-templates.js && tsc --build tsconfig-vue.json",
     "test": "mocha --file build/tests/utils/Vue.js --recursive build/tests",
     "testgiven": "tsc --build tsconfig.json && npm run webpack && tsc --build tsconfig-test.json && mocha",
+    "watch": "WATCH_IT=1 npm run webpack",
     "webpack": "webpack --config webpack.config.js"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,4 +21,5 @@ module.exports = {
   stats: {
     warnings: false,
   },
+  watch: process.env.WATCH_IT !== undefined
 };


### PR DESCRIPTION
I am planning to pick up the work to show the mega credit total required when initially selecting cards. I plan to rewrite `AndOptions` and `OrOptions` to not rely on `PlayerInputFactory` but instead make use of vue templates. Once in a vue template I plan to then leverage a `SelectInitialCards` (or better name) for displaying that option. Without the custom javascript it should be easier for everyone to read.

While developing locally I have noticed I need to leverage watch so that as I make changes the build is updated for me to save me time. This introduces the tool I use for doing this.

First I start the watch command and leave it running in background

```
npm run watch &
```

Then after I make a change I run `npm run compile` to compile my typescript changes. This in turn gets detected by the running watch and generates `main.js` again. At this point I then run `npm run start` and I am good to go. This is all significantly faster than waiting for `npm run build` and fine for local development.

Eventually this can be expanded to have typescript also watch for changes automatically when `npm run watch` is running but this should be a good first step and at least provide some option to others.