### PR TITLE
Standard actions once again

### DIFF
--- a/src/CardName.ts
+++ b/src/CardName.ts
@@ -10,6 +10,10 @@ export enum CardName {
     CITY_STANDARD_PROJECT = 'City',
     AIR_SCRAPPING_STANDARD_PROJECT = 'Air Scrapping',
 
+    // Standard actions:
+    CONVERT_PLANTS = 'Convert Plants',
+    CONVERT_HEAT = 'Convert Heat',
+
     ACQUIRED_COMPANY = 'Acquired Company',
     ADAPTATION_TECHNOLOGY = 'Adaptation Technology',
     ADAPTED_LICHEN = 'Adapted Lichen',

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -1,4 +1,3 @@
-
 import {CardMetadata} from './CardMetadata';
 import {CardName} from '../CardName';
 import {CardType} from './CardType';
@@ -32,7 +31,7 @@ export abstract class Card {
       if (properties.cardType === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
         throw new Error('must define startingMegaCredits for corporation cards');
       }
-      if (properties.cardType !== CardType.CORPORATION && properties.cardType !== CardType.PRELUDE && properties.cost === undefined) {
+      if ([CardType.CORPORATION, CardType.PRELUDE, CardType.STANDARD_ACTION].includes(properties.cardType) === false && properties.cost === undefined) {
         throw new Error('must define cost for project cards');
       }
       staticCardProperties.set(properties.name, properties);

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -31,8 +31,10 @@ export abstract class Card {
       if (properties.cardType === CardType.CORPORATION && properties.startingMegaCredits === undefined) {
         throw new Error('must define startingMegaCredits for corporation cards');
       }
-      if ([CardType.CORPORATION, CardType.PRELUDE, CardType.STANDARD_ACTION].includes(properties.cardType) === false && properties.cost === undefined) {
-        throw new Error('must define cost for project cards');
+      if (properties.cost === undefined) {
+        if ([CardType.CORPORATION, CardType.PRELUDE, CardType.STANDARD_ACTION].includes(properties.cardType) === false) {
+          throw new Error(`${properties.name} must have a cost property`);
+        }
       }
       staticCardProperties.set(properties.name, properties);
       staticInstance = properties;

--- a/src/cards/CardManifest.ts
+++ b/src/cards/CardManifest.ts
@@ -5,6 +5,7 @@ import {CorporationCard} from './corporation/CorporationCard';
 import {ICardFactory} from './ICardFactory';
 import {IProjectCard} from './IProjectCard';
 import {StandardProjectCard} from './StandardProjectCard';
+import {StandardActionCard} from './StandardActionCard';
 
 export class CardManifest {
     module: GameModule;
@@ -13,6 +14,7 @@ export class CardManifest {
     corporationCards : Deck<CorporationCard>;
     preludeCards : Deck<IProjectCard>;
     standardProjects : Deck<StandardProjectCard>;
+    standardActions : Deck<StandardActionCard>;
     constructor(arg: {
          module: GameModule,
          projectCards?: Array<ICardFactory<IProjectCard>>,
@@ -20,6 +22,7 @@ export class CardManifest {
          corporationCards?: Array<ICardFactory<CorporationCard>>,
          preludeCards?: Array<ICardFactory<IProjectCard>>,
          standardProjects?: Array<ICardFactory<StandardProjectCard>>,
+         standardActions?: Array<ICardFactory<StandardActionCard>>,
          }) {
       this.module = arg.module;
       this.projectCards = new Deck<IProjectCard>(arg.projectCards || []);
@@ -27,5 +30,6 @@ export class CardManifest {
       this.corporationCards = new Deck<CorporationCard>(arg.corporationCards || []);
       this.preludeCards = new Deck<IProjectCard>(arg.preludeCards || []);
       this.standardProjects = new Deck<StandardProjectCard>(arg.standardProjects || []);
+      this.standardActions = new Deck<StandardActionCard>(arg.standardActions || []);
     }
 }

--- a/src/cards/CardType.ts
+++ b/src/cards/CardType.ts
@@ -1,10 +1,11 @@
 export enum CardType {
-    EVENT = 'red',
-    ACTIVE = 'blue',
-    AUTOMATED = 'green',
-    PRELUDE = 'pink',
-    CORPORATION = 'brown',
-    STANDARD_PROJECT = 'gray',
+    EVENT = 'event',
+    ACTIVE = 'active',
+    AUTOMATED = 'automated',
+    PRELUDE = 'prelude',
+    CORPORATION = 'corporation',
+    STANDARD_PROJECT = 'standard_project',
+    STANDARD_ACTION = 'standard_action',
     // Proxy cards are not real cards, but for operations that need a card-like behavior.
     PROXY = 'proxy',
 }

--- a/src/cards/StandardActionCard.ts
+++ b/src/cards/StandardActionCard.ts
@@ -1,0 +1,33 @@
+import {CardType} from './CardType';
+import {Player} from '../Player';
+import {CardMetadata} from './CardMetadata';
+import {CardName} from '../CardName';
+import {Card} from './Card';
+import {IActionCard, ICard} from './ICard';
+import {PlayerInput} from '../PlayerInput';
+
+interface StaticStandardActionCardProperties {
+  name: CardName,
+  metadata: CardMetadata,
+}
+
+export abstract class StandardActionCard extends Card implements IActionCard, ICard {
+  constructor(properties: StaticStandardActionCardProperties) {
+    super({
+      cardType: CardType.STANDARD_ACTION,
+      ...properties,
+    });
+  }
+
+  public abstract canAct(player: Player): boolean
+
+  public abstract action(player: Player): PlayerInput | undefined
+
+  protected actionUsed(player: Player) {
+    player.game.log('${0} used ${1} Standard Action', (b) => b.player(player).card(this));
+  }
+
+  public play() {
+    return undefined;
+  }
+}

--- a/src/cards/StandardActionCard.ts
+++ b/src/cards/StandardActionCard.ts
@@ -24,7 +24,7 @@ export abstract class StandardActionCard extends Card implements IActionCard, IC
   public abstract action(player: Player): PlayerInput | undefined
 
   protected actionUsed(player: Player) {
-    player.game.log('${0} used ${1} Standard Action', (b) => b.player(player).card(this));
+    player.game.log('${0} used ${1} standard action', (b) => b.player(player).card(this));
   }
 
   public play() {

--- a/src/cards/StandardCardManifests.ts
+++ b/src/cards/StandardCardManifests.ts
@@ -228,6 +228,8 @@ import {PowerPlantStandardProject} from './base/standardProjects/PowerPlantStand
 import {GreeneryStandardProject} from './base/standardProjects/GreeneryStandardProject';
 import {AsteroidStandardProject} from './base/standardProjects/AsteroidStandardProject';
 import {SellPatentsStandardProject} from './base/standardProjects/SellPatentsStandardProject';
+import {ConvertPlants} from './base/standardActions/ConvertPlants';
+import {ConvertHeat} from './base/standardActions/ConvertHeat';
 
 export const BASE_CARD_MANIFEST = new CardManifest({
   module: GameModule.Base,
@@ -390,6 +392,10 @@ export const BASE_CARD_MANIFEST = new CardManifest({
     {cardName: CardName.GREENERY_STANDARD_PROJECT, Factory: GreeneryStandardProject},
     {cardName: CardName.ASTEROID_STANDARD_PROJECT, Factory: AsteroidStandardProject},
     {cardName: CardName.SELL_PATENTS_STANDARD_PROJECT, Factory: SellPatentsStandardProject},
+  ],
+  standardActions: [
+    {cardName: CardName.CONVERT_PLANTS, Factory: ConvertPlants},
+    {cardName: CardName.CONVERT_HEAT, Factory: ConvertHeat},
   ],
 });
 

--- a/src/cards/base/standardActions/ConvertHeat.ts
+++ b/src/cards/base/standardActions/ConvertHeat.ts
@@ -1,0 +1,47 @@
+import {StandardActionCard} from '../../StandardActionCard';
+import {CardName} from '../../../CardName';
+import {CardRenderer} from '../../render/CardRenderer';
+import {Player} from '../../../Player';
+import {PartyHooks} from '../../../turmoil/parties/PartyHooks';
+import {PartyName} from '../../../turmoil/parties/PartyName';
+import {HEAT_FOR_TEMPERATURE, MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../../../constants';
+
+
+export class ConvertHeat extends StandardActionCard {
+  constructor() {
+    super({
+      name: CardName.CONVERT_HEAT,
+      metadata: {
+        cardNumber: 'SA2',
+        renderData: CardRenderer.builder((b) =>
+          b.standardProject('Spend 8 Heat to raise temperature 1 step.', (eb) => {
+            eb.heat(8).startAction.temperature(1);
+          }),
+        ),
+      },
+    });
+  }
+
+  public canAct(player: Player): boolean {
+    if (player.game.getTemperature() === MAX_TEMPERATURE) {
+      return false;
+    }
+    if (player.availableHeat < HEAT_FOR_TEMPERATURE) {
+      return false;
+    }
+
+    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+      return (!player.isCorporation(CardName.HELION) && player.canAfford(REDS_RULING_POLICY_COST)) ||
+        player.canAfford(REDS_RULING_POLICY_COST + 8);
+    }
+    return true;
+  }
+
+  public action(player: Player) {
+    return player.spendHeat(HEAT_FOR_TEMPERATURE, () => {
+      this.actionUsed(player);
+      player.game.increaseTemperature(player, 1);
+      return undefined;
+    });
+  }
+}

--- a/src/cards/base/standardActions/ConvertPlants.ts
+++ b/src/cards/base/standardActions/ConvertPlants.ts
@@ -1,0 +1,56 @@
+import {StandardActionCard} from '../../StandardActionCard';
+import {CardName} from '../../../CardName';
+import {CardRenderer} from '../../render/CardRenderer';
+import {Player} from '../../../Player';
+import {PartyHooks} from '../../../turmoil/parties/PartyHooks';
+import {PartyName} from '../../../turmoil/parties/PartyName';
+import {MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST} from '../../../constants';
+import {AltSecondaryTag} from '../../render/CardRenderItem';
+import {SelectSpace} from '../../../inputs/SelectSpace';
+import {ISpace} from '../../../boards/ISpace';
+
+
+export class ConvertPlants extends StandardActionCard {
+  constructor() {
+    super({
+      name: CardName.CONVERT_PLANTS,
+      metadata: {
+        cardNumber: 'SA2',
+        renderData: CardRenderer.builder((b) =>
+          b.standardProject('Spend 8 Plants to place a greenery tile and raise oxygen 1 step.', (eb) => {
+            eb.plants(8).startAction.greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+          }),
+        ),
+      },
+    });
+  }
+
+  public canAct(player: Player): boolean {
+    if (player.plants < player.plantsNeededForGreenery) {
+      return false;
+    }
+    if (player.game.board.getAvailableSpacesForGreenery(player).length === 0) {
+      return false;
+    }
+    if (player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL) {
+      return true;
+    }
+    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+      return player.canAfford(REDS_RULING_POLICY_COST);
+    }
+    return true;
+  }
+
+  public action(player: Player) {
+    return new SelectSpace(
+      `Convert ${player.plantsNeededForGreenery} plants into greenery`,
+      player.game.board.getAvailableSpacesForGreenery(player),
+      (space: ISpace) => {
+        this.actionUsed(player);
+        player.game.addGreenery(player, space.id);
+        player.plants -= player.plantsNeededForGreenery;
+        return undefined;
+      },
+    );
+  }
+}

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -9,6 +9,7 @@ import {PlayerModel} from '../models/PlayerModel';
 import {Card} from './card/Card';
 import {$t} from '../directives/i18n';
 import {CardFinder} from './../CardFinder';
+import {ICard} from '../cards/ICard';
 
 export const LogPanel = Vue.component('log-panel', {
   props: {
@@ -47,7 +48,7 @@ export const LogPanel = Vue.component('log-panel', {
         className = 'background-color-automated';
       } else if (cardType === CardType.PRELUDE) {
         className = 'background-color-prelude';
-      } else if (cardType === CardType.STANDARD_PROJECT) {
+      } else if (cardType === CardType.STANDARD_PROJECT || cardType === CardType.STANDARD_ACTION) {
         className = 'background-color-standard-project';
       }
 
@@ -85,10 +86,11 @@ export const LogPanel = Vue.component('log-panel', {
               }
             }
           }
-          const card = new CardFinder().getCardByName(data.value, (manifest) => [
+          const card = new CardFinder().getCardByName<ICard>(data.value, (manifest) => [
             manifest.projectCards,
             manifest.preludeCards,
             manifest.standardProjects,
+            manifest.standardActions,
           ]);
           if (card && card.cardType) return this.parseCardType(card.cardType, data.value);
         } else if (translatableMessageDataTypes.includes(data.type)) {

--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -41,7 +41,14 @@ export const Card = Vue.component('card', {
     const cardName = this.card.name;
     let expansion: GameModule | undefined;
     for (const manifest of ALL_CARD_MANIFESTS) {
-      for (const deck of [manifest.corporationCards, manifest.projectCards, manifest.preludeCards, manifest.standardProjects]) {
+      const decks = [
+        manifest.corporationCards,
+        manifest.projectCards,
+        manifest.preludeCards,
+        manifest.standardProjects,
+        manifest.standardActions,
+      ];
+      for (const deck of decks) {
         const factory = deck.findByCardName(cardName);
         if (factory !== undefined) {
           cardInstance = new factory.Factory();
@@ -116,7 +123,7 @@ export const Card = Vue.component('card', {
       return this.getCardType() === CardType.CORPORATION;
     },
     isStandardProject: function() : boolean {
-      return this.getCardType() === CardType.STANDARD_PROJECT;
+      return this.getCardType() === CardType.STANDARD_PROJECT || this.getCardType() === CardType.STANDARD_ACTION;
     },
   },
   template: `

--- a/src/components/card/CardTitle.ts
+++ b/src/components/card/CardTitle.ts
@@ -35,7 +35,7 @@ export const CardTitle = Vue.component('CardTitle', {
         classes.push('background-color-events');
       } else if (this.type === CardType.PRELUDE) {
         classes.push('background-color-prelude');
-      } else if (this.type === CardType.STANDARD_PROJECT) {
+      } else if (this.type === CardType.STANDARD_PROJECT || this.type === CardType.STANDARD_ACTION) {
         classes.push('background-color-standard-project');
       }
 
@@ -51,7 +51,7 @@ export const CardTitle = Vue.component('CardTitle', {
     },
     getMainClasses() {
       const classes: Array<String> = ['card-title'];
-      if (this.type === CardType.STANDARD_PROJECT) {
+      if (this.type === CardType.STANDARD_PROJECT || this.type === CardType.STANDARD_ACTION) {
         classes.push('card-title-standard-project');
       }
       return classes.join(' ');

--- a/tests/cards/base/standardActions/ConvertHeat.spec.ts
+++ b/tests/cards/base/standardActions/ConvertHeat.spec.ts
@@ -1,0 +1,38 @@
+import {expect} from 'chai';
+import {ConvertHeat} from '../../../../src/cards/base/standardActions/ConvertHeat';
+import {Player} from '../../../../src/Player';
+import {setCustomGameOptions, TestPlayers} from '../../../TestingUtils';
+import {Game} from '../../../../src/Game';
+import {PoliticalAgendas} from '../../../../src/turmoil/PoliticalAgendas';
+import {Reds} from '../../../../src/turmoil/parties/Reds';
+
+describe('ConvertHeat', function() {
+  let card: ConvertHeat; let player: Player;
+
+  beforeEach(function() {
+    card = new ConvertHeat();
+    player = TestPlayers.BLUE.newPlayer();
+    const player2 = TestPlayers.RED.newPlayer();
+    Game.newInstance('foobar', [player, player2], player, setCustomGameOptions());
+  });
+
+  it('Can not act without heat', function() {
+    expect(card.canAct(player)).eq(false);
+    player.heat = 7;
+    expect(card.canAct(player)).eq(false);
+  });
+
+  it('Can not act with reds', function() {
+    player.heat = 8;
+    player.game.turmoil!.rulingParty = new Reds();
+    PoliticalAgendas.setNextAgenda(player.game.turmoil!, player.game);
+    expect(card.canAct(player)).eq(false);
+  });
+
+  it('Should play', function() {
+    player.heat = 8;
+    expect(card.canAct(player)).eq(true);
+    expect(card.action(player)).eq(undefined);
+    expect(player.game.getTemperature()).eq(-28);
+  });
+});

--- a/tests/cards/base/standardActions/ConvertPlants.spec.ts
+++ b/tests/cards/base/standardActions/ConvertPlants.spec.ts
@@ -1,0 +1,42 @@
+import {expect} from 'chai';
+import {ConvertPlants} from '../../../../src/cards/base/standardActions/ConvertPlants';
+import {Player} from '../../../../src/Player';
+import {setCustomGameOptions, TestPlayers} from '../../../TestingUtils';
+import {Game} from '../../../../src/Game';
+import {PoliticalAgendas} from '../../../../src/turmoil/PoliticalAgendas';
+import {Reds} from '../../../../src/turmoil/parties/Reds';
+
+describe('ConvertPlants', function() {
+  let card: ConvertPlants; let player: Player;
+
+  beforeEach(function() {
+    card = new ConvertPlants();
+    player = TestPlayers.BLUE.newPlayer();
+    const player2 = TestPlayers.RED.newPlayer();
+    Game.newInstance('foobar', [player, player2], player, setCustomGameOptions());
+  });
+
+  it('Can not act without plants', function() {
+    expect(card.canAct(player)).eq(false);
+    player.plants = 7;
+    expect(card.canAct(player)).eq(false);
+  });
+
+  it('Can not act with reds', function() {
+    player.plants = 8;
+    player.game.turmoil!.rulingParty = new Reds();
+    PoliticalAgendas.setNextAgenda(player.game.turmoil!, player.game);
+    expect(card.canAct(player)).eq(false);
+  });
+
+  it('Should play', function() {
+    player.plants = 8;
+
+    expect(card.canAct(player)).eq(true);
+    const action = card.action(player);
+    expect(action).not.eq(undefined);
+    action.cb(action.availableSpaces[0]);
+
+    expect(player.game.getOxygenLevel()).eq(1);
+  });
+});

--- a/tests/cards/corporation/EcoLine.spec.ts
+++ b/tests/cards/corporation/EcoLine.spec.ts
@@ -2,15 +2,28 @@ import {expect} from 'chai';
 import {EcoLine} from '../../../src/cards/corporation/EcoLine';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestingUtils';
+import {ConvertPlants} from '../../../src/cards/base/standardActions/ConvertPlants';
+import {Game} from '../../../src/Game';
 
 describe('EcoLine', function() {
   it('Should play', function() {
     const card = new EcoLine();
     const player = TestPlayers.BLUE.newPlayer();
+    Game.newInstance('foobar', [player], player);
     const action = card.play(player);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.PLANTS)).to.eq(2);
     expect(player.plants).to.eq(3);
     expect(player.plantsNeededForGreenery).to.eq(7);
+
+    const convert = new ConvertPlants();
+    expect(convert.canAct(player)).eq(false);
+    player.plants = 7;
+    expect(convert.canAct(player)).eq(true);
+
+    const action2 = convert.action(player);
+    expect(action2).not.eq(undefined);
+    action2.cb(action2.availableSpaces[0]);
+    expect(player.plants).to.eq(0);
   });
 });


### PR DESCRIPTION
Hi, once again the Standard Actions - SAs. (I closed old messy https://github.com/bafolts/terraforming-mars/pull/2288 PR and opened this one, clearer imo).

In this PR I've:
1. Added the class StandardActionCard, which is meant to be a class for actions like converting plants / heat, turmoil actions, claiming milestone and similar. This time it is parallel to `StandardProjectCard`, those two do not extend each other. The most important part of it is:
  ```ts
  export abstract class StandardActionCard extends Card implements IActionCard, ICard {
  constructor(...) {
    super({
      cardType: CardType.STANDARD_ACTION,
      name: name,
      metadata: metadata,
    });
  }
    public abstract canAct(player: Player): boolean
    public abstract action(player: Player): PlayerInput | undefined
  }
  ```
2. Added first two SAs - Convert Plants and Convert Heat. I switched old code in `Player.ts` like `private convertPlantsIntoGreenery(): PlayerInput` to new using `ConvertPlants` methods.
3. Added displaying them as cards in log:
![Screenshot from 2021-01-21 01-00-48](https://user-images.githubusercontent.com/19472604/105255856-c989e400-5b84-11eb-8660-ec57765cb8cb.png)

For now the SA cards are using the same css classes as standard projects, they are meant to look the same. Those classes are named after standard projects which I did not change to improve PR readability. If you think this is necessary, let me know, I'll add that.

In next PRs I want to:
1. Display them as cards in player input section (right now this part is unchanged)
2. Add more SAs