### PR TITLE
Resolves #2587 - Adds a configurable number of history lines in game log via .env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,3 +29,6 @@
 
 ## When non-empty, stores game states in JSON files. Good for local development and debugging, bad for hosting lots of games.
 # LOCAL_FS_DB=
+
+## Specifies the number of lines of history to be shown in the game log (default 50)
+# LOG_LENGTH=

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A [.env](https://www.npmjs.com/package/dotenv) file allows you to store environm
 * `ASSET_CACHE_MAX_AGE`: (default 0) How many seconds should assets (fonts, stylesheets, images) be cached by browsers
 * `SERVER_ID`: (default random) Static pass phrase to restrict access to /games-overview and /api/games endpoints
 * `LOCAL_FS_DB`: When non-empty, stores game states in JSON files. Good for local development and debugging, bad for hosting lots of games.
+* `LOG_LENGTH`: (default 50) The number of lines of history shown in the game log 
 
 A `.env.sample` file can be used as a template. You can rename it to `.env` and it will take effect in your environment. Note that `.env` is ignored in source control.
 

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -58,13 +58,21 @@ function getWaitingForTimeout() {
     return 5000;
 }
 
+function getLogLength() {
+    if (process.env.LOG_LENGTH) {
+	return Number(process.env.LOG_LENGTH);
+    }
+    return 50;
+}
+
 if (!fs.existsSync('src/genfiles')) {
     fs.mkdirSync('src/genfiles');
 }
 
 fs.writeFileSync("src/genfiles/settings.json", JSON.stringify({
     version: generateAppVersion(),
-    waitingForTimeout: getWaitingForTimeout()
+    waitingForTimeout: getWaitingForTimeout(),
+    logLength: getLogLength()
 }));
 
 fs.writeFileSync("src/genfiles/translations.json", JSON.stringify(

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -161,7 +161,9 @@ export const LogPanel = Vue.component('log-panel', {
     },
   },
   mounted: function() {
-    fetch(`/api/game/logs?id=${this.id}&limit=50`)
+    const envLength = parseInt(process.env.LOG_LENGTH || '' );
+    const logLength = Number.isInteger(envLength) ? envLength : 50;
+    fetch(`/api/game/logs?id=${this.id}&limit=${logLength}`)
       .then((response) => response.json())
       .then((messages) => {
         this.messages.splice(0, this.messages.length);

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -11,6 +11,8 @@ import {$t} from '../directives/i18n';
 import {CardFinder} from './../CardFinder';
 import {ICard} from '../cards/ICard';
 
+import * as raw_settings from '../genfiles/settings.json';
+
 export const LogPanel = Vue.component('log-panel', {
   props: {
     id: {
@@ -161,9 +163,7 @@ export const LogPanel = Vue.component('log-panel', {
     },
   },
   mounted: function() {
-    const envLength = parseInt(process.env.LOG_LENGTH || '' );
-    const logLength = Number.isInteger(envLength) ? envLength : 50;
-    fetch(`/api/game/logs?id=${this.id}&limit=${logLength}`)
+    fetch(`/api/game/logs?id=${this.id}&limit=${raw_settings.logLength}`)
       .then((response) => response.json())
       .then((messages) => {
         this.messages.splice(0, this.messages.length);


### PR DESCRIPTION
This commit allows a variable number of lines of history in the game log. The number defaults to 50 to maintain the previous behavior, but can be configured using the new LOG_LENGTH variable noted in the updated README.
I used the same pattern as PostgreSQL.ts (for purge days) to define and parse the number of lines.