### PR TITLE
add button to hide tiles

### DIFF
--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -59,6 +59,7 @@ export const Board = Vue.component('board', {
   data: function() {
     return {
       'constants': constants,
+      'isTileHidden': false,
     };
   },
   mounted: function() {
@@ -157,9 +158,16 @@ export const Board = Vue.component('board', {
     getGameBoardClassName: function():string {
       return this.venusNextExtension ? 'board-cont board-with-venus' : 'board-cont board-without-venus';
     },
+    hideTile: function() {
+      return this.isTileHidden = !this.isTileHidden;
+    },
+    checkHideTile: function():boolean {
+      return this.isTileHidden;
+    },
   },
   template: `
     <div :class="getGameBoardClassName()">
+        <div class="hide-tile-button" v-on:click.prevent="hideTile()">Hide tiles</div>
         <div class="board-outer-spaces">
             <board-space :space="getSpaceById('01')" text="Ganymede Colony"></board-space>
             <board-space :space="getSpaceById('02')" text="Phobos Space Haven"></board-space>
@@ -207,7 +215,7 @@ export const Board = Vue.component('board', {
         </div>
 
         <div class="board" id="main_board">
-            <board-space :space="curSpace" :is_selectable="true" :key="'board-space-'+curSpace.id" :aresExtension="aresExtension" v-for="curSpace in getAllSpacesOnMars()"></board-space>
+            <board-space :space="curSpace" :is_selectable="true" :key="'board-space-'+curSpace.id" :aresExtension="aresExtension" :isTileHidden="checkHideTile()" v-for="curSpace in getAllSpacesOnMars()"></board-space>
             <svg id="board_legend" height="550" width="630" class="board-legend">
                 <g v-if="boardName === 'tharsis'" id="ascraeus_mons" transform="translate(95, 192)">
                     <text class="board-caption">

--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -158,8 +158,11 @@ export const Board = Vue.component('board', {
     getGameBoardClassName: function():string {
       return this.venusNextExtension ? 'board-cont board-with-venus' : 'board-cont board-without-venus';
     },
-    hideTile: function() {
-      return this.isTileHidden = !this.isTileHidden;
+    toggleHideTile: function() {
+      this.isTileHidden = !this.isTileHidden;
+    },
+    toggleHideTileLabel: function(): string {
+      return this.isTileHidden ? 'show tiles' : 'hide tiles';
     },
     checkHideTile: function():boolean {
       return this.isTileHidden;
@@ -167,7 +170,9 @@ export const Board = Vue.component('board', {
   },
   template: `
     <div :class="getGameBoardClassName()">
-        <div class="hide-tile-button" v-on:click.prevent="hideTile()">Hide tiles</div>
+        <div class="hide-tile-button-container">
+          <div class="hide-tile-button" v-on:click.prevent="toggleHideTile()">{{ toggleHideTileLabel() }}</div>
+        </div>
         <div class="board-outer-spaces">
             <board-space :space="getSpaceById('01')" text="Ganymede Colony"></board-space>
             <board-space :space="getSpaceById('02')" text="Phobos Space Haven"></board-space>

--- a/src/components/BoardSpace.ts
+++ b/src/components/BoardSpace.ts
@@ -137,6 +137,10 @@ export const BoardSpace = Vue.component('board-space', {
       if (this.is_selectable) {
         css += ' board-space-selectable';
       }
+      return css;
+    },
+    getTileClass: function(): string {
+      let css = 'board-space';
       const tileType = this.space.tileType;
       if (tileType !== undefined) {
         switch (this.space.tileType) {
@@ -171,16 +175,16 @@ export const BoardSpace = Vue.component('board-space', {
       if (this.isTileHidden) {
         css += ' board-hidden-tile';
       }
-
       return css;
     },
   },
   template: `
-        <div :class="getMainClass()" :data_space_id="space.id" :title="getVerboseTitle(space.tileType)">
+        <div :class="getMainClass()" :data_space_id="space.id">
+            <div :class="getTileClass()" :title="getVerboseTitle(space.tileType)"></div>
             <div class="board-space-text" v-if="text" v-i18n>{{ text }}</div>
             <bonus :bonus="space.bonus" v-if="space.tileType === undefined"></bonus>
             <bonus :bonus="space.bonus" v-if="space.tileType !== undefined && isTileHidden"></bonus>
-            <div :class="'board-cube board-cube--'+space.color" v-if="space.color !== undefined"></div>
+            <div :class="'board-cube board-cube--'+space.color" v-if="space.color !== undefined && !isTileHidden "></div>
         </div>
     `,
 });

--- a/src/components/BoardSpace.ts
+++ b/src/components/BoardSpace.ts
@@ -60,6 +60,9 @@ export const BoardSpace = Vue.component('board-space', {
     aresExtension: {
       type: Boolean,
     },
+    isTileHidden: {
+      type: Boolean,
+    },
   },
   data: function() {
     return {};
@@ -165,6 +168,9 @@ export const BoardSpace = Vue.component('board-space', {
           }
         }
       }
+      if (this.isTileHidden) {
+        css += ' board-hidden-tile';
+      }
 
       return css;
     },
@@ -173,6 +179,7 @@ export const BoardSpace = Vue.component('board-space', {
         <div :class="getMainClass()" :data_space_id="space.id" :title="getVerboseTitle(space.tileType)">
             <div class="board-space-text" v-if="text" v-i18n>{{ text }}</div>
             <bonus :bonus="space.bonus" v-if="space.tileType === undefined"></bonus>
+            <bonus :bonus="space.bonus" v-if="space.tileType !== undefined && isTileHidden"></bonus>
             <div :class="'board-cube board-cube--'+space.color" v-if="space.color !== undefined"></div>
         </div>
     `,

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -283,7 +283,7 @@
 }
 
 .board-hidden-tile{
-	opacity: 0.6;
+	opacity: 0.4;
 }
 
 

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -57,7 +57,7 @@
     width: 16px;
     height: 16px;
     margin: 0 0 0 2px;
-    border-radius: 2px;
+		border-radius: 2px;
 
 	&.board-space-bonus-pos--1 {
 		margin: 15px 0 0 5px;
@@ -284,3 +284,18 @@
     margin-bottom: -1px;
 }
 
+.board-hidden-tile{
+	opacity: 0.6;
+}
+
+.hide-tile-button {
+	position: absolute;
+	top: 610px;
+	text-transform: uppercase;
+	border-radius: 4px;
+	font-size: 12px;
+	padding: 1px 10px;
+	color: black;
+	background: #666;
+	cursor: pointer;
+}

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -242,8 +242,6 @@
 
 	.board-space-bonuses {
 		position: absolute;
-
-
 	}
 
 	&.board-space--available {

--- a/src/styles/board.less
+++ b/src/styles/board.less
@@ -288,14 +288,23 @@
 	opacity: 0.6;
 }
 
-.hide-tile-button {
-	position: absolute;
-	top: 610px;
-	text-transform: uppercase;
-	border-radius: 4px;
-	font-size: 12px;
-	padding: 1px 10px;
-	color: black;
-	background: #666;
-	cursor: pointer;
+
+.hide-tile-button-container {
+	position: relative;
+	width: 0px;
+	height: 0px;
+
+	.hide-tile-button {
+		position: absolute;
+    width: fit-content;
+    white-space: nowrap;
+    bottom: -560px;
+    text-transform: uppercase;
+    border-radius: 4px;
+    font-size: @font_size_small;
+    padding: 1px 5px;
+    color: black;
+    background: #666;
+    cursor: pointer;
+	}
 }


### PR DESCRIPTION
Normal ![image](https://user-images.githubusercontent.com/14239220/106386978-98d85480-63a5-11eb-96bc-23a3a3120f6b.png)

Once click 'hide tiles'
![image](https://user-images.githubusercontent.com/14239220/106386989-a68dda00-63a5-11eb-957c-5dac5cc4a9af.png)

It does not persist. As soon as you refresh or other player take an action, the view mode goes back to default. I think this is what we want.

Question: Not sure what the button name should be. 'hide tiles'? 'show bonus'?
Question: Should we show player cube during hide tiles?

Still have to adjust the position so it does show over the card during initial research phase.

This PR can close #2050 . 