### PR TITLE
replace waitingForCb with object

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -781,7 +781,7 @@ export class Game implements ISerializable<SerializedGame> {
     this.deferredActions.runAll(new Game.DraftOrResearch(this));
   }
 
-  public goToDraftOrResearch() {
+  private goToDraftOrResearch() {
     this.generation++;
     this.log('Generation ${0}', (b) => b.forNewGeneration().number(this.generation));
     this.incrementFirstPlayer();
@@ -1065,7 +1065,7 @@ export class Game implements ISerializable<SerializedGame> {
     player.takeActionForFinalGreenery();
   }
 
-  public startActionsForPlayer(player: Player) {
+  private startActionsForPlayer(player: Player) {
     this.activePlayer = player.id;
     player.actionsTakenThisRound = 0;
 

--- a/src/deferredActions/BuildColony.ts
+++ b/src/deferredActions/BuildColony.ts
@@ -34,7 +34,6 @@ export class BuildColony implements DeferredAction {
         if (colony.name === colonyName) {
           colony.addColony(this.player);
         }
-        return undefined;
       });
       return undefined;
     });

--- a/src/deferredActions/GiveColonyBonus.ts
+++ b/src/deferredActions/GiveColonyBonus.ts
@@ -50,7 +50,7 @@ export class GiveColonyBonus implements DeferredAction {
       return undefined;
     }
 
-    public giveColonyBonus(player: Player): void {
+    private giveColonyBonus(player: Player): void {
       if (this.waitingFor.get(player.id) !== undefined && this.waitingFor.get(player.id)! > 0) {
         this.waitingFor.subtract(player.id);
         const input = this.colony.giveColonyBonus(player, true);

--- a/src/server/PlayerCallback.ts
+++ b/src/server/PlayerCallback.ts
@@ -1,0 +1,12 @@
+
+import {Game} from '../Game';
+import {Player} from '../Player';
+import {PlayerCallbackId} from './PlayerCallbackId';
+
+export interface PlayerCallback {
+  execute: () => void;
+  game: Game;
+  id: PlayerCallbackId;
+  player?: Player;
+}
+

--- a/src/server/PlayerCallbackId.ts
+++ b/src/server/PlayerCallbackId.ts
@@ -1,0 +1,16 @@
+
+export enum PlayerCallbackId {
+  DONE_PLAYING_PRELUDE_CARD = 'done-player-prelude-card',
+  DONE_WITH_ACTION = 'done-with-action',
+  DONE_WITH_RESEARCH = 'done-with-research',
+  DONE_WITH_RESEARCH_PHASE = 'done-with-research-phase',
+  DONE_WORLD_GOVERNMENT_TERRAFORMING = 'done-world-government-terraforming',
+  DRAFT_OR_RESEARCH = 'draft-or-research',
+  FINAL_GREENERY = 'final-greenery',
+  GIVE_COLONY_BONUS_AGAIN = 'give-colony-bonus-again',
+  NOOP = 'noop',
+  PLAYER_FINISHED_TAKING_ACTIONS = 'player-finished-taking-actions',
+  REALLY_DONE = 'really-done',
+  RUN_ALL = 'run-all',
+  TAKE_ACTION = 'take-action'
+}

--- a/src/server/callbacks/NoopCallback.ts
+++ b/src/server/callbacks/NoopCallback.ts
@@ -1,0 +1,9 @@
+import {Game} from '../../Game';
+import {PlayerCallback} from '../PlayerCallback';
+import {PlayerCallbackId} from '../PlayerCallbackId';
+
+export class NoopCallback implements PlayerCallback {
+  public readonly id = PlayerCallbackId.NOOP;
+  constructor(public game: Game) {}
+  public execute() {}
+}

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -11,6 +11,7 @@ import {TestPlayers} from './TestingUtils';
 import {SerializedPlayer} from '../src/SerializedPlayer';
 import {SerializedTimer} from '../src/SerializedTimer';
 import {Player} from '../src/Player';
+import {PlayerCallbackId} from '../src/server/PlayerCallbackId';
 import {Color} from '../src/Color';
 import {VictoryPointsBreakdown} from '../src/VictoryPointsBreakdown';
 import {CardName} from '../src/CardName';
@@ -41,7 +42,7 @@ describe('Player', function() {
     player.playedCards.push(new LunarBeam());
     const action = card.play(player); //  Game.newInstance('foobar', [player, player2, player3], player));
     if (action !== undefined) {
-      player.setWaitingFor(action, () => undefined);
+      player.setWaitingFor(action, {id: PlayerCallbackId.NOOP, execute: () => undefined, game: player.game});
       player.process([[player2.id]]);
       expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     }
@@ -56,7 +57,7 @@ describe('Player', function() {
     player.playedCards.push(new LunarBeam());
     const action = card.play(player); // , Game.newInstance('foobar', [player, redPlayer], player));
     if (action !== undefined) {
-      player.setWaitingFor(action, () => undefined);
+      player.setWaitingFor(action, {id: PlayerCallbackId.NOOP, execute: () => undefined, game: player.game});
       expect(player.getWaitingFor()).is.not.undefined;
       expect(function() {
         player.process([[]]);
@@ -79,7 +80,7 @@ describe('Player', function() {
     const action = card.play(player); // Game.newInstance('foobar', [player, redPlayer], player));
     expect(action).is.not.undefined;
     if (action === undefined) return;
-    player.setWaitingFor(action, () => undefined);
+    player.setWaitingFor(action, {id: PlayerCallbackId.NOOP, execute: () => undefined, game: player.game});
     expect(player.getWaitingFor()).is.not.undefined;
     expect(function() {
       player.process([[]]);
@@ -118,7 +119,7 @@ describe('Player', function() {
     const mockOption = new SelectOption('Mock select option', 'Save', () => {
       return mockOption2;
     });
-    player.setWaitingFor(mockOption, () => done());
+    player.setWaitingFor(mockOption, {id: PlayerCallbackId.NOOP, execute: () => done(), game: player.game});
     player.process([['1']]);
     expect(player.getWaitingFor()).not.to.be.undefined;
     player.process([['1']]);

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -7,6 +7,7 @@ import {RandomMAOptionType} from '../src/RandomMAOptionType';
 import {ISpace} from '../src/boards/ISpace';
 import {Color} from '../src/Color';
 import {AgendaStyle} from '../src/turmoil/PoliticalAgendas';
+import {NoopCallback} from '../src/server/callbacks/NoopCallback';
 import {Phase} from '../src/Phase';
 import {IParty} from '../src/turmoil/parties/IParty';
 import {Turmoil} from '../src/turmoil/Turmoil';
@@ -79,8 +80,17 @@ export const setRulingPartyAndRulingPolicy = function(game: Game, turmoil: Turmo
   game.phase = Phase.ACTION;
 };
 
-// This could be moved to TestPlayer.ts, but that would require HUNDREDS of updates.
-// So, someone do that sometime soon, please.
+export function runAllActions(game: Game) {
+  game.deferredActions.runAll(new NoopCallback(game));
+}
+
+export function runNextAction(game: Game) {
+  const action = game.deferredActions.pop();
+  if (action !== undefined) {
+    game.deferredActions.run(action, new NoopCallback(game));
+  }
+}
+
 class TestPlayerFactory {
   constructor(private color: Color) {}
   newPlayer(): TestPlayer {

--- a/tests/cards/base/AquiferPumping.spec.ts
+++ b/tests/cards/base/AquiferPumping.spec.ts
@@ -2,15 +2,15 @@ import {expect} from 'chai';
 import {AquiferPumping} from '../../../src/cards/base/AquiferPumping';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
-import {maxOutOceans, TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('AquiferPumping', function() {
   let card : AquiferPumping; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new AquiferPumping();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -22,7 +22,7 @@ describe('AquiferPumping', function() {
     player.megaCredits = 8;
     const action = card.action(player);
     expect(action).is.undefined;
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
   });
 
@@ -31,7 +31,7 @@ describe('AquiferPumping', function() {
   });
 
   it('Can act if can pay even after oceans are maxed', function() {
-    maxOutOceans(player, game);
+    utils.maxOutOceans(player, game);
     player.megaCredits = 8;
 
     expect(card.canAct(player)).is.true;

--- a/tests/cards/base/BusinessNetwork.spec.ts
+++ b/tests/cards/base/BusinessNetwork.spec.ts
@@ -5,15 +5,15 @@ import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Resources} from '../../../src/Resources';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('BusinessNetwork', function() {
   let card : BusinessNetwork; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new BusinessNetwork();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -56,7 +56,7 @@ describe('BusinessNetwork', function() {
     player.megaCredits = 3;
     (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
     expect(game.deferredActions).has.lengthOf(1);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.cardsInHand).has.lengthOf(1);
   });

--- a/tests/cards/base/IndustrialCenter.spec.ts
+++ b/tests/cards/base/IndustrialCenter.spec.ts
@@ -4,15 +4,15 @@ import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
 import {TileType} from '../../../src/TileType';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('IndustrialCenter', function() {
   let card : IndustrialCenter; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new IndustrialCenter();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -24,7 +24,7 @@ describe('IndustrialCenter', function() {
   it('Should action', function() {
     player.megaCredits = 7;
     card.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.STEEL)).to.eq(1);
   });
@@ -35,9 +35,9 @@ describe('IndustrialCenter', function() {
 
     const action = card.play(player);
     const space = action!.availableSpaces[0];
-        action!.cb(space);
-        expect(space.tile).is.not.undefined;
-        expect(space.tile && space.tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
-        expect(space.adjacency?.bonus).eq(undefined);
+    action!.cb(space);
+    expect(space.tile).is.not.undefined;
+    expect(space.tile && space.tile.tileType).to.eq(TileType.INDUSTRIAL_CENTER);
+    expect(space.adjacency?.bonus).eq(undefined);
   });
 });

--- a/tests/cards/base/InventorsGuild.spec.ts
+++ b/tests/cards/base/InventorsGuild.spec.ts
@@ -4,15 +4,15 @@ import {IProjectCard} from '../../../src/cards/IProjectCard';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('InventorsGuild', function() {
   let card : InventorsGuild; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new InventorsGuild();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -32,7 +32,7 @@ describe('InventorsGuild', function() {
     player.megaCredits = 3;
 
     (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.cardsInHand).has.lengthOf(1);
   });

--- a/tests/cards/base/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/base/NitriteReducingBacteria.spec.ts
@@ -3,22 +3,22 @@ import {NitriteReducingBacteria} from '../../../src/cards/base/NitriteReducingBa
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('NitriteReducingBacteria', function() {
   let card : NitriteReducingBacteria; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new NitriteReducingBacteria();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
   it('Should play', function() {
     player.playedCards.push(card);
     card.play(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(card.resourceCount).to.eq(3);
   });
 
@@ -31,11 +31,11 @@ describe('NitriteReducingBacteria', function() {
     const orOptions = card.action(player) as OrOptions;
     expect(orOptions instanceof OrOptions).is.true;
 
-        orOptions!.options[1].cb();
-        expect(card.resourceCount).to.eq(5);
+    orOptions!.options[1].cb();
+    expect(card.resourceCount).to.eq(5);
 
-        orOptions!.options[0].cb();
-        expect(card.resourceCount).to.eq(2);
-        expect(player.getTerraformRating()).to.eq(21);
+    orOptions!.options[0].cb();
+    expect(card.resourceCount).to.eq(2);
+    expect(player.getTerraformRating()).to.eq(21);
   });
 });

--- a/tests/cards/base/RestrictedArea.spec.ts
+++ b/tests/cards/base/RestrictedArea.spec.ts
@@ -3,15 +3,15 @@ import {RestrictedArea} from '../../../src/cards/base/RestrictedArea';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {TileType} from '../../../src/TileType';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('RestrictedArea', function() {
   let card : RestrictedArea; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new RestrictedArea();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -36,7 +36,7 @@ describe('RestrictedArea', function() {
     expect(card.canAct(player)).is.true;
     card.action(player);
 
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.cardsInHand).has.lengthOf(1);
   });

--- a/tests/cards/base/SearchForLife.spec.ts
+++ b/tests/cards/base/SearchForLife.spec.ts
@@ -3,15 +3,15 @@ import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {Tags} from '../../../src/cards/Tags';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('SearchForLife', function() {
   let card : SearchForLife; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new SearchForLife();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -43,7 +43,7 @@ describe('SearchForLife', function() {
                game.dealer.discarded.find((c) => c.tags.length === 1 && c.tags[0] !== Tags.MICROBE) === undefined) {
       player.megaCredits = 1;
       card.action(player);
-      game.deferredActions.runNext();
+      utils.runNextAction(game);
       expect(player.megaCredits).to.eq(0);
     }
 

--- a/tests/cards/base/SpaceMirrors.spec.ts
+++ b/tests/cards/base/SpaceMirrors.spec.ts
@@ -3,15 +3,15 @@ import {SpaceMirrors} from '../../../src/cards/base/SpaceMirrors';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('SpaceMirrors', function() {
   let card : SpaceMirrors; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new SpaceMirrors();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -25,7 +25,7 @@ describe('SpaceMirrors', function() {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);
   });

--- a/tests/cards/base/UndergroundDetonations.spec.ts
+++ b/tests/cards/base/UndergroundDetonations.spec.ts
@@ -3,15 +3,15 @@ import {UndergroundDetonations} from '../../../src/cards/base/UndergroundDetonat
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('UndergroundDetonations', function() {
   let card : UndergroundDetonations; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new UndergroundDetonations();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -25,7 +25,7 @@ describe('UndergroundDetonations', function() {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.HEAT)).to.eq(2);
   });

--- a/tests/cards/base/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/base/WaterImportFromEuropa.spec.ts
@@ -3,15 +3,15 @@ import {WaterImportFromEuropa} from '../../../src/cards/base/WaterImportFromEuro
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
 import {Player} from '../../../src/Player';
-import {maxOutOceans, TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('WaterImportFromEuropa', function() {
   let card : WaterImportFromEuropa; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new WaterImportFromEuropa();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -31,7 +31,7 @@ describe('WaterImportFromEuropa', function() {
     const action = card.action(player);
     expect(action).is.undefined;
 
-    game.deferredActions.runNext(); // HowToPay
+    utils.runNextAction(game); // HowToPay
     expect(player.megaCredits).to.eq(1);
 
     expect(game.deferredActions).has.lengthOf(1);
@@ -41,7 +41,7 @@ describe('WaterImportFromEuropa', function() {
   });
 
   it('Can act if can pay even after oceans are maxed', function() {
-    maxOutOceans(player, game);
+    utils.maxOutOceans(player, game);
     player.megaCredits = 12;
 
     expect(card.canAct(player)).is.true;

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -6,15 +6,15 @@ import {ICard} from '../../../src/cards/ICard';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('NitrogenFromTitan', function() {
   let card : NitrogenFromTitan; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new NitrogenFromTitan();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -31,7 +31,7 @@ describe('NitrogenFromTitan', function() {
     player.playedCards.push(jovianLanterns);
 
     card.play(player, game);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(jovianLanterns.resourceCount).to.eq(2);
   });
 

--- a/tests/cards/colonies/Polyphemos.spec.ts
+++ b/tests/cards/colonies/Polyphemos.spec.ts
@@ -7,14 +7,14 @@ import {Game} from '../../../src/Game';
 import {AndOptions} from '../../../src/inputs/AndOptions';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('Polyphemos', function() {
   it('Should play', function() {
     const card = new Polyphemos();
     const card2 = new PowerPlant();
     const card3 = new BusinessNetwork();
-    const player = TestPlayers.BLUE.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
     const pi = player.getWaitingFor() as AndOptions;
     pi.options[0].cb([card]);
@@ -30,7 +30,7 @@ describe('Polyphemos', function() {
     expect(action).is.not.undefined;
     expect(action instanceof SelectCard).is.true;
     (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-    game.deferredActions.runNext();
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(35);
     expect(player.cardsInHand).has.lengthOf(3);
   });

--- a/tests/cards/colonies/ProductiveOutpost.spec.ts
+++ b/tests/cards/colonies/ProductiveOutpost.spec.ts
@@ -3,13 +3,13 @@ import {ProductiveOutpost} from '../../../src/cards/colonies/ProductiveOutpost';
 import {Luna} from '../../../src/colonies/Luna';
 import {Triton} from '../../../src/colonies/Triton';
 import {Game} from '../../../src/Game';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('ProductiveOutpost', function() {
   it('Should play', function() {
     const card = new ProductiveOutpost();
-    const player = TestPlayers.BLUE.newPlayer();
-    const player2 = TestPlayers.RED.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
+    const player2 = utils.TestPlayers.RED.newPlayer();
     const game = Game.newInstance('foobar', [player, player2], player);
     const colony1 = new Luna();
     const colony2 = new Triton();
@@ -21,7 +21,7 @@ describe('ProductiveOutpost', function() {
     game.colonies.push(colony2);
 
     card.play(player, game);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(2);
     expect(player.titanium).to.eq(1);
   });

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -12,15 +12,15 @@ import {SelectCard} from '../../../src/inputs/SelectCard';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('Playwrights', function() {
   let card : Playwrights; let player : Player; let player2: Player; let game : Game;
 
   beforeEach(function() {
     card = new Playwrights();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
 
     card.play(player);
@@ -48,7 +48,7 @@ describe('Playwrights', function() {
     selectCard.cb([event]);
 
     game.deferredActions.pop()!.execute(); // SelectHowToPay
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getTerraformRating()).to.eq(tr + 4);
     expect(player.megaCredits).eq(0);
@@ -68,7 +68,7 @@ describe('Playwrights', function() {
     selectCard.cb([event]);
 
     game.deferredActions.pop()!.execute(); // SelectHowToPay
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getTerraformRating()).to.eq(tr + 2);
     expect(player.megaCredits).eq(0);
@@ -116,7 +116,7 @@ describe('Playwrights', function() {
     const selectPlayer = game.deferredActions.pop()!.execute() as SelectPlayer;
     selectPlayer.cb(player2);
 
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.playedCards).has.lengthOf(0);
     expect(player2.playedCards).has.lengthOf(0); // Card is removed from play for sued player

--- a/tests/cards/community/TradeAdvance.spec.ts
+++ b/tests/cards/community/TradeAdvance.spec.ts
@@ -3,17 +3,16 @@ import {TradeAdvance} from '../../../src/cards/community/TradeAdvance';
 import {ColonyName} from '../../../src/colonies/ColonyName';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
-import {setCustomGameOptions} from '../../TestingUtils';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('TradeAdvance', function() {
   let card : TradeAdvance; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new TradeAdvance();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
-    const gameOptions = setCustomGameOptions({
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
+    const gameOptions = utils.setCustomGameOptions({
       coloniesExtension: true,
       customColoniesList: [ColonyName.LUNA, ColonyName.CALLISTO, ColonyName.CERES, ColonyName.IO, ColonyName.TITAN],
     });
@@ -23,7 +22,7 @@ describe('TradeAdvance', function() {
   it('Should play', function() {
     card.play(player, game);
 
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.megaCredits).to.eq(6); // 2 from card + 4 from Luna
     expect(player.energy).to.eq(3);

--- a/tests/cards/prelude/AquiferTurbines.spec.ts
+++ b/tests/cards/prelude/AquiferTurbines.spec.ts
@@ -3,14 +3,14 @@ import {AquiferTurbines} from '../../../src/cards/prelude/AquiferTurbines';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('AquiferTurbines', function() {
   let card : AquiferTurbines; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new AquiferTurbines();
-    player = TestPlayers.BLUE.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
     game = Game.newInstance('foobar', [player], player);
   });
 
@@ -27,7 +27,7 @@ describe('AquiferTurbines', function() {
     game.deferredActions.pop();
 
     // SelectHowToPayDeferred
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.getProduction(Resources.ENERGY)).to.eq(2);
     expect(player.megaCredits).to.eq(0);

--- a/tests/cards/prelude/BusinessEmpire.spec.ts
+++ b/tests/cards/prelude/BusinessEmpire.spec.ts
@@ -3,14 +3,14 @@ import {BusinessEmpire} from '../../../src/cards/prelude/BusinessEmpire';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('BusinessEmpire', function() {
   let card : BusinessEmpire; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new BusinessEmpire();
-    player = TestPlayers.BLUE.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
     game = Game.newInstance('foobar', [player], player);
   });
 
@@ -25,7 +25,7 @@ describe('BusinessEmpire', function() {
     card.play(player, game);
 
     // SelectHowToPayDeferred
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(6);

--- a/tests/cards/prelude/GalileanMining.spec.ts
+++ b/tests/cards/prelude/GalileanMining.spec.ts
@@ -3,14 +3,14 @@ import {GalileanMining} from '../../../src/cards/prelude/GalileanMining';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('GalileanMining', function() {
   let card : GalileanMining; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new GalileanMining();
-    player = TestPlayers.BLUE.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
     game = Game.newInstance('foobar', [player], player);
   });
 
@@ -26,7 +26,7 @@ describe('GalileanMining', function() {
     card.play(player, game);
 
     // SelectHowToPayDeferred
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(2);

--- a/tests/cards/prelude/HugeAsteroid.spec.ts
+++ b/tests/cards/prelude/HugeAsteroid.spec.ts
@@ -3,14 +3,14 @@ import {HugeAsteroid} from '../../../src/cards/prelude/HugeAsteroid';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('HugeAsteroid', function() {
   let card : HugeAsteroid; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new HugeAsteroid();
-    player = TestPlayers.BLUE.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
     game = Game.newInstance('foobar', [player], player);
   });
 
@@ -27,7 +27,7 @@ describe('HugeAsteroid', function() {
     card.play(player, game);
 
     // SelectHowToPayDeferred
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.megaCredits).to.eq(0);
     expect(player.getProduction(Resources.HEAT)).to.eq(1);

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -13,15 +13,15 @@ import {Game} from '../../../src/Game';
 import {AndOptions} from '../../../src/inputs/AndOptions';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('PharmacyUnion', function() {
   let card : PharmacyUnion; let player : Player; let player2 : Player; let game : Game;
 
   beforeEach(function() {
     card = new PharmacyUnion();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
 
     player.corporationCard = card;
@@ -49,14 +49,14 @@ describe('PharmacyUnion', function() {
     const ants = new Ants();
     player.playedCards.push(ants);
     card.onCardPlayed(player, ants);
-    game.deferredActions.runNext(); // Add microbe and lose 4 MC
+    utils.runNextAction(game); // Add microbe and lose 4 MC
     expect(card.resourceCount).to.eq(3);
     expect(player.megaCredits).to.eq(4);
 
     const viralEnhancers = new ViralEnhancers();
     player2.playedCards.push(viralEnhancers);
     card.onCardPlayed(player2, viralEnhancers);
-    game.deferredActions.runNext(); // Add microbe and lose 4 MC
+    utils.runNextAction(game); // Add microbe and lose 4 MC
     expect(player2.megaCredits).to.eq(8); // should not change
     expect(card.resourceCount).to.eq(4);
     expect(player.megaCredits).to.eq(0);
@@ -151,7 +151,7 @@ describe('PharmacyUnion', function() {
     card.resourceCount = 0;
     player2.playedCards.push(viralEnhancers);
     card.onCardPlayed(player2, viralEnhancers);
-    game.deferredActions.runNext(); // Add microbe and lose 4 MC
+    utils.runNextAction(game); // Add microbe and lose 4 MC
     expect(card.resourceCount).to.eq(1);
     expect(player.megaCredits).to.eq(8);
     expect(game.deferredActions).has.lengthOf(0);

--- a/tests/cards/turmoil/GMOContract.spec.ts
+++ b/tests/cards/turmoil/GMOContract.spec.ts
@@ -2,13 +2,13 @@ import {expect} from 'chai';
 import {GMOContract} from '../../../src/cards/turmoil/GMOContract';
 import {Game} from '../../../src/Game';
 import {PartyName} from '../../../src/turmoil/parties/PartyName';
-import {setCustomGameOptions, TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('GMOContract', function() {
   it('Should play', function() {
     const card = new GMOContract();
-    const player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    const player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     const game = Game.newInstance('foobar', [player], player, gameOptions);
 
     if (game.turmoil !== undefined) {
@@ -21,7 +21,7 @@ describe('GMOContract', function() {
       }
       card.play();
       card.onCardPlayed(player, card);
-      game.deferredActions.runNext();
+      utils.runNextAction(game);
       expect(player.megaCredits).to.eq(2);
     }
   });

--- a/tests/cards/turmoil/TerralabsResearch.spec.ts
+++ b/tests/cards/turmoil/TerralabsResearch.spec.ts
@@ -6,14 +6,14 @@ import {TerralabsResearch} from '../../../src/cards/turmoil/TerralabsResearch';
 import {Game} from '../../../src/Game';
 import {AndOptions} from '../../../src/inputs/AndOptions';
 import {SelectCard} from '../../../src/inputs/SelectCard';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('TerralabsResearch', function() {
   it('Should play', function() {
     const card = new TerralabsResearch();
     const card2 = new PowerPlant();
     const card3 = new BusinessNetwork();
-    const player = TestPlayers.BLUE.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
     const pi = player.getWaitingFor() as AndOptions;
     pi.options[0].cb([card]);
@@ -30,7 +30,7 @@ describe('TerralabsResearch', function() {
     expect(action).is.not.undefined;
     expect(action instanceof SelectCard).is.true;
     (action as SelectCard<IProjectCard>).cb([(action as SelectCard<IProjectCard>).cards[0]]);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(11);
     expect(player.cardsInHand).has.lengthOf(3);
   });

--- a/tests/cards/venusNext/FloatingHabs.spec.ts
+++ b/tests/cards/venusNext/FloatingHabs.spec.ts
@@ -6,15 +6,15 @@ import {FloatingHabs} from '../../../src/cards/venusNext/FloatingHabs';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('FloatingHabs', function() {
   let card : FloatingHabs; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new FloatingHabs();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -34,7 +34,7 @@ describe('FloatingHabs', function() {
     player.megaCredits = 10;
 
     card.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(card.resourceCount).to.eq(1);
     expect(player.megaCredits).to.eq(8);
   });
@@ -46,7 +46,7 @@ describe('FloatingHabs', function() {
     expect(action instanceof SelectCard).is.true;
 
     (action as SelectCard<ICard>).cb([card]);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(card.resourceCount).to.eq(1);
     expect(player.megaCredits).to.eq(8);
   });

--- a/tests/cards/venusNext/ForcedPrecipitation.spec.ts
+++ b/tests/cards/venusNext/ForcedPrecipitation.spec.ts
@@ -3,15 +3,15 @@ import {ForcedPrecipitation} from '../../../src/cards/venusNext/ForcedPrecipitat
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('ForcedPrecipitation', function() {
   let card : ForcedPrecipitation; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new ForcedPrecipitation();
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player);
   });
 
@@ -25,7 +25,7 @@ describe('ForcedPrecipitation', function() {
     player.megaCredits = 10;
 
     const action = card.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(action).is.undefined;
     expect(card.resourceCount).to.eq(1);
     expect(player.megaCredits).to.eq(8);

--- a/tests/cards/venusNext/SponsoredAcademies.spec.ts
+++ b/tests/cards/venusNext/SponsoredAcademies.spec.ts
@@ -5,15 +5,15 @@ import {HousePrinting} from '../../../src/cards/prelude/HousePrinting';
 import {SponsoredAcademies} from '../../../src/cards/venusNext/SponsoredAcademies';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
-import {TestPlayers} from '../../TestingUtils';
+import * as utils from '../../TestingUtils';
 
 describe('SponsoredAcademies', function() {
   it('Should play', function() {
     const card = new SponsoredAcademies();
     const card2 = new HousePrinting();
     const card3 = new Tardigrades();
-    const player = TestPlayers.BLUE.newPlayer();
-    const player2 = TestPlayers.RED.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
+    const player2 = utils.TestPlayers.RED.newPlayer();
     const game = Game.newInstance('foobar', [player, player2], player);
     player.cardsInHand.push(card);
     expect(card.canPlay(player)).is.not.true;
@@ -28,7 +28,7 @@ describe('SponsoredAcademies', function() {
     expect(discardCard.cards.filter((c) => c.name === card.name)).has.lengthOf(0);
 
     discardCard.cb([card2]);
-    game.deferredActions.runAll(() => {}); // Draw cards
+    utils.runAllActions(game); // Draw cards
     expect(player.cardsInHand).has.lengthOf(4);
     expect(player2.cardsInHand).has.lengthOf(1);
   });

--- a/tests/colonies/Callisto.spec.ts
+++ b/tests/colonies/Callisto.spec.ts
@@ -3,16 +3,15 @@ import {Callisto} from '../../src/colonies/Callisto';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
-
+import * as utils from '../TestingUtils';
 
 describe('Callisto', function() {
   let callisto: Callisto; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     callisto = new Callisto();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(callisto);
@@ -34,7 +33,7 @@ describe('Callisto', function() {
     callisto.addColony(player);
 
     callisto.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     expect(player2.getProduction(Resources.ENERGY)).to.eq(0);

--- a/tests/colonies/Ceres.spec.ts
+++ b/tests/colonies/Ceres.spec.ts
@@ -3,15 +3,15 @@ import {Ceres} from '../../src/colonies/Ceres';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Ceres', function() {
   let ceres: Ceres; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     ceres = new Ceres();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(ceres);
@@ -33,7 +33,7 @@ describe('Ceres', function() {
     ceres.addColony(player);
 
     ceres.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.STEEL)).to.eq(1);
     expect(player2.getProduction(Resources.STEEL)).to.eq(0);

--- a/tests/colonies/Colony.spec.ts
+++ b/tests/colonies/Colony.spec.ts
@@ -1,4 +1,4 @@
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {expect} from 'chai';
 import {Luna} from '../../src/colonies/Luna';
 import {Pluto} from '../../src/colonies/Pluto';
@@ -12,10 +12,9 @@ import {SelectColony} from '../../src/inputs/SelectColony';
 import {SelectCard} from '../../src/inputs/SelectCard';
 import {IProjectCard} from '../../src/cards/IProjectCard';
 import {MAX_COLONY_TRACK_POSITION} from '../../src/constants';
-import {setCustomGameOptions} from '../TestingUtils';
 import {BuildColonyStandardProject} from '../../src/cards/colonies/BuildColonyStandardProject';
 
-const gameOptions = setCustomGameOptions({coloniesExtension: true});
+const gameOptions = utils.setCustomGameOptions({coloniesExtension: true});
 
 function isBuildColonyStandardProjectAvailable(player: Player) {
   return new BuildColonyStandardProject().canAct(player);
@@ -39,10 +38,10 @@ describe('Colony', function() {
 
   beforeEach(function() {
     luna = new Luna();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
-    player3 = TestPlayers.YELLOW.newPlayer();
-    player4 = TestPlayers.GREEN.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
+    player3 = utils.TestPlayers.YELLOW.newPlayer();
+    player4 = utils.TestPlayers.GREEN.newPlayer();
     game = Game.newInstance('foobar', [player, player2, player3, player4], player, gameOptions);
     game.colonies = [luna];
   });
@@ -99,14 +98,14 @@ describe('Colony', function() {
   it('Should decrease trackPosition after trade', function() {
     luna.trackPosition = MAX_COLONY_TRACK_POSITION;
     luna.trade(player);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(luna.trackPosition).to.eq(0);
 
     luna.addColony(player);
     luna.addColony(player2);
     luna.trackPosition = MAX_COLONY_TRACK_POSITION;
     luna.trade(player);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(luna.trackPosition).to.eq(2);
   });
 
@@ -127,7 +126,7 @@ describe('Colony', function() {
       player.megaCredits = 0;
       luna.trackPosition = i;
       luna.trade(player);
-      game.deferredActions.runAll(() => {});
+      utils.runAllActions(game);
       expect(player.megaCredits).to.eq(income[i]);
     }
   });
@@ -136,7 +135,7 @@ describe('Colony', function() {
     // No colonies
     luna.trackPosition = 3; // 7 MC
     luna.trade(player);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(7);
     expect(player2.megaCredits).to.eq(0);
     expect(player3.megaCredits).to.eq(0);
@@ -147,7 +146,7 @@ describe('Colony', function() {
     luna.trackPosition = 3; // 7 MC
     luna.addColony(player);
     luna.trade(player);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(9);
     expect(player2.megaCredits).to.eq(0);
     expect(player3.megaCredits).to.eq(0);
@@ -158,7 +157,7 @@ describe('Colony', function() {
     luna.trackPosition = 3; // 7 MC
     luna.addColony(player2);
     luna.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(2);
     expect(player2.megaCredits).to.eq(9);
     expect(player3.megaCredits).to.eq(0);
@@ -170,7 +169,7 @@ describe('Colony', function() {
     luna.trackPosition = 3; // 7 MC
     luna.addColony(player3);
     luna.trade(player4);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(2);
     expect(player2.megaCredits).to.eq(2);
     expect(player3.megaCredits).to.eq(2);
@@ -184,7 +183,7 @@ describe('Colony', function() {
     luna.addColony(player);
 
     luna.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(6);
     expect(player2.megaCredits).to.eq(7);
     expect(player3.megaCredits).to.eq(0);
@@ -267,25 +266,18 @@ describe('Colony', function() {
     pluto.addColony(player3);
     pluto.trade(player4);
 
-    let callbackWasCalled = false;
-    game.deferredActions.runAll(() => {
-      callbackWasCalled = true;
-    });
-    expect(callbackWasCalled).to.be.false;
+    utils.runAllActions(game);
 
     const input = player.getWaitingFor()! as SelectCard<IProjectCard>;
     expect(input).to.be.an.instanceof(SelectCard);
     player.process([['Dust Seals']]); // Discard a card
-    expect(callbackWasCalled).to.be.false;
 
     const input2 = player2.getWaitingFor()! as SelectCard<IProjectCard>;
     expect(input2).to.be.an.instanceof(SelectCard);
     player2.process([['Dust Seals']]); // Discard a card
-    expect(callbackWasCalled).to.be.false;
 
     const input3 = player3.getWaitingFor()! as SelectCard<IProjectCard>;
     expect(input3).to.be.an.instanceof(SelectCard);
     player3.process([['Dust Seals']]); // Discard a card
-    expect(callbackWasCalled).to.be.true;
   });
 });

--- a/tests/colonies/Enceladus.spec.ts
+++ b/tests/colonies/Enceladus.spec.ts
@@ -5,7 +5,7 @@ import {Enceladus} from '../../src/colonies/Enceladus';
 import {AddResourcesToCard} from '../../src/deferredActions/AddResourcesToCard';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Enceladus', function() {
   let enceladus: Enceladus; let tardigrades: Tardigrades; let player: Player; let player2: Player; let game: Game;
@@ -13,8 +13,8 @@ describe('Enceladus', function() {
   beforeEach(function() {
     enceladus = new Enceladus();
     tardigrades = new Tardigrades();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(enceladus);
@@ -66,7 +66,7 @@ describe('Enceladus', function() {
     enceladus.trade(player2);
     game.deferredActions.pop()!.execute(); // Gain trade microbes
 
-    game.deferredActions.runAll(() => {}); // Trade bonus
+    utils.runAllActions(game); // Trade bonus
 
     expect(tardigrades.resourceCount).to.eq(4);
     expect(regolithEaters.resourceCount).to.eq(1);

--- a/tests/colonies/Europa.spec.ts
+++ b/tests/colonies/Europa.spec.ts
@@ -4,15 +4,15 @@ import {PlaceOceanTile} from '../../src/deferredActions/PlaceOceanTile';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Europa', function() {
   let europa: Europa; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     europa = new Europa();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(europa);
@@ -37,7 +37,7 @@ describe('Europa', function() {
     game.deferredActions.pop();
 
     europa.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(0);
     expect(player2.getProduction(Resources.MEGACREDITS)).to.eq(1);

--- a/tests/colonies/Ganymede.spec.ts
+++ b/tests/colonies/Ganymede.spec.ts
@@ -3,15 +3,15 @@ import {Ganymede} from '../../src/colonies/Ganymede';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Ganymede', function() {
   let ganymede: Ganymede; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     ganymede = new Ganymede();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(ganymede);
@@ -33,7 +33,7 @@ describe('Ganymede', function() {
     ganymede.addColony(player);
 
     ganymede.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.PLANTS)).to.eq(1);
     expect(player2.getProduction(Resources.PLANTS)).to.eq(0);

--- a/tests/colonies/Io.spec.ts
+++ b/tests/colonies/Io.spec.ts
@@ -3,15 +3,15 @@ import {Io} from '../../src/colonies/Io';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Io', function() {
   let io: Io; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     io = new Io();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(io);
@@ -33,7 +33,7 @@ describe('Io', function() {
     io.addColony(player);
 
     io.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.HEAT)).to.eq(1);
     expect(player2.getProduction(Resources.HEAT)).to.eq(0);

--- a/tests/colonies/Luna.spec.ts
+++ b/tests/colonies/Luna.spec.ts
@@ -3,15 +3,15 @@ import {Luna} from '../../src/colonies/Luna';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {Resources} from '../../src/Resources';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Luna', function() {
   let luna: Luna; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     luna = new Luna();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(luna);
@@ -33,7 +33,7 @@ describe('Luna', function() {
     luna.addColony(player);
 
     luna.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(2);
     expect(player2.getProduction(Resources.MEGACREDITS)).to.eq(0);

--- a/tests/colonies/Miranda.spec.ts
+++ b/tests/colonies/Miranda.spec.ts
@@ -5,7 +5,7 @@ import {Miranda} from '../../src/colonies/Miranda';
 import {AddResourcesToCard} from '../../src/deferredActions/AddResourcesToCard';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Miranda', function() {
   let miranda: Miranda; let pets: Pets; let player: Player; let player2: Player; let game: Game;
@@ -13,8 +13,8 @@ describe('Miranda', function() {
   beforeEach(function() {
     miranda = new Miranda();
     pets = new Pets();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(miranda);
@@ -66,7 +66,7 @@ describe('Miranda', function() {
     miranda.trade(player2);
     game.deferredActions.pop()!.execute(); // Gain trade animals
 
-    game.deferredActions.runAll(() => {}); // Trade bonus
+    utils.runAllActions(game); // Trade bonus
 
     expect(pets.resourceCount).to.eq(2);
     expect(predators.resourceCount).to.eq(1);

--- a/tests/colonies/Pluto.spec.ts
+++ b/tests/colonies/Pluto.spec.ts
@@ -4,15 +4,15 @@ import {Pluto} from '../../src/colonies/Pluto';
 import {Game} from '../../src/Game';
 import {SelectCard} from '../../src/inputs/SelectCard';
 import {Player} from '../../src/Player';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Pluto', function() {
   let pluto: Pluto; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     pluto = new Pluto();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(pluto);
@@ -20,13 +20,13 @@ describe('Pluto', function() {
 
   it('Should build', function() {
     pluto.addColony(player);
-    game.deferredActions.runAll(() => {}); // Draw cards
+    utils.runAllActions(game); // Draw cards
     expect(player.cardsInHand).has.lengthOf(2);
   });
 
   it('Should trade', function() {
     pluto.trade(player);
-    game.deferredActions.runAll(() => {}); // Draw cards
+    utils.runAllActions(game); // Draw cards
     expect(player.cardsInHand).has.lengthOf(1);
   });
 
@@ -35,7 +35,7 @@ describe('Pluto', function() {
 
     pluto.trade(player2);
 
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     const input = player.getWaitingFor()! as SelectCard<IProjectCard>;
     expect(input).to.be.an.instanceof(SelectCard);

--- a/tests/colonies/Titan.spec.ts
+++ b/tests/colonies/Titan.spec.ts
@@ -5,7 +5,7 @@ import {Titan} from '../../src/colonies/Titan';
 import {AddResourcesToCard} from '../../src/deferredActions/AddResourcesToCard';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Titan', function() {
   let titan: Titan; let aerialMappers: AerialMappers; let player: Player; let player2: Player; let game: Game;
@@ -13,8 +13,8 @@ describe('Titan', function() {
   beforeEach(function() {
     titan = new Titan();
     aerialMappers = new AerialMappers();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(titan);
@@ -66,7 +66,7 @@ describe('Titan', function() {
     titan.trade(player2);
     game.deferredActions.pop()!.execute(); // Gain trade floaters
 
-    game.deferredActions.runAll(() => {}); // Trade bonus
+    utils.runAllActions(game); // Trade bonus
 
     expect(aerialMappers.resourceCount).to.eq(4);
     expect(dirigibles.resourceCount).to.eq(1);

--- a/tests/colonies/Triton.spec.ts
+++ b/tests/colonies/Triton.spec.ts
@@ -2,15 +2,15 @@ import {expect} from 'chai';
 import {Triton} from '../../src/colonies/Triton';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('Triton', function() {
   let triton: Triton; let player: Player; let player2: Player; let game: Game;
 
   beforeEach(function() {
     triton = new Triton();
-    player = TestPlayers.BLUE.newPlayer();
-    player2 = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    player2 = utils.TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, player2], player);
     game.gameOptions.coloniesExtension = true;
     game.colonies.push(triton);
@@ -31,7 +31,7 @@ describe('Triton', function() {
     triton.addColony(player);
 
     triton.trade(player2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
 
     expect(player.titanium).to.eq(4);
     expect(player2.titanium).to.eq(1);

--- a/tests/deferredActions/DrawCards.spec.ts
+++ b/tests/deferredActions/DrawCards.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {DrawCards} from '../../src/deferredActions/DrawCards';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Game} from '../../src/Game';
 import {Player} from '../../src/Player';
 import {AICentral} from '../../src/cards/base/AICentral';
@@ -16,12 +16,11 @@ describe('DrawCards', function() {
   const cards = [new AICentral(), new Asteroid(), new CapitalAres()];
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const redPlayer = utils.TestPlayers.RED.newPlayer();
     Game.newInstance('foobar', [player, redPlayer], player);
     dealer = player.game.dealer;
   });
-
 
   it('keeps cards', function() {
     DrawCards.keep(player, [cards[0], cards[1]]);
@@ -65,7 +64,7 @@ describe('DrawCards', function() {
     expect(action!.minCardsToSelect).to.eq(0);
     expect(action!.maxCardsToSelect).to.eq(1);
     action!.cb([action!.cards[0]]);
-    player.game.deferredActions.runNext();
+    utils.runNextAction(player.game);
     expect(player.cardsInHand).has.length(1);
     expect(dealer.discarded).has.length(0);
     expect(player.megaCredits).to.eq(0);

--- a/tests/globalEvents/CloudSocieties.spec.ts
+++ b/tests/globalEvents/CloudSocieties.spec.ts
@@ -4,12 +4,12 @@ import {Game} from '../../src/Game';
 import {CloudSocieties} from '../../src/turmoil/globalEvents/CloudSocieties';
 import {Kelvinists} from '../../src/turmoil/parties/Kelvinists';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('CloudSocieties', function() {
   it('resolve play', function() {
     const card = new CloudSocieties();
-    const player = TestPlayers.BLUE.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
     const turmoil = Turmoil.newInstance(game);
     player.playedCards.push(new FloatingHabs());
@@ -18,7 +18,7 @@ describe('CloudSocieties', function() {
     turmoil.dominantParty.partyLeader = player.id;
     turmoil.dominantParty.delegates.push(player.id);
     card.resolve(game, turmoil);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.playedCards[0].resourceCount).to.eq(3);
   });
 });

--- a/tests/globalEvents/CorrosiveRain.spec.ts
+++ b/tests/globalEvents/CorrosiveRain.spec.ts
@@ -3,13 +3,13 @@ import {Game} from '../../src/Game';
 import {CorrosiveRain} from '../../src/turmoil/globalEvents/CorrosiveRain';
 import {Kelvinists} from '../../src/turmoil/parties/Kelvinists';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 
 describe('CorrosiveRain', function() {
   it('resolve play', function() {
     const card = new CorrosiveRain();
-    const player = TestPlayers.BLUE.newPlayer();
-    const player2 = TestPlayers.RED.newPlayer();
+    const player = utils.TestPlayers.BLUE.newPlayer();
+    const player2 = utils.TestPlayers.RED.newPlayer();
     const game = Game.newInstance('foobar', [player, player2], player);
     const turmoil = Turmoil.newInstance(game);
 
@@ -24,7 +24,7 @@ describe('CorrosiveRain', function() {
 
     card.resolve(game, turmoil);
     expect(game.deferredActions).has.lengthOf(2);
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(game.deferredActions).has.lengthOf(0);
     expect(player2.cardsInHand).has.lengthOf(3);
     expect(player.cardsInHand).has.lengthOf(0);

--- a/tests/politicalAgendas/Greens.spec.ts
+++ b/tests/politicalAgendas/Greens.spec.ts
@@ -3,7 +3,7 @@ import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
 import {ISpace} from '../../src/boards/ISpace';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Greens, GREENS_BONUS_1, GREENS_BONUS_2, GREENS_POLICY_4} from '../../src/turmoil/parties/Greens';
 import {Lichen} from '../../src/cards/base/Lichen';
 import {Fish} from '../../src/cards/base/Fish';
@@ -16,13 +16,13 @@ describe('Greens', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let greens: Greens;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
     turmoil = game.turmoil!;
     greens = new Greens();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: Gain 1 MC for each Plant, Microbe and Animal tag you have', function() {
@@ -45,14 +45,14 @@ describe('Greens', function() {
   });
 
   it('Ruling policy 1: When you place a greenery tile, gain 4 MC', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[0].id);
 
     game.addGreenery(player, '10');
     expect(player.megaCredits).to.eq(4);
   });
 
   it('Ruling policy 2: When you place a tile, gain 1 plant', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[1].id);
 
     const emptySpace: ISpace = game.board.spaces.find((space) => space.spaceType === SpaceType.LAND && space.bonus.length === 0) as ISpace;
     game.addTile(player, emptySpace.spaceType, emptySpace, {tileType: TileType.NATURAL_PRESERVE});
@@ -60,7 +60,7 @@ describe('Greens', function() {
   });
 
   it('Ruling policy 3: When you play an animal, plant or microbe tag, gain 2 MC', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[2].id);
 
     const lichen = new Lichen();
     player.playCard(lichen);
@@ -68,14 +68,14 @@ describe('Greens', function() {
   });
 
   it('Ruling policy 4: Spend 5 MC to gain 3 plants or add 2 microbes to any card', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, greens, greens.policies[3].id);
 
     const greensPolicy = GREENS_POLICY_4;
     player.megaCredits = 10;
 
     // Gain plants
     greensPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.plants).to.eq(3);
     expect(player.megaCredits).to.eq(5);
 
@@ -83,7 +83,7 @@ describe('Greens', function() {
     const tardigrades = new Tardigrades();
     player.playedCards.push(tardigrades);
     greensPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     const orOptions = game.deferredActions.peek()!.execute() as OrOptions;
 
     orOptions.options[0].cb();

--- a/tests/politicalAgendas/Kelvinists.spec.ts
+++ b/tests/politicalAgendas/Kelvinists.spec.ts
@@ -3,7 +3,7 @@ import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
 import {ISpace} from '../../src/boards/ISpace';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Kelvinists, KELVINISTS_BONUS_1, KELVINISTS_BONUS_2, KELVINISTS_POLICY_1, KELVINISTS_POLICY_3} from '../../src/turmoil/parties/Kelvinists';
 import {TileType} from '../../src/TileType';
 import {Resources} from '../../src/Resources';
@@ -12,13 +12,13 @@ describe('Kelvinists', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let kelvinists: Kelvinists;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
     turmoil = game.turmoil!;
     kelvinists = new Kelvinists();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: Gain 1 MC for each Heat production you have', function() {
@@ -38,25 +38,25 @@ describe('Kelvinists', function() {
   });
 
   it('Ruling policy 1: Pay 10 MC to increase your Energy and Heat production 1 step', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[0].id);
 
     const kelvinistsPolicy = KELVINISTS_POLICY_1;
     kelvinistsPolicy.action(player);
 
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);
     expect(player.getProduction(Resources.HEAT)).to.eq(1);
   });
 
   it('Ruling policy 2: When you raise temperature, gain 3 MC per step raised', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[1].id);
 
     game.increaseTemperature(player, 1);
     expect(player.megaCredits).to.eq(3);
   });
 
   it('Ruling policy 3: Convert 6 heat into temperature', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[2].id);
 
     const kelvinistsPolicy = KELVINISTS_POLICY_3;
     expect(kelvinistsPolicy.canAct(player)).to.be.false;
@@ -72,7 +72,7 @@ describe('Kelvinists', function() {
   });
 
   it('Ruling policy 4: When you place a tile, gain 2 heat', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, kelvinists, kelvinists.policies[3].id);
 
     const emptySpace: ISpace = game.board.spaces.find((space) => space.bonus.length === 0) as ISpace;
     game.addTile(player, emptySpace.spaceType, emptySpace, {tileType: TileType.CITY});

--- a/tests/politicalAgendas/MarsFirst.spec.ts
+++ b/tests/politicalAgendas/MarsFirst.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {MarsFirst, MARS_FIRST_BONUS_1, MARS_FIRST_BONUS_2, MARS_FIRST_POLICY_4} from '../../src/turmoil/parties/MarsFirst';
 import {Mine} from '../../src/cards/base/Mine';
 import {Tags} from '../../src/cards/Tags';
@@ -11,13 +11,13 @@ describe('MarsFirst', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let marsFirst: MarsFirst;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
     turmoil = game.turmoil!;
     marsFirst = new MarsFirst();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: Gain 1 MC for each Building tag you have', function() {
@@ -37,14 +37,14 @@ describe('MarsFirst', function() {
   });
 
   it('Ruling policy 1: When you place a tile ON MARS, gain 1 steel', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[0].id);
 
     game.addGreenery(player, '11');
     expect(player.steel).to.eq(1);
   });
 
   it('Ruling policy 2: When you play a Building tag, gain 2 MC', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[1].id);
 
     const mine = new Mine();
     player.playCard(mine);
@@ -52,19 +52,19 @@ describe('MarsFirst', function() {
   });
 
   it('Ruling policy 3: Your steel resources are worth 1 MC extra', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[2].id);
     expect(player.getSteelValue()).to.eq(3);
   });
 
   it('Ruling policy 4: Spend 4 MC to draw a Building card', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, marsFirst, marsFirst.policies[3].id);
 
     const marsFirstPolicy = MARS_FIRST_POLICY_4;
     player.megaCredits = 7;
 
     marsFirstPolicy.action(player);
     expect(marsFirstPolicy.canAct(player)).to.be.true;
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.cardsInHand).has.lengthOf(1);
     expect(player.megaCredits).to.eq(3);

--- a/tests/politicalAgendas/Reds.spec.ts
+++ b/tests/politicalAgendas/Reds.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Reds, REDS_BONUS_1, REDS_BONUS_2, REDS_POLICY_3} from '../../src/turmoil/parties/Reds';
 import {Resources} from '../../src/Resources';
 
@@ -10,14 +10,14 @@ describe('Reds', function() {
   let player : Player; let secondPlayer : Player; let game : Game; let turmoil: Turmoil; let reds: Reds;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    secondPlayer = TestPlayers.RED.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    secondPlayer = utils.TestPlayers.RED.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player, secondPlayer], player, gameOptions);
     turmoil = game.turmoil!;
     reds = new Reds();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: The player(s) with the lowest TR gains 1 TR', function() {
@@ -39,25 +39,25 @@ describe('Reds', function() {
   });
 
   it('Ruling policy 1: When you take an action that raises TR, you MUST pay 3 MC per step raised', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[0].id);
 
     player.megaCredits = 3;
     player.increaseTerraformRating();
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.megaCredits).to.eq(0);
   });
 
   it('Ruling policy 2: When you place a tile, pay 3 MC or as much as possible', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[1].id);
 
     player.megaCredits = 3;
     game.addGreenery(player, '10');
-    game.deferredActions.runAll(() => {});
+    utils.runAllActions(game);
     expect(player.megaCredits).to.eq(0);
   });
 
   it('Ruling policy 3: Pay 4 MC to reduce a non-maxed global parameter 1 step', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[2].id);
 
     const redsPolicy = REDS_POLICY_3;
     player.megaCredits = 7;
@@ -66,7 +66,7 @@ describe('Reds', function() {
 
     expect(redsPolicy.canAct(player)).to.be.true;
     redsPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.megaCredits).to.eq(3);
     expect(game.getOxygenLevel()).to.eq(0);
@@ -74,7 +74,7 @@ describe('Reds', function() {
   });
 
   it('Ruling policy 4: When you raise a global parameter, decrease your MC production 1 step per step raised if possible', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, reds, reds.policies[3].id);
 
     game.increaseOxygenLevel(player, 1);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(-1);

--- a/tests/politicalAgendas/Scientists.spec.ts
+++ b/tests/politicalAgendas/Scientists.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Scientists, SCIENTISTS_BONUS_1, SCIENTISTS_BONUS_2, SCIENTISTS_POLICY_1, SCIENTISTS_POLICY_4} from '../../src/turmoil/parties/Scientists';
 import {SearchForLife} from '../../src/cards/base/SearchForLife';
 import {Research} from '../../src/cards/base/Research';
@@ -12,13 +12,13 @@ describe('Scientists', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let scientists: Scientists;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
     turmoil = game.turmoil!;
     scientists = new Scientists();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: Gain 1 MC for each Science tag you have', function() {
@@ -38,21 +38,21 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 1: Pay 10 MC to draw 3 cards', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[0].id);
 
     const scientistsPolicy = SCIENTISTS_POLICY_1;
     player.megaCredits = 10;
     expect(scientistsPolicy.canAct(player)).to.be.true;
 
     scientistsPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.cardsInHand).has.lengthOf(3);
     expect(player.megaCredits).to.eq(0);
     expect(scientistsPolicy.canAct(player)).to.be.false;
   });
 
   it('Ruling policy 2: Your global requirements are +/- 2 steps', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[1].id);
 
     const card = new SearchForLife();
     (game as any).oxygenLevel = 8;
@@ -60,19 +60,19 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 3: When you raise a global parameter, draw a card per step raised', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[2].id);
 
     game.increaseOxygenLevel(player, 1);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.cardsInHand).has.lengthOf(1);
 
     game.increaseTemperature(player, 2);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.cardsInHand).has.lengthOf(3);
   });
 
   it('Ruling policy 4: Cards with Science tag requirements may be played with 1 less Science tag', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[3].id);
 
     const card = new GeneRepair();
     expect(card.canPlay(player)).to.be.false;

--- a/tests/politicalAgendas/Unity.spec.ts
+++ b/tests/politicalAgendas/Unity.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {Player} from '../../src/Player';
 import {Game} from '../../src/Game';
 import {Turmoil} from '../../src/turmoil/Turmoil';
-import {resetBoard, setCustomGameOptions, setRulingPartyAndRulingPolicy, TestPlayers} from '../TestingUtils';
+import * as utils from '../TestingUtils';
 import {Unity, UNITY_BONUS_1, UNITY_BONUS_2, UNITY_POLICY_2, UNITY_POLICY_3} from '../../src/turmoil/parties/Unity';
 import {SisterPlanetSupport} from '../../src/cards/venusNext/SisterPlanetSupport';
 import {VestaShipyard} from '../../src/cards/base/VestaShipyard';
@@ -14,13 +14,13 @@ describe('Unity', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let unity: Unity;
 
   beforeEach(function() {
-    player = TestPlayers.BLUE.newPlayer();
-    const gameOptions = setCustomGameOptions();
+    player = utils.TestPlayers.BLUE.newPlayer();
+    const gameOptions = utils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
     turmoil = game.turmoil!;
     unity = new Unity();
 
-    resetBoard(game);
+    utils.resetBoard(game);
   });
 
   it('Ruling bonus 1: Gain 1 MC for each Venus, Earth and Jovian tag you have', function() {
@@ -40,19 +40,19 @@ describe('Unity', function() {
   });
 
   it('Ruling policy 1: Your titanium resources are worth 1 MC extra', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[0].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[0].id);
     expect(player.getTitaniumValue()).to.eq(4);
   });
 
   it('Ruling policy 2: Spend 4 MC to gain 2 titanium or add 2 floaters to any card', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[1].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[1].id);
 
     const unityPolicy = UNITY_POLICY_2;
     player.megaCredits = 8;
 
     // Gain titanium
     unityPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     expect(player.titanium).to.eq(2);
     expect(player.megaCredits).to.eq(4);
 
@@ -60,7 +60,7 @@ describe('Unity', function() {
     const localShading = new LocalShading();
     player.playedCards.push(localShading);
     unityPolicy.action(player);
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
     const orOptions = game.deferredActions.peek()!.execute() as OrOptions;
 
     orOptions.options[0].cb();
@@ -69,14 +69,14 @@ describe('Unity', function() {
   });
 
   it('Ruling policy 3: Spend 4 MC to draw a Space card', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[2].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[2].id);
 
     const unityPolicy = UNITY_POLICY_3;
     player.megaCredits = 7;
 
     unityPolicy.action(player);
     expect(unityPolicy.canAct(player)).to.be.true;
-    game.deferredActions.runNext();
+    utils.runNextAction(game);
 
     expect(player.cardsInHand).has.lengthOf(1);
     expect(player.megaCredits).to.eq(3);
@@ -85,7 +85,7 @@ describe('Unity', function() {
   });
 
   it('Ruling policy 4: Cards with Space tags cost 2 MC less to play', function() {
-    setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[3].id);
+    utils.setRulingPartyAndRulingPolicy(game, turmoil, unity, unity.policies[3].id);
 
     const card = new VestaShipyard();
     expect(player.getCardCost(card)).to.eq(card.cost - 2);


### PR DESCRIPTION
This will start to close #2539. The `waitingForCb` on `Player` is a function. This can't be serialized and it relies on closures to keep state. For this change the `waitingForCb` is replaced with a `PlayerCallback` (probably a better name) interface. These objects can be serialized as we can store `PlayerId`, `GameId`, and `PlayerCallbackId` to store the callback. Then upon deserialization we can have `Player` where it was when serialized. This will give us more flexibility with when we can save game state and hopefully eventually save game state during every state update.

I also added new `TestingUtils` functions for running actions from the `DeferredActionsQueue`. These should help us change the API with `DeferredActionsQueue` without needing to update every place we use the API in tests. It also removes the separate test only function from `DeferredActionsQueue`.