### PR TITLE
Requirements in card

### DIFF
--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -6,6 +6,7 @@ import {ResourceType} from '../ResourceType';
 import {Tags} from './Tags';
 import {Player} from '../Player';
 import {Units} from '../Units';
+import {CardRequirements} from './CardRequirements';
 
 export interface IDiscount {
   tag: Tags;
@@ -18,6 +19,7 @@ export interface StaticCardProperties {
   cost?: number;
   initialActionText?: string;
   metadata: CardMetadata;
+  requirements?: CardRequirements;
   name: CardName;
   resourceType?: ResourceType;
   startingMegaCredits?: number;
@@ -60,6 +62,9 @@ export abstract class Card {
   public get metadata() {
     return this.properties.metadata;
   }
+  public get requirements() {
+    return this.properties.requirements;
+  }
   public get name() {
     return this.properties.name;
   }
@@ -76,9 +81,9 @@ export abstract class Card {
     return this.properties.productionBox || Units.EMPTY;
   }
   public canPlay(player: Player) {
-    if (this.properties.metadata.requirements === undefined) {
+    if (this.properties.requirements === undefined) {
       return true;
     }
-    return this.properties.metadata.requirements.satisfies(player);
+    return this.properties.requirements.satisfies(player);
   }
 }

--- a/src/cards/CardMetadata.ts
+++ b/src/cards/CardMetadata.ts
@@ -1,12 +1,10 @@
 import {CardRenderer} from '../cards/render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from './render/CardRenderDynamicVictoryPoints';
 import {ICardRenderDescription} from './render/ICardRenderDescription';
-import {CardRequirements} from './CardRequirements';
 
 export interface CardMetadata {
   cardNumber: string;
   description?: string | ICardRenderDescription;
-  requirements?: CardRequirements;
   victoryPoints?: number | CardRenderDynamicVictoryPoints;
   renderData?: CardRenderer;
 }

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -17,6 +17,7 @@ import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
 import {CardMetadata} from './CardMetadata';
 import {StandardProjectCard} from './StandardProjectCard';
+import {CardRequirements} from './CardRequirements';
 
 export interface IActionCard {
     action: (player: Player) => OrOptions | SelectOption | AndOptions | SelectAmount | SelectCard<ICard> | SelectCard<IProjectCard> | SelectHowToPay | SelectPlayer | SelectSpace | undefined;
@@ -44,6 +45,7 @@ export interface ICard {
     resourceCount?: number;
     cost?: number;
     cardType: CardType;
+    requirements?: CardRequirements;
     metadata: CardMetadata;
     warning?: string | Message;
 }

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -6,7 +6,6 @@ import {Units} from '../Units';
 export interface IProjectCard extends ICard {
     canPlay?: (player: Player) => boolean;
     cost: number;
-    hasRequirements?: boolean;
 
     // A field dedicated to Robotic Workforce which tracks whether a card has an additional production
     // bonus besides the obvious ones printed on the card. Mining Rights and Mining Area are the only

--- a/src/cards/ares/BioengineeringEnclosure.ts
+++ b/src/cards/ares/BioengineeringEnclosure.ts
@@ -21,10 +21,10 @@ export class BioengineeringEnclosure extends Card implements IProjectCard, IActi
       cost: 7,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE)),
       metadata: {
         description: 'Requires 1 science tag to play. Add 2 animals to this card. OTHERS MAY NOT REMOVE ANIMALS FROM THIS CARD.',
         cardNumber: 'A01',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE)),
         renderData: CardRenderer.builder((b) => {
           b.action('Remove 1 animal from THIS card to add 1 animal to ANOTHER card.', (eb) => {
             eb.animals(1).asterix().startAction.animals(1).asterix();

--- a/src/cards/ares/BiofertilizerFacility.ts
+++ b/src/cards/ares/BiofertilizerFacility.ts
@@ -25,12 +25,12 @@ export class BiofertilizerFacility extends Card implements IProjectCard {
       cost: 12,
       productionBox: Units.of({plants: 1}),
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE)),
       metadata: {
         description: 'Requires 1 science tag. Increase your plant production 1 step. ' +
                   'Add up to 2 microbes to any card. ' +
                   'Place this tile which grants an ADJACENCY BONUS of 1 plant and 1 microbe.',
         cardNumber: 'A02',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1));
           b.microbes(2);

--- a/src/cards/ares/CapitalAres.ts
+++ b/src/cards/ares/CapitalAres.ts
@@ -2,7 +2,6 @@ import {SpaceBonus} from '../../SpaceBonus';
 import {CardName} from '../../CardName';
 import {TileType} from '../../TileType';
 import {Capital} from '../base/Capital';
-import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 
@@ -17,7 +16,6 @@ export class CapitalAres extends Capital {
           text: 'Requires 4 ocean tiles. Place tile with ADJACENCY BONUS of 2MC. Energy prod -2 and MC prod +5.',
           align: 'left',
         },
-        requirements: CardRequirements.builder((b) => b.oceans(4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().energy(2).br;

--- a/src/cards/ares/EcologicalSurvey.ts
+++ b/src/cards/ares/EcologicalSurvey.ts
@@ -14,10 +14,10 @@ export class EcologicalSurvey extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 9,
 
+      requirements: CardRequirements.builder((b) => b.greeneries(3).any()),
       metadata: {
         description: 'Requires 3 greeneries on Mars.',
         cardNumber: 'A07',
-        requirements: CardRequirements.builder((b) => b.greeneries(3).any()),
         renderData: CardRenderer.builder((b) => {
           b.effect('When placing a tile grants you any plants, animals or microbes, you gain one additional of each of those resources that you gain.', (eb) => {
             eb.emptyTile().startEffect;

--- a/src/cards/ares/EcologicalZoneAres.ts
+++ b/src/cards/ares/EcologicalZoneAres.ts
@@ -2,7 +2,6 @@ import {CardName} from '../../CardName';
 import {EcologicalZone} from '../base/EcologicalZone';
 import {SpaceBonus} from '../../SpaceBonus';
 import {TileType} from '../../TileType';
-import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 
@@ -18,7 +17,6 @@ export class EcologicalZoneAres extends EcologicalZone {
           align: 'left',
         },
         cardNumber: 'A08',
-        requirements: CardRequirements.builder((b) => b.greeneries()),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play an animal or plant tag /including these/, add an animal to this card.', (eb) => {
             eb.animals(1).played.slash().plants(1).played.startEffect;

--- a/src/cards/ares/GeologicalSurvey.ts
+++ b/src/cards/ares/GeologicalSurvey.ts
@@ -14,9 +14,9 @@ export class GeologicalSurvey extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.greeneries(5).any().max()),
       metadata: {
         cardNumber: 'A09',
-        requirements: CardRequirements.builder((b) => b.greeneries(5).any().max()),
         renderData: CardRenderer.builder((b) => {
           b.effect('When placing a tile grants you any steel, titanium, or heat, you gain one additional of each of those resources that you gain.', (eb) => {
             eb.emptyTile().startEffect;

--- a/src/cards/ares/NaturalPreserveAres.ts
+++ b/src/cards/ares/NaturalPreserveAres.ts
@@ -2,7 +2,6 @@ import {SpaceBonus} from '../../SpaceBonus';
 import {TileType} from '../../TileType';
 import {CardName} from '../../CardName';
 import {NaturalPreserve} from '../base/NaturalPreserve';
-import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class NaturalPreserveAres extends NaturalPreserve {
@@ -12,7 +11,6 @@ export class NaturalPreserveAres extends NaturalPreserve {
       {bonus: [SpaceBonus.MEGACREDITS]},
       {
         cardNumber: 'A18',
-        requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(1)).nbsp.tile(TileType.NATURAL_PRESERVE, false, true).asterix();
         }),

--- a/src/cards/ares/OceanCity.ts
+++ b/src/cards/ares/OceanCity.ts
@@ -21,9 +21,9 @@ export class OceanCity extends Card implements IProjectCard {
       cost: 18,
       productionBox: Units.of({energy: -1, megacredits: 3}),
 
+      requirements: CardRequirements.builder((b) => b.oceans(6)),
       metadata: {
         cardNumber: 'A20',
-        requirements: CardRequirements.builder((b) => b.oceans(6)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().energy(1).br;

--- a/src/cards/ares/OceanFarm.ts
+++ b/src/cards/ares/OceanFarm.ts
@@ -22,9 +22,9 @@ export class OceanFarm extends Card implements IProjectCard {
       cost: 15,
       productionBox: Units.of({plants: 1, heat: 1}),
 
+      requirements: CardRequirements.builder((b) => b.oceans(4)),
       metadata: {
         cardNumber: 'A21',
-        requirements: CardRequirements.builder((b) => b.oceans(4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.heat(1).br;

--- a/src/cards/ares/OceanSanctuary.ts
+++ b/src/cards/ares/OceanSanctuary.ts
@@ -22,9 +22,9 @@ export class OceanSanctuary extends Card implements IResourceCard {
       cost: 9,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oceans(5)),
       metadata: {
         cardNumber: 'A22',
-        requirements: CardRequirements.builder((b) => b.oceans(5)),
         renderData: CardRenderer.builder((b) => {
           b.tile(TileType.OCEAN_SANCTUARY, false, true).nbsp.animals(1).br;
           b.vpText('1 VP per animal on this card.');

--- a/src/cards/base/AICentral.ts
+++ b/src/cards/base/AICentral.ts
@@ -19,13 +19,13 @@ export class AICentral extends Card implements IActionCard, IProjectCard {
       cost: 21,
       productionBox: Units.of({energy: -1}),
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         description: {
           text: 'Requires 3 Science tags to play. Decrease your Energy production 1 step.',
           align: 'left',
         },
         cardNumber: '208',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => {
           b.action('Draw 2 cards.', (ab) => ab.empty().startAction.cards(2)).br;
           b.production((pb) => pb.minus().energy(1));

--- a/src/cards/base/AdvancedEcosystems.ts
+++ b/src/cards/base/AdvancedEcosystems.ts
@@ -13,10 +13,10 @@ export class AdvancedEcosystems extends Card implements IProjectCard {
       tags: [Tags.PLANT, Tags.MICROBE, Tags.ANIMAL],
       cost: 11,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.PLANT).tag(Tags.ANIMAL).tag(Tags.MICROBE)),
       metadata: {
         description: 'Requires a Plant tag, a Microbe tag, and an Animal tag.',
         cardNumber: '135',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.PLANT).tag(Tags.ANIMAL).tag(Tags.MICROBE)),
         victoryPoints: 3,
       },
     });

--- a/src/cards/base/Algae.ts
+++ b/src/cards/base/Algae.ts
@@ -16,10 +16,10 @@ export class Algae extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 10,
 
+      requirements: CardRequirements.builder((b) => b.oceans(5)),
       metadata: {
         description: 'Requires 5 ocean tiles. Gain 1 Plant and increase your Plant production 2 steps.',
         cardNumber: '047',
-        requirements: CardRequirements.builder((b) => b.oceans(5)),
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.plants(2)).plants(1)),
       },
     });

--- a/src/cards/base/AntiGravityTechnology.ts
+++ b/src/cards/base/AntiGravityTechnology.ts
@@ -14,10 +14,10 @@ export class AntiGravityTechnology extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 14,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 7)),
       metadata: {
         description: 'Requires 7 science tags.',
         cardNumber: '150',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 7)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a card, you pay 2 MC less for it.', (be) => be.empty().startEffect.megacredits(-2));
         }),

--- a/src/cards/base/Ants.ts
+++ b/src/cards/base/Ants.ts
@@ -21,10 +21,10 @@ export class Ants extends Card implements IActionCard, IProjectCard, IResourceCa
       cost: 9,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(4)),
       metadata: {
         cardNumber: '035',
         description: 'Requires 4% oxygen.',
-        requirements: CardRequirements.builder((b) => b.oxygen(4)),
         renderData: CardRenderer.builder((b) => {
           b.action('Remove 1 Microbe from any card to add 1 to this card.', (eb) => {
             eb.microbes(1).any.startAction.microbes(1);

--- a/src/cards/base/ArchaeBacteria.ts
+++ b/src/cards/base/ArchaeBacteria.ts
@@ -16,10 +16,10 @@ export class ArchaeBacteria extends Card implements IProjectCard {
       tags: [Tags.MICROBE],
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-18).max()),
       metadata: {
         description: 'It must be -18 C or colder. Increase your Plant production 1 step.',
         cardNumber: '042',
-        requirements: CardRequirements.builder((b) => b.temperature(-18).max()),
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.plants(1))),
       },
     });

--- a/src/cards/base/ArcticAlgae.ts
+++ b/src/cards/base/ArcticAlgae.ts
@@ -17,10 +17,10 @@ export class ArcticAlgae extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-12).max()),
       metadata: {
         description: 'It must be -12 C or colder to play. Gain 1 plant.',
         cardNumber: '023',
-        requirements: CardRequirements.builder((b) => b.temperature(-12).max()),
         renderData: CardRenderer.builder((b) => {
           b.effect('When anyone places an ocean tile, gain 2 plants.', (be) => be.oceans(1).any.startEffect.plants(2)).br;
           b.plants(1);

--- a/src/cards/base/ArtificialLake.ts
+++ b/src/cards/base/ArtificialLake.ts
@@ -21,10 +21,10 @@ export class ArtificialLake extends Card implements IProjectCard {
       tags: [Tags.BUILDING],
       cost: 15,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-6)),
       metadata: {
         description: 'Requires -6 C or warmer. Place 1 ocean tile ON AN AREA NOT RESERVED FOR OCEAN.',
         cardNumber: '116',
-        requirements: CardRequirements.builder((b) => b.temperature(-6)),
         renderData: CardRenderer.builder((b) => b.oceans(1).asterix()),
         victoryPoints: 1,
       },

--- a/src/cards/base/AsteroidMiningConsortium.ts
+++ b/src/cards/base/AsteroidMiningConsortium.ts
@@ -17,10 +17,10 @@ export class AsteroidMiningConsortium extends Card implements IProjectCard {
       tags: [Tags.JOVIAN],
       cost: 13,
 
+      requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM)),
       metadata: {
         description: 'Requires that you have titanium production. Decrease any titanium production 1 step and increase your own 1 step.',
         cardNumber: '002',
-        requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().titanium(-1).any.br;

--- a/src/cards/base/BeamFromAThoriumAsteroid.ts
+++ b/src/cards/base/BeamFromAThoriumAsteroid.ts
@@ -17,10 +17,10 @@ export class BeamFromAThoriumAsteroid extends Card implements IProjectCard {
       tags: [Tags.JOVIAN, Tags.SPACE, Tags.ENERGY],
       cost: 32,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN)),
       metadata: {
         cardNumber: '058',
         description: 'Requires a Jovian tag. Increase your heat production and Energy production 3 steps each',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.heat(3).br;

--- a/src/cards/base/BiomassCombustors.ts
+++ b/src/cards/base/BiomassCombustors.ts
@@ -19,10 +19,10 @@ export class BiomassCombustors extends Card implements IProjectCard {
       cost: 4,
       productionBox: Units.of({energy: 2}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(6)),
       metadata: {
         description: 'Requires 6% oxygen. Decrease any Plant production 1 step and increase your Energy production 2 steps.',
         cardNumber: '183',
-        requirements: CardRequirements.builder((b) => b.oxygen(6)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().plants(-1).any.br;

--- a/src/cards/base/Birds.ts
+++ b/src/cards/base/Birds.ts
@@ -20,10 +20,10 @@ export class Birds extends Card implements IActionCard, IProjectCard, IResourceC
       tags: [Tags.ANIMAL],
       cost: 10,
       resourceType: ResourceType.ANIMAL,
+      requirements: CardRequirements.builder((b) => b.oxygen(13)),
       metadata: {
         cardNumber: '072',
         description: 'Requires 13% oxygen. Decrease any plant production 2 steps. 1 VP per Animal on this card.',
-        requirements: CardRequirements.builder((b) => b.oxygen(13)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add an animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/base/BreathingFilters.ts
+++ b/src/cards/base/BreathingFilters.ts
@@ -13,10 +13,10 @@ export class BreathingFilters extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 11,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(7)),
       metadata: {
         description: 'Requires 7% oxygen.',
         cardNumber: '114',
-        requirements: CardRequirements.builder((b) => b.oxygen(7)),
         victoryPoints: 2,
       },
     });

--- a/src/cards/base/Bushes.ts
+++ b/src/cards/base/Bushes.ts
@@ -17,10 +17,10 @@ export class Bushes extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 10,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-10)),
       metadata: {
         cardNumber: '093',
         description: 'Requires -10 C or warmer. Increase your plant production 2 steps. Gain 2 plants.',
-        requirements: CardRequirements.builder((b) => b.temperature(-10)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.plants(2);

--- a/src/cards/base/Capital.ts
+++ b/src/cards/base/Capital.ts
@@ -27,7 +27,6 @@ export class Capital extends Card implements IProjectCard {
         text: 'Requires 4 ocean tiles. Place this tile. Decrease your Energy production 2 steps and increase your MC production 5 steps.',
         align: 'left',
       },
-      requirements: CardRequirements.builder((b) => b.oceans(4)),
       renderData: CardRenderer.builder((b) => {
         b.production((pb) => {
           pb.minus().energy(2).br;
@@ -45,6 +44,7 @@ export class Capital extends Card implements IProjectCard {
       cost: 26,
       adjacencyBonus,
 
+      requirements: CardRequirements.builder((b) => b.oceans(4)),
       metadata,
     });
   }

--- a/src/cards/base/CaretakerContract.ts
+++ b/src/cards/base/CaretakerContract.ts
@@ -16,10 +16,10 @@ export class CaretakerContract extends Card implements IActionCard, IProjectCard
       cardType: CardType.ACTIVE,
       name: CardName.CARETAKER_CONTRACT,
       cost: 3,
+      requirements: CardRequirements.builder((b) => b.temperature(0)),
       metadata: {
         cardNumber: '154',
         description: 'Requires 0° C or warmer.',
-        requirements: CardRequirements.builder((b) => b.temperature(0)),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 8 heat to increase your terraform rating 1 step.', (eb) => {
             eb.heat(8).startAction.tr(1);

--- a/src/cards/base/CloudSeeding.ts
+++ b/src/cards/base/CloudSeeding.ts
@@ -16,10 +16,10 @@ export class CloudSeeding extends Card implements IProjectCard {
       name: CardName.CLOUD_SEEDING,
       cost: 11,
 
+      requirements: CardRequirements.builder((b) => b.oceans(3)),
       metadata: {
         cardNumber: '004',
         description: 'Requires 3 ocean tiles. Decrease your MC production 1 step and any heat production 1 step. Increase your Plant production 2 steps.',
-        requirements: CardRequirements.builder((b) => b.oceans(3)),
         renderData: CardRenderer.builder((b) => b.production((pb) => {
           pb.minus().megacredits(1).heat(1).any.br;
           pb.plus().plants(2);

--- a/src/cards/base/ColonizerTrainingCamp.ts
+++ b/src/cards/base/ColonizerTrainingCamp.ts
@@ -13,10 +13,10 @@ export class ColonizerTrainingCamp extends Card implements IProjectCard {
       tags: [Tags.JOVIAN, Tags.BUILDING],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(5).max()),
       metadata: {
         description: 'Oxygen must be 5% or less.',
         cardNumber: '001',
-        requirements: CardRequirements.builder((b) => b.oxygen(5).max()),
         victoryPoints: 2,
       },
     });

--- a/src/cards/base/CupolaCity.ts
+++ b/src/cards/base/CupolaCity.ts
@@ -21,9 +21,9 @@ export class CupolaCity extends Card implements IProjectCard {
       cost: 16,
       productionBox: Units.of({energy: -1, megacredits: 3}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(9).max()),
       metadata: {
         cardNumber: '029',
-        requirements: CardRequirements.builder((b) => b.oxygen(9).max()),
         description: 'Oxygen must be 9% or less. Place a City tile. Decrease your Energy production 1 step and increase your MC production 3 steps.',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {

--- a/src/cards/base/Decomposers.ts
+++ b/src/cards/base/Decomposers.ts
@@ -19,9 +19,9 @@ export class Decomposers extends Card implements IProjectCard, IResourceCard {
       cost: 5,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(3)),
       metadata: {
         cardNumber: '131',
-        requirements: CardRequirements.builder((b) => b.oxygen(3)),
         description: 'Requires 3% oxygen.',
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play an Animal, Plant, or Microbe tag, including this, add a Microbe to this card.', (be) => {

--- a/src/cards/base/DesignedMicroOrganisms.ts
+++ b/src/cards/base/DesignedMicroOrganisms.ts
@@ -17,10 +17,10 @@ export class DesignedMicroOrganisms extends Card implements IProjectCard {
       tags: [Tags.SCIENCE, Tags.MICROBE],
       cost: 16,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-14).max()),
       metadata: {
         cardNumber: '155',
         description: 'It must be -14 C or colder. Increase your Plant production 2 steps.',
-        requirements: CardRequirements.builder((b) => b.temperature(-14).max()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(2));
         }),

--- a/src/cards/base/DomedCrater.ts
+++ b/src/cards/base/DomedCrater.ts
@@ -21,9 +21,9 @@ export class DomedCrater extends Card implements IProjectCard {
       cost: 24,
       productionBox: Units.of({energy: -1, megacredits: 3}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(7).max()),
       metadata: {
         cardNumber: 'T03',
-        requirements: CardRequirements.builder((b) => b.oxygen(7).max()),
         description: {
           text: 'Oxygen must be 7% or less. Gain 3 plants. Place a City tile. Decrease your Energy production 1 step and increase your MC production 3 steps.',
           align: 'left',

--- a/src/cards/base/DustSeals.ts
+++ b/src/cards/base/DustSeals.ts
@@ -11,10 +11,10 @@ export class DustSeals extends Card implements IProjectCard {
       name: CardName.DUST_SEALS,
       cost: 2,
 
+      requirements: CardRequirements.builder((b) => b.oceans(3).max()),
       metadata: {
         description: 'Requires 3 or less ocean tiles.',
         cardNumber: '119',
-        requirements: CardRequirements.builder((b) => b.oceans(3).max()),
         victoryPoints: 1,
       },
     });

--- a/src/cards/base/EOSChasmaNationalPark.ts
+++ b/src/cards/base/EOSChasmaNationalPark.ts
@@ -23,9 +23,9 @@ export class EosChasmaNationalPark extends Card implements IProjectCard {
       cost: 16,
       productionBox: Units.of({energy: 2}),
 
+      requirements: CardRequirements.builder((b) => b.temperature(-12)),
       metadata: {
         cardNumber: '026',
-        requirements: CardRequirements.builder((b) => b.temperature(-12)),
         description: 'Requires -12 C or warmer. Add 1 Animal TO ANY ANIMAL CARD. Gain 3 Plants. Increase your MC production 2 steps.',
         renderData: CardRenderer.builder((b) => {
           b.animals(1).asterix().plants(3).br;

--- a/src/cards/base/EcologicalZone.ts
+++ b/src/cards/base/EcologicalZone.ts
@@ -26,7 +26,6 @@ export class EcologicalZone extends Card implements IProjectCard, IResourceCard 
         align: 'left',
       },
       cardNumber: '128',
-      requirements: CardRequirements.builder((b) => b.greeneries()),
       renderData: CardRenderer.builder((b) => {
         b.effect('When you play an animal or plant tag /including these/, add an animal to this card.', (eb) => {
           eb.animals(1).played.slash().plants(1).played.startEffect.animals(1);
@@ -44,6 +43,7 @@ export class EcologicalZone extends Card implements IProjectCard, IResourceCard 
       resourceType: ResourceType.ANIMAL,
       adjacencyBonus,
 
+      requirements: CardRequirements.builder((b) => b.greeneries()),
       metadata,
     });
   }

--- a/src/cards/base/ElectroCatapult.ts
+++ b/src/cards/base/ElectroCatapult.ts
@@ -22,13 +22,13 @@ export class ElectroCatapult extends Card implements IActionCard, IProjectCard {
       cost: 17,
       productionBox: Units.of({energy: -1}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(8).max()),
       metadata: {
         cardNumber: '069',
         description: {
           text: 'Oxygen must be 8% or less. Decrease your energy production 1 step.',
           align: 'left',
         },
-        requirements: CardRequirements.builder((b) => b.oxygen(8).max()),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 1 plant or 1 steel to gain 7MC.', (eb) => {
             eb.plants(1).slash().steel(1).startAction.megacredits(7);

--- a/src/cards/base/ExtremeColdFungus.ts
+++ b/src/cards/base/ExtremeColdFungus.ts
@@ -23,10 +23,10 @@ export class ExtremeColdFungus extends Card implements IActionCard, IProjectCard
       tags: [Tags.MICROBE],
       cost: 13,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-10).max()),
       metadata: {
         cardNumber: '134',
         description: 'It must be -10 C or colder.',
-        requirements: CardRequirements.builder((b) => b.temperature(-10).max()),
         renderData: CardRenderer.builder((b) => {
           b.action('Gain 1 plant.', (eb) => {
             eb.empty().startAction.plants(1);

--- a/src/cards/base/Farming.ts
+++ b/src/cards/base/Farming.ts
@@ -17,9 +17,9 @@ export class Farming extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 16,
 
+      requirements: CardRequirements.builder((b) => b.temperature(4)),
       metadata: {
         cardNumber: '118',
-        requirements: CardRequirements.builder((b) => b.temperature(4)),
         description: 'Requires +4° C or warmer. Increase your MC production 2 steps and your plant production 2 steps. Gain 2 Plants.',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {

--- a/src/cards/base/Fish.ts
+++ b/src/cards/base/Fish.ts
@@ -21,9 +21,9 @@ export class Fish extends Card implements IActionCard, IProjectCard, IResourceCa
       cost: 9,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.temperature(2)),
       metadata: {
         cardNumber: '052',
-        requirements: CardRequirements.builder((b) => b.temperature(2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/base/FusionPower.ts
+++ b/src/cards/base/FusionPower.ts
@@ -18,9 +18,9 @@ export class FusionPower extends Card implements IProjectCard {
       cost: 14,
       productionBox: Units.of({energy: 3}),
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
       metadata: {
         cardNumber: '132',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(3));
         }),

--- a/src/cards/base/GHGProducingBacteria.ts
+++ b/src/cards/base/GHGProducingBacteria.ts
@@ -25,10 +25,10 @@ export class GHGProducingBacteria extends Card implements IActionCard, IProjectC
       cost: 8,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(4)),
       metadata: {
         description: 'Requires 4% oxygen.',
         cardNumber: '034',
-        requirements: CardRequirements.builder((b) => b.oxygen(4)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Microbe to this card.', (eb) => {
             eb.empty().startAction.microbes(1);

--- a/src/cards/base/GeneRepair.ts
+++ b/src/cards/base/GeneRepair.ts
@@ -16,9 +16,9 @@ export class GeneRepair extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: '091',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.megacredits(2))),
         description: 'Requires 3 science tags. Increase your MC production 2 steps.',
         victoryPoints: 2,

--- a/src/cards/base/Grass.ts
+++ b/src/cards/base/Grass.ts
@@ -16,9 +16,9 @@ export class Grass extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 11,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-16)),
       metadata: {
         cardNumber: '087',
-        requirements: CardRequirements.builder((b) => b.temperature(-16)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1)).plants(3);
         }),

--- a/src/cards/base/GreatDam.ts
+++ b/src/cards/base/GreatDam.ts
@@ -19,9 +19,9 @@ export class GreatDam extends Card implements IProjectCard {
       cost: 12,
       productionBox: Units.of({energy: 2}),
 
+      requirements: CardRequirements.builder((b) => b.oceans(4)),
       metadata: {
         cardNumber: '136',
-        requirements: CardRequirements.builder((b) => b.oceans(4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(2));
         }),

--- a/src/cards/base/GreatEscarpmentConsortium.ts
+++ b/src/cards/base/GreatEscarpmentConsortium.ts
@@ -15,9 +15,9 @@ export class GreatEscarpmentConsortium extends Card implements IProjectCard {
       name: CardName.GREAT_ESCARPMENT_CONSORTIUM,
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.production(Resources.STEEL)),
       metadata: {
         cardNumber: '061',
-        requirements: CardRequirements.builder((b) => b.production(Resources.STEEL)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().steel(-1).any.br;

--- a/src/cards/base/Heather.ts
+++ b/src/cards/base/Heather.ts
@@ -16,9 +16,9 @@ export class Heather extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-14)),
       metadata: {
         cardNumber: '178',
-        requirements: CardRequirements.builder((b) => b.temperature(-14)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1)).plants(1);
         }),

--- a/src/cards/base/Herbivores.ts
+++ b/src/cards/base/Herbivores.ts
@@ -25,9 +25,9 @@ export class Herbivores extends Card implements IProjectCard, IResourceCard {
       cost: 12,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(8)),
       metadata: {
         cardNumber: '147',
-        requirements: CardRequirements.builder((b) => b.oxygen(8)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you place a greenery tile, add an Animal to this card.', (eb) => {
             eb.greenery(CardRenderItemSize.MEDIUM, false).startEffect.animals(1);

--- a/src/cards/base/IceCapMelting.ts
+++ b/src/cards/base/IceCapMelting.ts
@@ -18,9 +18,9 @@ export class IceCapMelting extends Card implements IProjectCard {
       name: CardName.ICE_CAP_MELTING,
       cost: 5,
 
+      requirements: CardRequirements.builder((b) => b.temperature(2)),
       metadata: {
         cardNumber: '181',
-        requirements: CardRequirements.builder((b) => b.temperature(2)),
         renderData: CardRenderer.builder((b) => b.oceans(1)),
         description: 'Requires +2 C or warmer. Place 1 ocean tile.',
       },

--- a/src/cards/base/Insects.ts
+++ b/src/cards/base/Insects.ts
@@ -16,9 +16,9 @@ export class Insects extends Card implements IProjectCard {
       tags: [Tags.MICROBE],
       cost: 9,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(6)),
       metadata: {
         cardNumber: '148',
-        requirements: CardRequirements.builder((b) => b.oxygen(6)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1).slash().plants(1).played);
         }),

--- a/src/cards/base/InterstellarColonyShip.ts
+++ b/src/cards/base/InterstellarColonyShip.ts
@@ -14,10 +14,10 @@ export class InterstellarColonyShip extends Card implements IProjectCard {
       tags: [Tags.EARTH, Tags.SPACE],
       cost: 24,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
       metadata: {
         description: 'Requires that you have 5 Science tags.',
         cardNumber: '027',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
         victoryPoints: 4,
       },
     });

--- a/src/cards/base/KelpFarming.ts
+++ b/src/cards/base/KelpFarming.ts
@@ -16,9 +16,9 @@ export class KelpFarming extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 17,
 
+      requirements: CardRequirements.builder((b) => b.oceans(6)),
       metadata: {
         cardNumber: '055',
-        requirements: CardRequirements.builder((b) => b.oceans(6)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(2).br;

--- a/src/cards/base/LakeMarineris.ts
+++ b/src/cards/base/LakeMarineris.ts
@@ -17,9 +17,9 @@ export class LakeMarineris extends Card implements IProjectCard {
       name: CardName.LAKE_MARINERIS,
       cost: 18,
 
+      requirements: CardRequirements.builder((b) => b.temperature(0)),
       metadata: {
         cardNumber: '053',
-        requirements: CardRequirements.builder((b) => b.temperature(0)),
         renderData: CardRenderer.builder((b) => b.oceans(2)),
         description: 'Requires 0° C or warmer. Place 2 ocean tiles.',
         victoryPoints: 2,

--- a/src/cards/base/Lichen.ts
+++ b/src/cards/base/Lichen.ts
@@ -17,9 +17,9 @@ export class Lichen extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-24)),
       metadata: {
         cardNumber: '159',
-        requirements: CardRequirements.builder((b) => b.temperature(-24)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1));
         }),

--- a/src/cards/base/LightningHarvest.ts
+++ b/src/cards/base/LightningHarvest.ts
@@ -16,9 +16,9 @@ export class LightningHarvest extends Card implements IProjectCard {
       cost: 8,
       tags: [Tags.ENERGY],
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: '046',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(1).megacredits(1));
         }),

--- a/src/cards/base/Livestock.ts
+++ b/src/cards/base/Livestock.ts
@@ -21,9 +21,9 @@ export class Livestock extends Card implements IActionCard, IProjectCard, IResou
       cost: 13,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(9)),
       metadata: {
         cardNumber: '184',
-        requirements: CardRequirements.builder((b) => b.oxygen(9)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/base/Mangrove.ts
+++ b/src/cards/base/Mangrove.ts
@@ -23,9 +23,9 @@ export class Mangrove extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.temperature(4)),
       metadata: {
         cardNumber: '059',
-        requirements: CardRequirements.builder((b) => b.temperature(4)),
         renderData: CardRenderer.builder((b) => b.greenery(CardRenderItemSize.MEDIUM).asterix()),
         description: 'Requires +4 C or warmer. Place a greenery tile ON AN AREA RESERVED FOR OCEAN and raise oxygen 1 step. Disregard normal placement restrictions for this.',
         victoryPoints: 1,

--- a/src/cards/base/MassConverter.ts
+++ b/src/cards/base/MassConverter.ts
@@ -16,9 +16,9 @@ export class MassConverter extends Card implements IProjectCard {
       tags: [Tags.SCIENCE, Tags.ENERGY],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
       metadata: {
         cardNumber: '094',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a Space card, you pay 2 MC less for it.', (eb) => {
             eb.space().played.startEffect.megacredits(-2);

--- a/src/cards/base/MethaneFromTitan.ts
+++ b/src/cards/base/MethaneFromTitan.ts
@@ -16,10 +16,10 @@ export class MethaneFromTitan extends Card implements IProjectCard {
       tags: [Tags.JOVIAN, Tags.SPACE],
       cost: 28,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(2)),
       metadata: {
         description: 'Requires 2% oxygen. Increase your heat production 2 steps and your plant production 2 steps.',
         cardNumber: '018',
-        requirements: CardRequirements.builder((b) => b.oxygen(2)),
         renderData: CardRenderer.builder((b) => b.production((pb) => {
           pb.heat(2).br;
           pb.plants(2);

--- a/src/cards/base/Moss.ts
+++ b/src/cards/base/Moss.ts
@@ -17,9 +17,9 @@ export class Moss extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 4,
 
+      requirements: CardRequirements.builder((b) => b.oceans(3)),
       metadata: {
         cardNumber: '122',
-        requirements: CardRequirements.builder((b) => b.oceans(3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1)).nbsp.minus().plants(1);
         }),

--- a/src/cards/base/NaturalPreserve.ts
+++ b/src/cards/base/NaturalPreserve.ts
@@ -20,7 +20,6 @@ export class NaturalPreserve extends Card implements IProjectCard {
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
     metadata: CardMetadata = {
       cardNumber: '044',
-      requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
       renderData: CardRenderer.builder((b) => {
         b.production((pb) => pb.megacredits(1)).nbsp.tile(TileType.NATURAL_PRESERVE, true).asterix();
       }),
@@ -33,6 +32,7 @@ export class NaturalPreserve extends Card implements IProjectCard {
       tags: [Tags.SCIENCE, Tags.BUILDING],
       cost: 9,
       adjacencyBonus,
+      requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
       metadata,
     });
   }

--- a/src/cards/base/NitrophilicMoss.ts
+++ b/src/cards/base/NitrophilicMoss.ts
@@ -17,9 +17,9 @@ export class NitrophilicMoss extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.oceans(3)),
       metadata: {
         cardNumber: '146',
-        requirements: CardRequirements.builder((b) => b.oceans(3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.plants(2);

--- a/src/cards/base/NoctisFarming.ts
+++ b/src/cards/base/NoctisFarming.ts
@@ -18,9 +18,9 @@ export class NoctisFarming extends Card implements IProjectCard {
       cost: 10,
       productionBox: Units.of({megacredits: 1}),
 
+      requirements: CardRequirements.builder((b) => b.temperature(-20)),
       metadata: {
         cardNumber: '176',
-        requirements: CardRequirements.builder((b) => b.temperature(-20)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(1);

--- a/src/cards/base/OpenCity.ts
+++ b/src/cards/base/OpenCity.ts
@@ -20,9 +20,9 @@ export class OpenCity extends Card implements IProjectCard {
       cost: 23,
       productionBox: Units.of({energy: -1, megacredits: 4}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(12)),
       metadata: {
         cardNumber: '108',
-        requirements: CardRequirements.builder((b) => b.oxygen(12)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().energy(1).br;

--- a/src/cards/base/PermafrostExtraction.ts
+++ b/src/cards/base/PermafrostExtraction.ts
@@ -18,9 +18,9 @@ export class PermafrostExtraction extends Card implements IProjectCard {
       name: CardName.PERMAFROST_EXTRACTION,
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-8)),
       metadata: {
         cardNumber: '191',
-        requirements: CardRequirements.builder((b) => b.temperature(-8)),
         renderData: CardRenderer.builder((b) => {
           b.oceans(1);
         }),

--- a/src/cards/base/Plantation.ts
+++ b/src/cards/base/Plantation.ts
@@ -20,9 +20,9 @@ export class Plantation extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 15,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '193',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.greenery();
         }),

--- a/src/cards/base/PowerSupplyConsortium.ts
+++ b/src/cards/base/PowerSupplyConsortium.ts
@@ -17,9 +17,9 @@ export class PowerSupplyConsortium extends Card implements IProjectCard {
       tags: [Tags.ENERGY],
       cost: 5,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
       metadata: {
         cardNumber: '160',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().energy(1).any.br;

--- a/src/cards/base/Predators.ts
+++ b/src/cards/base/Predators.ts
@@ -21,9 +21,9 @@ export class Predators extends Card implements IProjectCard, IActionCard, IResou
       cost: 14,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(11)),
       metadata: {
         cardNumber: '024',
-        requirements: CardRequirements.builder((b) => b.oxygen(11)),
         renderData: CardRenderer.builder((b) => {
           b.action('Remove 1 Animal from any card and add it to this card.', (eb) => {
             eb.animals(1).any.startAction.animals(1);

--- a/src/cards/base/QuantumExtractor.ts
+++ b/src/cards/base/QuantumExtractor.ts
@@ -16,9 +16,9 @@ export class QuantumExtractor extends Card implements IProjectCard {
       tags: [Tags.SCIENCE, Tags.ENERGY],
       cost: 13,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
       metadata: {
         cardNumber: '079',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a Space card, you pay 2 MC less for it.', (eb) => {
             eb.space().played.startEffect.megacredits(-2);

--- a/src/cards/base/RadSuits.ts
+++ b/src/cards/base/RadSuits.ts
@@ -14,9 +14,9 @@ export class RadSuits extends Card implements IProjectCard {
       name: CardName.RAD_SUITS,
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.cities(2).any()),
       metadata: {
         cardNumber: '186',
-        requirements: CardRequirements.builder((b) => b.cities(2).any()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(1));
         }),

--- a/src/cards/base/SearchForLife.ts
+++ b/src/cards/base/SearchForLife.ts
@@ -20,10 +20,10 @@ export class SearchForLife extends Card implements IActionCard, IProjectCard, IR
       cost: 3,
       resourceType: ResourceType.SCIENCE,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(6).max()),
       metadata: {
         cardNumber: '005',
         description: 'Oxygen must be 6% or less.',
-        requirements: CardRequirements.builder((b) => b.oxygen(6).max()),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 1 MC to reveal the top card of the draw deck. If that card has a Microbe tag, add a Science resource here.', (eb) => {
             eb.megacredits(1).startAction.microbes(1).played.asterix().nbsp.colon().nbsp.science();

--- a/src/cards/base/Shuttles.ts
+++ b/src/cards/base/Shuttles.ts
@@ -15,9 +15,9 @@ export class Shuttles extends Card implements IProjectCard {
       name: CardName.SHUTTLES,
       tags: [Tags.SPACE],
       cost: 10,
+      requirements: CardRequirements.builder((b) => b.oxygen(5)),
       metadata: {
         cardNumber: '166',
-        requirements: CardRequirements.builder((b) => b.oxygen(5)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a Space card, you pay 2 MC less for it.', (eb) => {
             eb.space().played.startEffect.megacredits(-2);

--- a/src/cards/base/SmallAnimals.ts
+++ b/src/cards/base/SmallAnimals.ts
@@ -21,9 +21,9 @@ export class SmallAnimals extends Card implements IActionCard, IProjectCard, IRe
       cost: 6,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(6)),
       metadata: {
         cardNumber: '054',
-        requirements: CardRequirements.builder((b) => b.oxygen(6)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/base/SymbioticFungus.ts
+++ b/src/cards/base/SymbioticFungus.ts
@@ -19,9 +19,9 @@ export class SymbioticFungus extends Card implements IActionCard, IProjectCard {
       tags: [Tags.MICROBE],
       cost: 4,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-14)),
       metadata: {
         cardNumber: '133',
-        requirements: CardRequirements.builder((b) => b.temperature(-14)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add a microbe to ANOTHER card.', (eb) => {
             eb.empty().startAction.microbes(1).asterix();

--- a/src/cards/base/TectonicStressPower.ts
+++ b/src/cards/base/TectonicStressPower.ts
@@ -18,9 +18,9 @@ export class TectonicStressPower extends Card implements IProjectCard {
       cost: 18,
       productionBox: Units.of({energy: 3}),
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '145',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(3));
         }),

--- a/src/cards/base/Trees.ts
+++ b/src/cards/base/Trees.ts
@@ -16,9 +16,9 @@ export class Trees extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 13,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-4)),
       metadata: {
         cardNumber: '060',
-        requirements: CardRequirements.builder((b) => b.temperature(-4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(3)).plants(1);
         }),

--- a/src/cards/base/TundraFarming.ts
+++ b/src/cards/base/TundraFarming.ts
@@ -17,9 +17,9 @@ export class TundraFarming extends Card implements IProjectCard {
       tags: [Tags.PLANT],
       cost: 16,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-6)),
       metadata: {
         cardNumber: '169',
-        requirements: CardRequirements.builder((b) => b.temperature(-6)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) =>{
             pb.plants(1).megacredits(2);

--- a/src/cards/base/WaterSplittingPlant.ts
+++ b/src/cards/base/WaterSplittingPlant.ts
@@ -18,9 +18,9 @@ export class WaterSplittingPlant extends Card implements IProjectCard {
       tags: [Tags.BUILDING],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.oceans(2)),
       metadata: {
         cardNumber: '177',
-        requirements: CardRequirements.builder((b) => b.oceans(2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 3 Energy to raise oxygen 1 step.', (eb) => {
             eb.energy(3).startAction.oxygen(1);

--- a/src/cards/base/WavePower.ts
+++ b/src/cards/base/WavePower.ts
@@ -17,9 +17,9 @@ export class WavePower extends Card implements IProjectCard {
       tags: [Tags.ENERGY],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.oceans(3)),
       metadata: {
         cardNumber: '139',
-        requirements: CardRequirements.builder((b) => b.oceans(3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(1));
         }),

--- a/src/cards/base/Windmills.ts
+++ b/src/cards/base/Windmills.ts
@@ -20,9 +20,9 @@ export class Windmills extends Card implements IProjectCard {
       cost: 6,
       productionBox: Units.of({energy: 1}),
 
+      requirements: CardRequirements.builder((b) => b.oxygen(7)),
       metadata: {
         cardNumber: '168',
-        requirements: CardRequirements.builder((b) => b.oxygen(7)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(1));
         }),

--- a/src/cards/base/Worms.ts
+++ b/src/cards/base/Worms.ts
@@ -17,9 +17,9 @@ export class Worms extends Card implements IProjectCard {
       tags: [Tags.MICROBE],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(4)),
       metadata: {
         cardNumber: '129',
-        requirements: CardRequirements.builder((b) => b.oxygen(4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1).slash().microbes(2).played);
         }),

--- a/src/cards/base/Zeppelins.ts
+++ b/src/cards/base/Zeppelins.ts
@@ -15,9 +15,9 @@ export class Zeppelins extends Card implements IProjectCard {
       name: CardName.ZEPPELINS,
       cost: 13,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(5)),
       metadata: {
         cardNumber: '129',
-        requirements: CardRequirements.builder((b) => b.oxygen(5)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(1).slash();

--- a/src/cards/colonies/Airliners.ts
+++ b/src/cards/colonies/Airliners.ts
@@ -16,10 +16,10 @@ export class Airliners extends Card implements IProjectCard {
       name: CardName.AIRLINERS,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.floaters(3)),
       metadata: {
         cardNumber: 'C01',
         description: 'Requires that you have 3 floaters. Increase your MC production 2 steps. Add 2 floaters to ANY card.',
-        requirements: CardRequirements.builder((b) => b.floaters(3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(2)).br;
           b.floaters(2).asterix();

--- a/src/cards/colonies/Conscription.ts
+++ b/src/cards/colonies/Conscription.ts
@@ -16,9 +16,9 @@ export class Conscription extends Card implements IProjectCard {
       tags: [Tags.EARTH],
       name: CardName.CONSCRIPTION,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
       metadata: {
         cardNumber: 'C05',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
         renderData: CardRenderer.builder((b) => {
           b.text('next card', CardRenderItemSize.SMALL, true).colon().megacredits(-16);
         }),

--- a/src/cards/colonies/CoronaExtractor.ts
+++ b/src/cards/colonies/CoronaExtractor.ts
@@ -16,9 +16,9 @@ export class CoronaExtractor extends Card implements IProjectCard {
       cost: 10,
       tags: [Tags.SPACE, Tags.ENERGY],
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
       metadata: {
         cardNumber: 'C06',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
         description: 'Requires 4 science tags. Increase your energy production 4 steps.',
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.energy(4).digit)),
       },

--- a/src/cards/colonies/HeavyTaxation.ts
+++ b/src/cards/colonies/HeavyTaxation.ts
@@ -16,9 +16,9 @@ export class HeavyTaxation extends Card implements IProjectCard {
       name: CardName.HEAVY_TAXATION,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
       metadata: {
         cardNumber: 'C14',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(2)).nbsp.megacredits(4);
         }),

--- a/src/cards/colonies/ImpactorSwarm.ts
+++ b/src/cards/colonies/ImpactorSwarm.ts
@@ -16,9 +16,9 @@ export class ImpactorSwarm extends Card implements IProjectCard {
       name: CardName.IMPACTOR_SWARM,
       cardType: CardType.EVENT,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN, 2)),
       metadata: {
         cardNumber: 'C16',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN, 2)),
         renderData: CardRenderer.builder((b) => {
           b.heat(12).digit.br;
           b.minus().plants(2).any;

--- a/src/cards/colonies/JovianLanterns.ts
+++ b/src/cards/colonies/JovianLanterns.ts
@@ -23,9 +23,9 @@ export class JovianLanterns extends Card implements IProjectCard, IResourceCard 
       cardType: CardType.ACTIVE,
       resourceType: ResourceType.FLOATER,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN)),
       metadata: {
         cardNumber: 'C18',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.JOVIAN)),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 1 titanium to add 2 floaters here.', (eb) => {
             eb.titanium(1).startAction.floaters(2);

--- a/src/cards/colonies/JupiterFloatingStation.ts
+++ b/src/cards/colonies/JupiterFloatingStation.ts
@@ -24,9 +24,9 @@ export class JupiterFloatingStation extends Card implements IProjectCard, IResou
       cardType: CardType.ACTIVE,
       resourceType: ResourceType.FLOATER,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: 'C19',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 floater to a JOVIAN CARD.', (eb) => {
             eb.empty().startAction.floaters(1).secondaryTag(Tags.JOVIAN);

--- a/src/cards/colonies/LunaGovernor.ts
+++ b/src/cards/colonies/LunaGovernor.ts
@@ -16,9 +16,9 @@ export class LunaGovernor extends Card implements IProjectCard {
       name: CardName.LUNA_GOVERNOR,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 3)),
       metadata: {
         cardNumber: 'C20',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 3)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(2));
         }),

--- a/src/cards/colonies/MartianZoo.ts
+++ b/src/cards/colonies/MartianZoo.ts
@@ -18,9 +18,9 @@ export class MartianZoo extends Card implements IProjectCard, IResourceCard {
       cardType: CardType.ACTIVE,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.cities(2).any()),
       metadata: {
         cardNumber: 'C24',
-        requirements: CardRequirements.builder((b) => b.cities(2).any()),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play an Earth tag, place an animal here.', (eb) => {
             eb.earth().played.startEffect.animals(1);

--- a/src/cards/colonies/PioneerSettlement.ts
+++ b/src/cards/colonies/PioneerSettlement.ts
@@ -18,9 +18,9 @@ export class PioneerSettlement extends Card implements IProjectCard {
       name: CardName.PIONEER_SETTLEMENT,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.colonies(1).max()),
       metadata: {
         cardNumber: 'C29',
-        requirements: CardRequirements.builder((b) => b.colonies(1).max()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(-2));
           b.nbsp.colonies(1);

--- a/src/cards/colonies/QuantumCommunications.ts
+++ b/src/cards/colonies/QuantumCommunications.ts
@@ -16,9 +16,9 @@ export class QuantumCommunications extends Card implements IProjectCard {
       name: CardName.QUANTUM_COMMUNICATIONS,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
       metadata: {
         cardNumber: '079',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(1).slash().colonies(1, CardRenderItemSize.SMALL).any;

--- a/src/cards/colonies/RedSpotObservatory.ts
+++ b/src/cards/colonies/RedSpotObservatory.ts
@@ -20,9 +20,9 @@ export class RedSpotObservatory extends Card implements IProjectCard, IResourceC
       cardType: CardType.ACTIVE,
       resourceType: ResourceType.FLOATER,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: 'C32',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 floater to this card, or spend 1 floater here to draw a card.', (eb) => {
             eb.empty().arrow().floaters(1).or();

--- a/src/cards/colonies/SkyDocks.ts
+++ b/src/cards/colonies/SkyDocks.ts
@@ -15,9 +15,9 @@ export class SkyDocks extends Card implements IProjectCard {
       name: CardName.SKY_DOCKS,
       cardType: CardType.ACTIVE,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
       metadata: {
         cardNumber: 'C36',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a card, you pay 1 MC less for it.', (eb) => {
             eb.empty().startEffect.megacredits(-1);

--- a/src/cards/colonies/SpacePort.ts
+++ b/src/cards/colonies/SpacePort.ts
@@ -18,9 +18,9 @@ export class SpacePort extends Card implements IProjectCard {
       name: CardName.SPACE_PORT,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.colonies()),
       metadata: {
         cardNumber: 'C39',
-        requirements: CardRequirements.builder((b) => b.colonies()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.minus().energy(1).br;

--- a/src/cards/colonies/SpacePortColony.ts
+++ b/src/cards/colonies/SpacePortColony.ts
@@ -17,9 +17,9 @@ export class SpacePortColony extends Card implements IProjectCard {
       name: CardName.SPACE_PORT_COLONY,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.colonies()),
       metadata: {
         cardNumber: 'C39',
-        requirements: CardRequirements.builder((b) => b.colonies()),
         renderData: CardRenderer.builder((b) => {
           b.colonies(1).asterix().nbsp.tradeFleet().br;
           b.vpText('1VP per 2 colonies in play.');

--- a/src/cards/colonies/SubZeroSaltFish.ts
+++ b/src/cards/colonies/SubZeroSaltFish.ts
@@ -22,9 +22,9 @@ export class SubZeroSaltFish extends Card implements IProjectCard, IResourceCard
       cardType: CardType.ACTIVE,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-6)),
       metadata: {
         cardNumber: 'C42',
-        requirements: CardRequirements.builder((b) => b.temperature(-6)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/colonies/UrbanDecomposers.ts
+++ b/src/cards/colonies/UrbanDecomposers.ts
@@ -18,9 +18,9 @@ export class UrbanDecomposers extends Card implements IProjectCard {
       name: CardName.URBAN_DECOMPOSERS,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.colonies().cities()),
       metadata: {
         cardNumber: 'C48',
-        requirements: CardRequirements.builder((b) => b.colonies().cities()),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.plants(1)).microbes(2).asterix();
         }),

--- a/src/cards/colonies/WarpDrive.ts
+++ b/src/cards/colonies/WarpDrive.ts
@@ -15,9 +15,9 @@ export class WarpDrive extends Card implements IProjectCard {
       name: CardName.WARP_DRIVE,
       cardType: CardType.ACTIVE,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
       metadata: {
         cardNumber: 'C49',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 5)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a Space card, you pay 4 MC less for it.', (eb) => {
             eb.space().played.startEffect.megacredits(-4);

--- a/src/cards/moon/AIControlledMineNetwork.ts
+++ b/src/cards/moon/AIControlledMineNetwork.ts
@@ -15,10 +15,10 @@ export class AIControlledMineNetwork extends Card {
       tags: [Tags.SCIENCE],
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.logisticRate(2)),
       metadata: {
         description: 'Requires Logistic Rate to be 2 or higher. Raise Logistic Rate 1 step',
         cardNumber: 'M32',
-        requirements: CardRequirements.builder((b) => b.logisticRate(2)),
         renderData: CardRenderer.builder((b) => {
           b.moonLogisticsRate(1);
         }),

--- a/src/cards/moon/HE3FusionPlant.ts
+++ b/src/cards/moon/HE3FusionPlant.ts
@@ -26,10 +26,11 @@ export class HE3FusionPlant implements IProjectCard {
     return undefined;
   }
 
+  public readonly requirements = CardRequirements.builder((b) => b.miningRate(2));
+
   public readonly metadata: CardMetadata = {
     description: 'Requires Mining Rate of 2 or higher. Increase your energy production 1 step for each mining tile on the Moon.',
     cardNumber: 'M48',
-    requirements: CardRequirements.builder((b) => b.miningRate(2)),
     renderData: CardRenderer.builder((b) => {
       b.production((pb) => pb.energy(1)).slash().moonMine();
     }),

--- a/src/cards/moon/LunaMiningHub.ts
+++ b/src/cards/moon/LunaMiningHub.ts
@@ -20,9 +20,9 @@ export class LunaMiningHub extends MoonCard {
       cost: 16,
       productionBox: Units.of({steel: 1, titanium: 1}),
 
+      requirements: CardRequirements.builder((b) => b.miningRate(5)),
       metadata: {
         cardNumber: 'M14',
-        requirements: CardRequirements.builder((b) => b.miningRate(5)),
         description: 'Requires a Mining Rate of 5 or higher. ' +
           'Spend 1 titanium and 1 steel. Increase your steel and titanium production 1 step each. ' +
           'Place this tile on the Moon and raise Mining Rate 1 step. ' +

--- a/src/cards/moon/LunaResort.ts
+++ b/src/cards/moon/LunaResort.ts
@@ -18,8 +18,8 @@ export class LunaResort extends MoonCard {
       cost: 11,
       productionBox: Units.of({energy: -1, megacredits: 3}),
 
+      requirements: CardRequirements.builder((b) => b.colonies(2)),
       metadata: {
-        requirements: CardRequirements.builder((b) => b.colonies(2)),
         description:
           'Requires 2 colonies on the Moon. Spend 2 titanium. Decrease your energy prodcution 1 step and increase your MC production 3 steps. Raise Colony Rate 1 step.',
         cardNumber: 'M21',

--- a/src/cards/moon/LunaStagingStation.ts
+++ b/src/cards/moon/LunaStagingStation.ts
@@ -16,10 +16,10 @@ export class LunaStagingStation extends MoonCard {
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.logisticRate(2)),
       metadata: {
         description: 'Requires Logistic Rate to be 2 or higher. Spend 1 titanium. Raise Logistic Rate 2 steps.',
         cardNumber: 'M30',
-        requirements: CardRequirements.builder((b) => b.logisticRate(2)),
         renderData: CardRenderer.builder((b) => {
           b.minus().titanium(1).br;
           b.moonLogisticsRate(2);

--- a/src/cards/moon/LunarTradeFleet.ts
+++ b/src/cards/moon/LunarTradeFleet.ts
@@ -16,11 +16,11 @@ export class LunarTradeFleet extends Card {
       tags: [Tags.MOON, Tags.SPACE],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM, 2)),
       metadata: {
         description: 'Requires that you have 2 titanium production. ' +
         'Increase your MC production 1 step. Raise Logistic Rate 1 step.',
         cardNumber: 'M35',
-        requirements: CardRequirements.builder((b) => b.production(Resources.TITANIUM, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(1));
           b.br;

--- a/src/cards/moon/NewColonyPlanningInitiaitives.ts
+++ b/src/cards/moon/NewColonyPlanningInitiaitives.ts
@@ -13,10 +13,10 @@ export class NewColonyPlanningInitiaitives extends Card {
       cardType: CardType.ACTIVE,
       cost: 6,
 
+      requirements: CardRequirements.builder((b) => b.colonyRate(2)),
       metadata: {
         description: 'Requires Colony Rate to be 2 or higher. Raise Colony Rate 1 step.',
         cardNumber: 'M31',
-        requirements: CardRequirements.builder((b) => b.colonyRate(2)),
         renderData: CardRenderer.builder((b) => {
           b.moonColonyRate(1);
         }),

--- a/src/cards/moon/SteelMarketMonopolists.ts
+++ b/src/cards/moon/SteelMarketMonopolists.ts
@@ -15,11 +15,11 @@ export class SteelMarketMonopolists extends MarketCard {
         name: CardName.STEEL_MARKET_MONOPOLISTS,
         cardType: CardType.ACTIVE,
         cost: 15,
+        requirements: CardRequirements.builder((b) => b.miningRate(3)),
 
         metadata: {
           description: 'Requires Mining Rate to be 3 or higher.',
           cardNumber: 'M28',
-          requirements: CardRequirements.builder((b) => b.miningRate(3)),
           renderData: CardRenderer.builder((b) => {
             b.action('Spend 3X MC to gain 2X steel (max 9MC)', (eb) => {
               eb.megacredits(3).multiplier.startAction.text('x').steel(2).asterix();

--- a/src/cards/moon/TitaniumMarketMonopolists.ts
+++ b/src/cards/moon/TitaniumMarketMonopolists.ts
@@ -16,10 +16,10 @@ export class TitaniumMarketMonopolists extends MarketCard {
         cardType: CardType.ACTIVE,
         cost: 21,
 
+        requirements: CardRequirements.builder((b) => b.miningRate(3)),
         metadata: {
           description: 'Requires Mining Rate to be 3 or higher.',
           cardNumber: 'M29',
-          requirements: CardRequirements.builder((b) => b.miningRate(3)),
           renderData: CardRenderer.builder((b) => {
             b.action('Spend 2X MC to gain X titanium [max 8MC]', (eb) => {
               eb.megacredits(2).multiplier.startAction.text('X').titanium(1).asterix();

--- a/src/cards/prelude/MartianSurvey.ts
+++ b/src/cards/prelude/MartianSurvey.ts
@@ -16,9 +16,9 @@ export class MartianSurvey extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 9,
 
+      requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
       metadata: {
         cardNumber: 'P38',
-        requirements: CardRequirements.builder((b) => b.oxygen(4).max()),
         renderData: CardRenderer.builder((b) => {
           b.cards(2);
         }),

--- a/src/cards/prelude/Psychrophiles.ts
+++ b/src/cards/prelude/Psychrophiles.ts
@@ -19,9 +19,9 @@ export class Psychrophiles extends Card implements IActionCard, IProjectCard, IR
       cost: 2,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.temperature(-20).max()),
       metadata: {
         cardNumber: 'P39',
-        requirements: CardRequirements.builder((b) => b.temperature(-20).max()),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 microbe to this card.', (eb) => {
             eb.empty().startAction.microbes(1);

--- a/src/cards/prelude/SpaceHotels.ts
+++ b/src/cards/prelude/SpaceHotels.ts
@@ -16,9 +16,9 @@ export class SpaceHotels extends Card implements IProjectCard {
       tags: [Tags.SPACE, Tags.EARTH],
       cost: 12,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
       metadata: {
         cardNumber: 'P42',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.EARTH, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(4);

--- a/src/cards/promo/CrashSiteCleanup.ts
+++ b/src/cards/promo/CrashSiteCleanup.ts
@@ -17,10 +17,10 @@ export class CrashSiteCleanup extends Card implements IProjectCard {
       name: CardName.CRASH_SITE_CLEANUP,
       cost: 4,
 
+      requirements: CardRequirements.builder((b) => b.plantsRemoved()),
       metadata: {
         description: 'Requires that a player removed ANOTHER PLAYER\'s plants this generation. Gain 1 titanium or 2 steel.',
         cardNumber: 'X16',
-        requirements: CardRequirements.builder((b) => b.plantsRemoved()),
         renderData: CardRenderer.builder((b) => {
           b.titanium(1).nbsp.or().nbsp.steel(2);
         }),

--- a/src/cards/promo/CuttingEdgeTechnology.ts
+++ b/src/cards/promo/CuttingEdgeTechnology.ts
@@ -32,7 +32,7 @@ export class CuttingEdgeTechnology extends Card implements IProjectCard {
   }
 
   public getCardDiscount(_player: Player, card: IProjectCard) {
-    if (card.metadata.requirements !== undefined) return 2;
+    if (card.requirements !== undefined) return 2;
     return 0;
   }
 

--- a/src/cards/promo/DiversitySupport.ts
+++ b/src/cards/promo/DiversitySupport.ts
@@ -14,10 +14,10 @@ export class DiversitySupport extends Card implements IProjectCard {
       tags: [],
       cost: 1,
 
+      requirements: CardRequirements.builder((b) => b.resourceTypes(9)),
       metadata: {
         cardNumber: 'X23',
         description: 'Requires that you have 9 different types of resources. Gain 1 TR.',
-        requirements: CardRequirements.builder((b) => b.resourceTypes(9)),
         renderData: CardRenderer.builder((b) => b.tr(1)),
       },
     });

--- a/src/cards/promo/DuskLaserMining.ts
+++ b/src/cards/promo/DuskLaserMining.ts
@@ -16,9 +16,9 @@ export class DuskLaserMining extends Card implements IProjectCard {
       cost: 8,
       tags: [Tags.SPACE],
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: 'X01',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         description: 'Requires 2 Science tags. Decrease your energy production 1 step, and increase your titanium production 1 step. Gain 4 titanium.',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {

--- a/src/cards/promo/GreatDamPromo.ts
+++ b/src/cards/promo/GreatDamPromo.ts
@@ -20,9 +20,9 @@ export class GreatDamPromo extends Card implements IProjectCard {
       cost: 15,
       tags: [Tags.ENERGY, Tags.BUILDING],
 
+      requirements: CardRequirements.builder((b) => b.oceans(4)),
       metadata: {
         cardNumber: '136',
-        requirements: CardRequirements.builder((b) => b.oceans(4)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.energy(2)).tile(TileType.GREAT_DAM, true, false).asterix();
         }),

--- a/src/cards/promo/MagneticShield.ts
+++ b/src/cards/promo/MagneticShield.ts
@@ -18,9 +18,9 @@ export class MagneticShield extends Card implements IProjectCard {
       tags: [Tags.SPACE],
       cost: 26,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
       metadata: {
         cardNumber: 'X20',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.ENERGY, 2)),
         renderData: CardRenderer.builder((b) => b.tr(4).digit),
         description: 'Requires 2 power tags. Raise your TR 4 steps.',
       },

--- a/src/cards/promo/MercurianAlloys.ts
+++ b/src/cards/promo/MercurianAlloys.ts
@@ -16,9 +16,9 @@ export class MercurianAlloys extends Card implements IProjectCard {
       tags: [Tags.SPACE],
       cost: 3,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: 'X07',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.effect('Your titanium resources are worth 1 MC extra.', (eb) => {
             eb.titanium(1).startEffect.plus(CardRenderItemSize.SMALL).megacredits(1);

--- a/src/cards/promo/Penguins.ts
+++ b/src/cards/promo/Penguins.ts
@@ -20,9 +20,9 @@ export class Penguins extends Card implements IActionCard, IProjectCard, IResour
       cost: 7,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.oceans(8)),
       metadata: {
         cardNumber: '212',
-        requirements: CardRequirements.builder((b) => b.oceans(8)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/promo/SelfReplicatingRobots.ts
+++ b/src/cards/promo/SelfReplicatingRobots.ts
@@ -22,9 +22,9 @@ export class SelfReplicatingRobots extends Card implements IProjectCard {
       name: CardName.SELF_REPLICATING_ROBOTS,
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '210',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Reveal and place a SPACE OR BUILDING card here from hand, and place 2 resources on it, OR double the resources on a card here.', (eb) => {
             eb.empty().startAction.selfReplicatingRobots();

--- a/src/cards/promo/SnowAlgae.ts
+++ b/src/cards/promo/SnowAlgae.ts
@@ -16,9 +16,9 @@ export class SnowAlgae extends Card implements IProjectCard {
       cost: 12,
       tags: [Tags.PLANT],
 
+      requirements: CardRequirements.builder((b) => b.oceans(2)),
       metadata: {
         cardNumber: '211',
-        requirements: CardRequirements.builder((b) => b.oceans(2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.plants(1).heat(1);

--- a/src/cards/promo/SubCrustMeasurements.ts
+++ b/src/cards/promo/SubCrustMeasurements.ts
@@ -16,9 +16,9 @@ export class SubCrustMeasurements extends Card implements IActionCard, IProjectC
       tags: [Tags.SCIENCE, Tags.BUILDING, Tags.EARTH],
       cost: 20,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: 'X28',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Draw a card.', (eb) => {
             eb.empty().startAction.cards(1);

--- a/src/cards/turmoil/AerialLenses.ts
+++ b/src/cards/turmoil/AerialLenses.ts
@@ -16,10 +16,10 @@ export class AerialLenses extends Card implements IProjectCard {
       name: CardName.AERIAL_LENSES,
       cost: 2,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
       metadata: {
         description: 'Requires that Kelvinists are ruling or that you have 2 delegates there. Remove up to 2 plants from any player. Increase your heat production 2 steps.',
         cardNumber: 'T01',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
         renderData: CardRenderer.builder((b) => b.minus().plants(-2).any.production((pb) => pb.heat(2))),
         victoryPoints: -1,
       },

--- a/src/cards/turmoil/BannedDelegate.ts
+++ b/src/cards/turmoil/BannedDelegate.ts
@@ -17,10 +17,10 @@ export class BannedDelegate extends Card implements IProjectCard {
       name: CardName.BANNED_DELEGATE,
       cost: 0,
 
+      requirements: CardRequirements.builder((b) => b.chairman()),
       metadata: {
         cardNumber: 'T02',
         description: 'Requires that you are Chairman. Remove any NON-LEADER delegate.',
-        requirements: CardRequirements.builder((b) => b.chairman()),
         renderData: CardRenderer.builder((b) => {
           b.minus().delegates(1).any;
         }),

--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -19,9 +19,9 @@ export class CulturalMetropolis extends Card implements IProjectCard {
       tags: [Tags.CITY, Tags.BUILDING],
       cost: 20,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.UNITY)),
       metadata: {
         cardNumber: 'T03',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.UNITY)),
         description: 'Requires that Unity is ruling or that you have 2 delegates there. Decrease your energy production 1 step and increase your MC production 3 steps. Place a city tile. Place 2 delegates in 1 party.',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {

--- a/src/cards/turmoil/DiasporaMovement.ts
+++ b/src/cards/turmoil/DiasporaMovement.ts
@@ -17,9 +17,9 @@ export class DiasporaMovement extends Card implements IProjectCard {
       tags: [Tags.JOVIAN],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.REDS)),
       metadata: {
         cardNumber: 'TO4',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.REDS)),
         description: 'Requires that Reds are ruling or that you have 2 delegates there. Gain 1MC for each Jovian tag in play, including this.',
         renderData: CardRenderer.builder((b) => {
           b.megacredits(1).slash().jovian().played.any;

--- a/src/cards/turmoil/EventAnalysts.ts
+++ b/src/cards/turmoil/EventAnalysts.ts
@@ -16,10 +16,10 @@ export class EventAnalysts extends Card implements IProjectCard {
       tags: [Tags.SCIENCE],
       cost: 5,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
       metadata: {
         description: 'Requires that Scientists are ruling or that you have 2 delegates there.',
         cardNumber: 'T05',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
         renderData: CardRenderer.builder((b) => b.effect('You have +1 influence.', (be) => {
           be.startEffect.influence(1);
         })),

--- a/src/cards/turmoil/GMOContract.ts
+++ b/src/cards/turmoil/GMOContract.ts
@@ -18,10 +18,10 @@ export class GMOContract extends Card implements IProjectCard {
       tags: [Tags.MICROBE, Tags.SCIENCE],
       cost: 3,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.GREENS)),
       metadata: {
         description: 'Requires that Greens are ruling or that you have 2 delegates there.',
         cardNumber: 'T06',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.GREENS)),
         renderData: CardRenderer.builder((b) => {
           b.effect('Each time you play a plant, animal or microbe tag, including this, gain 2MC.', (be) => {
             be.animals(1).played.slash().plants(1).played.slash().microbes(1).played;

--- a/src/cards/turmoil/MartianMediaCenter.ts
+++ b/src/cards/turmoil/MartianMediaCenter.ts
@@ -19,9 +19,9 @@ export class MartianMediaCenter extends Card implements IProjectCard {
       tags: [Tags.BUILDING],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.MARS)),
       metadata: {
         cardNumber: 'T07',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.MARS)),
         renderData: CardRenderer.builder((b) => {
           b.action('Pay 3 MC to add a delegate to any party.', (eb) => {
             eb.megacredits(3).startAction.delegates(1);

--- a/src/cards/turmoil/PROffice.ts
+++ b/src/cards/turmoil/PROffice.ts
@@ -19,9 +19,9 @@ export class PROffice extends Card implements IProjectCard {
       tags: [Tags.EARTH],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.UNITY)),
       metadata: {
         cardNumber: 'T09',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.UNITY)),
         renderData: CardRenderer.builder((b) => {
           b.tr(1).br;
           b.megacredits(1).slash().earth().played;

--- a/src/cards/turmoil/ParliamentHall.ts
+++ b/src/cards/turmoil/ParliamentHall.ts
@@ -17,9 +17,9 @@ export class ParliamentHall extends Card implements IProjectCard {
       tags: [Tags.BUILDING],
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.MARS)),
       metadata: {
         cardNumber: 'T08',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.MARS)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {
             pb.megacredits(1).slash().building(3).played;

--- a/src/cards/turmoil/PoliticalAlliance.ts
+++ b/src/cards/turmoil/PoliticalAlliance.ts
@@ -16,9 +16,9 @@ export class PoliticalAlliance extends Card implements IProjectCard {
       name: CardName.POLITICAL_ALLIANCE,
       cost: 4,
 
+      requirements: CardRequirements.builder((b) => b.partyLeaders(2)),
       metadata: {
         cardNumber: 'X09',
-        requirements: CardRequirements.builder((b) => b.partyLeaders(2)),
         renderData: CardRenderer.builder((b) => {
           b.tr(1);
         }),

--- a/src/cards/turmoil/PublicCelebrations.ts
+++ b/src/cards/turmoil/PublicCelebrations.ts
@@ -13,10 +13,10 @@ export class PublicCelebrations extends Card implements IProjectCard {
       name: CardName.PUBLIC_CELEBRATIONS,
       cardType: CardType.EVENT,
 
+      requirements: CardRequirements.builder((b) => b.chairman()),
       metadata: {
         description: 'Requires that you are Chairman.',
         cardNumber: 'T10',
-        requirements: CardRequirements.builder((b) => b.chairman()),
         victoryPoints: 2,
       },
     });

--- a/src/cards/turmoil/RedTourismWave.ts
+++ b/src/cards/turmoil/RedTourismWave.ts
@@ -18,9 +18,9 @@ export class RedTourismWave extends Card implements IProjectCard {
       name: CardName.RED_TOURISM_WAVE,
       cardType: CardType.EVENT,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.REDS)),
       metadata: {
         cardNumber: 'T12',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.REDS)),
         renderData: CardRenderer.builder((b) => {
           b.megacredits(1).slash().emptyTile('normal', CardRenderItemSize.SMALL).asterix();
         }),

--- a/src/cards/turmoil/SponsoredMohole.ts
+++ b/src/cards/turmoil/SponsoredMohole.ts
@@ -18,9 +18,9 @@ export class SponsoredMohole extends Card implements IProjectCard {
       name: CardName.SPONSORED_MOHOLE,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
       metadata: {
         cardNumber: 'T13',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.KELVINISTS)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.heat(2));
         }),

--- a/src/cards/turmoil/SupportedResearch.ts
+++ b/src/cards/turmoil/SupportedResearch.ts
@@ -16,9 +16,9 @@ export class SupportedResearch extends Card implements IProjectCard {
       name: CardName.SUPPORTED_RESEARCH,
       cardType: CardType.AUTOMATED,
 
+      requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
       metadata: {
         cardNumber: 'T14',
-        requirements: CardRequirements.builder((b) => b.party(PartyName.SCIENTISTS)),
         renderData: CardRenderer.builder((b) => {
           b.cards(2);
         }),

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -43,9 +43,9 @@ export class VoteOfNoConfidence implements IProjectCard {
       }
       return undefined;
     }
+    public readonly requirements = CardRequirements.builder((b) => b.partyLeaders());
     public metadata: CardMetadata = {
       cardNumber: 'T16',
-      requirements: CardRequirements.builder((b) => b.partyLeaders()),
       renderData: CardRenderer.builder((b) => {
         b.minus().chairman().any.asterix();
         b.nbsp.plus().partyLeaders().br;

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -38,9 +38,10 @@ export class WildlifeDome implements IProjectCard {
         return player.game.addGreenery(player, space.id);
       });
     }
+    public requirements = CardRequirements.builder((b) => b.party(PartyName.GREENS));
+
     public metadata: CardMetadata = {
       cardNumber: 'T15',
-      requirements: CardRequirements.builder((b) => b.party(PartyName.GREENS)),
       renderData: CardRenderer.builder((b) => {
         b.greenery();
       }),

--- a/src/cards/venusNext/AerosportTournament.ts
+++ b/src/cards/venusNext/AerosportTournament.ts
@@ -17,10 +17,10 @@ export class AerosportTournament extends Card {
       cardType: CardType.EVENT,
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.floaters(5)),
       metadata: {
         cardNumber: '214',
         description: 'Requires that you have 5 Floaters. Gain 1 MC per each City tile in play.',
-        requirements: CardRequirements.builder((b) => b.floaters(5)),
         renderData: CardRenderer.builder((b) => {
           b.megacredits(1).slash().city(CardRenderItemSize.SMALL).any;
         }),

--- a/src/cards/venusNext/AtalantaPlanitiaLab.ts
+++ b/src/cards/venusNext/AtalantaPlanitiaLab.ts
@@ -14,10 +14,10 @@ export class AtalantaPlanitiaLab extends Card {
       tags: [Tags.VENUS, Tags.SCIENCE],
       cost: 10,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: '216',
         description: 'Requires 3 science tags. Draw 2 cards.',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => b.cards(2)),
         victoryPoints: 2,
       },

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -26,10 +26,10 @@ export class Atmoscoop extends Card implements IProjectCard {
       cost: 22,
       tags: [Tags.JOVIAN, Tags.SPACE],
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
       metadata: {
         cardNumber: '217',
         description: 'Requires 3 Science tags. Either raise the temperature 2 steps, or raise Venus 2 steps. Add 2 Floaters to ANY card.',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 3)),
         renderData: CardRenderer.builder((b) => {
           b.temperature(2).or(CardRenderItemSize.SMALL).venus(2).br;
           b.floaters(2).asterix();

--- a/src/cards/venusNext/DawnCity.ts
+++ b/src/cards/venusNext/DawnCity.ts
@@ -17,9 +17,9 @@ export class DawnCity extends Card {
       tags: [Tags.CITY, Tags.SPACE],
       cost: 15,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
       metadata: {
         cardNumber: '220',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 4)),
         description: 'Requires 4 Science tags. Decrease your energy production 1 step. Increase your titanium production 1 step. Place a City tile on the RESERVED AREA.',
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => {

--- a/src/cards/venusNext/Extremophiles.ts
+++ b/src/cards/venusNext/Extremophiles.ts
@@ -20,10 +20,10 @@ export class Extremophiles extends Card implements IActionCard, IResourceCard {
       cost: 3,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '224',
         description: 'Requires 2 Science tags.',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 microbe to ANY card.', (eb) => {
             eb.empty().startAction.microbes(1).asterix();

--- a/src/cards/venusNext/FloatingHabs.ts
+++ b/src/cards/venusNext/FloatingHabs.ts
@@ -21,9 +21,9 @@ export class FloatingHabs extends Card implements IActionCard, IResourceCard {
       cost: 5,
       resourceType: ResourceType.FLOATER,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '225',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 2 MC to add 1 Floater to ANY card', (eb) => {
             eb.megacredits(2).startAction.floaters(1).asterix();

--- a/src/cards/venusNext/FreyjaBiodomes.ts
+++ b/src/cards/venusNext/FreyjaBiodomes.ts
@@ -20,9 +20,9 @@ export class FreyjaBiodomes extends Card {
       tags: [Tags.PLANT, Tags.VENUS],
       cost: 14,
 
+      requirements: CardRequirements.builder((b) => b.venus(10)),
       metadata: {
         cardNumber: '227',
-        requirements: CardRequirements.builder((b) => b.venus(10)),
         renderData: CardRenderer.builder((b) => {
           b.microbes(2).secondaryTag(Tags.VENUS).or().animals(2).secondaryTag(Tags.VENUS).br;
           b.production((pb) => pb.minus().energy(1).nbsp.plus().megacredits(2));

--- a/src/cards/venusNext/IshtarMining.ts
+++ b/src/cards/venusNext/IshtarMining.ts
@@ -16,9 +16,9 @@ export class IshtarMining extends Card {
       tags: [Tags.VENUS],
       cost: 5,
 
+      requirements: CardRequirements.builder((b) => b.venus(8)),
       metadata: {
         cardNumber: '233',
-        requirements: CardRequirements.builder((b) => b.venus(8)),
         renderData: CardRenderer.builder((b) => b.production((pb) => pb.titanium(1))),
         description: 'Requires Venus 8%. Increase your titanium production 1 step.',
       },

--- a/src/cards/venusNext/LuxuryFoods.ts
+++ b/src/cards/venusNext/LuxuryFoods.ts
@@ -12,12 +12,10 @@ export class LuxuryFoods extends Card {
       cardType: CardType.AUTOMATED,
       cost: 8,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
       metadata: {
         description: 'Requires that you have a Venus tag, an Earth tag and a Jovian tag.',
         cardNumber: 'T10',
-        requirements: CardRequirements.builder((b) =>
-          b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN),
-        ),
         victoryPoints: 2,
       },
     });

--- a/src/cards/venusNext/MaxwellBase.ts
+++ b/src/cards/venusNext/MaxwellBase.ts
@@ -22,9 +22,9 @@ export class MaxwellBase extends Card implements IActionCard {
       tags: [Tags.CITY, Tags.VENUS],
       cost: 18,
 
+      requirements: CardRequirements.builder((b) => b.venus(12)),
       metadata: {
         cardNumber: '238',
-        requirements: CardRequirements.builder((b) => b.venus(12)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 resource to ANOTHER VENUS CARD.', (eb) => {
             eb.empty().startAction.wild(1).secondaryTag(Tags.VENUS);

--- a/src/cards/venusNext/MiningQuota.ts
+++ b/src/cards/venusNext/MiningQuota.ts
@@ -15,9 +15,9 @@ export class MiningQuota extends Card {
       tags: [Tags.BUILDING],
       cost: 5,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
       metadata: {
         cardNumber: '239',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.steel(2));
         }),

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -18,9 +18,9 @@ export class NeutralizerFactory extends Card {
       tags: [Tags.VENUS],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.venus(10)),
       metadata: {
         cardNumber: '240',
-        requirements: CardRequirements.builder((b) => b.venus(10)),
         renderData: CardRenderer.builder((b) => {
           b.venus(1);
         }),

--- a/src/cards/venusNext/Omnicourt.ts
+++ b/src/cards/venusNext/Omnicourt.ts
@@ -17,9 +17,9 @@ export class Omnicourt extends Card {
       tags: [Tags.BUILDING],
       cost: 11,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
       metadata: {
         cardNumber: '241',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
         renderData: CardRenderer.builder((b) => {
           b.tr(2);
         }),

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -25,9 +25,9 @@ export class RotatorImpacts extends Card implements IActionCard, IResourceCard {
       cost: 6,
       resourceType: ResourceType.ASTEROID,
 
+      requirements: CardRequirements.builder((b) => b.venus(14).max()),
       metadata: {
         cardNumber: '243',
-        requirements: CardRequirements.builder((b) => b.venus(14).max()),
         renderData: CardRenderer.builder((b) => {
           b.action('Spend 6 MC to add an asteroid resource to this card [TITANIUM MAY BE USED].', (eb) => {
             eb.megacredits(6).titanium(1).brackets.startAction.asteroids(1);

--- a/src/cards/venusNext/SisterPlanetSupport.ts
+++ b/src/cards/venusNext/SisterPlanetSupport.ts
@@ -15,9 +15,9 @@ export class SisterPlanetSupport extends Card {
       tags: [Tags.VENUS, Tags.EARTH],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH)),
       metadata: {
         cardNumber: '244',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(3));
         }),

--- a/src/cards/venusNext/Solarnet.ts
+++ b/src/cards/venusNext/Solarnet.ts
@@ -13,9 +13,9 @@ export class Solarnet extends Card {
       cardType: CardType.AUTOMATED,
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
       metadata: {
         cardNumber: '245',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS).tag(Tags.EARTH).tag(Tags.JOVIAN)),
         renderData: CardRenderer.builder((b) => {
           b.cards(2);
         }),

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -18,9 +18,9 @@ export class SpinInducingAsteroid extends Card implements IProjectCard {
       cost: 16,
       tags: [Tags.SPACE],
 
+      requirements: CardRequirements.builder((b) => b.venus(10).max()),
       metadata: {
         cardNumber: '246',
-        requirements: CardRequirements.builder((b) => b.venus(10).max()),
         renderData: CardRenderer.builder((b) => {
           b.venus(2);
         }),

--- a/src/cards/venusNext/Stratopolis.ts
+++ b/src/cards/venusNext/Stratopolis.ts
@@ -23,9 +23,9 @@ export class Stratopolis extends Card implements IActionCard, IResourceCard {
       cost: 22,
       resourceType: ResourceType.FLOATER,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
       metadata: {
         cardNumber: '248',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 2)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 2 floaters to ANY VENUS CARD.', (eb) => {
             eb.empty().startAction.floaters(2).secondaryTag(Tags.VENUS);

--- a/src/cards/venusNext/StratosphericBirds.ts
+++ b/src/cards/venusNext/StratosphericBirds.ts
@@ -20,9 +20,9 @@ export class StratosphericBirds extends Card implements IActionCard, IResourceCa
       cost: 12,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.venus(12)),
       metadata: {
         cardNumber: '249',
-        requirements: CardRequirements.builder((b) => b.venus(12)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 animal to this card.', (eb) => {
             eb.empty().startAction.animals(1);

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -22,9 +22,9 @@ export class SulphurEatingBacteria extends Card implements IActionCard, IResourc
       cost: 6,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.venus(6)),
       metadata: {
         cardNumber: '251',
-        requirements: CardRequirements.builder((b) => b.venus(6)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Microbe to this card.', (eb) => {
             eb.empty().startAction.microbes(1);

--- a/src/cards/venusNext/TerraformingContract.ts
+++ b/src/cards/venusNext/TerraformingContract.ts
@@ -16,9 +16,9 @@ export class TerraformingContract extends Card implements IProjectCard {
       cost: 8,
       tags: [Tags.EARTH],
 
+      requirements: CardRequirements.builder((b) => b.tr(25)),
       metadata: {
         cardNumber: '252',
-        requirements: CardRequirements.builder((b) => b.tr(25)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(4));
         }),

--- a/src/cards/venusNext/Thermophiles.ts
+++ b/src/cards/venusNext/Thermophiles.ts
@@ -25,9 +25,9 @@ export class Thermophiles extends Card implements IActionCard, IResourceCard {
       cost: 9,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.venus(6)),
       metadata: {
         cardNumber: '253',
-        requirements: CardRequirements.builder((b) => b.venus(6)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Microbe to ANY Venus CARD.', (eb) => {
             eb.empty().startAction.microbes(1).secondaryTag(Tags.VENUS);

--- a/src/cards/venusNext/VenusGovernor.ts
+++ b/src/cards/venusNext/VenusGovernor.ts
@@ -15,9 +15,9 @@ export class VenusGovernor extends Card {
       tags: [Tags.VENUS, Tags.VENUS],
       cost: 4,
 
+      requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS, 2)),
       metadata: {
         cardNumber: '255',
-        requirements: CardRequirements.builder((b) => b.tag(Tags.VENUS, 2)),
         renderData: CardRenderer.builder((b) => {
           b.production((pb) => pb.megacredits(2));
         }),

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -20,9 +20,9 @@ export class VenusMagnetizer extends Card implements IActionCard {
       tags: [Tags.VENUS],
       cost: 7,
 
+      requirements: CardRequirements.builder((b) => b.venus(10)),
       metadata: {
         cardNumber: '256',
-        requirements: CardRequirements.builder((b) => b.venus(10)),
         renderData: CardRenderer.builder((b) => {
           b.action('Decrease your Energy production 1 step to raise Venus 1 step.', (eb) => {
             eb.production((pb) => pb.energy(1)).startAction.venus(1);

--- a/src/cards/venusNext/VenusianAnimals.ts
+++ b/src/cards/venusNext/VenusianAnimals.ts
@@ -20,9 +20,9 @@ export class VenusianAnimals extends Card implements IResourceCard {
       cost: 15,
       resourceType: ResourceType.ANIMAL,
 
+      requirements: CardRequirements.builder((b) => b.venus(18)),
       metadata: {
         cardNumber: '259',
-        requirements: CardRequirements.builder((b) => b.venus(18)),
         renderData: CardRenderer.builder((b) => {
           b.effect('When you play a Science tag, including this, add 1 Animal to this card.', (eb)=> {
             eb.science().played.startEffect.animals(1);

--- a/src/cards/venusNext/VenusianInsects.ts
+++ b/src/cards/venusNext/VenusianInsects.ts
@@ -19,9 +19,9 @@ export class VenusianInsects extends Card implements IActionCard, IResourceCard 
       cost: 5,
       resourceType: ResourceType.MICROBE,
 
+      requirements: CardRequirements.builder((b) => b.venus(12)),
       metadata: {
         cardNumber: '260',
-        requirements: CardRequirements.builder((b) => b.venus(12)),
         renderData: CardRenderer.builder((b) => {
           b.action('Add 1 Microbe to this card.', (eb)=> {
             eb.empty().startAction.microbes(1);

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -22,9 +22,9 @@ export class VenusianPlants extends Card implements IProjectCard {
       cost: 13,
       tags: [Tags.VENUS, Tags.PLANT],
 
+      requirements: CardRequirements.builder((b) => b.venus(16)),
       metadata: {
         cardNumber: '261',
-        requirements: CardRequirements.builder((b) => b.venus(16)),
         renderData: CardRenderer.builder((b) => {
           b.venus(1).br.br; // intentional double br
           b.microbes(1).secondaryTag(Tags.VENUS).nbsp;

--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -15,6 +15,7 @@ import {CardMetadata} from '../../cards/CardMetadata';
 import {Tags} from '../../cards/Tags';
 import {ALL_CARD_MANIFESTS} from '../../cards/AllCards';
 import {GameModule} from '../../GameModule';
+import {CardRequirements} from '../../cards/CardRequirements';
 
 export const Card = Vue.component('card', {
   components: {
@@ -116,6 +117,9 @@ export const Card = Vue.component('card', {
     getCardMetadata: function(): CardMetadata | undefined {
       return this.getCard()?.metadata;
     },
+    getCardRequirements: function(): CardRequirements | undefined {
+      return this.getCard()?.requirements;
+    },
     getResourceAmount: function(card: CardModel): number {
       return card.resources !== undefined ? card.resources : 0;
     },
@@ -134,7 +138,7 @@ export const Card = Vue.component('card', {
                     <CardTags :tags="getTags()" />
                 </div>
                 <CardTitle :title="card.name" :type="getCardType()"/>
-                <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :isCorporation="isCorporationCard()"/>
+                <CardContent v-if="getCardMetadata() !== undefined" :metadata="getCardMetadata()" :requirements="getCardRequirements()" :isCorporation="isCorporationCard()"/>
                 <CardNumber v-if="getCardMetadata() !== undefined" :number="getCardNumber()"/>
             </div>
             <CardExpansion :expansion="getCardExpansion()" :isCorporation="isCorporationCard()"/>

--- a/src/components/card/CardContent.ts
+++ b/src/components/card/CardContent.ts
@@ -4,12 +4,16 @@ import {CardRequirementsComponent} from './CardRequirementsComponent';
 import {CardVictoryPoints} from './CardVictoryPoints';
 import {CardDescription} from './CardDescription';
 import {CardRenderData} from './CardRenderData';
+import {CardRequirements} from '../../cards/CardRequirements';
 
 export const CardContent = Vue.component('CardContent', {
   props: {
     metadata: {
       type: Object as () => CardMetadata,
       required: true,
+    },
+    requirements: {
+      type: Object as () => CardRequirements,
     },
     isCorporation: {
       type: Boolean,
@@ -33,7 +37,7 @@ export const CardContent = Vue.component('CardContent', {
   },
   template: `
         <div :class="getClasses()">
-            <CardRequirementsComponent v-if="metadata.requirements !== undefined" :requirements="metadata.requirements"/>
+            <CardRequirementsComponent v-if="requirements !== undefined" :requirements="requirements"/>
             <CardRenderData v-if="metadata.renderData !== undefined" :renderData="metadata.renderData" />
             <CardDescription v-if="metadata.description !== undefined" :item="metadata.description" />
             <CardVictoryPoints v-if="metadata.victoryPoints !== undefined" :victoryPoints="metadata.victoryPoints" />

--- a/src/milestones/Tactician.ts
+++ b/src/milestones/Tactician.ts
@@ -10,7 +10,7 @@ export class Tactician implements IMilestone {
     public getScore(player: Player): number {
       const validCards = player.playedCards.filter((card) => {
         const isValidCardType = !this.excludedCardTypes.includes(card.cardType);
-        const hasRequirements = card.metadata.requirements !== undefined;
+        const hasRequirements = card.requirements !== undefined;
 
         return isValidCardType && hasRequirements;
       });


### PR DESCRIPTION
I moved the `card.metadata.requirements` to `card.requirements`.

This PR is in two commits.
1. All important files that you should check out.
2. Updating all the cards, just moving the requirements out of metadata. Was made in 95% automatically with some regexes. 

Why?
The `CardRequirements` are now not only the UI. They can check if the requirements are satisfied with `requirements.satisfies(player): boolean`. In next PR i'd like to update the rest of `card.canPlay()` with this `.satisfies`.