### PR TITLE
add solarphaseoption to gameoptionmodel

### DIFF
--- a/src/models/GameOptionsModel.ts
+++ b/src/models/GameOptionsModel.ts
@@ -21,6 +21,7 @@ export interface GameOptionsModel {
   showOtherPlayersVP: boolean,
   showTimers: boolean,
   shuffleMapOption: boolean,
+  solarPhaseOption: boolean,
   soloTR: boolean,
   randomMA: RandomMAOptionType,
   turmoilExtension: boolean,

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -499,6 +499,7 @@ function getGameOptionsAsModel(options: GameOptions): GameOptionsModel {
     showOtherPlayersVP: options.showOtherPlayersVP,
     showTimers: options.showTimers,
     shuffleMapOption: options.shuffleMapOption,
+    solarPhaseOption: options.solarPhaseOption,
     soloTR: options.soloTR,
     randomMA: options.randomMA,
     turmoilExtension: options.turmoilExtension,


### PR DESCRIPTION
This allows WGT to display correctly here:

![image](https://user-images.githubusercontent.com/14239220/104856301-ed78cb80-58df-11eb-85fd-badcdcd7bfef.png)
