### PR TITLE
Use UPSERT in saveGame() to overwrite previous saves

### DIFF
--- a/src/database/PostgreSQL.ts
+++ b/src/database/PostgreSQL.ts
@@ -193,15 +193,17 @@ export class PostgreSQL implements IDatabase {
   }
 
   saveGame(game: Game): void {
+    const gameJSON = game.toJSON();
     this.client.query(
-      'INSERT INTO games(game_id, save_id, game, players) VALUES($1, $2, $3, $4)',
-      [game.id, game.lastSaveId, game.toJSON(), game.getPlayers().length], (err) => {
+      'INSERT INTO games (game_id, save_id, game, players) VALUES ($1, $2, $3, $4) ON CONFLICT (game_id, save_id) DO UPDATE SET game = $3',
+      [game.id, game.lastSaveId, gameJSON, game.getPlayers().length], (err) => {
         if (err) {
-          // Should be a duplicate, does not matter
+          console.error('PostgreSQL:saveGame', err);
           return;
         }
       },
     );
+
     // This must occur after the save.
     game.lastSaveId++;
   }

--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -150,13 +150,14 @@ export class SQLite implements IDatabase {
   }
 
   saveGame(game: Game): void {
+    const gameJSON = game.toJSON();
     // Insert
     this.db.run(
-      'INSERT INTO games(game_id, save_id, game, players) VALUES(?, ?, ?, ?)',
-      [game.id, game.lastSaveId, game.toJSON(), game.getPlayers().length],
+      'INSERT INTO games (game_id, save_id, game, players) VALUES (?, ?, ?, ?) ON CONFLICT (game_id, save_id) DO UPDATE SET game = ?',
+      [game.id, game.lastSaveId, gameJSON, game.getPlayers().length, gameJSON],
       (err: Error | null) => {
         if (err) {
-          // Should be a duplicate, does not matter
+          console.error(err.message);
           return;
         }
       },


### PR DESCRIPTION
I don't know why I thought it was already the case, and the undo mechanism I wrote expected it to...

Anyway, so this allow overwriting saves when undoing actions, and fixes the [last known undo bug](https://github.com/bafolts/terraforming-mars/issues/2328) (solo games only).

Edit: I'm not sure what to do in the event the save failed. We only assumed that it would be because of a duplicate entry before that, so I only added a console output for now. Please tell me your thoughts @bafolts @kberg 