### PR TITLE
Fix infinite loop issue with Playwrights + ProjectInspection

### DIFF
--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -45,6 +45,9 @@ export class Playwrights implements CorporationCard {
           });
 
           const cost = player.getCardCost(game, selectedCard);
+          // Special case for Law Suit which enters another player's discard pile
+          const isLawSuit = selectedCard.name === CardName.LAW_SUIT ? false : true;
+
           game.defer(new SelectHowToPayDeferred(
             player,
             cost,
@@ -63,7 +66,7 @@ export class Playwrights implements CorporationCard {
                     }
                   }
                   return undefined;
-                }));
+                }), isLawSuit);
               },
             },
           ));


### PR DESCRIPTION
@bafolts Regarding https://github.com/bafolts/terraforming-mars/pull/2437 it would enable two stall actions every time which is not ideal rules-wise. Was discussing with @Lynesth and we verified that this would address the issue. Can you see if it is a better approach?