### PR TITLE
static property card memory: convert the prelude cards

### DIFF
--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -29,8 +29,8 @@ export abstract class Card {
       if (properties.cardType === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
         throw new Error('must define startingMegaCredits for corporation cards');
       }
-      if (properties.cardType !== CardType.CORPORATION && properties.cost === undefined) {
-        throw new Error('must define cost for non-corporation cards');
+      if (properties.cardType !== CardType.CORPORATION && properties.cardType !== CardType.PRELUDE && properties.cost === undefined) {
+        throw new Error('must define cost for project cards');
       }
       staticCardProperties.set(properties.name, properties);
       staticInstance = properties;

--- a/src/cards/community/AerospaceMission.ts
+++ b/src/cards/community/AerospaceMission.ts
@@ -4,29 +4,33 @@ import {PreludeCard} from '../prelude/PreludeCard';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {BuildColony} from '../../deferredActions/BuildColony';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class AerospaceMission extends PreludeCard {
-    public tags = [Tags.SPACE];
-    public name = CardName.AEROSPACE_MISSION;
+  constructor() {
+    super({
+      name: CardName.AEROSPACE_MISSION,
+      tags: [Tags.SPACE],
 
-    public canPlay(player: Player, _game: Game) {
-      return player.canAfford(14);
-    }
+      metadata: {
+        cardNumber: 'Y01',
+        renderData: CardRenderer.builder((b) => {
+          b.colonies(1).nbsp.colonies(1).br;
+          b.minus().megacredits(14);
+        }),
+        description: 'Place 2 colonies. Pay 14 MC.',
+      },
+    });
+  }
 
-    public play(player: Player, game: Game) {
-      player.megaCredits -= 14;
-      game.defer(new BuildColony(player, game, false, 'Select where to build the first colony'));
-      game.defer(new BuildColony(player, game, false, 'Select where to build the second colony'));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y01',
-      renderData: CardRenderer.builder((b) => {
-        b.colonies(1).nbsp.colonies(1).br;
-        b.minus().megacredits(14);
-      }),
-      description: 'Place 2 colonies. Pay 14 MC.',
-    }
+  public canPlay(player: Player, _game: Game) {
+    return player.canAfford(14);
+  }
+
+  public play(player: Player, game: Game) {
+    player.megaCredits -= 14;
+    game.defer(new BuildColony(player, game, false, 'Select where to build the first colony'));
+    game.defer(new BuildColony(player, game, false, 'Select where to build the second colony'));
+    return undefined;
+  }
 }

--- a/src/cards/community/ByElection.ts
+++ b/src/cards/community/ByElection.ts
@@ -8,48 +8,52 @@ import {ALL_PARTIES} from '../../turmoil/Turmoil';
 import {SelectOption} from '../../inputs/SelectOption';
 import {OrOptions} from '../../inputs/OrOptions';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 import {PoliticalAgendas} from '../../turmoil/PoliticalAgendas';
 
 export class ByElection extends PreludeCard implements IProjectCard {
-    public tags = [Tags.WILDCARD];
-    public name = CardName.BY_ELECTION;
-    public canPlay(_player: Player, game: Game) {
-      return game.turmoil !== undefined;
-    }
-    public play(player: Player, game: Game) {
-      const turmoil = game.turmoil;
-      if (turmoil === undefined) {
-        return;
-      }
-      turmoil.addInfluenceBonus(player);
-      const setRulingParty = new OrOptions();
+  constructor() {
+    super({
+      name: CardName.BY_ELECTION,
+      tags: [Tags.WILDCARD],
 
-      setRulingParty.title = 'Select new ruling party';
-      setRulingParty.options = [...ALL_PARTIES.map((p) => new SelectOption(
-        p.partyName, 'Select', () => {
-          turmoil.rulingParty = turmoil.getPartyByName(p.partyName);
-          PoliticalAgendas.setNextAgenda(turmoil, game);
-
-          return undefined;
+      metadata: {
+        cardNumber: 'Y02',
+        renderData: CardRenderer.builder((b) => {
+          b.text('set ruling party', CardRenderItemSize.SMALL, true).br;
+          b.plus().influence(1);
         }),
-      )];
-
-      game.defer(new DeferredAction(
-        player,
-        () => setRulingParty,
-      ));
-
-      return undefined;
+        description: 'Set the ruling party to one of your choice. Gain 1 influence.',
+      },
+    });
+  }
+  public canPlay(_player: Player, game: Game) {
+    return game.turmoil !== undefined;
+  }
+  public play(player: Player, game: Game) {
+    const turmoil = game.turmoil;
+    if (turmoil === undefined) {
+      return;
     }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y02',
-      renderData: CardRenderer.builder((b) => {
-        b.text('set ruling party', CardRenderItemSize.SMALL, true).br;
-        b.plus().influence(1);
+    turmoil.addInfluenceBonus(player);
+    const setRulingParty = new OrOptions();
+
+    setRulingParty.title = 'Select new ruling party';
+    setRulingParty.options = [...ALL_PARTIES.map((p) => new SelectOption(
+      p.partyName, 'Select', () => {
+        turmoil.rulingParty = turmoil.getPartyByName(p.partyName);
+        PoliticalAgendas.setNextAgenda(turmoil, game);
+
+        return undefined;
       }),
-      description: 'Set the ruling party to one of your choice. Gain 1 influence.',
-    }
+    )];
+
+    game.defer(new DeferredAction(
+      player,
+      () => setRulingParty,
+    ));
+
+    return undefined;
+  }
 }

--- a/src/cards/community/PoliticalUprising.ts
+++ b/src/cards/community/PoliticalUprising.ts
@@ -5,45 +5,48 @@ import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {TURMOIL_CARD_MANIFEST} from '../turmoil/TurmoilCardManifest';
 import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class PoliticalUprising extends PreludeCard implements IProjectCard {
-    public tags = [];
-    public name = CardName.POLITICAL_UPRISING;
+  constructor() {
+    super({
+      name: CardName.POLITICAL_UPRISING,
 
-    public play(player: Player, game: Game) {
-      this.drawTurmoilCard(player, game);
+      metadata: {
+        cardNumber: 'Y03',
+        renderData: CardRenderer.builder((b) => {
+          b.delegates(4).br.br;
+          b.cards(1).secondaryTag(AltSecondaryTag.TURMOIL);
+        }),
+        description: 'Place 4 delegates. Draw a Turmoil card.',
+      },
+    });
+  }
 
-      for (let i = 0; i < 4; i++) {
-        game.defer(new SendDelegateToArea(player, game, 'Select where to send delegate', 1, undefined, undefined, false));
-      }
+  public play(player: Player, game: Game) {
+    this.drawTurmoilCard(player, game);
 
-      return undefined;
+    for (let i = 0; i < 4; i++) {
+      game.defer(new SendDelegateToArea(player, game, 'Select where to send delegate', 1, undefined, undefined, false));
     }
 
-    private drawTurmoilCard(player: Player, game: Game) {
-      const turmoilCards: Array<CardName> = [];
-      TURMOIL_CARD_MANIFEST.projectCards.factories.forEach((cf) => turmoilCards.push(cf.cardName));
-      const drawnCard = game.dealer.deck.find((card) => turmoilCards.includes(card.name));
+    return undefined;
+  }
 
-      if (drawnCard) {
-        const cardIndex = game.dealer.deck.findIndex((c) => c.name === drawnCard.name);
-        game.dealer.deck.splice(cardIndex, 1);
+  private drawTurmoilCard(player: Player, game: Game) {
+    const turmoilCards: Array<CardName> = [];
+    TURMOIL_CARD_MANIFEST.projectCards.factories.forEach((cf) => turmoilCards.push(cf.cardName));
+    const drawnCard = game.dealer.deck.find((card) => turmoilCards.includes(card.name));
 
-        player.cardsInHand.push(drawnCard);
-        game.log('${0} drew ${1}', (b) => b.player(player).card(drawnCard));
-      }
+    if (drawnCard) {
+      const cardIndex = game.dealer.deck.findIndex((c) => c.name === drawnCard.name);
+      game.dealer.deck.splice(cardIndex, 1);
 
-      return undefined;
+      player.cardsInHand.push(drawnCard);
+      game.log('${0} drew ${1}', (b) => b.player(player).card(drawnCard));
     }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y03',
-      renderData: CardRenderer.builder((b) => {
-        b.delegates(4).br.br;
-        b.cards(1).secondaryTag(AltSecondaryTag.TURMOIL);
-      }),
-      description: 'Place 4 delegates. Draw a Turmoil card.',
-    }
+
+    return undefined;
+  }
 }

--- a/src/cards/community/ResearchGrant.ts
+++ b/src/cards/community/ResearchGrant.ts
@@ -3,23 +3,27 @@ import {Player} from '../../Player';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class ResearchGrant extends PreludeCard implements IProjectCard {
-    public tags = [Tags.SCIENCE, Tags.SCIENCE];
-    public name = CardName.RESEARCH_GRANT;
+  constructor() {
+    super({
+      name: CardName.RESEARCH_GRANT,
+      tags: [Tags.SCIENCE, Tags.SCIENCE],
 
-    public play(player: Player) {
-      player.megaCredits += 8;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y04',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(8);
-      }),
-      description: 'Gain 8 MC.',
-    }
+      metadata: {
+        cardNumber: 'Y04',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(8);
+        }),
+        description: 'Gain 8 MC.',
+      },
+    });
+  }
+
+  public play(player: Player) {
+    player.megaCredits += 8;
+    return undefined;
+  }
 }
 

--- a/src/cards/community/TradeAdvance.ts
+++ b/src/cards/community/TradeAdvance.ts
@@ -5,40 +5,44 @@ import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class TradeAdvance extends PreludeCard implements IProjectCard {
-    public tags = [Tags.EARTH];
-    public name = CardName.TRADE_ADVANCE;
+  constructor() {
+    super({
+      name: CardName.TRADE_ADVANCE,
+      tags: [Tags.EARTH],
 
-    public play(player: Player, game: Game) {
-      game.defer(new DeferredAction(
-        player,
-        () => {
-          const openColonies = game.colonies.filter((colony) => colony.isActive);
-          openColonies.forEach((colony) => {
-            colony.trade(player, game, 1, false);
-          });
-          return undefined;
-        },
-      ));
+      metadata: {
+        cardNumber: 'Y05',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(2).text('[ solo').colon().megacredits(10).text(']').br;
+          b.text('Trade all colonies with').br;
+          b.trade().colon().text('+1');
+        }),
+        description: 'Gain 2 MC [SOLO: Gain 10 MC]. Immediately trade with all active colonies. You may increase the Colony Tile track 1 step before each of these trades.',
+      },
+    });
+  }
 
-      if (game.isSoloMode()) {
-        player.megaCredits += 10;
-      } else {
-        player.megaCredits += 2;
-      }
+  public play(player: Player, game: Game) {
+    game.defer(new DeferredAction(
+      player,
+      () => {
+        const openColonies = game.colonies.filter((colony) => colony.isActive);
+        openColonies.forEach((colony) => {
+          colony.trade(player, game, 1, false);
+        });
+        return undefined;
+      },
+    ));
 
-      return undefined;
+    if (game.isSoloMode()) {
+      player.megaCredits += 10;
+    } else {
+      player.megaCredits += 2;
     }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y05',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(2).text('[ solo').colon().megacredits(10).text(']').br;
-        b.text('Trade all colonies with').br;
-        b.trade().colon().text('+1');
-      }),
-      description: 'Gain 2 MC [SOLO: Gain 10 MC]. Immediately trade with all active colonies. You may increase the Colony Tile track 1 step before each of these trades.',
-    }
+
+    return undefined;
+  }
 }

--- a/src/cards/community/ValuableGases.ts
+++ b/src/cards/community/ValuableGases.ts
@@ -6,45 +6,49 @@ import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {ResourceType} from '../../ResourceType';
 import {SelectHowToPayForProjectCard} from '../../inputs/SelectHowToPayForProjectCard';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class ValuableGases extends PreludeCard implements IProjectCard {
-    public tags = [Tags.JOVIAN, Tags.VENUS];
-    public name = CardName.VALUABLE_GASES;
+  constructor() {
+    super({
+      name: CardName.VALUABLE_GASES,
+      tags: [Tags.JOVIAN, Tags.VENUS],
 
-    public play(player: Player, game: Game) {
-      player.megaCredits += 6;
+      metadata: {
+        cardNumber: 'Y06',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(6).br.br;
+          b.text('play', CardRenderItemSize.MEDIUM, true).cards(1).secondaryTag(Tags.VENUS).colon();
+          b.floaters(4).digit;
+        }),
+        description: 'Gain 6 MC. Play a Venus card from your hand and add 4 floaters to it.',
+      },
+    });
+  }
 
-      const playableCards = player.getPlayableCards(game).filter((card) => card.tags.indexOf(Tags.VENUS) !== -1);
+  public play(player: Player, game: Game) {
+    player.megaCredits += 6;
 
-      if (playableCards.length > 0) {
-        return new SelectHowToPayForProjectCard(
-          playableCards,
-          player.getMicrobesCanSpend(),
-          player.getFloatersCanSpend(),
-          player.canUseHeatAsMegaCredits,
-          (selectedCard, howToPay) => {
-            const result = player.checkHowToPayAndPlayCard(selectedCard, howToPay, game);
-            if (selectedCard.resourceType === ResourceType.FLOATER) {
-              player.addResourceTo(selectedCard, 4);
-            }
-            return result;
-          },
-        );
-      }
+    const playableCards = player.getPlayableCards(game).filter((card) => card.tags.indexOf(Tags.VENUS) !== -1);
 
-      return undefined;
+    if (playableCards.length > 0) {
+      return new SelectHowToPayForProjectCard(
+        playableCards,
+        player.getMicrobesCanSpend(),
+        player.getFloatersCanSpend(),
+        player.canUseHeatAsMegaCredits,
+        (selectedCard, howToPay) => {
+          const result = player.checkHowToPayAndPlayCard(selectedCard, howToPay, game);
+          if (selectedCard.resourceType === ResourceType.FLOATER) {
+            player.addResourceTo(selectedCard, 4);
+          }
+          return result;
+        },
+      );
     }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y06',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(6).br.br;
-        b.text('play', CardRenderItemSize.MEDIUM, true).cards(1).secondaryTag(Tags.VENUS).colon();
-        b.floaters(4).digit;
-      }),
-      description: 'Gain 6 MC. Play a Venus card from your hand and add 4 floaters to it.',
-    }
+
+    return undefined;
+  }
 }
 

--- a/src/cards/community/VenusFirst.ts
+++ b/src/cards/community/VenusFirst.ts
@@ -5,27 +5,31 @@ import {PreludeCard} from '../prelude/PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class VenusFirst extends PreludeCard implements IProjectCard {
-    public tags = [Tags.VENUS];
-    public name = CardName.VENUS_FIRST;
+  constructor() {
+    super({
+      name: CardName.VENUS_FIRST,
+      tags: [Tags.VENUS],
 
-    public play(player: Player, game: Game) {
-      game.increaseVenusScaleLevel(player, 2);
-      const cards = game.drawCardsByTag(Tags.VENUS, 2);
-      player.cardsInHand.push(...cards);
-      LogHelper.logDrawnCards(player, cards);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'Y07',
-      renderData: CardRenderer.builder((b) => {
-        b.venus(2).br.br;
-        b.cards(2).secondaryTag(Tags.VENUS);
-      }),
-      description: 'Raise Venus 2 steps. Draw 2 Venus cards from the deck.',
-    }
+      metadata: {
+        cardNumber: 'Y07',
+        renderData: CardRenderer.builder((b) => {
+          b.venus(2).br.br;
+          b.cards(2).secondaryTag(Tags.VENUS);
+        }),
+        description: 'Raise Venus 2 steps. Draw 2 Venus cards from the deck.',
+      },
+    });
+  }
+
+  public play(player: Player, game: Game) {
+    game.increaseVenusScaleLevel(player, 2);
+    const cards = game.drawCardsByTag(Tags.VENUS, 2);
+    player.cardsInHand.push(...cards);
+    LogHelper.logDrawnCards(player, cards);
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/AcquiredSpaceAgency.ts
+++ b/src/cards/prelude/AcquiredSpaceAgency.ts
@@ -4,24 +4,27 @@ import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class AcquiredSpaceAgency extends PreludeCard {
-    public tags = [];
-    public name = CardName.ACQUIRED_SPACE_AGENCY;
-    public play(player: Player, game: Game) {
-      game.defer(new DrawCards(player, game, 2, Tags.SPACE));
-      player.titanium += 6;
-      return undefined;
-    };
-    public metadata: CardMetadata = {
-      cardNumber: 'P35',
-      renderData: CardRenderer.builder((b) => {
-        b.titanium(6, false).br.br; // double break intentional
-        b.cards(2).secondaryTag(Tags.SPACE);
-      }),
-      description: 'Gain 6 titanium. Reveal cards until you reveal two cards with Space Tags. Take them into your hand, discard the rest.',
-    }
+  constructor() {
+    super({
+      name: CardName.ACQUIRED_SPACE_AGENCY,
+
+      metadata: {
+        cardNumber: 'P35',
+        renderData: CardRenderer.builder((b) => {
+          b.titanium(6, false).br.br; // double break intentional
+          b.cards(2).secondaryTag(Tags.SPACE);
+        }),
+        description: 'Gain 6 titanium. Reveal cards until you reveal two cards with Space Tags. Take them into your hand, discard the rest.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    game.defer(new DrawCards(player, game, 2, Tags.SPACE));
+    player.titanium += 6;
+    return undefined;
+  };
 }
 

--- a/src/cards/prelude/AlliedBanks.ts
+++ b/src/cards/prelude/AlliedBanks.ts
@@ -3,25 +3,28 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class AlliedBanks extends PreludeCard {
-    public tags = [Tags.EARTH];
-    public name = CardName.ALLIED_BANKS;
+  constructor() {
+    super({
+      name: CardName.ALLIED_BANKS,
+      tags: [Tags.EARTH],
 
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, 4);
-      player.megaCredits += 3;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P01',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(4)).br;
-        b.megacredits(3);
-      }),
-      description: 'Increase your MC production 4 steps. Gain 3 MC.',
-    }
+      metadata: {
+        cardNumber: 'P01',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(4)).br;
+          b.megacredits(3);
+        }),
+        description: 'Increase your MC production 4 steps. Gain 3 MC.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, 4);
+    player.megaCredits += 3;
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/AquiferTurbines.ts
+++ b/src/cards/prelude/AquiferTurbines.ts
@@ -6,28 +6,32 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class AquiferTurbines extends PreludeCard {
-    public tags = [Tags.ENERGY];
-    public name = CardName.AQUIFER_TURBINES;
-    public canPlay(player: Player, _game: Game) {
-      return player.canAfford(3);
-    }
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.ENERGY, 2);
-      game.defer(new PlaceOceanTile(player, game));
-      game.defer(new SelectHowToPayDeferred(player, 3));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P02',
-      renderData: CardRenderer.builder((b) => {
-        b.oceans(1).production((pb) => pb.energy(2)).br;
-        b.megacredits(-3);
-      }),
-      description: 'Place an Ocean. Increase your energy production 2 steps. Pay 3 MC.',
-    }
+  constructor() {
+    super({
+      name: CardName.AQUIFER_TURBINES,
+      tags: [Tags.ENERGY],
+
+      metadata: {
+        cardNumber: 'P02',
+        renderData: CardRenderer.builder((b) => {
+          b.oceans(1).production((pb) => pb.energy(2)).br;
+          b.megacredits(-3);
+        }),
+        description: 'Place an Ocean. Increase your energy production 2 steps. Pay 3 MC.',
+      },
+    });
+  }
+  public canPlay(player: Player, _game: Game) {
+    return player.canAfford(3);
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.ENERGY, 2);
+    game.defer(new PlaceOceanTile(player, game));
+    game.defer(new SelectHowToPayDeferred(player, 3));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/Biofuels.ts
+++ b/src/cards/prelude/Biofuels.ts
@@ -3,25 +3,29 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Biofuels extends PreludeCard {
-    public tags = [Tags.MICROBE];
-    public name = CardName.BIOFUELS;
-    public play(player: Player) {
-      player.addProduction(Resources.ENERGY);
-      player.addProduction(Resources.PLANTS);
-      player.plants += 2;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P03',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.energy(1).plants(1)).br;
-        b.plants(2);
-      }),
-      description: 'Increase your energy and plant production 1 step. Gain 2 plants.',
-    }
+  constructor() {
+    super({
+      name: CardName.BIOFUELS,
+      tags: [Tags.MICROBE],
+
+      metadata: {
+        cardNumber: 'P03',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.energy(1).plants(1)).br;
+          b.plants(2);
+        }),
+        description: 'Increase your energy and plant production 1 step. Gain 2 plants.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.ENERGY);
+    player.addProduction(Resources.PLANTS);
+    player.plants += 2;
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/Biolab.ts
+++ b/src/cards/prelude/Biolab.ts
@@ -5,24 +5,28 @@ import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Biolab extends PreludeCard {
-    public tags = [Tags.SCIENCE];
-    public name = CardName.BIOLAB;
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.PLANTS);
-      game.defer(new DrawCards(player, game, 3));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P04',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.plants(1)).br;
-        b.cards(3);
-      }),
-      description: 'Increase your plant production 1 step. Draw 3 cards.',
-    }
+  constructor() {
+    super({
+      name: CardName.BIOLAB,
+      tags: [Tags.SCIENCE],
+
+      metadata: {
+        cardNumber: 'P04',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.plants(1)).br;
+          b.cards(3);
+        }),
+        description: 'Increase your plant production 1 step. Draw 3 cards.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.PLANTS);
+    game.defer(new DrawCards(player, game, 3));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/BiosphereSupport.ts
+++ b/src/cards/prelude/BiosphereSupport.ts
@@ -3,30 +3,33 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class BiosphereSupport extends PreludeCard {
-    public tags = [Tags.PLANT];
-    public name = CardName.BIOSPHERE_SUPPORT;
-    public hasRequirements = false;
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.MEGACREDITS) >= -4;
-    }
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, -1);
-      player.addProduction(Resources.PLANTS, 2);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P05',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.minus().megacredits(1).br;
-          pb.plants(2);
-        });
-      }),
-      description: 'Increase your plant production 2 steps. Decrease your MC production 1 step.',
-    }
+  constructor() {
+    super({
+      name: CardName.BIOSPHERE_SUPPORT,
+      tags: [Tags.PLANT],
+
+      metadata: {
+        cardNumber: 'P05',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.minus().megacredits(1).br;
+            pb.plants(2);
+          });
+        }),
+        description: 'Increase your plant production 2 steps. Decrease your MC production 1 step.',
+      },
+    });
+  }
+  public canPlay(player: Player): boolean {
+    return player.getProduction(Resources.MEGACREDITS) >= -4;
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, -1);
+    player.addProduction(Resources.PLANTS, 2);
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/BusinessEmpire.ts
+++ b/src/cards/prelude/BusinessEmpire.ts
@@ -5,28 +5,32 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class BusinessEmpire extends PreludeCard {
-    public tags = [Tags.EARTH];
-    public name = CardName.BUSINESS_EMPIRE;
-    public canPlay(player: Player, _game: Game) {
-      if (player.isCorporation(CardName.MANUTECH)) return true;
-      return player.canAfford(6);
-    }
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.MEGACREDITS, 6);
-      game.defer(new SelectHowToPayDeferred(player, 6));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P06',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(6)).br;
-        b.megacredits(-6);
-      }),
-      description: 'Increase your MC production 6 steps. Pay 6 MC.',
-    }
+  constructor() {
+    super({
+      name: CardName.BUSINESS_EMPIRE,
+      tags: [Tags.EARTH],
+
+      metadata: {
+        cardNumber: 'P06',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(6)).br;
+          b.megacredits(-6);
+        }),
+        description: 'Increase your MC production 6 steps. Pay 6 MC.',
+      },
+    });
+  }
+  public canPlay(player: Player, _game: Game) {
+    if (player.isCorporation(CardName.MANUTECH)) return true;
+    return player.canAfford(6);
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.MEGACREDITS, 6);
+    game.defer(new SelectHowToPayDeferred(player, 6));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/CheungShingMARS.ts
+++ b/src/cards/prelude/CheungShingMARS.ts
@@ -4,37 +4,41 @@ import {CorporationCard} from './../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {Game} from '../../Game';
 import {Resources} from '../../Resources';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class CheungShingMARS implements CorporationCard {
-    public name = CardName.CHEUNG_SHING_MARS;
-    public tags = [Tags.BUILDING];
-    public startingMegaCredits: number = 44;
-    public cardType = CardType.CORPORATION;
+export class CheungShingMARS extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.CHEUNG_SHING_MARS,
+      tags: [Tags.BUILDING],
+      startingMegaCredits: 44,
 
-    public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-      return card.tags.filter((tag) => tag === Tags.BUILDING).length * 2;
-    }
-
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, 3);
-      return undefined;
-    }
-
-    public metadata: CardMetadata = {
-      cardNumber: 'R16',
-      description: 'You start with 3 MC production and 44 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.production((pb) => pb.megacredits(3)).nbsp.megacredits(44);
-        b.corpBox('effect', (ce) => {
-          ce.effect('When you play a building tag, you pay 2 MC less for it.', (eb) => {
-            eb.building().played.startEffect.megacredits(-2);
+      metadata: {
+        cardNumber: 'R16',
+        description: 'You start with 3 MC production and 44 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.production((pb) => pb.megacredits(3)).nbsp.megacredits(44);
+          b.corpBox('effect', (ce) => {
+            ce.effect('When you play a building tag, you pay 2 MC less for it.', (eb) => {
+              eb.building().played.startEffect.megacredits(-2);
+            });
           });
-        });
-      }),
-    }
+        }),
+      },
+    });
+  }
+
+  public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
+    return card.tags.filter((tag) => tag === Tags.BUILDING).length * 2;
+  }
+
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, 3);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/DomeFarming.ts
+++ b/src/cards/prelude/DomeFarming.ts
@@ -3,23 +3,27 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class DomeFarming extends PreludeCard {
-    public tags = [Tags.PLANT, Tags.BUILDING];
-    public name = CardName.DOME_FARMING;
-    public play(player: Player) {
-      player.addProduction(Resources.PLANTS);
-      player.addProduction(Resources.MEGACREDITS, 2);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P07',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(2).plants(1));
-      }),
-      description: 'Increase your MC production 2 steps and plant production 1 step.',
-    }
+  constructor() {
+    super({
+      name: CardName.DOME_FARMING,
+      tags: [Tags.PLANT, Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P07',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(2).plants(1));
+        }),
+        description: 'Increase your MC production 2 steps and plant production 1 step.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.PLANTS);
+    player.addProduction(Resources.MEGACREDITS, 2);
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/Donation.ts
+++ b/src/cards/prelude/Donation.ts
@@ -1,23 +1,25 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Donation extends PreludeCard {
-    public tags = [];
-    public name = CardName.DONATION;
+  constructor() {
+    super({
+      name: CardName.DONATION,
 
-    public play(player: Player) {
-      player.megaCredits += 21;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P08',
-      renderData: CardRenderer.builder((b) => {
-        b.megacredits(21);
-      }),
-      description: 'Gain 21 MC.',
-    }
+      metadata: {
+        cardNumber: 'P08',
+        renderData: CardRenderer.builder((b) => {
+          b.megacredits(21);
+        }),
+        description: 'Gain 21 MC.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.megaCredits += 21;
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/EarlySettlement.ts
+++ b/src/cards/prelude/EarlySettlement.ts
@@ -5,23 +5,27 @@ import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class EarlySettlement extends PreludeCard {
-    public tags = [Tags.BUILDING, Tags.CITY];
-    public name = CardName.EARLY_SETTLEMENT;
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.PLANTS);
-      game.defer(new PlaceCityTile(player, game));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P09',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.plants(1)).city();
-      }),
-      description: 'Increase your plant production 1 step. Place a city tile.',
-    }
+  constructor() {
+    super({
+      name: CardName.EARLY_SETTLEMENT,
+      tags: [Tags.BUILDING, Tags.CITY],
+
+      metadata: {
+        cardNumber: 'P09',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.plants(1)).city();
+        }),
+        description: 'Increase your plant production 1 step. Place a city tile.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.PLANTS);
+    game.defer(new PlaceCityTile(player, game));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/EccentricSponsor.ts
+++ b/src/cards/prelude/EccentricSponsor.ts
@@ -3,29 +3,31 @@ import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {PreludeCard} from './PreludeCard';
 import {PlayProjectCard} from '../../deferredActions/PlayProjectCard';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class EccentricSponsor extends PreludeCard {
-    public tags = [];
-    public name = CardName.ECCENTRIC_SPONSOR;
+  constructor() {
+    super({
+      name: CardName.ECCENTRIC_SPONSOR,
 
-    public getCardDiscount(player: Player, _game: Game) {
-      if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
-        return 25;
-      }
-      return 0;
+      metadata: {
+        cardNumber: 'P11',
+        renderData: CardRenderer.builder((b) => {
+          b.text('Play a card from hand, reducing its cost by 25 MC', CardRenderItemSize.SMALL, true);
+        }),
+      },
+    });
+  }
+  public getCardDiscount(player: Player, _game: Game) {
+    if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
+      return 25;
     }
+    return 0;
+  }
 
-    public play(player: Player, game: Game) {
-      game.defer(new PlayProjectCard(player, game));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P11',
-      renderData: CardRenderer.builder((b) => {
-        b.text('Play a card from hand, reducing its cost by 25 MC', CardRenderItemSize.SMALL, true);
-      }),
-    }
+  public play(player: Player, game: Game) {
+    game.defer(new PlayProjectCard(player, game));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/EcologyExperts.ts
+++ b/src/cards/prelude/EcologyExperts.ts
@@ -5,30 +5,34 @@ import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {Game} from '../../Game';
 import {PlayProjectCard} from '../../deferredActions/PlayProjectCard';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class EcologyExperts extends PreludeCard {
-    public tags = [Tags.PLANT, Tags.MICROBE];
-    public name = CardName.ECOLOGY_EXPERTS;
-    public getRequirementBonus(player: Player): number {
-      if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
-        // Magic number high enough to always ignore requirements.
-        return 50;
-      }
-      return 0;
+  constructor() {
+    super({
+      name: CardName.ECOLOGY_EXPERTS,
+      tags: [Tags.PLANT, Tags.MICROBE],
+
+      metadata: {
+        cardNumber: 'P10',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.plants(1)).br.br;
+          b.projectRequirements();
+        }),
+        description: 'Increase your plant production 1 step. Play a card from hand, ignoring global requirements.',
+      },
+    });
+  }
+  public getRequirementBonus(player: Player): number {
+    if (player.lastCardPlayed !== undefined && player.lastCardPlayed.name === this.name) {
+      // Magic number high enough to always ignore requirements.
+      return 50;
     }
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.PLANTS);
-      game.defer(new PlayProjectCard(player, game));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P10',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.plants(1)).br.br;
-        b.projectRequirements();
-      }),
-      description: 'Increase your plant production 1 step. Play a card from hand, ignoring global requirements.',
-    }
+    return 0;
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.PLANTS);
+    game.defer(new PlayProjectCard(player, game));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/ExperimentalForest.ts
+++ b/src/cards/prelude/ExperimentalForest.ts
@@ -5,25 +5,28 @@ import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
 import {PlaceGreeneryTile} from '../../deferredActions/PlaceGreeneryTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class ExperimentalForest extends PreludeCard {
-    public tags = [Tags.PLANT];
-    public name = CardName.EXPERIMENTAL_FOREST
+  constructor() {
+    super({
+      name: CardName.EXPERIMENTAL_FOREST,
+      tags: [Tags.PLANT],
 
-    public play(player: Player, game: Game) {
-      game.defer(new DrawCards(player, game, 2, Tags.PLANT));
-      game.defer(new PlaceGreeneryTile(player, game));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P12',
-      renderData: CardRenderer.builder((b) => {
-        b.greenery().secondaryTag(AltSecondaryTag.OXYGEN).cards(2).secondaryTag(Tags.PLANT);
-      }),
-      description: 'Place 1 Greenery Tile. Reveal cards until you reveal two cards with plant tags on them. Take them into your hand and discard the rest.',
-    }
+      metadata: {
+        cardNumber: 'P12',
+        renderData: CardRenderer.builder((b) => {
+          b.greenery().secondaryTag(AltSecondaryTag.OXYGEN).cards(2).secondaryTag(Tags.PLANT);
+        }),
+        description: 'Place 1 Greenery Tile. Reveal cards until you reveal two cards with plant tags on them. Take them into your hand and discard the rest.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    game.defer(new DrawCards(player, game, 2, Tags.PLANT));
+    game.defer(new PlaceGreeneryTile(player, game));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/GalileanMining.ts
+++ b/src/cards/prelude/GalileanMining.ts
@@ -5,28 +5,32 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
-import {CardMetadata} from '../../cards/CardMetadata';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
 export class GalileanMining extends PreludeCard {
-    public tags = [Tags.JOVIAN];
-    public name = CardName.GALILEAN_MINING;
-    public canPlay(player: Player, _game: Game) {
-      return player.canAfford(5);
-    }
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.TITANIUM, 2);
-      game.defer(new SelectHowToPayDeferred(player, 5));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P13',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.titanium(2);
-        }).br;
-        b.megacredits(-5);
-      }),
-      description: 'Increase your titanium production 2 steps. Pay 5 MC.',
-    }
+  constructor() {
+    super({
+      name: CardName.GALILEAN_MINING,
+      tags: [Tags.JOVIAN],
+
+      metadata: {
+        cardNumber: 'P13',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.titanium(2);
+          }).br;
+          b.megacredits(-5);
+        }),
+        description: 'Increase your titanium production 2 steps. Pay 5 MC.',
+      },
+    });
+  }
+  public canPlay(player: Player, _game: Game) {
+    return player.canAfford(5);
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.TITANIUM, 2);
+    game.defer(new SelectHowToPayDeferred(player, 5));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/GreatAquifer.ts
+++ b/src/cards/prelude/GreatAquifer.ts
@@ -3,24 +3,26 @@ import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class GreatAquifer extends PreludeCard {
-    public tags = [];
-    public name = CardName.GREAT_AQUIFER;
+  constructor() {
+    super({
+      name: CardName.GREAT_AQUIFER,
 
-    public play(player: Player, game: Game) {
-      game.defer(new PlaceOceanTile(player, game, 'Select space for first ocean'));
-      game.defer(new PlaceOceanTile(player, game, 'Select space for second ocean'));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P13',
-      renderData: CardRenderer.builder((b) => {
-        b.oceans(2);
-      }),
-      description: 'Place 2 Ocean tiles.',
-    }
+      metadata: {
+        cardNumber: 'P13',
+        renderData: CardRenderer.builder((b) => {
+          b.oceans(2);
+        }),
+        description: 'Place 2 Ocean tiles.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    game.defer(new PlaceOceanTile(player, game, 'Select space for first ocean'));
+    game.defer(new PlaceOceanTile(player, game, 'Select space for second ocean'));
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/HousePrinting.ts
+++ b/src/cards/prelude/HousePrinting.ts
@@ -2,29 +2,33 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class HousePrinting {
-    public cost = 10;
-    public tags = [Tags.BUILDING];
-    public name = CardName.HOUSE_PRINTING;
-    public cardType = CardType.AUTOMATED;
+export class HousePrinting extends Card {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.HOUSE_PRINTING,
+      tags: [Tags.BUILDING],
+      cost: 10,
 
-    public play(player: Player) {
-      player.addProduction(Resources.STEEL);
-      return undefined;
-    }
-    public getVictoryPoints() {
-      return 1;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P36',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.steel(1));
-      }),
-      description: 'Increase your steel production 1 step.',
-      victoryPoints: 1,
-    };
+      metadata: {
+        cardNumber: 'P36',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.steel(1));
+        }),
+        description: 'Increase your steel production 1 step.',
+        victoryPoints: 1,
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.STEEL);
+    return undefined;
+  }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/prelude/HugeAsteroid.ts
+++ b/src/cards/prelude/HugeAsteroid.ts
@@ -3,26 +3,29 @@ import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class HugeAsteroid extends PreludeCard {
-    public tags = [];
-    public name = CardName.HUGE_ASTEROID;
-    public canPlay(player: Player, _game: Game) {
-      return player.canAfford(5);
-    }
-    public play(player: Player, game: Game) {
-      game.increaseTemperature(player, 3);
-      game.defer(new SelectHowToPayDeferred(player, 5));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P15',
-      renderData: CardRenderer.builder((b) => {
-        b.temperature(3).br;
-        b.megacredits(-5);
-      }),
-      description: 'Increase Temperature 3 steps. Pay 5 MC.',
-    }
+  constructor() {
+    super({
+      name: CardName.HUGE_ASTEROID,
+
+      metadata: {
+        cardNumber: 'P15',
+        renderData: CardRenderer.builder((b) => {
+          b.temperature(3).br;
+          b.megacredits(-5);
+        }),
+        description: 'Increase Temperature 3 steps. Pay 5 MC.',
+      },
+    });
+  }
+  public canPlay(player: Player, _game: Game) {
+    return player.canAfford(5);
+  }
+  public play(player: Player, game: Game) {
+    game.increaseTemperature(player, 3);
+    game.defer(new SelectHowToPayDeferred(player, 5));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/IoResearchOutpost.ts
+++ b/src/cards/prelude/IoResearchOutpost.ts
@@ -5,23 +5,27 @@ import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class IoResearchOutpost extends PreludeCard {
-    public tags = [Tags.JOVIAN, Tags.SCIENCE];
-    public name = CardName.IO_RESEARCH_OUTPOST;
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.TITANIUM);
-      game.defer(new DrawCards(player, game, 1));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P16',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.titanium(1)).br;
-        b.cards(1);
-      }),
-      description: 'Increase your titanium production 1 step. Draw a card.',
-    }
+  constructor() {
+    super({
+      name: CardName.IO_RESEARCH_OUTPOST,
+      tags: [Tags.JOVIAN, Tags.SCIENCE],
+
+      metadata: {
+        cardNumber: 'P16',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.titanium(1)).br;
+          b.cards(1);
+        }),
+        description: 'Increase your titanium production 1 step. Draw a card.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.TITANIUM);
+    game.defer(new DrawCards(player, game, 1));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/LavaTubeSettlement.ts
+++ b/src/cards/prelude/LavaTubeSettlement.ts
@@ -1,5 +1,6 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
+import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
@@ -8,50 +9,53 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {BoardName} from '../../boards/BoardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class LavaTubeSettlement implements IProjectCard {
-    public cost = 15;
-    public tags = [Tags.BUILDING, Tags.CITY];
-    public name = CardName.LAVA_TUBE_SETTLEMENT;
-    public cardType = CardType.AUTOMATED;
-    public hasRequirements = false;
+export class LavaTubeSettlement extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.LAVA_TUBE_SETTLEMENT,
+      tags: [Tags.BUILDING, Tags.CITY],
+      cost: 15,
+      hasRequirements: false,
 
-    private getSpacesForCity(player: Player, game: Game) {
-      if (game.gameOptions.boardName === BoardName.HELLAS) {
-        // https://boardgamegeek.com/thread/1953628/article/29627211#29627211
-        return game.board.getAvailableSpacesForCity(player);
-      }
+      metadata: {
+        cardNumber: 'P37',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.minus().energy(1).br;
+            pb.plus().megacredits(2);
+          }).br;
+          b.city().asterix();
+        }),
+        description: 'Decrease your Energy production 1 step and increase your MC production 2 steps. Place a City Tile on a VOLCANIC AREA regardless of adjacent cities.',
+      },
+    });
+  }
 
-      return LavaFlows.getVolcanicSpaces(player, game);
+  private getSpacesForCity(player: Player, game: Game) {
+    if (game.gameOptions.boardName === BoardName.HELLAS) {
+      // https://boardgamegeek.com/thread/1953628/article/29627211#29627211
+      return game.board.getAvailableSpacesForCity(player);
     }
 
-    public canPlay(player: Player, game: Game): boolean {
-      return this.getSpacesForCity(player, game).length > 0 && player.getProduction(Resources.ENERGY) >= 1;
-    }
+    return LavaFlows.getVolcanicSpaces(player, game);
+  }
 
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.MEGACREDITS, 2);
-      player.addProduction(Resources.ENERGY, -1);
-      game.defer(new PlaceCityTile(
-        player,
-        game,
-        'Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons',
-        this.getSpacesForCity(player, game),
-      ));
-      return undefined;
-    }
+  public canPlay(player: Player, game: Game): boolean {
+    return this.getSpacesForCity(player, game).length > 0 && player.getProduction(Resources.ENERGY) >= 1;
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'P37',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.minus().energy(1).br;
-          pb.plus().megacredits(2);
-        }).br;
-        b.city().asterix();
-      }),
-      description: 'Decrease your Energy production 1 step and increase your MC production 2 steps. Place a City Tile on a VOLCANIC AREA regardless of adjacent cities.',
-    }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.MEGACREDITS, 2);
+    player.addProduction(Resources.ENERGY, -1);
+    game.defer(new PlaceCityTile(
+      player,
+      game,
+      'Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons',
+      this.getSpacesForCity(player, game),
+    ));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/Loan.ts
+++ b/src/cards/prelude/Loan.ts
@@ -3,28 +3,30 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Loan extends PreludeCard implements IProjectCard {
-    public tags = [];
-    public name = CardName.LOAN;
+  constructor() {
+    super({
+      name: CardName.LOAN,
 
-    public canPlay(player: Player): boolean {
-      return player.getProduction(Resources.MEGACREDITS) >= -3;
-    }
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, -2);
-      player.megaCredits += 30;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P17',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.minus().megacredits(2)).br;
-        b.megacredits(30);
-      }),
-      description: 'Gain 30 MC. Decrease your MC production 2 steps.',
-    }
+      metadata: {
+        cardNumber: 'P17',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.minus().megacredits(2)).br;
+          b.megacredits(30);
+        }),
+        description: 'Gain 30 MC. Decrease your MC production 2 steps.',
+      },
+    });
+  }
+  public canPlay(player: Player): boolean {
+    return player.getProduction(Resources.MEGACREDITS) >= -3;
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, -2);
+    player.megaCredits += 30;
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/MartianIndustries.ts
+++ b/src/cards/prelude/MartianIndustries.ts
@@ -4,26 +4,29 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MartianIndustries extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.MARTIAN_INDUSTRIES;
+  constructor() {
+    super({
+      name: CardName.MARTIAN_INDUSTRIES,
+      tags: [Tags.BUILDING],
 
-    public play(player: Player) {
-      player.addProduction(Resources.ENERGY);
-      player.addProduction(Resources.STEEL);
-      player.megaCredits += 6;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P18',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.energy(1).steel(1)).br;
-        b.megacredits(6);
-      }),
-      description: 'Increase your energy and steel production 1 step. Gain 6 MC.',
-    }
+      metadata: {
+        cardNumber: 'P18',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.energy(1).steel(1)).br;
+          b.megacredits(6);
+        }),
+        description: 'Increase your energy and steel production 1 step. Gain 6 MC.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.ENERGY);
+    player.addProduction(Resources.STEEL);
+    player.megaCredits += 6;
+    return undefined;
+  }
 }
 

--- a/src/cards/prelude/MartianSurvey.ts
+++ b/src/cards/prelude/MartianSurvey.ts
@@ -3,39 +3,42 @@ import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {GlobalParameter} from '../../GlobalParameter';
 
-export class MartianSurvey implements IProjectCard {
-    public cost = 9;
-    public tags = [Tags.SCIENCE];
-    public name = CardName.MARTIAN_SURVEY;
-    public cardType = CardType.EVENT;
+export class MartianSurvey extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.EVENT,
+      name: CardName.MARTIAN_SURVEY,
+      tags: [Tags.SCIENCE],
+      cost: 9,
 
-    public canPlay(player: Player, game: Game): boolean {
-      return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 4);
-    }
+      metadata: {
+        cardNumber: 'P38',
+        requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
+        renderData: CardRenderer.builder((b) => {
+          b.cards(2);
+        }),
+        description: 'Oxygen must be 4% or lower. Draw two cards.',
+        victoryPoints: 1,
+      },
+    });
+  }
+  public canPlay(player: Player, game: Game): boolean {
+    return game.checkMaxRequirements(player, GlobalParameter.OXYGEN, 4);
+  }
 
-    public play(player: Player, game: Game) {
-      game.defer(new DrawCards(player, game, 2));
-      return undefined;
-    }
+  public play(player: Player, game: Game) {
+    game.defer(new DrawCards(player, game, 2));
+    return undefined;
+  }
 
-    public getVictoryPoints() {
-      return 1;
-    }
-
-    public metadata: CardMetadata = {
-      cardNumber: 'P38',
-      requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
-      renderData: CardRenderer.builder((b) => {
-        b.cards(2);
-      }),
-      description: 'Oxygen must be 4% or lower. Draw two cards.',
-      victoryPoints: 1,
-    }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/prelude/MetalRichAsteroid.ts
+++ b/src/cards/prelude/MetalRichAsteroid.ts
@@ -3,24 +3,26 @@ import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MetalRichAsteroid extends PreludeCard implements IProjectCard {
-    public tags = [];
-    public name = CardName.METAL_RICH_ASTEROID;
-    public play(player: Player, game: Game) {
-      player.titanium += 4;
-      player.steel += 4;
-      return game.increaseTemperature(player, 1);
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P19',
-      renderData: CardRenderer.builder((b) => {
-        b.temperature(1).titanium(4).br;
-        b.steel(4);
-      }),
-      description: 'Increase temperature 1 step. Gain 4 titanium and 4 steel.',
-    }
+  constructor() {
+    super({
+      name: CardName.METAL_RICH_ASTEROID,
+      metadata: {
+        cardNumber: 'P19',
+        renderData: CardRenderer.builder((b) => {
+          b.temperature(1).titanium(4).br;
+          b.steel(4);
+        }),
+        description: 'Increase temperature 1 step. Gain 4 titanium and 4 steel.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.titanium += 4;
+    player.steel += 4;
+    return game.increaseTemperature(player, 1);
+  }
 }
 

--- a/src/cards/prelude/MetalsCompany.ts
+++ b/src/cards/prelude/MetalsCompany.ts
@@ -3,23 +3,26 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MetalsCompany extends PreludeCard implements IProjectCard {
-    public tags = [];
-    public name = CardName.METALS_COMPANY;
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS);
-      player.addProduction(Resources.TITANIUM);
-      player.addProduction(Resources.STEEL);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P20',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(1).steel(1).titanium(1));
-      }),
-      description: 'Increase your MC, steel and titanium production 1 step.',
-    }
+  constructor() {
+    super({
+      name: CardName.METALS_COMPANY,
+
+      metadata: {
+        cardNumber: 'P20',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(1).steel(1).titanium(1));
+        }),
+        description: 'Increase your MC, steel and titanium production 1 step.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS);
+    player.addProduction(Resources.TITANIUM);
+    player.addProduction(Resources.STEEL);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/MiningOperations.ts
+++ b/src/cards/prelude/MiningOperations.ts
@@ -4,23 +4,27 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MiningOperations extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.MINING_OPERATIONS;
-    public play(player: Player) {
-      player.addProduction(Resources.STEEL, 2);
-      player.steel += 4;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P21',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.steel(2)).br;
-        b.steel(4);
-      }),
-      description: 'Increase your steel production 2 steps. Gain 4 steel.',
-    }
+  constructor() {
+    super({
+      name: CardName.MINING_OPERATIONS,
+      tags: [Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P21',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.steel(2)).br;
+          b.steel(4);
+        }),
+        description: 'Increase your steel production 2 steps. Gain 4 steel.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.STEEL, 2);
+    player.steel += 4;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/Mohole.ts
+++ b/src/cards/prelude/Mohole.ts
@@ -4,23 +4,27 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Mohole extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.MOHOLE;
-    public play(player: Player) {
-      player.addProduction(Resources.HEAT, 3);
-      player.heat += 3;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P22',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.heat(3)).br;
-        b.heat(3);
-      }),
-      description: 'Increase your heat production 3 steps. Gain 3 heat.',
-    }
+  constructor() {
+    super({
+      name: CardName.MOHOLE,
+      tags: [Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P22',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.heat(3)).br;
+          b.heat(3);
+        }),
+        description: 'Increase your heat production 3 steps. Gain 3 heat.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.HEAT, 3);
+    player.heat += 3;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/MoholeExcavation.ts
+++ b/src/cards/prelude/MoholeExcavation.ts
@@ -4,26 +4,30 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MoholeExcavation extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.MOHOLE_EXCAVATION;
-    public play(player: Player) {
-      player.addProduction(Resources.STEEL);
-      player.addProduction(Resources.HEAT, 2);
-      player.heat += 2;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P23',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.steel(1).br;
-          pb.heat(2);
-        }).heat(2);
-      }),
-      description: 'Increase your steel production 1 step and heat production 2 steps. Gain 2 heat.',
-    }
+  constructor() {
+    super({
+      name: CardName.MOHOLE_EXCAVATION,
+      tags: [Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P23',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.steel(1).br;
+            pb.heat(2);
+          }).heat(2);
+        }),
+        description: 'Increase your steel production 1 step and heat production 2 steps. Gain 2 heat.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.STEEL);
+    player.addProduction(Resources.HEAT, 2);
+    player.heat += 2;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/NitrogenDelivery.ts
+++ b/src/cards/prelude/NitrogenDelivery.ts
@@ -4,25 +4,27 @@ import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Game} from '../../Game';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class NitrogenDelivery extends PreludeCard implements IProjectCard {
-    public tags = [];
-    public name = CardName.NITROGEN_SHIPMENT;
+  constructor() {
+    super({
+      name: CardName.NITROGEN_SHIPMENT,
 
-    public play(player: Player, game: Game) {
-      player.megaCredits += 5;
-      player.increaseTerraformRating(game);
-      player.addProduction(Resources.PLANTS);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P24',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.plants(1)).tr(1).br;
-        b.megacredits(5);
-      }),
-      description: 'Increase your plant production 1 step. Increase your TR 1 step. Gain 5 MC.',
-    }
+      metadata: {
+        cardNumber: 'P24',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.plants(1)).tr(1).br;
+          b.megacredits(5);
+        }),
+        description: 'Increase your plant production 1 step. Increase your TR 1 step. Gain 5 MC.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.megaCredits += 5;
+    player.increaseTerraformRating(game);
+    player.addProduction(Resources.PLANTS);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/OrbitalConstructionYard.ts
+++ b/src/cards/prelude/OrbitalConstructionYard.ts
@@ -4,23 +4,27 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class OrbitalConstructionYard extends PreludeCard implements IProjectCard {
-    public tags = [Tags.SPACE];
-    public name = CardName.ORBITAL_CONSTRUCTION_YARD;
-    public play(player: Player) {
-      player.addProduction(Resources.TITANIUM);
-      player.titanium += 4;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P25',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.titanium(1)).br;
-        b.titanium(4);
-      }),
-      description: 'Increase your titanium production 1 step. Gain 4 titanium.',
-    }
+  constructor() {
+    super({
+      name: CardName.ORBITAL_CONSTRUCTION_YARD,
+      tags: [Tags.SPACE],
+
+      metadata: {
+        cardNumber: 'P25',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.titanium(1)).br;
+          b.titanium(4);
+        }),
+        description: 'Increase your titanium production 1 step. Gain 4 titanium.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.TITANIUM);
+    player.titanium += 4;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/PointLuna.ts
+++ b/src/cards/prelude/PointLuna.ts
@@ -4,38 +4,43 @@ import {CorporationCard} from './../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {Game} from '../../Game';
 import {Resources} from '../../Resources';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class PointLuna implements CorporationCard {
-    public name = CardName.POINT_LUNA;
-    public tags = [Tags.SPACE, Tags.EARTH];
-    public startingMegaCredits: number = 38;
-    public cardType = CardType.CORPORATION;
-    public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
-      const tagCount = card.tags.filter((tag) => tag === Tags.EARTH).length;
-      if (player.isCorporation(this.name) && card.tags.indexOf(Tags.EARTH) !== -1) {
-        player.drawCard(game, tagCount);
-      }
-    }
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.TITANIUM);
-      player.drawCard(game);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'R10',
-      description: 'You start with 1 titanium production and 38 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br;
-        b.production((pb) => pb.titanium(1)).nbsp.megacredits(38);
-        b.corpBox('effect', (ce) => {
-          ce.effect('When you play an Earth tag, including this, draw a card.', (eb) => {
-            eb.earth().played.startEffect.cards(1);
+export class PointLuna extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.POINT_LUNA,
+      tags: [Tags.SPACE, Tags.EARTH],
+      startingMegaCredits: 38,
+
+      metadata: {
+        cardNumber: 'R10',
+        description: 'You start with 1 titanium production and 38 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br;
+          b.production((pb) => pb.titanium(1)).nbsp.megacredits(38);
+          b.corpBox('effect', (ce) => {
+            ce.effect('When you play an Earth tag, including this, draw a card.', (eb) => {
+              eb.earth().played.startEffect.cards(1);
+            });
           });
-        });
-      }),
+        }),
+      },
+    });
+  }
+  public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
+    const tagCount = card.tags.filter((tag) => tag === Tags.EARTH).length;
+    if (player.isCorporation(this.name) && card.tags.indexOf(Tags.EARTH) !== -1) {
+      player.drawCard(game, tagCount);
     }
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.TITANIUM);
+    player.drawCard(game);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/PolarIndustries.ts
+++ b/src/cards/prelude/PolarIndustries.ts
@@ -6,23 +6,27 @@ import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class PolarIndustries extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.POLAR_INDUSTRIES;
-    public play(player: Player, game: Game) {
-      game.defer(new PlaceOceanTile(player, game));
-      player.addProduction(Resources.HEAT, 2);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P26',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.heat(2)).br;
-        b.oceans(1);
-      }),
-      description: 'Increase your heat production 2 steps. Place an Ocean tile.',
-    }
+  constructor() {
+    super({
+      name: CardName.POLAR_INDUSTRIES,
+      tags: [Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P26',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.heat(2)).br;
+          b.oceans(1);
+        }),
+        description: 'Increase your heat production 2 steps. Place an Ocean tile.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    game.defer(new PlaceOceanTile(player, game));
+    player.addProduction(Resources.HEAT, 2);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/PowerGeneration.ts
+++ b/src/cards/prelude/PowerGeneration.ts
@@ -4,21 +4,25 @@ import {PreludeCard} from './PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class PowerGeneration extends PreludeCard implements IProjectCard {
-    public tags = [Tags.ENERGY];
-    public name = CardName.POWER_GENERATION;
-    public play(player: Player) {
-      player.addProduction(Resources.ENERGY, 3);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P27',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.energy(3));
-      }),
-      description: 'Increase your energy production 3 steps.',
-    }
+  constructor() {
+    super({
+      name: CardName.POWER_GENERATION,
+      tags: [Tags.ENERGY],
+
+      metadata: {
+        cardNumber: 'P27',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.energy(3));
+        }),
+        description: 'Increase your energy production 3 steps.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.ENERGY, 3);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -1,3 +1,4 @@
+import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
@@ -7,15 +8,24 @@ import {CardName} from '../../CardName';
 import {Tags} from '../Tags';
 import {IProjectCard} from '../IProjectCard';
 
-export abstract class PreludeCard implements IProjectCard {
-    public cost = 0;
-    public cardType = CardType.PRELUDE;
-    public abstract metadata: CardMetadata;
-    public abstract name: CardName;
-    public abstract tags: Array<Tags>;
-    public abstract play(player: Player, game: Game): PlayerInput | undefined;
-    public hasRequirements = false;
-    public canPlay(_player: Player, _game: Game): boolean {
-      return true;
-    }
+interface StaticPreludeProperties {
+    metadata: CardMetadata;
+    name: CardName;
+    tags?: Array<Tags>;
+}
+
+export abstract class PreludeCard extends Card implements IProjectCard {
+  constructor(properties: StaticPreludeProperties) {
+    super({
+      cardType: CardType.PRELUDE,
+      name: properties.name,
+      tags: properties.tags,
+      hasRequirements: false,
+      metadata: properties.metadata,
+    });
+  }
+  public abstract play(player: Player, game: Game): PlayerInput | undefined;
+  public canPlay(_player: Player, _game: Game): boolean {
+    return true;
+  }
 }

--- a/src/cards/prelude/Psychrophiles.ts
+++ b/src/cards/prelude/Psychrophiles.ts
@@ -1,23 +1,41 @@
 import {IActionCard, IResourceCard} from '../ICard';
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
+import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {ResourceType} from '../../ResourceType';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {GlobalParameter} from '../../GlobalParameter';
 
-export class Psychrophiles implements IActionCard, IProjectCard, IResourceCard {
-    public cost = 2;
-    public resourceType = ResourceType.MICROBE;
-    public resourceCount: number = 0;
-    public tags = [Tags.MICROBE];
-    public name = CardName.PSYCHROPHILES;
-    public cardType = CardType.ACTIVE;
+export class Psychrophiles extends Card implements IActionCard, IProjectCard, IResourceCard {
+  constructor() {
+    super({
+      cardType: CardType.ACTIVE,
+      name: CardName.PSYCHROPHILES,
+      tags: [Tags.MICROBE],
+      cost: 2,
+      resourceType: ResourceType.MICROBE,
+
+      metadata: {
+        cardNumber: 'P39',
+        requirements: CardRequirements.builder((b) => b.temperature(-20).max()),
+        renderData: CardRenderer.builder((b) => {
+          b.action('Add 1 microbe to this card.', (eb) => {
+            eb.empty().startAction.microbes(1);
+          }).br;
+          b.effect('When paying for a plant card, microbes here may be used as 2 MC each.', (eb) => {
+            eb.plants(1).played.startEffect.microbes(1).equals().megacredits(2);
+          });
+        }),
+        description: 'Temperature must be -20 C or lower.',
+      },
+    });
+  }
+    public resourceCount = 0;
 
     public canPlay(player: Player, game: Game): boolean {
       return game.checkMaxRequirements(player, GlobalParameter.TEMPERATURE, -20);
@@ -34,19 +52,5 @@ export class Psychrophiles implements IActionCard, IProjectCard, IResourceCard {
     public action(player: Player) {
       player.addResourceTo(this);
       return undefined;
-    }
-
-    public metadata: CardMetadata = {
-      cardNumber: 'P39',
-      requirements: CardRequirements.builder((b) => b.temperature(-20).max()),
-      renderData: CardRenderer.builder((b) => {
-        b.action('Add 1 microbe to this card.', (eb) => {
-          eb.empty().startAction.microbes(1);
-        }).br;
-        b.effect('When paying for a plant card, microbes here may be used as 2 MC each.', (eb) => {
-          eb.plants(1).played.startEffect.microbes(1).equals().megacredits(2);
-        });
-      }),
-      description: 'Temperature must be -20 C or lower.',
     }
 }

--- a/src/cards/prelude/ResearchCoordination.ts
+++ b/src/cards/prelude/ResearchCoordination.ts
@@ -1,25 +1,29 @@
 import {CardType} from '../CardType';
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
-export class ResearchCoordination implements IProjectCard {
-    public cost = 4;
-    public cardType = CardType.AUTOMATED;
-    public tags = [Tags.WILDCARD];
-    public name = CardName.RESEARCH_COORDINATION;
+export class ResearchCoordination extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.RESEARCH_COORDINATION,
+      tags: [Tags.WILDCARD],
+      cost: 4,
 
-    public play() {
-      return undefined;
-    }
+      metadata: {
+        cardNumber: 'P40',
+        renderData: CardRenderer.builder((b) => {
+          b.text('After being played, when you perform an action, the wild tag counts as any tag of your choice.', CardRenderItemSize.SMALL, true);
+        }),
+      },
+    });
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'P40',
-      renderData: CardRenderer.builder((b) => {
-        b.text('After being played, when you perform an action, the wild tag counts as any tag of your choice.', CardRenderItemSize.SMALL, true);
-      }),
-    }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/prelude/ResearchNetwork.ts
+++ b/src/cards/prelude/ResearchNetwork.ts
@@ -6,23 +6,27 @@ import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class ResearchNetwork extends PreludeCard implements IProjectCard {
-    public tags = [Tags.WILDCARD];
-    public name = CardName.RESEARCH_NETWORK;
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.MEGACREDITS);
-      game.defer(new DrawCards(player, game, 3));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P28',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(1)).br;
-        b.cards(3);
-      }),
-      description: 'Increase your MC production 1 step. Draw 3 cards.',
-    }
+  constructor() {
+    super({
+      name: CardName.RESEARCH_NETWORK,
+      tags: [Tags.WILDCARD],
+
+      metadata: {
+        cardNumber: 'P28',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(1)).br;
+          b.cards(3);
+        }),
+        description: 'Increase your MC production 1 step. Draw 3 cards.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.MEGACREDITS);
+    game.defer(new DrawCards(player, game, 3));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/RobinsonIndustries.ts
+++ b/src/cards/prelude/RobinsonIndustries.ts
@@ -4,65 +4,67 @@ import {CorporationCard} from './../corporation/CorporationCard';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectOption} from '../../inputs/SelectOption';
 import {Resources} from '../../Resources';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {LogHelper} from '../../LogHelper';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class RobinsonIndustries implements IActionCard, CorporationCard {
-    public name = CardName.ROBINSON_INDUSTRIES;
-    public tags = [];
-    public startingMegaCredits: number = 47;
-    public cardType = CardType.CORPORATION;
-    public play() {
-      return undefined;
-    }
+export class RobinsonIndustries extends Card implements IActionCard, CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.ROBINSON_INDUSTRIES,
+      startingMegaCredits: 47,
 
-    public canAct(player: Player): boolean {
-      return player.canAfford(4);
-    }
+      metadata: {
+        cardNumber: 'R27',
+        description: 'You start with 47 MC.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br.br;
+          b.megacredits(47);
+          b.corpBox('action', (ce) => {
+            ce.action('Spend 4 MC to increase (one of) your LOWEST production 1 step.', (eb) => {
+              eb.megacredits(4).startAction.production((pb) => pb.wild(1).asterix());
+            });
+          });
+        }),
+      },
+    });
+  }
+  public play() {
+    return undefined;
+  }
 
-    public action(player: Player) {
-      let minimum = player.getProduction(Resources.MEGACREDITS);
-      let lowest: Array<SelectOption> = [];
+  public canAct(player: Player): boolean {
+    return player.canAfford(4);
+  }
 
-      [Resources.MEGACREDITS, Resources.STEEL, Resources.TITANIUM, Resources.PLANTS, Resources.ENERGY, Resources.HEAT].forEach((resource) => {
-        const option = new SelectOption('Increase ' + resource + ' production 1 step', 'Select', () => {
-          this.increaseAndLogProduction(player, resource);
-          return undefined;
-        });
+  public action(player: Player) {
+    let minimum = player.getProduction(Resources.MEGACREDITS);
+    let lowest: Array<SelectOption> = [];
 
-        if (player.getProduction(resource) < minimum) {
-          lowest = [];
-          minimum = player.getProduction(resource);
-        }
-
-        if (player.getProduction(resource) === minimum) lowest.push(option);
+    [Resources.MEGACREDITS, Resources.STEEL, Resources.TITANIUM, Resources.PLANTS, Resources.ENERGY, Resources.HEAT].forEach((resource) => {
+      const option = new SelectOption('Increase ' + resource + ' production 1 step', 'Select', () => {
+        this.increaseAndLogProduction(player, resource);
+        return undefined;
       });
 
-      const result = new OrOptions();
-      result.options = lowest;
-      return result;
-    }
+      if (player.getProduction(resource) < minimum) {
+        lowest = [];
+        minimum = player.getProduction(resource);
+      }
+      if (player.getProduction(resource) === minimum) lowest.push(option);
+    });
 
-    private increaseAndLogProduction(player: Player, resource: Resources) {
-      player.addProduction(resource);
-      player.megaCredits -= 4;
-      LogHelper.logGainProduction(player, resource);
-    }
+    const result = new OrOptions();
+    result.options = lowest;
+    return result;
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'R27',
-      description: 'You start with 47 MC.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br.br;
-        b.megacredits(47);
-        b.corpBox('action', (ce) => {
-          ce.action('Spend 4 MC to increase (one of) your LOWEST production 1 step.', (eb) => {
-            eb.megacredits(4).startAction.production((pb) => pb.wild(1).asterix());
-          });
-        });
-      }),
-    }
+  private increaseAndLogProduction(player: Player, resource: Resources) {
+    player.addProduction(resource);
+    player.megaCredits -= 4;
+    LogHelper.logGainProduction(player, resource);
+  }
 }

--- a/src/cards/prelude/SFMemorial.ts
+++ b/src/cards/prelude/SFMemorial.ts
@@ -1,32 +1,36 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
+import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SFMemorial implements IProjectCard {
-    public cost = 7;
-    public tags = [Tags.BUILDING];
-    public name = CardName.SF_MEMORIAL;
-    public cardType = CardType.AUTOMATED;
+export class SFMemorial extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.SF_MEMORIAL,
+      tags: [Tags.BUILDING],
+      cost: 7,
 
-    public play(player: Player, game: Game) {
-      game.defer(new DrawCards(player, game, 1));
-      return undefined;
-    }
+      metadata: {
+        cardNumber: 'P41',
+        renderData: CardRenderer.builder((b) => b.cards(1)),
+        description: 'Draw 1 card.',
+        victoryPoints: 1,
+      },
+    });
+  }
 
-    public getVictoryPoints() {
-      return 1;
-    }
+  public play(player: Player, game: Game) {
+    game.defer(new DrawCards(player, game, 1));
+    return undefined;
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'P41',
-      renderData: CardRenderer.builder((b) => b.cards(1)),
-      description: 'Draw 1 card.',
-      victoryPoints: 1,
-    }
+  public getVictoryPoints() {
+    return 1;
+  }
 }

--- a/src/cards/prelude/SelfSufficientSettlement.ts
+++ b/src/cards/prelude/SelfSufficientSettlement.ts
@@ -6,22 +6,26 @@ import {IProjectCard} from '../IProjectCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {PlaceCityTile} from '../../deferredActions/PlaceCityTile';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class SelfSufficientSettlement extends PreludeCard implements IProjectCard {
-    public tags = [Tags.BUILDING, Tags.CITY];
-    public name = CardName.SELF_SUFFICIENT_SETTLEMENT;
-    public play(player: Player, game: Game) {
-      player.addProduction(Resources.MEGACREDITS, 2);
-      game.defer(new PlaceCityTile(player, game));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P29',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.megacredits(2)).city();
-      }),
-      description: 'Increase your money production 2 steps. Place a City tile.',
-    }
+  constructor() {
+    super({
+      name: CardName.SELF_SUFFICIENT_SETTLEMENT,
+      tags: [Tags.BUILDING, Tags.CITY],
+
+      metadata: {
+        cardNumber: 'P29',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(2)).city();
+        }),
+        description: 'Increase your money production 2 steps. Place a City tile.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.addProduction(Resources.MEGACREDITS, 2);
+    game.defer(new PlaceCityTile(player, game));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/SmeltingPlant.ts
+++ b/src/cards/prelude/SmeltingPlant.ts
@@ -3,22 +3,26 @@ import {Player} from '../../Player';
 import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class SmeltingPlant extends PreludeCard {
-    public tags = [Tags.BUILDING];
-    public name = CardName.SMELTING_PLANT;
-    public play(player: Player, game: Game) {
-      player.steel += 5;
-      return game.increaseOxygenLevel(player, 2);
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P30',
-      renderData: CardRenderer.builder((b) => {
-        b.oxygen(2).br;
-        b.steel(5);
-      }),
-      description: 'Raise oxygen 2 steps. Gain 5 steel.',
-    }
+  constructor() {
+    super({
+      name: CardName.SMELTING_PLANT,
+      tags: [Tags.BUILDING],
+
+      metadata: {
+        cardNumber: 'P30',
+        renderData: CardRenderer.builder((b) => {
+          b.oxygen(2).br;
+          b.steel(5);
+        }),
+        description: 'Raise oxygen 2 steps. Gain 5 steel.',
+      },
+    });
+  }
+  public play(player: Player, game: Game) {
+    player.steel += 5;
+    return game.increaseOxygenLevel(player, 2);
+  }
 }

--- a/src/cards/prelude/SocietySupport.ts
+++ b/src/cards/prelude/SocietySupport.ts
@@ -2,27 +2,30 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class SocietySupport extends PreludeCard {
-    public tags = [];
-    public name = CardName.SOCIETY_SUPPORT;
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, -1);
-      player.addProduction(Resources.PLANTS);
-      player.addProduction(Resources.ENERGY);
-      player.addProduction(Resources.HEAT);
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P31',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.megacredits(-1).plants(1).br;
-          pb.energy(1).heat(1);
-        });
-      }),
-      description: 'Increase your plant, energy and heat production 1 step. Decrease money production 1 step.',
-    }
+  constructor() {
+    super({
+      name: CardName.SOCIETY_SUPPORT,
+
+      metadata: {
+        cardNumber: 'P31',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.megacredits(-1).plants(1).br;
+            pb.energy(1).heat(1);
+          });
+        }),
+        description: 'Increase your plant, energy and heat production 1 step. Decrease money production 1 step.',
+      },
+    });
+  }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, -1);
+    player.addProduction(Resources.PLANTS);
+    player.addProduction(Resources.ENERGY);
+    player.addProduction(Resources.HEAT);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/SpaceHotels.ts
+++ b/src/cards/prelude/SpaceHotels.ts
@@ -1,36 +1,40 @@
 import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
+import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class SpaceHotels implements IProjectCard {
-    public cost = 12;
-    public tags = [Tags.SPACE, Tags.EARTH];
-    public name = CardName.SPACE_HOTELS;
-    public cardType = CardType.AUTOMATED;
+export class SpaceHotels extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.SPACE_HOTELS,
+      tags: [Tags.SPACE, Tags.EARTH],
+      cost: 12,
 
-    public canPlay(player: Player): boolean {
-      return player.getTagCount(Tags.EARTH) >= 2;
-    }
+      metadata: {
+        cardNumber: 'P42',
+        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => {
+            pb.megacredits(4);
+          });
+        }),
+        description: 'Requires 2 Earth tags. Increase MC production 4 steps.',
+      },
+    });
+  }
 
-    public play(player: Player) {
-      player.addProduction(Resources.MEGACREDITS, 4);
-      return undefined;
-    }
+  public canPlay(player: Player): boolean {
+    return player.getTagCount(Tags.EARTH) >= 2;
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'P42',
-      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => {
-          pb.megacredits(4);
-        });
-      }),
-      description: 'Requires 2 Earth tags. Increase MC production 4 steps.',
-    }
+  public play(player: Player) {
+    player.addProduction(Resources.MEGACREDITS, 4);
+    return undefined;
+  }
 }

--- a/src/cards/prelude/Supplier.ts
+++ b/src/cards/prelude/Supplier.ts
@@ -3,24 +3,28 @@ import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class Supplier extends PreludeCard {
-    public tags = [Tags.ENERGY];
-    public name = CardName.SUPPLIER;
+  constructor() {
+    super({
+      name: CardName.SUPPLIER,
+      tags: [Tags.ENERGY],
 
-    public play(player: Player) {
-      player.addProduction(Resources.ENERGY, 2);
-      player.steel +=4;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P32',
-      renderData: CardRenderer.builder((b) => {
-        b.production((pb) => pb.energy(2)).br;
-        b.steel(4);
-      }),
-      description: 'Increase your energy production 2 steps. Gain 4 steel.',
-    }
+      metadata: {
+        cardNumber: 'P32',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.energy(2)).br;
+          b.steel(4);
+        }),
+        description: 'Increase your energy production 2 steps. Gain 4 steel.',
+      },
+    });
+  }
+
+  public play(player: Player) {
+    player.addProduction(Resources.ENERGY, 2);
+    player.steel +=4;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/SupplyDrop.ts
+++ b/src/cards/prelude/SupplyDrop.ts
@@ -1,24 +1,27 @@
 import {Player} from '../../Player';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class SupplyDrop extends PreludeCard {
-    public tags = [];
-    public name = CardName.SUPPLY_DROP;
+  constructor() {
+    super({
+      name: CardName.SUPPLY_DROP,
 
-    public play(player: Player) {
-      player.titanium +=3;
-      player.steel +=8;
-      player.plants +=3;
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P33',
-      renderData: CardRenderer.builder((b) => {
-        b.titanium(3).digit.steel(8).digit.plants(3).digit;
-      }),
-      description: 'Gain 3 titanium, 8 steel and 3 plants.',
-    }
+      metadata: {
+        cardNumber: 'P33',
+        renderData: CardRenderer.builder((b) => {
+          b.titanium(3).digit.steel(8).digit.plants(3).digit;
+        }),
+        description: 'Gain 3 titanium, 8 steel and 3 plants.',
+      },
+    });
+  }
+
+  public play(player: Player) {
+    player.titanium +=3;
+    player.steel +=8;
+    player.plants +=3;
+    return undefined;
+  }
 }

--- a/src/cards/prelude/UNMIContractor.ts
+++ b/src/cards/prelude/UNMIContractor.ts
@@ -4,24 +4,28 @@ import {Game} from '../../Game';
 import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {DrawCards} from '../../deferredActions/DrawCards';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class UNMIContractor extends PreludeCard {
-    public tags = [Tags.EARTH];
-    public name = CardName.UNMI_CONTRACTOR;
+  constructor() {
+    super({
+      name: CardName.UNMI_CONTRACTOR,
+      tags: [Tags.EARTH],
 
-    public play(player: Player, game: Game) {
-      player.increaseTerraformRatingSteps(3, game);
-      game.defer(new DrawCards(player, game, 1));
-      return undefined;
-    }
-    public metadata: CardMetadata = {
-      cardNumber: 'P34',
-      renderData: CardRenderer.builder((b) => {
-        b.tr(3).br;
-        b.cards(1);
-      }),
-      description: 'Increase your TR 3 steps. Draw a card.',
-    }
+      metadata: {
+        cardNumber: 'P34',
+        renderData: CardRenderer.builder((b) => {
+          b.tr(3).br;
+          b.cards(1);
+        }),
+        description: 'Increase your TR 3 steps. Draw a card.',
+      },
+    });
+  }
+
+  public play(player: Player, game: Game) {
+    player.increaseTerraformRatingSteps(3, game);
+    game.defer(new DrawCards(player, game, 1));
+    return undefined;
+  }
 }

--- a/src/cards/prelude/ValleyTrust.ts
+++ b/src/cards/prelude/ValleyTrust.ts
@@ -4,58 +4,62 @@ import {CorporationCard} from './../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {Game} from '../../Game';
 import {SelectCard} from '../../inputs/SelectCard';
+import {Card} from '../Card';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class ValleyTrust implements CorporationCard {
-    public name = CardName.VALLEY_TRUST;
-    public tags = [Tags.EARTH];
-    public startingMegaCredits: number = 37;
-    public cardType = CardType.CORPORATION;
+export class ValleyTrust extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.VALLEY_TRUST,
+      tags: [Tags.EARTH],
+      startingMegaCredits: 37,
+      initialActionText: 'Draw 3 Prelude cards, and play one of them',
 
-    public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
-      return card.tags.filter((tag) => tag === Tags.SCIENCE).length * 2;
-    }
+      metadata: {
+        cardNumber: 'R34',
+        description: 'You start with 37 MC. As your first action, draw 3 Prelude cards, and play one of them. Discard the other two.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(37).nbsp.prelude().asterix();
+          b.corpBox('effect', (ce) => {
+            ce.effect('When you play a Science tag, you pay 2MC less for it.', (eb) => {
+              eb.science(1).played.startEffect.megacredits(-2);
+            });
+          });
+        }),
+      },
+    });
+  }
 
-    public initialActionText: string = 'Draw 3 Prelude cards, and play one of them';
-    public initialAction(player: Player, game: Game) {
-      if (game.gameOptions.preludeExtension) {
-        const cardsDrawn: Array<IProjectCard> = [
-          game.dealer.dealPreludeCard(),
-          game.dealer.dealPreludeCard(),
-          game.dealer.dealPreludeCard(),
-        ];
+  public getCardDiscount(_player: Player, _game: Game, card: IProjectCard) {
+    return card.tags.filter((tag) => tag === Tags.SCIENCE).length * 2;
+  }
 
-        return new SelectCard('Choose prelude card to play', 'Play', cardsDrawn, (foundCards: Array<IProjectCard>) => {
-          if (foundCards[0].canPlay === undefined || foundCards[0].canPlay(player, game)) {
-            return player.playCard(game, foundCards[0]);
-          } else {
-            throw new Error('You cannot pay for this card');
-          }
-        }, 1, 1);
-      } else {
-        console.warn('Prelude extension isn\'t selected.');
-        return undefined;
-      }
-    }
+  public initialAction(player: Player, game: Game) {
+    if (game.gameOptions.preludeExtension) {
+      const cardsDrawn: Array<IProjectCard> = [
+        game.dealer.dealPreludeCard(),
+        game.dealer.dealPreludeCard(),
+        game.dealer.dealPreludeCard(),
+      ];
 
-    public play() {
+      return new SelectCard('Choose prelude card to play', 'Play', cardsDrawn, (foundCards: Array<IProjectCard>) => {
+        if (foundCards[0].canPlay === undefined || foundCards[0].canPlay(player, game)) {
+          return player.playCard(game, foundCards[0]);
+        } else {
+          throw new Error('You cannot pay for this card');
+        }
+      }, 1, 1);
+    } else {
+      console.warn('Prelude extension isn\'t selected.');
       return undefined;
     }
+  }
 
-    public metadata: CardMetadata = {
-      cardNumber: 'R34',
-      description: 'You start with 37 MC. As your first action, draw 3 Prelude cards, and play one of them. Discard the other two.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(37).nbsp.prelude().asterix();
-        b.corpBox('effect', (ce) => {
-          ce.effect('When you play a Science tag, you pay 2MC less for it.', (eb) => {
-            eb.science(1).played.startEffect.megacredits(-2);
-          });
-        });
-      }),
-    }
+  public play() {
+    return undefined;
+  }
 }

--- a/src/cards/prelude/Vitor.ts
+++ b/src/cards/prelude/Vitor.ts
@@ -1,5 +1,6 @@
 import {Tags} from '../Tags';
 import {Player} from '../../Player';
+import {Card} from '../Card';
 import {CorporationCard} from './../corporation/CorporationCard';
 import {IProjectCard} from '../IProjectCard';
 import {Game} from '../../Game';
@@ -8,56 +9,59 @@ import {SelectOption} from '../../inputs/SelectOption';
 import {IAward} from '../../awards/IAward';
 import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
-export class Vitor implements CorporationCard {
-    public name = CardName.VITOR;
-    public tags = [Tags.EARTH];
-    public startingMegaCredits: number = 48; // It's 45 + 3 when this corp is played
-    public cardType = CardType.CORPORATION;
+export class Vitor extends Card implements CorporationCard {
+  constructor() {
+    super({
+      cardType: CardType.CORPORATION,
+      name: CardName.VITOR,
+      tags: [Tags.EARTH],
+      startingMegaCredits: 48, // It's 45 + 3 when this corp is played
+      initialActionText: 'Fund an award for free',
 
-    private selectAwardToFund(player: Player, game: Game, award: IAward): SelectOption {
-      return new SelectOption('Fund ' + award.name + ' award', 'Confirm', () => {
-        game.fundAward(player, award);
-        return undefined;
-      });
-    }
-
-    public initialActionText: string = 'Fund an award for free';
-    public initialAction(player: Player, game: Game) {
-      // Awards are disabled for 1 player games
-      if (game.isSoloMode()) {
-        return;
-      }
-      const freeAward = new OrOptions();
-      freeAward.title = 'Select award to fund';
-      freeAward.buttonLabel = 'Confirm';
-      freeAward.options = game.awards.map((award) => this.selectAwardToFund(player, game, award));
-      return freeAward;
-    }
-
-    public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
-      if (player.isCorporation(this.name) && card.getVictoryPoints !== undefined && card.getVictoryPoints(player, game) >= 0) {
-        player.megaCredits += 3;
-      }
-    }
-
-    public play(_player: Player) {
-      return undefined;
-    }
-
-    public metadata: CardMetadata = {
-      cardNumber: 'R35',
-      description: 'You start with 45 MC. As your first action, fund an award for free.',
-      renderData: CardRenderer.builder((b) => {
-        b.br.br;
-        b.megacredits(45).nbsp.award();
-        b.corpBox('effect', (ce) => {
-          ce.effect('When you play a card with a NON-NEGATIVE VP icon, including this, gain 3MC.', (eb) => {
-            eb.vpIcon().asterix().startEffect.megacredits(3);
+      metadata: {
+        cardNumber: 'R35',
+        description: 'You start with 45 MC. As your first action, fund an award for free.',
+        renderData: CardRenderer.builder((b) => {
+          b.br.br;
+          b.megacredits(45).nbsp.award();
+          b.corpBox('effect', (ce) => {
+            ce.effect('When you play a card with a NON-NEGATIVE VP icon, including this, gain 3MC.', (eb) => {
+              eb.vpIcon().asterix().startEffect.megacredits(3);
+            });
           });
-        });
-      }),
+        }),
+      },
+    });
+  }
+
+  private selectAwardToFund(player: Player, game: Game, award: IAward): SelectOption {
+    return new SelectOption('Fund ' + award.name + ' award', 'Confirm', () => {
+      game.fundAward(player, award);
+      return undefined;
+    });
+  }
+
+  public initialAction(player: Player, game: Game) {
+    // Awards are disabled for 1 player games
+    if (game.isSoloMode()) {
+      return;
     }
+    const freeAward = new OrOptions();
+    freeAward.title = 'Select award to fund';
+    freeAward.buttonLabel = 'Confirm';
+    freeAward.options = game.awards.map((award) => this.selectAwardToFund(player, game, award));
+    return freeAward;
+  }
+
+  public onCardPlayed(player: Player, game: Game, card: IProjectCard) {
+    if (player.isCorporation(this.name) && card.getVictoryPoints !== undefined && card.getVictoryPoints(player, game) >= 0) {
+      player.megaCredits += 3;
+    }
+  }
+
+  public play(_player: Player) {
+    return undefined;
+  }
 }


### PR DESCRIPTION
The change to the `PreludeCard` api made it difficult to isolate this change to 25 cards. Apologize this one is slightly larger. Could have left some of the cards that didn't extend `PreludeCard` to a separate PR but didn't realize I would run into that scenario until I started converting.