### PR TITLE
Use windows build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [pull_request, push]
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -16,4 +16,17 @@ jobs:
     - run: npm run build
     - run: npm test
     - run: npm run cover
-      
+  build-linux:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: npm install
+    - run: npm run build
+    - run: npm test
+    - run: npm run cover
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - run: npm run build
     - run: npm test
     - run: npm run cover
-  build-linux:
+  build-windows:
 
     runs-on: windows-latest
 


### PR DESCRIPTION
Adds a windows machine to the build. This should provide some hope that windows users will be able to build as we change the build scripts.