### PR TITLE
use brotli when available

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -525,7 +525,10 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
   } else if (req.url === '/main.js' || req.url === '/main.js.map') {
     res.setHeader('Content-Type', 'text/javascript');
     let suffix = '';
-    if (supportsGzip(req)) {
+    if (supportsEncoding(req, 'br')) {
+      res.setHeader('Content-Encoding', 'br');
+      suffix = '.br';
+    } else if (supportsEncoding(req, 'gzip')) {
       res.setHeader('Content-Encoding', 'gzip');
       suffix = '.gz';
     }
@@ -569,14 +572,14 @@ function serveAsset(req: http.IncomingMessage, res: http.ServerResponse): void {
   });
 }
 
-function supportsGzip(req: http.IncomingMessage): boolean {
+function supportsEncoding(req: http.IncomingMessage, encoding: 'gzip' | 'br'): boolean {
   return req.headers['accept-encoding'] !== undefined &&
-         req.headers['accept-encoding'].includes('gzip');
+         req.headers['accept-encoding'].includes(encoding);
 }
 
 function serveStyles(req: http.IncomingMessage, res: http.ServerResponse): void {
   let buffer = styles;
-  if (compressedStyles !== undefined && supportsGzip(req)) {
+  if (compressedStyles !== undefined && supportsEncoding(req, 'gzip')) {
     res.setHeader('Content-Encoding', 'gzip');
     buffer = compressedStyles;
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
 
 const process = require('process');
 const CompressionPlugin = require('compression-webpack-plugin');
+const zlib = require("zlib");
 
 module.exports = {
   devtool: 'source-map',
@@ -9,7 +10,14 @@ module.exports = {
   entry: [
     './build/src/script.js',
   ],
-  plugins: [new CompressionPlugin()],
+  plugins: [
+    new CompressionPlugin(),
+    new CompressionPlugin({
+      algorithm: "brotliCompress",
+      filename: "[path][base].br",
+      compressionOptions: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 } }
+    })
+  ],
   resolve: {
     alias: {
       'vue$': 'vue/dist/vue.esm.js', // 'vue/dist/vue.common.js' for webpack 1

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     new CompressionPlugin({
       algorithm: "brotliCompress",
       filename: "[path][base].br",
-      compressionOptions: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 } }
+      compressionOptions: { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY } }
     })
   ],
   resolve: {


### PR DESCRIPTION
I have been slowly watching the `gzip` generated file size grow during the static property card refactor. Something with that change doesn't compress as well with `gzip`. Recently discovered brotli (`br`). The compression is much better.

```
Hash: f8a95101496ec90b61fe
Version: webpack 4.44.2
Time: 19076ms
Built at: 01/22/2021 6:33:36 PM
         Asset      Size  Chunks                   Chunk Names
       main.js   3.7 MiB    main  [emitted]        main
    main.js.br   380 KiB          [emitted]        
    main.js.gz   560 KiB          [emitted]        
```

Smaller file size means less code server has to send and smaller file client has to download. Everyone wins! 

The browser support is vast.

https://caniuse.com/brotli

If only `gzip` available that is still used as back-up.