### PR TITLE
Separate Event

### DIFF
--- a/src/cards/Tags.ts
+++ b/src/cards/Tags.ts
@@ -11,6 +11,6 @@ export enum Tags {
     ANIMAL = 'animal',
     CITY = 'city',
     WILDCARD = 'wild',
-    EVENT = 'event',
     MOON = 'moon',
+    EVENT = 'event', // please, always keep event at the tail
 }

--- a/src/components/Tag.ts
+++ b/src/components/Tag.ts
@@ -1,9 +1,10 @@
 import Vue from 'vue';
+import {Tags} from '../cards/Tags';
 
 export const Tag = Vue.component('tag', {
   props: {
     tag: {
-      type: String,
+      type: String as () => Tags,
     },
     size: {
       type: String,
@@ -22,7 +23,6 @@ export const Tag = Vue.component('tag', {
       if (this.type !== undefined) {
         classes.push(`tag-type-${this.type}`);
       }
-
       return classes.join(' ');
     },
   },

--- a/src/components/TagCount.ts
+++ b/src/components/TagCount.ts
@@ -1,10 +1,11 @@
 import Vue from 'vue';
 import {Tag} from './Tag';
+import {Tags} from '../cards/Tags';
 
 export const TagCount = Vue.component('tag-count', {
   props: {
     tag: {
-      type: String,
+      type: String as () => Tags,
     },
     count: {
       type: Number,
@@ -29,6 +30,12 @@ export const TagCount = Vue.component('tag-count', {
       if (this.count === 0) {
         classes.push('tag-no-show');
       }
+      // event tag is added to the tail because it is not counted for actual tag for some cards and turmoil events (e.g. Interplanetary Trade)
+      if (this.tag === Tags.EVENT) {
+        classes.push('tag-event-separate');
+      }
+      console.log(this.type);
+
       return classes.join(' ');
     },
     getCountClasses: function(): string {

--- a/src/components/TagCount.ts
+++ b/src/components/TagCount.ts
@@ -34,7 +34,6 @@ export const TagCount = Vue.component('tag-count', {
       if (this.tag === Tags.EVENT) {
         classes.push('tag-event-separate');
       }
-      console.log(this.type);
 
       return classes.join(' ');
     },

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -171,6 +171,10 @@
     margin-left: 0px;
     background-position: -2px;
 }
+.tag-event-separate {
+    border-left: 2px solid rgba(170, 170, 170, 0.5);
+    padding-left: 8px;
+}
 
 .tag-cards {
     background-image: url("./assets/sidebar/preferences_cards.png"); 


### PR DESCRIPTION
closes #1426

> Move none closer to wild tag since it is still a tag, somewhat.

@vsrisuknimit I'm not sure about moving `none` closer to `wild` just for the sake of it. It will complicate things in code if I do it anyway. But the separation would be helpful for those tag counting events and cards for sure!

![the-best](https://user-images.githubusercontent.com/836179/104752356-3ce3be00-575f-11eb-84d4-0a7bfaccee2d.png)
