### PR TITLE
Fixed helion card buying bug

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -764,7 +764,6 @@ export class Player implements ISerializable<SerializedPlayer> {
       megaCredits: 0,
       microbes: 0,
       floaters: 0,
-      isResearchPhase: false,
     };
     try {
       const howToPay: HowToPay = JSON.parse(json);

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -32,7 +32,6 @@ export const PaymentWidgetMixin = {
     },
     reduceValue: function(target: string, to: number): void {
       const currentValue: number = (this as any)[target];
-      const isResearchPhase = (this as any).$data.isResearchPhase;
 
       if (currentValue === 0) return;
 
@@ -41,21 +40,14 @@ export const PaymentWidgetMixin = {
 
       if (target === 'megaCredits' || realTo === 0) return;
 
-      this.setRemainingMCValue(isResearchPhase);
+      this.setRemainingMCValue();
     },
     addValue: function(target: string, to: number): void {
       const currentValue: number = (this as any)[target];
       let maxValue: number = (this as any).player[target];
-      const isResearchPhase = (this as any).$data.isResearchPhase;
 
-      if (isResearchPhase && target === 'megaCredits') {
-        maxValue = (this as any).player.cardCost * 4;
-      } else if (target === 'megaCredits') {
+      if (target === 'megaCredits') {
         maxValue = this.getMegaCreditsMax();
-      }
-
-      if (isResearchPhase && target === 'heat') {
-        maxValue = (this as any).player.cardCost * 4;
       }
 
       if (target === 'microbes') maxValue = (this as any).playerinput.microbes;
@@ -70,9 +62,9 @@ export const PaymentWidgetMixin = {
 
       if (target === 'megaCredits' || realTo === 0) return;
 
-      this.setRemainingMCValue(isResearchPhase);
+      this.setRemainingMCValue();
     },
-    setRemainingMCValue: function(isResearchPhase: boolean): void {
+    setRemainingMCValue: function(): void {
       const remainingMC: number = (this as any).$data.cost -
               (this as any)['heat'] -
               (this as any)['titanium'] * this.getResourceRate('titanium') -
@@ -80,11 +72,7 @@ export const PaymentWidgetMixin = {
               (this as any)['microbes'] * this.getResourceRate('microbes') -
               (this as any)['floaters'] * this.getResourceRate('floaters');
 
-      if (isResearchPhase) {
-        (this as any)['megaCredits'] = Math.max(0, (this as any).player.cardCost * 4 - (this as any)['heat']);
-      } else {
-        (this as any)['megaCredits'] = Math.max(0, Math.min(this.getMegaCreditsMax(), remainingMC));
-      }
+      (this as any)['megaCredits'] = Math.max(0, Math.min(this.getMegaCreditsMax(), remainingMC));
     },
     setMaxValue: function(target: string): void {
       let currentValue: number = (this as any)[target];

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -56,7 +56,6 @@ export const SelectHowToPay = Vue.component('select-how-to-pay', {
   mounted: function() {
     const app = this;
     Vue.nextTick(function() {
-      app.$data.isResearchPhase = app.playerinput.title === 'Select how to pay for cards';
       app.setInitialCost();
       app.$data.megaCredits = (app as any).getMegaCreditsMax();
 
@@ -73,10 +72,6 @@ export const SelectHowToPay = Vue.component('select-how-to-pay', {
       return this.$data.warning !== undefined;
     },
     setInitialCost: function() {
-      if (this.$data.isResearchPhase) {
-        this.playerinput.amount = this.player.cardCost * 4;
-      }
-
       this.$data.cost = this.playerinput.amount;
     },
     setDefaultSteelValue: function() {
@@ -157,7 +152,6 @@ export const SelectHowToPay = Vue.component('select-how-to-pay', {
         titanium: this.$data.titanium,
         microbes: 0,
         floaters: 0,
-        isResearchPhase: this.$data.isResearchPhase,
       };
 
       if (htp.megaCredits > this.player.megaCredits) {
@@ -180,12 +174,12 @@ export const SelectHowToPay = Vue.component('select-how-to-pay', {
       const requiredAmt = this.playerinput.amount || 0;
       const totalSpentAmt = htp.heat + htp.megaCredits + (htp.steel * this.player.steelValue) + (htp.titanium * this.player.titaniumValue) + (htp.microbes * 2) + (htp.floaters * 3);
 
-      if (requiredAmt > 0 && totalSpentAmt < requiredAmt && !htp.isResearchPhase) {
+      if (requiredAmt > 0 && totalSpentAmt < requiredAmt) {
         this.$data.warning = 'Haven\'t spent enough';
         return;
       }
 
-      if (htp.isResearchPhase && requiredAmt === 0) {
+      if (requiredAmt === 0) {
         htp.heat = 0;
         htp.megaCredits = 0;
       }

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -282,7 +282,6 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
         titanium: this.titanium,
         microbes: this.microbes,
         floaters: this.floaters,
-        isResearchPhase: false,
       };
       if (htp.megaCredits > this.player.megaCredits) {
         this.warning = 'You don\'t have that many mega credits';

--- a/src/deferredActions/SelectHowToPayDeferred.ts
+++ b/src/deferredActions/SelectHowToPayDeferred.ts
@@ -21,6 +21,8 @@ export class SelectHowToPayDeferred implements DeferredAction {
       return undefined;
     }
 
+    console.log('need to pay:', this.amount);
+
     return new SelectHowToPay(
       this.options.title || 'Select how to pay for ' + this.amount + ' MCs',
       this.options.canUseSteel || false,

--- a/src/inputs/HowToPay.ts
+++ b/src/inputs/HowToPay.ts
@@ -6,6 +6,5 @@ export interface HowToPay {
     titanium: number;
     microbes: number;
     floaters: number;
-    isResearchPhase: boolean;
 }
 


### PR DESCRIPTION
Bug from discord where helion could pay 0 mc and 0 heat and buy some cards.

Very ugly one.

It was caused by that line of code:
```ts
      app.$data.isResearchPhase = app.playerinput.title === 'Select how to pay for cards';
```
With my card rework I changed the card selection msg to exactly this one, while on main server it was earlier like this: `Select how to pay 6 for purchasing 2 card(s)`.

I removed the unnecessary `isResearchPhase` flag. It was added earlier to allow Helion pay with heat in Research Phase, now it works without it.