### PR TITLE
Updated CardType enum

### DIFF
--- a/src/cards/CardType.ts
+++ b/src/cards/CardType.ts
@@ -1,10 +1,10 @@
 export enum CardType {
-    EVENT = 'red',
-    ACTIVE = 'blue',
-    AUTOMATED = 'green',
-    PRELUDE = 'pink',
-    CORPORATION = 'brown',
-    STANDARD_PROJECT = 'gray',
+    EVENT = 'event',
+    ACTIVE = 'active',
+    AUTOMATED = 'automated',
+    PRELUDE = 'prelude',
+    CORPORATION = 'corporation',
+    STANDARD_PROJECT = 'standard_project',
     // Proxy cards are not real cards, but for operations that need a card-like behavior.
     PROXY = 'proxy',
 }


### PR DESCRIPTION
Values of this enum are unused and don't bring much new info.
I think it's better to have them the same way as in other enums, where values are lowercase of names.