### PR TITLE
Fix loading games from SQLite

### DIFF
--- a/src/database/Cloner.ts
+++ b/src/database/Cloner.ts
@@ -10,10 +10,10 @@ export class Cloner {
     newGameId: GameId,
     players: Array<Player>,
     firstPlayerIndex: number,
-    err: any,
+    err: Error | undefined,
     serialized: SerializedGame | undefined,
     cb: DbLoadCallback<Game>) {
-    const response: {err: any, game: Game | undefined} = {err: err, game: undefined};
+    const response: {err?: Error, game: Game | undefined} = {err: err, game: undefined};
 
     try {
       if (err === undefined && serialized !== undefined) {

--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -47,7 +47,7 @@ export interface IDatabase {
      * @param game_id the game id to load
      * @param cb called with game if exists, if game is undefined err will be truthy
      */
-    getGame(game_id: string, cb: (err: any, game?: SerializedGame) => void): void;
+    getGame(game_id: string, cb: (err: Error | undefined, game?: SerializedGame) => void): void;
 
     /**
      * Return a list of all `game_id`s.
@@ -57,7 +57,7 @@ export interface IDatabase {
      *
      * @param cb a callback either returning either an error or a list of all `game_id`s.
      */
-    getGames(cb:(err: any, allGames:Array<GameId>) => void): void;
+    getGames(cb:(err: Error | undefined, allGames:Array<GameId>) => void): void;
 
     /**
      * Load references to all games that can be cloned. Every game is cloneable,
@@ -70,7 +70,7 @@ export interface IDatabase {
      * @param cb a callback either returning either an error or a list of references
      * to cloneable games.
      */
-    getClonableGames(cb:(err: any, allGames:Array<IGameData>)=> void) : void;
+    getClonableGames(cb:(err: Error | undefined, allGames:Array<IGameData>)=> void) : void;
 
     /**
      * Saves the current state of the game. at a supplied save point. Used for

--- a/src/database/IDatabase.ts
+++ b/src/database/IDatabase.ts
@@ -38,7 +38,7 @@ export interface IGameData {
  * in the game. Why, I have no idea, says kberg.
  */
 
-export type DbLoadCallback<T> = (err: any, game: T | undefined) => void
+export type DbLoadCallback<T> = (err: Error | undefined, game: T | undefined) => void
 
 export interface IDatabase {
 

--- a/src/database/LocalFilesystem.ts
+++ b/src/database/LocalFilesystem.ts
@@ -39,7 +39,7 @@ export class Localfilesystem implements IDatabase {
     game.lastSaveId++;
   }
 
-  getGame(game_id: GameId, cb: (err: any, game?: SerializedGame) => void): void {
+  getGame(game_id: GameId, cb: (err: Error | undefined, game?: SerializedGame) => void): void {
     try {
       console.log(`Loading ${game_id}`);
       const text = fs.readFileSync(this._filename(game_id));
@@ -49,7 +49,7 @@ export class Localfilesystem implements IDatabase {
       cb(err, undefined);
     }
   }
-  getClonableGames(cb: (err: any, allGames: Array<IGameData>) => void) {
+  getClonableGames(cb: (err: Error | undefined, allGames: Array<IGameData>) => void) {
     this.getGames((err, gameIds) => {
       const filtered = gameIds.filter((gameId) => fs.existsSync(this._historyFilename(gameId, 0)));
       const gameData = filtered.map((gameId) => {
@@ -72,7 +72,7 @@ export class Localfilesystem implements IDatabase {
     }
   }
 
-  getGames(cb: (err: any, allGames: Array<GameId>) => void) {
+  getGames(cb: (err: Error | undefined, allGames: Array<GameId>) => void) {
     const gameIds: Array<GameId> = [];
 
     // TODO(kberg): use readdir since this is expected to be async anyway.

--- a/src/database/LocalFilesystem.ts
+++ b/src/database/LocalFilesystem.ts
@@ -91,7 +91,7 @@ export class Localfilesystem implements IDatabase {
   }
 
   restoreReferenceGame(_gameId: GameId, cb: DbLoadCallback<Game>) {
-    cb('Does not work', undefined);
+    cb(new Error('Does not work'), undefined);
   }
 
   saveGameResults(_game_id: GameId, _players: number, _generations: number, _gameOptions: GameOptions, _scores: Array<Score>): void {

--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -43,7 +43,7 @@ export class PostgreSQL implements IDatabase {
     });
   }
 
-  getClonableGames(cb: (err: any, allGames: Array<IGameData>) => void) {
+  getClonableGames(cb: (err: Error | undefined, allGames: Array<IGameData>) => void) {
     const allGames: Array<IGameData> = [];
     const sql = 'SELECT distinct game_id game_id, players players FROM games WHERE save_id = 0 order by game_id asc';
 
@@ -66,7 +66,7 @@ export class PostgreSQL implements IDatabase {
     });
   }
 
-  getGames(cb: (err: any, allGames: Array<GameId>) => void) {
+  getGames(cb: (err: Error | undefined, allGames: Array<GameId>) => void) {
     const allGames: Array<GameId> = [];
     const sql: string = 'SELECT games.game_id FROM games, (SELECT max(save_id) save_id, game_id FROM games WHERE status=\'running\' GROUP BY game_id) a WHERE games.game_id = a.game_id AND games.save_id = a.save_id ORDER BY created_time DESC';
     this.client.query(sql, (err, res) => {
@@ -84,7 +84,7 @@ export class PostgreSQL implements IDatabase {
 
   loadCloneableGame(game_id: GameId, cb: DbLoadCallback<SerializedGame>) {
     // Retrieve first save from database
-    this.client.query('SELECT game_id game_id, game game FROM games WHERE game_id = $1 AND save_id = 0', [game_id], (err: any, res) => {
+    this.client.query('SELECT game_id game_id, game game FROM games WHERE game_id = $1 AND save_id = 0', [game_id], (err: Error | undefined, res) => {
       if (err) {
         console.error('PostgreSQL:restoreReferenceGame', err);
         return cb(err, undefined);
@@ -103,7 +103,7 @@ export class PostgreSQL implements IDatabase {
     });
   }
 
-  getGame(game_id: GameId, cb: (err: any, game?: SerializedGame) => void): void {
+  getGame(game_id: GameId, cb: (err: Error | undefined, game?: SerializedGame) => void): void {
     // Retrieve last save from database
     this.client.query('SELECT game game FROM games WHERE game_id = $1 ORDER BY save_id DESC LIMIT 1', [game_id], (err, res) => {
       if (err) {

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -22,7 +22,7 @@ export class SQLite implements IDatabase {
     this.db.run('CREATE TABLE IF NOT EXISTS game_results(game_id varchar not null, seed_game_id varchar, players integer, generations integer, game_options text, scores text, PRIMARY KEY (game_id))');
   }
 
-  getClonableGames(cb: (err: any, allGames: Array<IGameData>) => void) {
+  getClonableGames(cb: (err: Error | undefined, allGames: Array<IGameData>) => void) {
     const allGames: Array<IGameData> = [];
     const sql = 'SELECT distinct game_id game_id, players players FROM games WHERE save_id = 0 order by game_id asc';
 
@@ -37,12 +37,12 @@ export class SQLite implements IDatabase {
           };
           allGames.push(gameData);
         });
-        return cb(err, allGames);
+        return cb(err ?? undefined, allGames);
       }
     });
   }
 
-  getGames(cb: (err: any, allGames: Array<GameId>) => void) {
+  getGames(cb: (err: Error | undefined, allGames: Array<GameId>) => void) {
     const allGames: Array<GameId> = [];
     const sql: string = 'SELECT distinct game_id game_id FROM games WHERE status = \'running\'';
     this.db.all(sql, [], (err, rows) => {
@@ -50,7 +50,7 @@ export class SQLite implements IDatabase {
         rows.forEach((row) => {
           allGames.push(row.game_id);
         });
-        return cb(err, allGames);
+        return cb(err ?? undefined, allGames);
       }
     });
   }
@@ -85,11 +85,11 @@ export class SQLite implements IDatabase {
     );
   }
 
-  getGame(game_id: GameId, cb: (err: any, game?: SerializedGame) => void): void {
+  getGame(game_id: GameId, cb: (err: Error | undefined, game?: SerializedGame) => void): void {
     // Retrieve last save from database
-    this.db.get('SELECT game game FROM games WHERE game_id = ? ORDER BY save_id DESC LIMIT 1', [game_id], (err: { message: any; }, row: { game: any; }) => {
+    this.db.get('SELECT game game FROM games WHERE game_id = ? ORDER BY save_id DESC LIMIT 1', [game_id], (err: Error | null, row: { game: any; }) => {
       if (err) {
-        return cb(err);
+        return cb(err ?? undefined);
       }
       cb(undefined, JSON.parse(row.game));
     });
@@ -97,20 +97,20 @@ export class SQLite implements IDatabase {
 
   cleanSaves(game_id: GameId, save_id: number): void {
     // DELETE all saves except initial and last one
-    this.db.run('DELETE FROM games WHERE game_id = ? AND save_id < ? AND save_id > 0', [game_id, save_id], function(err: { message: any; }) {
+    this.db.run('DELETE FROM games WHERE game_id = ? AND save_id < ? AND save_id > 0', [game_id, save_id], function(err: Error | null) {
       if (err) {
         return console.warn(err.message);
       }
     });
     // Flag game as finished
-    this.db.run('UPDATE games SET status = \'finished\' WHERE game_id = ?', [game_id], function(err: { message: any; }) {
+    this.db.run('UPDATE games SET status = \'finished\' WHERE game_id = ?', [game_id], function(err: Error | null) {
       if (err) {
         return console.warn(err.message);
       }
     });
     // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
     if (process.env.MAX_GAME_DAYS) {
-      this.db.run('DELETE FROM games WHERE created_time < strftime(\'%s\',date(\'now\', \'-? day\')) and status = \'running\'', [process.env.MAX_GAME_DAYS], function(err: { message: any; }) {
+      this.db.run('DELETE FROM games WHERE created_time < strftime(\'%s\',date(\'now\', \'-? day\')) and status = \'running\'', [process.env.MAX_GAME_DAYS], function(err: Error | null) {
         if (err) {
           return console.warn(err.message);
         }
@@ -141,7 +141,7 @@ export class SQLite implements IDatabase {
     this.db.run(
       'INSERT INTO games(game_id, save_id, game, players) VALUES(?, ?, ?, ?)',
       [game.id, game.lastSaveId, game.toJSON(), game.getPlayers().length],
-      (err: { message: any; }) => {
+      (err: Error | null) => {
         if (err) {
           // Should be a duplicate, does not matter
           return;
@@ -155,7 +155,7 @@ export class SQLite implements IDatabase {
 
   deleteGameNbrSaves(game_id: GameId, rollbackCount: number): void {
     if (rollbackCount > 0) {
-      this.db.run('DELETE FROM games WHERE rowid IN (SELECT rowid FROM games WHERE game_id = ? ORDER BY save_id DESC LIMIT ?)', [game_id, rollbackCount], function(err: { message: any; }) {
+      this.db.run('DELETE FROM games WHERE rowid IN (SELECT rowid FROM games WHERE game_id = ? ORDER BY save_id DESC LIMIT ?)', [game_id, rollbackCount], function(err: Error | null) {
         if (err) {
           return console.warn(err.message);
         }

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -57,14 +57,14 @@ export class SQLite implements IDatabase {
 
   loadCloneableGame(game_id: GameId, cb: DbLoadCallback<SerializedGame>) {
     // Retrieve first save from database
-    this.db.get('SELECT game_id game_id, game game FROM games WHERE game_id = ? AND save_id = 0', [game_id], (err: { message: any; }, row: { game_id: GameId, game: any; }) => {
+    this.db.get('SELECT game_id game_id, game game FROM games WHERE game_id = ? AND save_id = 0', [game_id], (err: Error | null, row: { game_id: GameId, game: any; }) => {
       if (row.game_id === undefined) {
         return cb(new Error('Game not found'), undefined);
       }
 
       try {
         const json = JSON.parse(row.game);
-        return cb(err, json);
+        return cb(err ?? undefined, json);
       } catch (exception) {
         console.error(`unable to load game ${game_id} at save point 0`, exception);
         cb(exception, undefined);
@@ -120,7 +120,7 @@ export class SQLite implements IDatabase {
 
   restoreGame(game_id: GameId, save_id: number, cb: DbLoadCallback<Game>): void {
     // Retrieve last save from database
-    this.db.get('SELECT game game FROM games WHERE game_id = ? AND save_id = ? ORDER BY save_id DESC LIMIT 1', [game_id, save_id], (err: { message: any; }, row: { game: any; }) => {
+    this.db.get('SELECT game game FROM games WHERE game_id = ? AND save_id = ? ORDER BY save_id DESC LIMIT 1', [game_id, save_id], (err: Error | null, row: { game: any; }) => {
       if (err) {
         console.error(err.message);
         cb(err, undefined);


### PR DESCRIPTION
The sqlite3 bindings return `err = null` when there's no error, but `Cloner.ts` checked `err === undefined`, so it thought there was an error.

This made it past the typechecker due to using `any` all over the place, which I have replaced with `Error | undefined` (or `Error | null` when using the sqlite3 bindings).