### PR TITLE
DeferredActionsQueue

### DIFF
--- a/tests/cards/venusNext/SponsoredAcademies.spec.ts
+++ b/tests/cards/venusNext/SponsoredAcademies.spec.ts
@@ -6,6 +6,8 @@ import {SponsoredAcademies} from '../../../src/cards/venusNext/SponsoredAcademie
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {TestPlayers} from '../../TestingUtils';
+import {DiscardCards} from '../../../src/deferredActions/DiscardCards';
+import {DrawCards} from '../../../src/deferredActions/DrawCards';
 
 describe('SponsoredAcademies', function() {
   it('Should play', function() {
@@ -31,5 +33,24 @@ describe('SponsoredAcademies', function() {
     game.deferredActions.runAll(() => {}); // Draw cards
     expect(player.cardsInHand).has.lengthOf(4);
     expect(player2.cardsInHand).has.lengthOf(1);
+  });
+
+  it('triggers in right order', function() {
+    const card = new SponsoredAcademies();
+
+    const player = TestPlayers.BLUE.newPlayer();
+    const player2 = TestPlayers.RED.newPlayer();
+    const player3 = TestPlayers.BLACK.newPlayer();
+    const player4 = TestPlayers.GREEN.newPlayer();
+    const game = Game.newInstance('foobar', [player, player2, player3, player4], player);
+
+    player.cardsInHand.push(card, new HousePrinting(), new Tardigrades());
+    player.playCard(card);
+
+    expect((game.deferredActions.pop() as DiscardCards).title).eq('Select 1 card to discard');
+    expect((game.deferredActions.pop() as DrawCards<any>).player.color).eq('blue');
+    expect((game.deferredActions.pop() as DrawCards<any>).player.color).eq('red');
+    expect((game.deferredActions.pop() as DrawCards<any>).player.color).eq('black');
+    expect((game.deferredActions.pop() as DrawCards<any>).player.color).eq('green');
   });
 });


### PR DESCRIPTION
@Lynesth 
The actions queue does not care about the initial order of its elements, only about the priorities. (As pointed out in https://discordapp.com/channels/737945098695999559/742721510376210583/805509673289515008)

I added the test that confirms this behavior.

I see those possible solutions:
1. Have a separate (standard) queue for each of the possible priorities
2. Use a different data structure than `Heap from 'mnemonist'`
3. Add some priority-like counter to each action (first sort by priority, then by counters)

I think the best solution is 1. It's fast (without the logarithmic complexity) and does not require additional packages.
I can gladly implement it if you want.

What do you think?