### PR TITLE
timer on by default

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -134,7 +134,7 @@ const DEFAULT_GAME_OPTIONS: GameOptions = {
   removeNegativeGlobalEventsOption: false,
   requiresVenusTrackCompletion: false,
   showOtherPlayersVP: false,
-  showTimers: false,
+  showTimers: true,
   shuffleMapOption: false,
   solarPhaseOption: false,
   soloTR: false,

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -118,7 +118,7 @@ export const CreateGameForm = Vue.component('create-game-form', {
       politicalAgendasExtension: AgendaStyle.STANDARD,
       moonExpansion: false,
       undoOption: false,
-      showTimers: false,
+      showTimers: true,
       fastModeOption: false,
       removeNegativeGlobalEventsOption: false,
       includeVenusMA: true,

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -53,7 +53,7 @@ export const setCustomGameOptions = function(options: object = {}): GameOptions 
     promoCardsOption: false,
     communityCardsOption: false,
     undoOption: false,
-    showTimers: false,
+    showTimers: true,
     startingCorporations: 2,
     includeVenusMA: true,
     soloTR: false,


### PR DESCRIPTION
Setting timer option to be checked by default.

![image](https://user-images.githubusercontent.com/14239220/104740206-ac34c000-5715-11eb-9538-f5febfe9c8c5.png)

This is only for the info-only timer as its current state. If we ever have a timer with penalty once someone runs out of time, I don't think it should be on by default.