### PR TITLE
delete moon icon when moon expansion not in play

### DIFF
--- a/src/components/overview/PlayerTags.ts
+++ b/src/components/overview/PlayerTags.ts
@@ -32,6 +32,9 @@ export const PlayerTags = Vue.component('player-tags', {
     showVenus: function(): boolean {
       return this.player.venusNextExtension;
     },
+    showMoon: function(): boolean {
+      return this.player.moonExtension;
+    },
     getTagsPlaceholders: function() {
       const tags: {[x: string]: Tags | SpecialTags} = {...Tags, ...SpecialTags};
       if (this.showColonyCount() === false) {
@@ -42,6 +45,9 @@ export const PlayerTags = Vue.component('player-tags', {
       }
       if (this.showVenus() === false) {
         delete tags.VENUS;
+      }
+      if (this.showMoon() === false) {
+        delete tags.MOON;
       }
       return tags;
     },

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -15,6 +15,7 @@ import {AgendaStyle} from '../turmoil/PoliticalAgendas';
 import {SerializedTimer} from '../SerializedTimer';
 
 export interface PlayerModel {
+    moonExtension: boolean;
     aresExtension: boolean;
     aresData: IAresData | undefined;
     politicalAgendasExtension: AgendaStyle;

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -128,6 +128,7 @@ export class Server {
       preludeExtension: game.gameOptions.preludeExtension,
       politicalAgendasExtension: game.gameOptions.politicalAgendasExtension,
       timer: player.timer.serialize(),
+      moonExtension: game.gameOptions.moonExpansion,
     };
   }
 }


### PR DESCRIPTION
@kberg @chosta I don't know why this does not work. It should follow the delete venus tag when venus not in use in parallel.