### PR TITLE
Add regression test for StripMine with Reds ruling

### DIFF
--- a/src/cards/base/StripMine.ts
+++ b/src/cards/base/StripMine.ts
@@ -37,9 +37,10 @@ export class StripMine extends Card implements IProjectCard {
     const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 2;
     const remainingOxygenSteps = MAX_OXYGEN_LEVEL - game.getOxygenLevel();
     const stepsRaised = Math.min(remainingOxygenSteps, 2);
+    const requiredMC = REDS_RULING_POLICY_COST * stepsRaised;
 
     if (PartyHooks.shouldApplyPolicy(game, PartyName.REDS)) {
-      return player.canAfford(player.getCardCost(game, this) + REDS_RULING_POLICY_COST * stepsRaised, game, true) && hasEnergyProduction;
+      return player.canAfford(player.getCardCost(game, this) + requiredMC, game, true) && player.canAfford(requiredMC) && hasEnergyProduction;
     }
 
     return hasEnergyProduction;


### PR DESCRIPTION
Adds a regression test related to https://discord.com/channels/737945098695999559/742826825922904225/798210229597634631.

The issue is related to an incorrect check which assumes that the user can pay for Reds tax using steel. It seems that canPlay requires 2 checks, namely (1) that the user has enough MC to pay Reds tax, and (2) the user has enough MC plus steel and/or titanium where applicable to pay the card's cost plus Reds taxes.

Pre-Lynesth's Reds tax PR we will likely need to update this check for all other building and space cards that can raise TR as an interim measure.