### PR TITLE
use dialog element instead of window.confirm

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -70,6 +70,11 @@ checkComponent(
   ['PLUTO', 'GANYMEDE'],
 );
 checkComponent(
+  'src/components/common/ConfirmDialog',
+  require('./build/src/components/common/ConfirmDialog').ConfirmDialog,
+  ['hide'],
+);
+checkComponent(
   'src/components/CorporationsFilter',
   require('./build/src/components/CorporationsFilter').CorporationsFilter,
   ['cardsByModuleMap', 'customCorporationsList', 'selectedCorporations', 'corpsByModule'],

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -1,8 +1,9 @@
-import Vue, {VNode} from 'vue';
+import Vue from 'vue';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {$t} from '../directives/i18n';
-import {SpaceId} from '../boards/ISpace';
+import {TranslateMixin} from './TranslateMixin';
 import {PreferencesManager} from './PreferencesManager';
+
+const dialogPolyfill = require('dialog-polyfill');
 
 export const SelectSpace = Vue.component('select-space', {
   props: {
@@ -21,11 +22,74 @@ export const SelectSpace = Vue.component('select-space', {
   },
   data: function() {
     return {
+      availableSpaces: new Set(this.playerinput.availableSpaces),
+      selectedTile: undefined as HTMLElement | undefined,
       spaceId: undefined,
       warning: undefined,
     };
   },
+  mixins: [TranslateMixin],
   methods: {
+    animateSpace: function(tile: Element, activate: boolean) {
+      if (activate) {
+        tile.classList.add('board-space--available');
+      } else {
+        tile.classList.remove('board-space--available');
+      }
+    },
+    animateAvailableSpaces: function(tiles: HTMLCollectionOf<Element>) {
+      for (let i = 0, length = tiles.length; i < length; i++) {
+        const tile: Element = tiles[i];
+        const spaceId = tile.getAttribute('data_space_id');
+        if (spaceId !== null && this.availableSpaces.has(spaceId)) {
+          this.animateSpace(tile, true);
+        }
+      }
+    },
+    cancelPlacement: function() {
+      if (this.selectedTile === undefined) {
+        throw new Error('unexpected, no tile selected!');
+      }
+      this.animateSpace(this.selectedTile, false);
+      this.animateAvailableSpaces(this.getSelectableSpaces());
+    },
+    confirmPlacement: function() {
+      const tiles = this.getSelectableSpaces();
+      for (let i = 0, length = tiles.length; i < length; i++) {
+        (tiles[i] as HTMLElement).onclick = null;
+      }
+      if (this.selectedTile === undefined) {
+        throw new Error('unexpected, no tile selected!');
+      }
+      this.$data.spaceId = this.selectedTile.getAttribute('data_space_id');
+      this.selectedTile.classList.add('board-space--selected');
+      this.saveData();
+    },
+    disableAvailableSpaceAnimation: function() {
+      const tiles = this.getSelectableSpaces();
+      for (let i = 0, length = tiles.length; i < length; i++) {
+        tiles[i].classList.remove('board-space--available', 'board-space--selected');
+      }
+    },
+    getSelectableSpaces: function() {
+      const board = document.getElementById('main_board');
+      if (board !== null) {
+        return board.getElementsByClassName('board-space-selectable');
+      }
+      throw new Error('main board not found!');
+    },
+    onTileSelected: function(tile: HTMLElement) {
+      this.selectedTile = tile;
+      this.disableAvailableSpaceAnimation();
+      this.animateSpace(tile, true);
+      tile.classList.remove('board-space--available');
+      const hideTileConfirmation = PreferencesManager.loadValue('hide_tile_confirmation') === '1';
+      if (hideTileConfirmation) {
+        this.confirmPlacement();
+      } else {
+        (document.getElementById('dialog-confirm-tile') as HTMLDialogElement).showModal();
+      }
+    },
     saveData: function() {
       if (this.$data.spaceId === undefined) {
         this.$data.warning = 'Must select a space';
@@ -35,97 +99,37 @@ export const SelectSpace = Vue.component('select-space', {
     },
   },
   mounted: function() {
-    const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
-    const setOfSpaces: {[x: string]: boolean} = {};
+    dialogPolyfill.default.registerDialog(
+      document.getElementById('dialog-confirm-tile'),
+    );
+    this.disableAvailableSpaceAnimation();
+    const tiles = this.getSelectableSpaces();
+    this.animateAvailableSpaces(tiles);
+    for (let i = 0, length = tiles.length; i < length; i++) {
+      const tile: HTMLElement = tiles[i] as HTMLElement;
+      const spaceId = tile.getAttribute('data_space_id');
+      if (spaceId === null || this.availableSpaces.has(spaceId) === false) {
+        continue;
+      };
 
-    if (playerInput.availableSpaces !== undefined) {
-      playerInput.availableSpaces.forEach((spaceId: SpaceId) => {
-        setOfSpaces[spaceId] = true;
-      });
-    }
-
-    const disableAvailableSpaceAnimation = function() {
-      const tiles = document.getElementsByClassName('board-space-selectable');
-      for (let i = 0; i < tiles.length; i++) {
-        tiles[i].classList.remove('board-space--available');
-        tiles[i].classList.remove('board-space--selected');
-      }
-    };
-
-    const animateSpace = function(tile: Element, activate: boolean) {
-      if (activate) {
-        tile.classList.add('board-space--available');
-      } else {
-        tile.classList.remove('board-space--available');
-      }
-    };
-
-    const animateAvailableSpaces = function(tiles: HTMLCollectionOf<Element>) {
-      for (let i = 0; i < tiles.length; i++) {
-        const tile: Element = tiles[i];
-        const spaceId = tile.getAttribute('data_space_id');
-        if (spaceId !== null && setOfSpaces[spaceId] === true) {
-          animateSpace(tile, true);
-        }
-      }
-    };
-
-    const confirm = function() {
-      const hideTileConfirmation = PreferencesManager.loadValue('hide_tile_confirmation') === '1';
-      if (hideTileConfirmation) {
-        return true;
-      }
-      return window.confirm('Place your tile here?\n\n(This confirmation can be disabled in preferences).');
-    };
-
-    {
-      disableAvailableSpaceAnimation();
-      const tiles = document.getElementsByClassName('board-space-selectable');
-      animateAvailableSpaces(tiles);
-      for (let i = 0; i < tiles.length; i++) {
-        const tile: HTMLElement = tiles[i] as HTMLElement;
-        const spaceId = tile.getAttribute('data_space_id');
-        if (spaceId === null || setOfSpaces[spaceId] !== true) {
-          continue;
-        };
-
-        tile.onclick = () => {
-          disableAvailableSpaceAnimation();
-          animateSpace(tile, true);
-          // All this goes on a timeout so it is executed after the animation changes.
-          // Otherwise the confirmation dialog prevents the CSS animation updates above
-          // this comment.
-          setTimeout(() => {
-            tile.classList.remove('board-space--available');
-            if (confirm()) {
-              for (let j = 0; j < tiles.length; j++) {
-                (tiles[j] as HTMLElement).onclick = null;
-              }
-              this.$data.spaceId = tile.getAttribute('data_space_id');
-              tile.classList.add('board-space--selected');
-              this.saveData();
-            } else {
-              animateSpace(tile, false);
-              // without the timeout, this flashing animation gets out of sync with
-              // the other tiles, like the blinker of the car in front of you.
-              setTimeout(() => animateAvailableSpaces(tiles), 0);
-            }
-          }, 15); // 15ms gives the entire DOM a chance to catch up.
-        };
-      }
+      tile.onclick = () => this.onTileSelected(tile);
     }
   },
-  render: function(createElement) {
-    const playerInput: PlayerInputModel = this.playerinput as PlayerInputModel;
-    const children: Array<VNode> = [];
-    if (this.showtitle) {
-      children.push(createElement('div', {'class': 'wf-select-space'}, $t(playerInput.title)));
-    }
-    if (this.$data.warning) {
-      children.push(createElement('div', {domProps: {className: 'nes-container is-rounded'}}, [createElement('span', {domProps: {className: 'nes-text is-warning'}}, this.$data.warning)]));
-    }
-
-    return createElement('div', children);
-  },
+  template: `<div>
+    <section>
+      <dialog id="dialog-confirm-tile">
+        <form method="dialog">
+          <p v-i18n>Place your tile here?</p>
+          <p v-i18n>(This confirmation can be disabled in preferences).</p>
+          <menu class="dialog-menu centered-content">
+            <button class="btn btn-lg btn-primary" v-on:click="confirmPlacement()">Ok</button>
+            <button class="btn btn-lg" v-on:click="cancelPlacement()">Cancel</button>
+          </menu>
+        </form>
+      </dialog>
+    </section>
+    <div v-if="showtitle" class="wf-select-space">{{ $t(playerinput.title) }}</div>
+    <div v-if="warning" class="nes-container is-rounded"><span class="nes-text is-warning">{{ warning }}</span></div>
+  </div>`,
 });
 

--- a/src/components/common/ConfirmDialog.ts
+++ b/src/components/common/ConfirmDialog.ts
@@ -34,8 +34,7 @@ export const ConfirmDialog = Vue.component('confirm-dialog', {
   mounted: function() {
     dialogPolyfill.default.registerDialog(this.$refs['dialog']);
   },
-  template: `<div>
-    <dialog ref="dialog">
+  template: `<dialog ref="dialog">
       <form method="dialog">
         <p v-i18n class="newlines">{{ message }}</p>
         <menu class="dialog-menu centered-content">
@@ -45,7 +44,6 @@ export const ConfirmDialog = Vue.component('confirm-dialog', {
         <input type="checkbox" v-model="hide" id="dialog-confirm-dismiss" />
         <label for="dialog-confirm-dismiss">Don't show this again</label>
       </form>
-    </dialog>
-  </div>`,
+    </dialog>`,
 });
 

--- a/src/components/common/ConfirmDialog.ts
+++ b/src/components/common/ConfirmDialog.ts
@@ -1,0 +1,51 @@
+import Vue from 'vue';
+import {TranslateMixin} from '../TranslateMixin';
+
+const dialogPolyfill = require('dialog-polyfill');
+
+export const ConfirmDialog = Vue.component('confirm-dialog', {
+  props: {
+    message: {
+      type: String,
+    },
+  },
+  data: function() {
+    return {
+      hide: false as unknown[] | boolean,
+    };
+  },
+  mixins: [TranslateMixin],
+  watch: {
+    hide: function() {
+      this.$emit('hide', this.hide);
+    },
+  },
+  methods: {
+    accept: function() {
+      this.$emit('accept');
+    },
+    dismiss: function() {
+      this.$emit('dismiss');
+    },
+    show: function() {
+      (this.$refs['dialog'] as HTMLDialogElement).showModal();
+    },
+  },
+  mounted: function() {
+    dialogPolyfill.default.registerDialog(this.$refs['dialog']);
+  },
+  template: `<div>
+    <dialog ref="dialog">
+      <form method="dialog">
+        <p v-i18n class="newlines">{{ message }}</p>
+        <menu class="dialog-menu centered-content">
+          <button class="btn btn-lg btn-primary" v-on:click="accept()">Yes</button>
+          <button class="btn btn-lg" v-on:click="dismiss()">No</button>
+        </menu>
+        <input type="checkbox" v-model="hide" id="dialog-confirm-dismiss" />
+        <label for="dialog-confirm-dismiss">Don't show this again</label>
+      </form>
+    </dialog>
+  </div>`,
+});
+

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -46,7 +46,7 @@ body {
     padding: 0px;
     justify-content: center;
 }
-.centered-content .button {
+.centered-content button {
     margin-right: 20px;
 }
 .dynamic-title {
@@ -121,6 +121,9 @@ h2 {
 
 .nowrap {
     white-space: nowrap;
+}
+.newlines {
+    white-space: pre;
 }
 
 .mt-5 {

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -46,6 +46,9 @@ body {
     padding: 0px;
     justify-content: center;
 }
+.centered-content .button {
+    margin-right: 20px;
+}
 .dynamic-title {
     font-size: @font_size_huge;
     margin-bottom: 16px;


### PR DESCRIPTION
This should work to replace `window.confirm` with a dialog element.

![image](https://user-images.githubusercontent.com/2707843/105615597-20630980-5d8f-11eb-91f0-0f55a4b70dd0.png)

Moved more logic into `methods` from the `mounted` function as well. Eventually we could probably work this all onto the board component.