### PR TITLE
throw when no spaces available

### DIFF
--- a/src/boards/Board.ts
+++ b/src/boards/Board.ts
@@ -168,6 +168,9 @@ export abstract class Board {
       return this.canPlaceTile(space) && (space.player === undefined || space.player === player);
     }).filter(predicate);
     let idx = (direction === 1) ? distance : (spaces.length - (distance + 1));
+    if (spaces.length === 0) {
+      throw new Error('no spaces available');
+    }
     while (idx < 0) {
       idx += spaces.length;
     }

--- a/tests/boards/Board.spec.ts
+++ b/tests/boards/Board.spec.ts
@@ -152,6 +152,12 @@ describe('Board', function() {
         expect(board.getNthAvailableLandSpace(3, -1).id).eq('59');
   });
 
+  it('getNthAvailableLandSpace throws if no spaces available', function() {
+    expect(function() {
+      board.getNthAvailableLandSpace(0, 1, undefined, () => false);
+    }).to.throw('no spaces available');
+  });
+
   function expectSpace(space: ISpace, id: string, x: number, y: number) {
     if (id !== space.id || x !== space.x || y !== space.y) {
       expect.fail(`space ${space.id} at (${space.x}, ${space.y}) does not match [${id}, ${x}, ${y}]`);


### PR DESCRIPTION
This throws an error when there are no spaces available to avoid blocking the thread. This would take down heroku instance.

Closes #2416 