### PR TITLE
Fix bug where Philares can place final greenery after passing

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1034,9 +1034,16 @@ export class Game implements ISerializable<SerializedGame> {
   }
 
   private gotoFinalGreeneryPlacement(): void {
-    const players = this.players.filter(
-      (player) => this.canPlaceGreenery(player),
-    );
+    const players: Player[] = [];
+
+    this.players.forEach((player) => {
+      if (this.canPlaceGreenery(player)) {
+        players.push(player);
+      } else {
+        this.donePlayers.add(player.id);
+      }
+    });
+
     // If no players can place greeneries we are done
     if (players.length === 0) {
       this.gotoEndGame();


### PR DESCRIPTION
Once Philares player has passed, the player should not be able to place greenery later using plants obtained from other players' adjacent tile placements