### PR TITLE
Add a single tsconfig that represents all files, breaking out behaviors for each custom case.

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -1,4 +1,3 @@
-
 /**
  * Provide a mock vue so we can interact with
  * the components from node

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "extends": "@istanbuljs/nyc-config-typescript"
   },
   "scripts": {
-    "build": "npm run lint && npm run compile && npm run templates && npm run webpack",
+    "build": "npm run compile && npm run templates && npm run webpack && npm run lint",
     "clean": "rm -r ./build/ ./styles.css || true",
-    "compile": "tsc",
+    "compile": "tsc --build tsconfig-backend.json",
     "cover": "nyc mocha --file build/tests/utils/Vue.js --recursive build/tests",
     "fix": "eslint --fix src server.ts script.ts tests --ext ts",
     "lint": "eslint src server.ts script.ts tests --ext ts",

--- a/script.ts
+++ b/script.ts
@@ -1,4 +1,3 @@
-
 import Vue from 'vue';
 
 import {translateTextNode} from './src/directives/i18n';

--- a/tsconfig-backend.json
+++ b/tsconfig-backend.json
@@ -1,0 +1,11 @@
+{
+    // TODO(kberg): splitting this into a frontend and backend, please. But make sure the tests split along with it.
+    "incremental": true,
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "exclude": [
+        "tests",
+    ]
+}

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,23 +1,10 @@
 {
+    "extends": "./tsconfig.json",
     "compilerOptions": {
-        "moduleResolution": "node",
-        "lib": ["dom"],
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "strict": true,
-        "removeComments": true,
-        "resolveJsonModule": true,
-        "preserveConstEnums": true,
-        "outDir": "build",
-        "skipLibCheck": true,
-        "sourceMap": true,
-        "target": "es5",
-        "types": ["node", "mocha", "chai"]
+        "declaration": false,
     },
-    "include": [
-        "tests/utils/Vue.ts",
-        "tests/**/*.spec.ts"
+    "exclude": [
+        "src",
+        "*.ts"
     ]
 }

--- a/tsconfig-vue.json
+++ b/tsconfig-vue.json
@@ -1,24 +1,19 @@
 {
+    "extends": "./tsconfig.json",
     "compilerOptions": {
-        "module": "commonjs",
-        "lib": ["dom"],
+        "declaration": false,
         "noEmit": true,
         "noImplicitAny": false,
-        "noImplicitReturns": true,
         "noUnusedLocals": false,
         "noUnusedParameters":false,
-        "outDir": "build",
-        "strict": true,
-        "removeComments": true,
-        "preserveConstEnums": true,
-        "skipLibCheck": true,
         "sourceMap": false,
-        "target": "es5",
-        "types": ["node"],
-        "moduleResolution": "node",
-        "resolveJsonModule": true
+        "types": ["node"]
     },
-    "exclude": [],
+    "exclude": [
+        "src",
+        "tests",
+        "*.ts"
+    ],
     "include": [
         "build/src/components/**/*Vue.ts"
     ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,14 +14,13 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "target": "es5",
-        "types": ["node"],
+        "types": ["node", "mocha", "chai"],
         "moduleResolution": "node",
         "resolveJsonModule": true,
-        "incremental": true
     },
     "include": [
         "src/**/*.ts",
-        "script.ts",
-        "server.ts"
+        "tests/**/*.ts",
+        "*.ts",
     ]
 }


### PR DESCRIPTION
This solves a few problems:
1. It removes the duplication between configurations
2. It restores test files as first class objects within vscode (I assume without disrupting other development patterns)
3. It paves the way for further separating frontend and backend code.