### PR TITLE
Minor fixes for cards

### DIFF
--- a/src/cards/base/CommercialDistrict.ts
+++ b/src/cards/base/CommercialDistrict.ts
@@ -29,7 +29,7 @@ export class CommercialDistrict extends Card implements IProjectCard {
         }).nbsp.nbsp.tile(TileType.COMMERCIAL_DISTRICT, true).br;
         b.vpText('1 VP per adjacent city tile.');
       }),
-      victoryPoints: CardRenderDynamicVictoryPoints.cities(1, 1),
+      victoryPoints: CardRenderDynamicVictoryPoints.cities(1, 1, true),
     },
   ) {
     super({

--- a/src/cards/base/Decomposers.ts
+++ b/src/cards/base/Decomposers.ts
@@ -27,7 +27,7 @@ export class Decomposers extends Card implements IProjectCard, IResourceCard {
           b.effect('When you play an Animal, Plant, or Microbe tag, including this, add a Microbe to this card.', (be) => {
             be.animals(1).played.slash();
             be.plants(1).played.slash();
-            be.microbes(1).played.slash();
+            be.microbes(1).played;
             be.startEffect.microbes(1);
           }).br;
           b.vpText('1 VP per 3 Microbes on this card.');

--- a/src/cards/base/Herbivores.ts
+++ b/src/cards/base/Herbivores.ts
@@ -14,6 +14,7 @@ import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {GlobalParameter} from '../../GlobalParameter';
+import {CardRenderItemSize} from '../render/CardRenderItemSize';
 
 export class Herbivores extends Card implements IProjectCard, IResourceCard {
   constructor() {
@@ -29,7 +30,7 @@ export class Herbivores extends Card implements IProjectCard, IResourceCard {
         requirements: CardRequirements.builder((b) => b.oxygen(8)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you place a greenery tile, add an Animal to this card.', (eb) => {
-            eb.greenery().startEffect.animals(1);
+            eb.greenery(CardRenderItemSize.MEDIUM, false).startEffect.animals(1);
           }).br;
           b.vpText('1 VP per 2 Animals on this card.');
           b.animals(1).production((pb) => pb.minus().plants(1).any);

--- a/src/cards/base/Mangrove.ts
+++ b/src/cards/base/Mangrove.ts
@@ -26,7 +26,7 @@ export class Mangrove extends Card implements IProjectCard {
       metadata: {
         cardNumber: '059',
         requirements: CardRequirements.builder((b) => b.temperature(4)),
-        renderData: CardRenderer.builder((b) => b.greenery(CardRenderItemSize.MEDIUM, true).asterix()),
+        renderData: CardRenderer.builder((b) => b.greenery(CardRenderItemSize.MEDIUM).asterix()),
         description: 'Requires +4 C or warmer. Place a greenery tile ON AN AREA RESERVED FOR OCEAN and raise oxygen 1 step. Disregard normal placement restrictions for this.',
         victoryPoints: 1,
       },

--- a/src/cards/base/MartianRails.ts
+++ b/src/cards/base/MartianRails.ts
@@ -22,7 +22,8 @@ export class MartianRails extends Card implements IActionCard, IProjectCard {
         cardNumber: '007',
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 1 Energy to gain 1 MC for each City tile ON MARS.', (eb) => {
-            eb.energy(1).startAction.megacredits(1).slash().city(CardRenderItemSize.SMALL);
+            eb.energy(1).startAction.megacredits(1).slash();
+            eb.city(CardRenderItemSize.SMALL).any.asterix();
           }).br;
         }),
       },

--- a/src/cards/base/Plantation.ts
+++ b/src/cards/base/Plantation.ts
@@ -11,7 +11,6 @@ import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class Plantation extends Card implements IProjectCard {
   constructor() {
@@ -25,7 +24,7 @@ export class Plantation extends Card implements IProjectCard {
         cardNumber: '193',
         requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
-          b.greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+          b.greenery();
         }),
         description: 'Requires 2 Science tags. Place a greenery tile and raise oxygen 1 step.',
       },

--- a/src/cards/base/ProtectedValley.ts
+++ b/src/cards/base/ProtectedValley.ts
@@ -12,7 +12,6 @@ import {MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST} from '../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardRenderer} from '../render/CardRenderer';
-import {AltSecondaryTag} from '../render/CardRenderItem';
 import {Units} from '../../Units';
 
 export class ProtectedValley extends Card implements IProjectCard {
@@ -28,7 +27,7 @@ export class ProtectedValley extends Card implements IProjectCard {
         cardNumber: '174',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(2)).nbsp;
-          b.greenery().secondaryTag(AltSecondaryTag.OXYGEN).asterix();
+          b.greenery().asterix();
         }),
         description: 'Increase your MC production 2 steps. Place on a greenery tile ON AN AREA RESERVED FOR OCEAN, disregarding normal placement restrictions, and increase oxygen 1 step.',
       },

--- a/src/cards/base/Zeppelins.ts
+++ b/src/cards/base/Zeppelins.ts
@@ -19,7 +19,10 @@ export class Zeppelins extends Card implements IProjectCard {
         cardNumber: '129',
         requirements: CardRequirements.builder((b) => b.oxygen(5)),
         renderData: CardRenderer.builder((b) => {
-          b.production((pb) => pb.megacredits(1).slash().city(CardRenderItemSize.SMALL).any);
+          b.production((pb) => {
+            pb.megacredits(1).slash();
+            pb.city(CardRenderItemSize.SMALL).any.asterix();
+          });
         }),
         description: 'Requires 5% oxygen. Increase your MC production 1 step for each City tile ON MARS.',
         victoryPoints: 1,

--- a/src/cards/base/standardActions/ConvertPlants.ts
+++ b/src/cards/base/standardActions/ConvertPlants.ts
@@ -5,7 +5,6 @@ import {Player} from '../../../Player';
 import {PartyHooks} from '../../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../../turmoil/parties/PartyName';
 import {MAX_OXYGEN_LEVEL, REDS_RULING_POLICY_COST} from '../../../constants';
-import {AltSecondaryTag} from '../../render/CardRenderItem';
 import {SelectSpace} from '../../../inputs/SelectSpace';
 import {ISpace} from '../../../boards/ISpace';
 
@@ -18,7 +17,7 @@ export class ConvertPlants extends StandardActionCard {
         cardNumber: 'SA2',
         renderData: CardRenderer.builder((b) =>
           b.standardProject('Spend 8 Plants to place a greenery tile and raise oxygen 1 step.', (eb) => {
-            eb.plants(8).startAction.greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+            eb.plants(8).startAction.greenery();
           }),
         ),
       },

--- a/src/cards/base/standardProjects/GreeneryStandardProject.ts
+++ b/src/cards/base/standardProjects/GreeneryStandardProject.ts
@@ -7,7 +7,6 @@ import {PartyHooks} from '../../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../../turmoil/parties/PartyName';
 import * as constants from '../../../constants';
 import {PlaceGreeneryTile} from '../../../deferredActions/PlaceGreeneryTile';
-import {AltSecondaryTag} from '../../render/CardRenderItem';
 
 export class GreeneryStandardProject extends StandardProjectCard {
   constructor() {
@@ -18,7 +17,7 @@ export class GreeneryStandardProject extends StandardProjectCard {
         cardNumber: 'SP6',
         renderData: CardRenderer.builder((b) =>
           b.standardProject('Spend 23 MC to place a greenery tile and raise oxygen 1 step.', (eb) => {
-            eb.megacredits(23).startAction.greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+            eb.megacredits(23).startAction.greenery();
           }),
         ),
       },

--- a/src/cards/prelude/ExperimentalForest.ts
+++ b/src/cards/prelude/ExperimentalForest.ts
@@ -4,7 +4,6 @@ import {PreludeCard} from './PreludeCard';
 import {CardName} from '../../CardName';
 import {PlaceGreeneryTile} from '../../deferredActions/PlaceGreeneryTile';
 import {CardRenderer} from '../render/CardRenderer';
-import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class ExperimentalForest extends PreludeCard {
   constructor() {
@@ -14,7 +13,7 @@ export class ExperimentalForest extends PreludeCard {
       metadata: {
         cardNumber: 'P12',
         renderData: CardRenderer.builder((b) => {
-          b.greenery().secondaryTag(AltSecondaryTag.OXYGEN).cards(2).secondaryTag(Tags.PLANT);
+          b.greenery().cards(2).secondaryTag(Tags.PLANT);
         }),
         description: 'Place 1 Greenery Tile and raise oxygen 1 step. Reveal cards until you reveal two cards with plant tags on them. Take them into your hand and discard the rest.',
       },

--- a/src/cards/promo/Philares.ts
+++ b/src/cards/promo/Philares.ts
@@ -12,7 +12,6 @@ import {CardType} from '../CardType';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderItemSize} from '../render/CardRenderItemSize';
-import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class Philares extends Card implements CorporationCard {
   constructor() {
@@ -27,7 +26,7 @@ export class Philares extends Card implements CorporationCard {
         cardNumber: 'R25',
         description: 'You start with 47 MC. As your first action, place a greenery tile and raise the oxygen 1 step.',
         renderData: CardRenderer.builder((b) => {
-          b.megacredits(47).greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+          b.megacredits(47).nbsp.greenery();
           b.corpBox('effect', (ce) => {
             ce.effect('Each new adjacency between your tile and an opponent\'s tile gives you a standard resource of your choice [regardless of who just placed a tile].', (eb) => {
               eb.emptyTile('normal', CardRenderItemSize.SMALL).any.nbsp;

--- a/src/cards/render/CardRenderer.ts
+++ b/src/cards/render/CardRenderer.ts
@@ -322,7 +322,7 @@ class Builder {
     return this;
   }
 
-  public greenery(size: CardRenderItemSize = CardRenderItemSize.MEDIUM, withO2: boolean = false) {
+  public greenery(size: CardRenderItemSize = CardRenderItemSize.MEDIUM, withO2: boolean = true) {
     const item = new CardRenderItem(CardRenderItemType.GREENERY);
     item.size = size;
     if (withO2) {

--- a/src/cards/turmoil/Recruitment.ts
+++ b/src/cards/turmoil/Recruitment.ts
@@ -31,7 +31,7 @@ export class Recruitment implements IProjectCard {
     public metadata: CardMetadata = {
       cardNumber: 'T11',
       renderData: CardRenderer.builder((b) => {
-        b.minus().delegates(1).any.asterix().nbsp.delegates(1);
+        b.minus().delegates(1).any.asterix().nbsp.plus().delegates(1);
       }),
       description: 'Exchange one NEUTRAL NON-LEADER delegate with one of your own from the reserve.',
     }

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -47,7 +47,8 @@ export class VoteOfNoConfidence implements IProjectCard {
       cardNumber: 'T16',
       requirements: CardRequirements.builder((b) => b.partyLeaders()),
       renderData: CardRenderer.builder((b) => {
-        b.chairman().any.asterix().nbsp.partyLeaders().br;
+        b.minus().chairman().any.asterix();
+        b.nbsp.plus().partyLeaders().br;
         b.tr(1);
       }),
       description: 'Requires that you have a Party Leader in any party and that the sitting Chairman is neutral. Remove the NEUTRAL Chairman and move your own delegate (from the reserve) there instead. Gain 1 TR.',

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -11,7 +11,6 @@ import {REDS_RULING_POLICY_COST, MAX_OXYGEN_LEVEL} from '../../constants';
 import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {AltSecondaryTag} from '../render/CardRenderItem';
 
 export class WildlifeDome implements IProjectCard {
     public cost = 15;
@@ -43,7 +42,7 @@ export class WildlifeDome implements IProjectCard {
       cardNumber: 'T15',
       requirements: CardRequirements.builder((b) => b.party(PartyName.GREENS)),
       renderData: CardRenderer.builder((b) => {
-        b.greenery().secondaryTag(AltSecondaryTag.OXYGEN);
+        b.greenery();
       }),
       description: 'Requires that Greens are ruling or that you have 2 delegates there. Place a greenery tile and raise oxygen 1 step.',
     }

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -59,8 +59,8 @@
         }
         .card-requirements-max {
             background-image: url(./assets/requisites/max_big.png);
-            background-size: 164px 34px;
-            background-position: -4px -4px;
+            background-size: 174px 34px;
+            background-position: -12px -4px;
             filter: grayscale(0.2);
         }
 
@@ -1268,17 +1268,18 @@
             .card-plate {
                 width: 130px;
                 text-shadow: none;
-                font-size: 12px;
+                font-size: 14px;
+                text-transform: uppercase;
                 font-weight: bold;
                 line-height: 17px;
                 display: inline-block;
                 vertical-align: middle;
-                padding-top: 5px;
+                padding: 4px 0px;
                 margin-right: 5px;
-                border-radius: 5px;
-                height: 20px;
-                background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
+                border-radius: 14px;
+                background: linear-gradient(90deg, #f3a10e 0%, #fdea25 45%, #fdea25 55%, #f3a10e 100%);
                 filter: drop-shadow(0px 0px 1px black);
+                box-shadow: 2px 2px 1px;
             }
             .card-text-size--XS {
                 font-size: @font_size_tiny;

--- a/tests/metadata/CardRenderer.spec.ts
+++ b/tests/metadata/CardRenderer.spec.ts
@@ -247,11 +247,10 @@ describe('CardRenderer', function() {
       expect(item.size).to.equal(CardRenderItemSize.SMALL);
       expect(item.amount).to.equal(-1);
     });
-    it('with 02', () => {
-      const renderer = CardRenderer.builder((b) => b.greenery(CardRenderItemSize.SMALL, true));
+    it('without 02', () => {
+      const renderer = CardRenderer.builder((b) => b.greenery());
       const item = renderer.rows[0][0] as CardRenderItem;
       expect(item.type).to.equal(CardRenderItemType.GREENERY);
-      expect(item.size).to.equal(CardRenderItemSize.SMALL);
       expect(item.secondaryTag).to.equal(AltSecondaryTag.OXYGEN);
       expect(item.amount).to.equal(-1);
     });


### PR DESCRIPTION
#2355
@kevinb9n 
The things I haven't done and probably won't any time soon becaues of other priorities:

- `Celestic: Floater icons should be square` - Current (overall) secondary tag design is round, didn't want to add squares as an exception
- `Arcadian Communities: missing "Effect" banner (space?). Also does it want to use an actual player cube icon perhaps?` - Again, a special case is needed just for one card
- `MIssing asterisk: Factorum (action 1)` - I skipped it when I did the card because, again a special design for just that card might be needed (to have smaller arrows, or smaller MC icon, or custom position for the asterix)
- `Capital (ocean icon)` - Probaby, doable but not in this PR, requires a bit of customization
- `The Trade Fleet icon usually looks like this, is there a reason we don't use it?` - I'm ok for it to be changed but maybe in another PR
- `On cards like Aquifer Pumping, it would be cool if the resource-icon-in-parens could be a smaller superscript kinda thing.` - cool but not a priority

All other issues should be resolved. Feel free to open another issue or update this one, once you confirm the changes.
