### PR TITLE
Fix not paying enough

### DIFF
--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -120,7 +120,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       this.titanium = 0;
       this.heat = 0;
 
-      let megacreditBalance = this.cost - this.player.megaCredits;
+      let megacreditBalance = Math.max(this.cost - this.player.megaCredits, 0);
 
       // Calcualtes the optimal number of units to use given the unit value.
       //
@@ -154,16 +154,21 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
 
       if (megacreditBalance > 0 && this.canUseSteel()) {
         const availableSteel = Math.max(this.player.steel - this.card.reserveUnits.steel, 0);
-        this.steel = deductUnits(availableSteel, this.player.steelValue, false);
+        this.steel = deductUnits(availableSteel, this.player.steelValue, true);
       }
 
       if (megacreditBalance > 0 && this.canUseTitanium()) {
         const availableTitanium = Math.max(this.player.titanium - this.card.reserveUnits.titanium, 0);
-        this.titanium = deductUnits(availableTitanium, this.player.titaniumValue, false);
+        this.titanium = deductUnits(availableTitanium, this.player.titaniumValue, true);
       }
 
       if (megacreditBalance > 0 && this.canUseHeat()) {
         this.heat = deductUnits(this.player.heat, 1);
+      }
+
+      // If we are overspending in mc, spend less mc.
+      if (megacreditBalance < 0) {
+        this.megaCredits += megacreditBalance;
       }
     },
     canUseHeat: function() {

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -167,7 +167,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       }
 
       // If we are overspending in mc, spend less mc.
-      if (megacreditBalance < 0) {
+      if (megacreditBalance < 0 && this.megaCredits + megacreditBalance >= 0) {
         this.megaCredits += megacreditBalance;
       }
     },

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -119,10 +119,10 @@ describe('SelectHowToPayForProjectCard', function() {
   });
 
   it('select how to pay uses steel', async function() {
-    // Forced Precipitation will cost 10. Player has 7MC and will 1 of the 4 available units of steel even though
-    // that leaves the player 1MC short.
+    // Regoplastic will cost 10. Player has 7MC and 4 steels.
+    // They should spend at least enough to pay for the card, that is 6 mc and 2 steel.
     const wrapper = setupCardForPurchase(
-      CardName.COMMERCIAL_DISTRICT, 10,
+      CardName.REGO_PLASTICS, 10,
       {steel: 4, megaCredits: 7, steelValue: 2},
       {canUseSteel: true});
 
@@ -131,7 +131,7 @@ describe('SelectHowToPayForProjectCard', function() {
 
     expect(vm.steel).eq(1);
     const steelTextBox = wrapper.find('[title~=Steel] ~ input').element as HTMLInputElement;
-    expect(steelTextBox.value).eq('1');
+    expect(steelTextBox.value).eq('2');
   });
 
   const setupCardForPurchase = function(

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -129,7 +129,7 @@ describe('SelectHowToPayForProjectCard', function() {
     const vm = wrapper.vm;
     await vm.$nextTick();
 
-    expect(vm.steel).eq(1);
+    expect(vm.steel).eq(2);
     const steelTextBox = wrapper.find('[title~=Steel] ~ input').element as HTMLInputElement;
     expect(steelTextBox.value).eq('2');
   });


### PR DESCRIPTION
Pay enough mc by default when playing a card. 

This is done by trying to overspend steel and Ti if possible. Then if we are overspending the mc at the end, spend less mc if possible.

This can close #2483 .