### PR TITLE
Playwrights and ProjectInspection can always play or act

### DIFF
--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -25,15 +25,18 @@ export class Playwrights implements CorporationCard {
       return undefined;
     }
 
-    public canAct(player: Player, game: Game): boolean {
-      const replayableEvents = this.getReplayableEvents(player, game);
-      return replayableEvents.length > 0;
+    public canAct(): boolean {
+      return true;
     }
 
     public action(player: Player, game: Game) {
-      const players = game.getPlayers();
       const replayableEvents = this.getReplayableEvents(player, game);
 
+      if (replayableEvents.length === 0) {
+        return undefined;
+      }
+
+      const players = game.getPlayers();
       return new SelectCard<ICard>(
         'Select event card to replay at cost in MC and remove from play', 'Select', replayableEvents,
         (foundCards: Array<ICard>) => {

--- a/src/cards/promo/ProjectInspection.ts
+++ b/src/cards/promo/ProjectInspection.ts
@@ -35,18 +35,19 @@ export class ProjectInspection implements IProjectCard {
       return result;
     }
 
-    public canPlay(player: Player, game: Game): boolean {
-      return this.getActionCards(player, game).length > 0;
+    public canPlay(): boolean {
+      return true;
     }
 
     public play(player: Player, game: Game) {
-      if (this.getActionCards(player, game).length === 0 ) {
+      const actionCards = this.getActionCards(player, game);
+      if (actionCards.length === 0) {
         return undefined;
       }
       return new SelectCard(
         'Perform an action from a played card again',
         'Take action',
-        this.getActionCards(player, game),
+        actionCards,
         (foundCards: Array<ICard>) => {
           const foundCard = foundCards[0];
           game.log('${0} used ${1} action with ${2}', (b) => b.player(player).card(foundCard).card(this));

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -1,17 +1,14 @@
 import {expect} from 'chai';
 import {DeimosDown} from '../../../src/cards/base/DeimosDown';
 import {IndenturedWorkers} from '../../../src/cards/base/IndenturedWorkers';
-import {LocalHeatTrapping} from '../../../src/cards/base/LocalHeatTrapping';
 import {ReleaseOfInertGases} from '../../../src/cards/base/ReleaseOfInertGases';
 import {Playwrights} from '../../../src/cards/community/Playwrights';
 import {ICard} from '../../../src/cards/ICard';
-import {MartianSurvey} from '../../../src/cards/prelude/MartianSurvey';
 import {LawSuit} from '../../../src/cards/promo/LawSuit';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 import {Player} from '../../../src/Player';
-import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestingUtils';
 
 describe('Playwrights', function() {
@@ -27,9 +24,9 @@ describe('Playwrights', function() {
     player.corporationCard = card;
   });
 
-  it('Cannot act without any played events', function() {
-    expect(player.getProduction(Resources.ENERGY)).eq(1);
-    expect(card.canAct(player, game)).is.not.true;
+  it('Can always act', function() {
+    expect(card.canAct()).is.true;
+    expect(card.action(player, game)).is.undefined;
   });
 
   it('Can replay own event', function() {
@@ -39,10 +36,9 @@ describe('Playwrights', function() {
     player.playedCards.push(event);
 
     expect(player.getTerraformRating()).to.eq(tr + 2);
-    expect(card.canAct(player, game)).is.not.true;
 
     player.megaCredits = event.cost;
-    expect(card.canAct(player, game)).is.true;
+    expect(card.canAct()).is.true;
 
     const selectCard = card.action(player, game) as SelectCard<ICard>;
     selectCard.cb([event]);
@@ -63,7 +59,7 @@ describe('Playwrights', function() {
     player2.playedCards.push(event);
 
     player.megaCredits = event.cost;
-    expect(card.canAct(player, game)).is.true;
+    expect(card.canAct()).is.true;
     const selectCard = card.action(player, game) as SelectCard<ICard>;
     selectCard.cb([event]);
 
@@ -74,15 +70,6 @@ describe('Playwrights', function() {
     expect(player.megaCredits).eq(0);
     expect(player2.playedCards).has.lengthOf(0);
     expect(player.removedFromPlayCards).has.lengthOf(1);
-  });
-
-  it('Cannot act without any playable events', function() {
-    player2.playedCards.push(new MartianSurvey(), new LocalHeatTrapping(), new DeimosDown());
-
-    (game as any).oxygenLevel = 5;
-    player.heat = 4;
-    player.megaCredits = 30;
-    expect(card.canAct(player, game)).is.not.true;
   });
 
   it('Acts correctly for event cards that give one time discount', function() {
@@ -107,7 +94,7 @@ describe('Playwrights', function() {
 
     player.megaCredits = event.cost;
     player.removingPlayers = [player2.id];
-    expect(card.canAct(player, game)).is.true;
+    expect(card.canAct()).is.true;
 
     const selectCard = card.action(player, game) as SelectCard<ICard>;
     selectCard.cb([event]);

--- a/tests/cards/promo/ProjectInspection.spec.ts
+++ b/tests/cards/promo/ProjectInspection.spec.ts
@@ -18,21 +18,15 @@ describe('ProjectInspection', function() {
     player.playedCards.push(actionCard);
   });
 
-  it('Can\'t play if no actions played this turn', function() {
-    expect(card.canPlay(player, game)).is.not.true;
-  });
-
-  it('Can\'t play if available actions can\'t act', function() {
-    player.setActionsThisGeneration(actionCard.name);
-    player.megaCredits = 1;
-
-    expect(card.canPlay(player, game)).is.not.true;
+  it('Can always play', function() {
+    expect(card.canPlay()).is.true;
+    expect(card.play(player, game)).is.undefined;
   });
 
   it('Should play', function() {
     player.setResource(Resources.MEGACREDITS, 2);
     player.setActionsThisGeneration(actionCard.name);
-    expect(card.canPlay(player, game)).is.true;
+    expect(card.canPlay()).is.true;
 
     const play = card.play(player, game);
     expect(play instanceof SelectCard).is.true;


### PR DESCRIPTION
Allows `Playwrights` and `ProjectInspection` to always take action or play. This brings this card up to date with the change to allow a card to do nothing if the user wants to and also avoids infinite loop between the two cards when played together.