### PR TITLE
Reorganize SelectHowToPayForProjectCard, which was needlessly overcomplicated.

### DIFF
--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -180,6 +180,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       return false;
     },
     canUseMicrobes: function() {
+      // FYI Microbes are limited to the Psychrophiles card, which allows spending micrbes for Plant cards.
       if (this.card !== undefined && this.playerinput.microbes !== undefined && this.playerinput.microbes > 0) {
         if (this.tags.find((tag) => tag === Tags.PLANT) !== undefined) {
           return true;
@@ -188,6 +189,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       return false;
     },
     canUseFloaters: function() {
+      // FYI Floaters are limited to the DIRIGIBLES cards.
       if (this.card !== undefined && this.playerinput.floaters !== undefined && this.playerinput.floaters > 0) {
         if (this.tags.find((tag) => tag === Tags.VENUS) !== undefined) {
           return true;

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -90,11 +90,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       app.$data.tags = app.getCardTags(),
       app.$data.megaCredits = (app as unknown as typeof PaymentWidgetMixin.methods).getMegaCreditsMax();
 
-      app.setDefaultMicrobesValue();
-      app.setDefaultFloatersValue();
-      app.setDefaultSteelValue();
-      app.setDefaultTitaniumValue();
-      app.setDefaultHeatValue();
+      app.setDefaultValues();
     });
   },
   methods: {
@@ -113,112 +109,56 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       }
       return card.tags;
     },
-    setDefaultMicrobesValue: function() {
-      // automatically use available microbes to pay if not enough MC
-      if (!this.canAffordWithMcOnly() && this.canUseMicrobes()) {
-        const remainingCostToPay = this.cost - this.player.megaCredits;
-        const requiredMicrobes = Math.ceil(remainingCostToPay / 2);
+    setDefaultValues: function() {
+      this.microbes = 0;
+      this.floaters = 0;
+      this.steel = 0;
+      this.titanium = 0;
+      this.heat = 0;
 
-        if (this.playerinput.microbes !== undefined && requiredMicrobes > this.playerinput.microbes) {
-          this.microbes = this.playerinput.microbes;
-        } else {
-          this.microbes = requiredMicrobes;
+      let megacreditBalance = this.cost - this.player.megaCredits;
+
+      // Calcualtes the optimal number of units to use given the unit value.
+      //
+      // It reads `megacreditBalance` as the remaining balance, and deducts the
+      // consumed balance as part of this method.
+      //
+      // It returns the number of units consumed from availableUnits to make that
+      const deductUnits = function(
+        availableUnits: number | undefined,
+        unitValue: number,
+        overpay: boolean = true): number {
+        if (availableUnits === undefined || availableUnits === 0) {
+          return 0;
         }
+        // The number of units required to sell to meet the balance.
+        const _tmp = megacreditBalance / unitValue;
+        const balanceAsUnits = overpay ? Math.ceil(_tmp) : Math.floor(_tmp);
+        const contributingUnits = Math.min(availableUnits, balanceAsUnits);
 
-        const discountedCost = this.cost - (this.microbes * 2);
-        this.megaCredits = Math.max(discountedCost, 0);
-      } else {
-        this.microbes = 0;
+        megacreditBalance -= contributingUnits * unitValue;
+        return contributingUnits;
+      };
+
+      if (megacreditBalance > 0 && this.canUseMicrobes()) {
+        this.microbes = deductUnits(this.playerinput.microbes, 2);
       }
-    },
-    setDefaultFloatersValue: function() {
-      // automatically use available floaters to pay if not enough MC
-      if (!this.canAffordWithMcOnly() && this.canUseFloaters()) {
-        const remainingCostToPay = this.cost - this.player.megaCredits - (this.microbes * 2);
-        const requiredFloaters = Math.ceil(Math.max(remainingCostToPay, 0) / 3);
 
-        if (this.playerinput.floaters !== undefined && requiredFloaters > this.playerinput.floaters) {
-          this.floaters = this.playerinput.floaters;
-        } else {
-          this.floaters = requiredFloaters;
-        }
-
-        const discountedCost = this.cost - (this.microbes * 2) - (this.floaters * 3);
-        this.megaCredits = Math.max(discountedCost, 0);
-      } else {
-        this.floaters = 0;
+      if (megacreditBalance > 0 && this.canUseFloaters()) {
+        this.floaters = deductUnits(this.playerinput.floaters, 3);
       }
-    },
-    setDefaultSteelValue: function() {
-      // automatically use available steel to pay if not enough MC
-      if (!this.canAffordWithMcOnly() && this.canUseSteel()) {
-        const remainingCostToPay = this.cost - this.player.megaCredits - (this.microbes * 2) - (this.floaters * 3);
-        let requiredSteelQty = Math.ceil(Math.max(remainingCostToPay, 0) / this.player.steelValue);
 
-        if (requiredSteelQty > this.player.steel) {
-          this.steel = this.player.steel;
-        } else {
-          // use as much steel as possible without overpaying by default
-          let currentSteelValue = requiredSteelQty * this.player.steelValue;
-          while (currentSteelValue <= remainingCostToPay + this.player.megaCredits - this.player.steelValue && requiredSteelQty < this.player.steel) {
-            requiredSteelQty++;
-            currentSteelValue = requiredSteelQty * this.player.steelValue;
-          }
-
-          this.steel = requiredSteelQty;
-        }
-
-        const discountedCost = this.cost - (this.microbes * 2) - (this.floaters * 3) - (this.steel * this.player.steelValue);
-        this.megaCredits = Math.max(discountedCost, 0);
-      } else {
-        this.steel = 0;
+      if (megacreditBalance > 0 && this.canUseSteel()) {
+        this.steel = deductUnits(this.player.steel, this.player.steelValue, false);
       }
-    },
-    setDefaultTitaniumValue: function() {
-      // automatically use available titanium to pay if not enough MC
-      if (!this.canAffordWithMcOnly() && this.canUseTitanium()) {
-        const remainingCostToPay = this.cost - this.player.megaCredits - (this.microbes * 2) - (this.floaters * 3) - (this.steel * this.player.steelValue);
-        let requiredTitaniumQty = Math.ceil(Math.max(remainingCostToPay, 0) / this.player.titaniumValue);
 
-        if (requiredTitaniumQty > this.player.titanium) {
-          this.titanium = this.player.titanium;
-        } else {
-          // use as much titanium as possible without overpaying by default
-          let currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
-          while (currentTitaniumValue <= remainingCostToPay + this.player.megaCredits - this.player.titaniumValue && requiredTitaniumQty < this.player.titanium) {
-            requiredTitaniumQty++;
-            currentTitaniumValue = requiredTitaniumQty * this.player.titaniumValue;
-          }
-
-          this.titanium = requiredTitaniumQty;
-        }
-
-        const discountedCost = this.cost - (this.microbes * 2) - (this.floaters * 3) - (this.steel * this.player.steelValue) - (this.titanium * this.player.titaniumValue);
-        this.megaCredits = Math.max(discountedCost, 0);
-      } else {
-        this.titanium = 0;
+      if (megacreditBalance > 0 && this.canUseTitanium()) {
+        this.titanium = deductUnits(this.player.titanium, this.player.titaniumValue, false);
       }
-    },
-    setDefaultHeatValue: function() {
-      // automatically use available heat for Helion if not enough MC
-      if (!this.canAffordWithMcOnly() && this.canUseHeat()) {
-        const remainingCostToPay = this.cost - this.player.megaCredits - (this.microbes * 2) - (this.floaters * 3) - (this.steel * this.player.steelValue) - (this.titanium * this.player.titaniumValue);
-        const requiredHeat = Math.max(remainingCostToPay, 0);
 
-        if (requiredHeat > this.player.heat) {
-          this.heat = this.player.heat;
-        } else {
-          this.heat = requiredHeat;
-        }
-
-        const discountedCost = this.cost - (this.microbes * 2) - (this.floaters * 3) - (this.steel * this.player.steelValue) - (this.titanium * this.player.titaniumValue) - this.heat;
-        this.megaCredits = Math.max(discountedCost, 0);
-      } else {
-        this.heat = 0;
+      if (megacreditBalance > 0 && this.canUseHeat()) {
+        this.heat = deductUnits(this.player.heat, 1);
       }
-    },
-    canAffordWithMcOnly: function() {
-      return this.player.megaCredits >= this.cost;
     },
     canUseHeat: function() {
       return this.playerinput.canUseHeat && this.player.heat > 0;
@@ -262,11 +202,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
 
       this.megaCredits = (this as unknown as typeof PaymentWidgetMixin.methods).getMegaCreditsMax();
 
-      this.setDefaultMicrobesValue();
-      this.setDefaultFloatersValue();
-      this.setDefaultSteelValue();
-      this.setDefaultTitaniumValue();
-      this.setDefaultHeatValue();
+      this.setDefaultValues();
     },
     hasWarning: function() {
       return this.warning !== undefined;

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -40,7 +40,7 @@ export interface PlayerModel {
     generation: number;
     heat: number;
     heatProduction: number;
-    id: string;
+    id: string; // PlayerId
     isActive: boolean;
     isSoloModeWin: boolean;
     megaCredits: number;

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -32,76 +32,125 @@ describe('SelectHowToPayForProjectCard', function() {
   beforeEach(function() {
     expectedStorage = {};
   });
-  // it('uses sort order for cards', async function() {
-  //   expectedStorage['cardOrderfoo'] = JSON.stringify({
-  //     [CardName.ANTS]: 2,
-  //     [CardName.BIRDS]: 1,
-  //   });
-  //   const sortable = mount(SelectHowToPayForProjectCard, {
-  //     localVue: getLocalVue(),
-  //     propsData: {
-  //       player: {
-  //         cardsInHand: [{
-  //           calculatedCost: 4,
-  //           name: CardName.ANTS,
-  //         }, {
-  //           calculatedCost: 3,
-  //           name: CardName.BIRDS,
-  //         }],
-  //         id: 'foo',
-  //         selfReplicatingRobotCards: [],
-  //       },
-  //       playerinput: {
-  //         title: 'foo',
-  //         cards: [{
-  //           name: CardName.ANTS,
-  //         }, {
-  //           name: CardName.BIRDS,
-  //         }],
-  //       },
-  //       onsave: function() {},
-  //       showsave: true,
-  //       showtitle: true,
-  //     },
-  //   });
-  //   const cards = sortable.findAllComponents({
-  //     name: 'Card',
-  //   });
-  //   expect(cards.length).to.eq(2);
-  //   expect(cards.at(0).props().card.name).to.eq(CardName.BIRDS);
-  //   expect(cards.at(1).props().card.name).to.eq(CardName.ANTS);
-  // });
-  it('select how to pay uses heat', async function() {
+  it('uses sort order for cards', async function() {
     expectedStorage['cardOrderfoo'] = JSON.stringify({
+      [CardName.ANTS]: 2,
       [CardName.BIRDS]: 1,
     });
-    const wrapper = mount(SelectHowToPayForProjectCard, {
+    const sortable = mount(SelectHowToPayForProjectCard, {
       localVue: getLocalVue(),
       propsData: {
         player: {
           cardsInHand: [{
+            calculatedCost: 4,
+            name: CardName.ANTS,
+          }, {
             calculatedCost: 3,
             name: CardName.BIRDS,
           }],
           id: 'foo',
           selfReplicatingRobotCards: [],
-          heat: 4,
-          megaCredits: 7,
         },
         playerinput: {
           title: 'foo',
           cards: [{
+            name: CardName.ANTS,
+          }, {
             name: CardName.BIRDS,
           }],
-          canUseHeat: true,
         },
         onsave: function() {},
         showsave: true,
         showtitle: true,
       },
     });
-    const heatTextBox = wrapper.find('[title~=Heat] ~ input');
-    console.log(heatTextBox);
-    expect(wrapper.vm.heat).eq(3);
+    const cards = sortable.findAllComponents({
+      name: 'Card',
+    });
+    expect(cards.length).to.eq(2);
+    expect(cards.at(0).props().card.name).to.eq(CardName.BIRDS);
+    expect(cards.at(1).props().card.name).to.eq(CardName.ANTS);
   });
+
+  it('select how to pay uses heat', async function() {
+    // Birds will cost 10. Player has 7MC and will use 3 of the 4 available heat units.
+    const wrapper = setupCardForPurchase(
+      CardName.BIRDS, 10,
+      {heat: 4, megaCredits: 7},
+      {canUseHeat: true});
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.heat).eq(3);
+    const heatTextBox = wrapper.find('[title~=Heat] ~ input').element as HTMLInputElement;
+    expect(heatTextBox.value).eq('3');
+  });
+
+  it('select how to pay uses microbes', async function() {
+    // Moss will cost 10. Player has 7MC and will 2 of the 4 available microbes units.
+    const wrapper = setupCardForPurchase(
+      CardName.MOSS, 10,
+      {megaCredits: 7},
+      {microbes: 4});
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.microbes).eq(2);
+    const microbesTextBox = wrapper.find('[title~=Microbes] ~ input').element as HTMLInputElement;
+    expect(microbesTextBox.value).eq('2');
+  });
+
+  it('select how to pay uses floaters', async function() {
+    // Forced Precipitation will cost 10. Player has 7MC and will 2 of the 4 available floaters.
+    const wrapper = setupCardForPurchase(
+      CardName.FORCED_PRECIPITATION, 10,
+      {megaCredits: 6},
+      {floaters: 4});
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.floaters).eq(2);
+    const floatersTextBox = wrapper.find('[title~=Floaters] ~ input').element as HTMLInputElement;
+    expect(floatersTextBox.value).eq('2');
+  });
+
+  it('select how to pay uses steel', async function() {
+    // Forced Precipitation will cost 10. Player has 7MC and will 1 of the 4 available units of steel even though
+    // that leaves the player 1MC short.
+    const wrapper = setupCardForPurchase(
+      CardName.COMMERCIAL_DISTRICT, 10,
+      {steel: 4, megaCredits: 7, steelValue: 2},
+      {canUseSteel: true});
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.steel).eq(1);
+    const steelTextBox = wrapper.find('[title~=Steel] ~ input').element as HTMLInputElement;
+    expect(steelTextBox.value).eq('1');
+  });
+
+  const setupCardForPurchase = function(
+    cardName: CardName, cardCost: number, playerFields: object, playerInputFields: object) {
+    const player = Object.assign({
+      cardsInHand: [{name: cardName, calculatedCost: cardCost}],
+      id: 'foo',
+      selfReplicatingRobotCards: [],
+    }, playerFields);
+    const playerInput = Object.assign({title: 'foo', cards: [{name: cardName}]}, playerInputFields);
+
+    return mount(SelectHowToPayForProjectCard, {
+      localVue: getLocalVue(),
+      propsData: {
+        player: player,
+        playerinput: playerInput,
+        onsave: function() {},
+        showsave: true,
+        showtitle: true,
+      },
+    });
+  };
 });

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -32,43 +32,76 @@ describe('SelectHowToPayForProjectCard', function() {
   beforeEach(function() {
     expectedStorage = {};
   });
-  it('uses sort order for cards', async function() {
+  // it('uses sort order for cards', async function() {
+  //   expectedStorage['cardOrderfoo'] = JSON.stringify({
+  //     [CardName.ANTS]: 2,
+  //     [CardName.BIRDS]: 1,
+  //   });
+  //   const sortable = mount(SelectHowToPayForProjectCard, {
+  //     localVue: getLocalVue(),
+  //     propsData: {
+  //       player: {
+  //         cardsInHand: [{
+  //           calculatedCost: 4,
+  //           name: CardName.ANTS,
+  //         }, {
+  //           calculatedCost: 3,
+  //           name: CardName.BIRDS,
+  //         }],
+  //         id: 'foo',
+  //         selfReplicatingRobotCards: [],
+  //       },
+  //       playerinput: {
+  //         title: 'foo',
+  //         cards: [{
+  //           name: CardName.ANTS,
+  //         }, {
+  //           name: CardName.BIRDS,
+  //         }],
+  //       },
+  //       onsave: function() {},
+  //       showsave: true,
+  //       showtitle: true,
+  //     },
+  //   });
+  //   const cards = sortable.findAllComponents({
+  //     name: 'Card',
+  //   });
+  //   expect(cards.length).to.eq(2);
+  //   expect(cards.at(0).props().card.name).to.eq(CardName.BIRDS);
+  //   expect(cards.at(1).props().card.name).to.eq(CardName.ANTS);
+  // });
+  it('select how to pay uses heat', async function() {
     expectedStorage['cardOrderfoo'] = JSON.stringify({
-      [CardName.ANTS]: 2,
       [CardName.BIRDS]: 1,
     });
-    const sortable = mount(SelectHowToPayForProjectCard, {
+    const wrapper = mount(SelectHowToPayForProjectCard, {
       localVue: getLocalVue(),
       propsData: {
         player: {
           cardsInHand: [{
-            calculatedCost: 4,
-            name: CardName.ANTS,
-          }, {
             calculatedCost: 3,
             name: CardName.BIRDS,
           }],
           id: 'foo',
           selfReplicatingRobotCards: [],
+          heat: 4,
+          megaCredits: 7,
         },
         playerinput: {
           title: 'foo',
           cards: [{
-            name: CardName.ANTS,
-          }, {
             name: CardName.BIRDS,
           }],
+          canUseHeat: true,
         },
         onsave: function() {},
         showsave: true,
         showtitle: true,
       },
     });
-    const cards = sortable.findAllComponents({
-      name: 'Card',
-    });
-    expect(cards.length).to.eq(2);
-    expect(cards.at(0).props().card.name).to.eq(CardName.BIRDS);
-    expect(cards.at(1).props().card.name).to.eq(CardName.ANTS);
+    const heatTextBox = wrapper.find('[title~=Heat] ~ input');
+    console.log(heatTextBox);
+    expect(wrapper.vm.heat).eq(3);
   });
 });


### PR DESCRIPTION
By simplifying this, it will significantly localize the changes I need to add to accommodate Moon cards with steel and titanium costs.

I am not afraid to say that those tests were a huge pain. But now I know how to do them.

SelectHowToPay is different from SelectHowToPayForProjectCard, but the enterprising coder will merge the two, I am sure.