### PR TITLE
Player.canAfford - further optimizations

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1594,6 +1594,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   // and additionally pay the reserveUnits (no replaces here)
   // TODO(sienmich): use options parameter
   public canAfford(cost: number, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false, reserveUnits: Partial<Units> = {}): boolean {
+    // Check if player has the reserveUnits - required resources
     const units = Units.of(reserveUnits);
     if (!Units.hasUnits(units, this)) {
       return false;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1593,18 +1593,17 @@ export class Player implements ISerializable<SerializedPlayer> {
   // Checks if the player can afford to pay `cost` mc (possibly replaceable with steal, titanium etc.)
   // and additionally pay the reserveUnits (no replaces here)
   // TODO(sienmich): use options parameter
-  public canAfford(cost: number, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false, reserveUnits: Partial<Units> = {}): boolean {
+  public canAfford(cost: number, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false, reserveUnits: Units = Units.EMPTY): boolean {
     // Check if player has the reserveUnits - required resources
-    const units = Units.of(reserveUnits);
-    if (!Units.hasUnits(units, this)) {
+    if (!Units.hasUnits(reserveUnits, this)) {
       return false;
     }
 
     return cost <=
-      this.megaCredits - units.megacredits +
-      (this.canUseHeatAsMegaCredits ? this.heat - units.heat : 0) +
-      (canUseSteel ? (this.steel - units.steel) * this.steelValue : 0) +
-      (canUseTitanium ? (this.titanium - units.titanium) * this.getTitaniumValue() : 0) +
+      this.megaCredits - reserveUnits.megacredits +
+      (this.canUseHeatAsMegaCredits ? this.heat - reserveUnits.heat : 0) +
+      (canUseSteel ? (this.steel - reserveUnits.steel) * this.steelValue : 0) +
+      (canUseTitanium ? (this.titanium - reserveUnits.titanium) * this.getTitaniumValue() : 0) +
       (canUseFloaters ? this.getFloatersCanSpend() * 3 : 0) +
       (canUseMicrobes ? this.getMicrobesCanSpend() * 2 : 0);
   }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1578,39 +1578,14 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public canPlay(card: IProjectCard): boolean {
-    const canUseSteel = card.tags.includes(Tags.BUILDING);
-    const canUseTitanium = card.tags.includes(Tags.SPACE);
-    const canUseMicrobes = card.tags.includes(Tags.PLANT);
-    const canUseFloaters = card.tags.includes(Tags.VENUS);
-
-    let steel = this.steel;
-    let titanium = this.titanium;
-
-    // Adjust available steel based on reserve costs on Moon cards. Also reject cards with
-    // reserve costs that a player cannot afford.
-    if (card.reserveUnits !== undefined) {
-      const reserveUnits = MoonExpansion.adjustedReserveCosts(this, card);
-      // Set aside reserve units in case the card has a building tag.
-      // If there isn't enough steel to meet the purchase reserve, this isn't a playable card.
-      steel = steel - reserveUnits.steel;
-      if (steel < 0) {
-        return false;
-      }
-
-      // Set aside reserve units in case the card has a space tag.
-      // If there isn't enough titanium to meet the purchase reserve, this isn't a playable card.
-      titanium = titanium - reserveUnits.titanium;
-      if (titanium < 0) {
-        return false;
-      }
-    }
-
-    const canAfford = this.getCardCost(card) <=
-      this.spendableMegacredits() +
-      (canUseSteel ? steel * this.steelValue : 0) +
-      (canUseTitanium ? titanium * this.getTitaniumValue() : 0) +
-      (canUseFloaters ? this.getFloatersCanSpend() * 3 : 0) +
-      (canUseMicrobes ? this.getMicrobesCanSpend() * 2 : 0);
+    const canAfford = this.canAfford(
+      this.getCardCost(card),
+      card.tags.includes(Tags.BUILDING),
+      card.tags.includes(Tags.SPACE),
+      card.tags.includes(Tags.PLANT),
+      card.tags.includes(Tags.VENUS),
+      MoonExpansion.adjustedReserveCosts(this, card),
+    );
 
     return canAfford && (card.canPlay === undefined || card.canPlay(this, this.game));
   }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1615,10 +1615,20 @@ export class Player implements ISerializable<SerializedPlayer> {
     return canAfford && (card.canPlay === undefined || card.canPlay(this, this.game));
   }
 
-  public canAfford(cost: number, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false): boolean {
-    return cost <= this.spendableMegacredits() +
-      (canUseSteel ? this.steel * this.steelValue : 0) +
-      (canUseTitanium ? this.titanium * this.getTitaniumValue() : 0) +
+  // Checks if the player can afford to pay `cost` mc (possibly replaceable with steal, titanium etc.)
+  // and additionally pay the reserveUnits (no replaces here)
+  // TODO(sienmich): use options parameter
+  public canAfford(cost: number, canUseSteel: boolean = false, canUseTitanium: boolean = false, canUseFloaters: boolean = false, canUseMicrobes : boolean = false, reserveUnits: Partial<Units> = {}): boolean {
+    const units = Units.of(reserveUnits);
+    if (!Units.hasUnits(units, this)) {
+      return false;
+    }
+
+    return cost <=
+      this.megaCredits - units.megacredits +
+      (this.canUseHeatAsMegaCredits ? this.heat - units.heat : 0) +
+      (canUseSteel ? (this.steel - units.steel) * this.steelValue : 0) +
+      (canUseTitanium ? (this.titanium - units.titanium) * this.getTitaniumValue() : 0) +
       (canUseFloaters ? this.getFloatersCanSpend() * 3 : 0) +
       (canUseMicrobes ? this.getMicrobesCanSpend() * 2 : 0);
   }

--- a/tests/cards/venusNext/Dirigibles.spec.ts
+++ b/tests/cards/venusNext/Dirigibles.spec.ts
@@ -23,8 +23,11 @@ describe('Dirigibles', function() {
   });
 
   it('Should act - single target', function() {
+    expect(player.getFloatersCanSpend()).to.eq(0);
     const action = card.action(player);
     expect(action).is.undefined;
+    expect(player.getCardsWithResources()).has.lengthOf(1);
+    expect(player.getFloatersCanSpend()).to.eq(1);
     expect(card.resourceCount).to.eq(1);
   });
 


### PR DESCRIPTION
I added `reserveUnits` to `Player.canAfford`.
This allows to simplify the `Player.canPlay` significantly.

In future it could be used a lot in cards:
The `LocalHeatTrapping` could change from:
```ts
  public canPlay(player: Player): boolean {
    const requiredHeatAmt = 5;

    // Helion must be able to pay for both the card and its effect
    if (player.canUseHeatAsMegaCredits) {
      return (player.heat >= requiredHeatAmt) && (player.heat + player.megaCredits >= requiredHeatAmt + player.getCardCost(this));
    }

    return player.availableHeat >= requiredHeatAmt;
  }
```
to
```ts
  public canPlay(player: Player): boolean {
    return player.canAfford(player.getCardCost(this), false, false, false, false, {heat: 5});
  }
```
and a lot of cards like `Asteroid`:
```ts
return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, false, true);
```
could properly calculate the `canAfford()`. Right now they count the `REDS_RULING_POLICY_COST` as part of card price, which means it can be payed with titanium, but it can not. But that's not this PR.