### PR TITLE
Auto Requirements

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1613,7 +1613,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       MoonExpansion.adjustedReserveCosts(this, card),
     );
 
-    return canAfford && (card.canPlay === undefined || card.canPlay(this));
+    return canAfford && card.requirements?.satisfies(this) !== false && (card.canPlay === undefined || card.canPlay(this));
   }
 
   // Checks if the player can afford to pay `cost` mc (possibly replaceable with steal, titanium etc.)

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -4,7 +4,6 @@ import {CardType} from './CardType';
 import {IAdjacencyBonus} from '../ares/IAdjacencyBonus';
 import {ResourceType} from '../ResourceType';
 import {Tags} from './Tags';
-import {Player} from '../Player';
 import {Units} from '../Units';
 import {CardRequirements} from './CardRequirements';
 
@@ -79,11 +78,5 @@ export abstract class Card {
   }
   public get productionBox(): Units {
     return this.properties.productionBox || Units.EMPTY;
-  }
-  public canPlay(player: Player) {
-    if (this.properties.requirements === undefined) {
-      return true;
-    }
-    return this.properties.requirements.satisfies(player);
   }
 }

--- a/src/cards/ares/OceanCity.ts
+++ b/src/cards/ares/OceanCity.ts
@@ -36,7 +36,7 @@ export class OceanCity extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && (player.getProduction(Resources.ENERGY) > 0);
+    return (player.getProduction(Resources.ENERGY) > 0);
   }
 
   public play(player: Player) {

--- a/src/cards/ares/OceanCity.ts
+++ b/src/cards/ares/OceanCity.ts
@@ -36,7 +36,7 @@ export class OceanCity extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return (player.getProduction(Resources.ENERGY) > 0);
+    return player.getProduction(Resources.ENERGY) > 0;
   }
 
   public play(player: Player) {

--- a/src/cards/base/AICentral.ts
+++ b/src/cards/base/AICentral.ts
@@ -35,7 +35,7 @@ export class AICentral extends Card implements IActionCard, IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1;
+    return player.getProduction(Resources.ENERGY) >= 1;
   }
   public play(player: Player) {
     player.addProduction(Resources.ENERGY, -1);

--- a/src/cards/base/ArtificialLake.ts
+++ b/src/cards/base/ArtificialLake.ts
@@ -31,14 +31,12 @@ export class ArtificialLake extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    const meetsRequirements = super.canPlay(player);
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, true) && meetsRequirements;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, true);
     }
-
-    return meetsRequirements;
+    return true;
   }
   public play(player: Player) {
     if (player.game.board.getOceansOnBoard() >= MAX_OCEAN_TILES) return undefined;

--- a/src/cards/base/BiomassCombustors.ts
+++ b/src/cards/base/BiomassCombustors.ts
@@ -35,7 +35,7 @@ export class BiomassCombustors extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+    return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
   }
 
   public play(player: Player) {

--- a/src/cards/base/Birds.ts
+++ b/src/cards/base/Birds.ts
@@ -40,7 +40,7 @@ export class Birds extends Card implements IActionCard, IProjectCard, IResourceC
     public resourceCount = 0;
 
     public canPlay(player: Player): boolean {
-      return super.canPlay(player) && player.game.someoneHasResourceProduction(Resources.PLANTS, 2);
+      return player.game.someoneHasResourceProduction(Resources.PLANTS, 2);
     }
     public getVictoryPoints(): number {
       return this.resourceCount;

--- a/src/cards/base/CupolaCity.ts
+++ b/src/cards/base/CupolaCity.ts
@@ -35,8 +35,7 @@ export class CupolaCity extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) &&
-        player.getProduction(Resources.ENERGY) >= 1 &&
+    return player.getProduction(Resources.ENERGY) >= 1 &&
         player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
   public play(player: Player) {

--- a/src/cards/base/DomedCrater.ts
+++ b/src/cards/base/DomedCrater.ts
@@ -40,8 +40,7 @@ export class DomedCrater extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) &&
-      player.getProduction(Resources.ENERGY) >= 1 &&
+    return player.getProduction(Resources.ENERGY) >= 1 &&
       player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
   public play(player: Player) {

--- a/src/cards/base/EcologicalZone.ts
+++ b/src/cards/base/EcologicalZone.ts
@@ -60,7 +60,7 @@ export class EcologicalZone extends Card implements IProjectCard, IResourceCard 
       );
   }
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && this.getAvailableSpaces(player).length > 0;
+    return this.getAvailableSpaces(player).length > 0;
   }
   public onCardPlayed(player: Player, card: IProjectCard): void {
     player.addResourceTo(this, card.tags.filter((tag) => tag === Tags.ANIMAL || tag === Tags.PLANT).length);

--- a/src/cards/base/Fish.ts
+++ b/src/cards/base/Fish.ts
@@ -42,7 +42,7 @@ export class Fish extends Card implements IActionCard, IProjectCard, IResourceCa
     public resourceCount: number = 0;
 
     public canPlay(player: Player): boolean {
-      return super.canPlay(player) && player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
     public getVictoryPoints(): number {
       return this.resourceCount;

--- a/src/cards/base/LakeMarineris.ts
+++ b/src/cards/base/LakeMarineris.ts
@@ -27,15 +27,14 @@ export class LakeMarineris extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    const meetsTemperatureRequirements = super.canPlay(player);
     const remainingOceans = MAX_OCEAN_TILES - player.game.board.getOceansOnBoard();
     const oceansPlaced = Math.min(remainingOceans, 2);
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * oceansPlaced) && meetsTemperatureRequirements;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * oceansPlaced);
     }
 
-    return meetsTemperatureRequirements;
+    return true;
   }
 
   public play(player: Player) {

--- a/src/cards/base/OpenCity.ts
+++ b/src/cards/base/OpenCity.ts
@@ -39,7 +39,7 @@ export class OpenCity extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1 && player.game.board.getAvailableSpacesForCity(player).length > 0;
+    return player.getProduction(Resources.ENERGY) >= 1 && player.game.board.getAvailableSpacesForCity(player).length > 0;
   }
   public play(player: Player) {
     return new SelectSpace('Select space for city tile', player.game.board.getAvailableSpacesForCity(player), (space: ISpace) => {

--- a/src/cards/base/PermafrostExtraction.ts
+++ b/src/cards/base/PermafrostExtraction.ts
@@ -30,14 +30,13 @@ export class PermafrostExtraction extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsTemperatureRequirements = super.canPlay(player);
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 
-    return meetsTemperatureRequirements;
+    return true;
   }
 
   public play(player: Player) {

--- a/src/cards/base/Plantation.ts
+++ b/src/cards/base/Plantation.ts
@@ -32,15 +32,14 @@ export class Plantation extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsTagRequirements = super.canPlay(player);
     const canPlaceTile = player.game.board.getAvailableSpacesOnLand(player).length > 0;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, false, false, false, true) && meetsTagRequirements && canPlaceTile;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, false, false, false, true) && canPlaceTile;
     }
 
-    return meetsTagRequirements && canPlaceTile;
+    return canPlaceTile;
   }
 
   public play(player: Player) {

--- a/src/cards/base/Shuttles.ts
+++ b/src/cards/base/Shuttles.ts
@@ -36,7 +36,7 @@ export class Shuttles extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1;
+    return player.getProduction(Resources.ENERGY) >= 1;
   }
   public getCardDiscount(_player: Player, card: IProjectCard) {
     if (card.tags.indexOf(Tags.SPACE) !== -1) {

--- a/src/cards/base/SmallAnimals.ts
+++ b/src/cards/base/SmallAnimals.ts
@@ -41,7 +41,7 @@ export class SmallAnimals extends Card implements IActionCard, IProjectCard, IRe
   }
     public resourceCount = 0;
     public canPlay(player: Player): boolean {
-      return super.canPlay(player) && player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
+      return player.game.someoneHasResourceProduction(Resources.PLANTS, 1);
     }
     public getVictoryPoints(): number {
       return Math.floor(this.resourceCount / 2);

--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -91,7 +91,8 @@ export class Playwrights implements CorporationCard {
         playedEvents.push(...p.playedCards.filter((card) => {
           return card.cardType === CardType.EVENT &&
             player.canAfford(player.getCardCost(card)) &&
-            (card.canPlay === undefined || card.canPlay(player));
+            (card.canPlay === undefined || card.canPlay(player)) &&
+            card.requirements?.satisfies(player) !== false;
         }));
       });
       this.checkLoops--;

--- a/src/cards/promo/DuskLaserMining.ts
+++ b/src/cards/promo/DuskLaserMining.ts
@@ -31,7 +31,7 @@ export class DuskLaserMining extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1;
+    return player.getProduction(Resources.ENERGY) >= 1;
   }
 
   public play(player: Player) {

--- a/src/cards/promo/GreatDamPromo.ts
+++ b/src/cards/promo/GreatDamPromo.ts
@@ -33,10 +33,7 @@ export class GreatDamPromo extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsOceanRequirements = super.canPlay(player);
-    const canPlaceTile = this.getAvailableSpaces(player).length > 0;
-
-    return meetsOceanRequirements && canPlaceTile;
+    return this.getAvailableSpaces(player).length > 0;
   }
 
   public play(player: Player) {

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -40,16 +40,14 @@ export class Atmoscoop extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsTagRequirements = super.canPlay(player);
     const remainingTemperatureSteps = (constants.MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const remainingVenusSteps = (constants.MAX_VENUS_SCALE - player.game.getVenusScaleLevel()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
-      return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, false, true) && meetsTagRequirements;
+      return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, false, true);
     }
-
-    return meetsTagRequirements;
+    return true;
   }
 
   public play(player: Player) {

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -30,13 +30,11 @@ export class SpinInducingAsteroid extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsVenusRequirements = super.canPlay(player);
-
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, false, true) && meetsVenusRequirements;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, false, true);
     }
 
-    return meetsVenusRequirements;
+    return true;
   }
 
   public play(player: Player) {

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -40,14 +40,13 @@ export class VenusianPlants extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    const meetsVenusRequirements = super.canPlay(player);
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
 
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
-      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, false, false, true, true) && meetsVenusRequirements;
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, false, false, true, true);
     }
 
-    return meetsVenusRequirements;
+    return true;
   }
 
   public play(player: Player) {


### PR DESCRIPTION
I'd like to automatically check the card requirements.

Changes in the first commit are doing that.
In the second commit, I'm updating some cards that were using `super.canPlay()` to check requirements.

Now there's a problem with tests. Most of the cards are checking the `card.canPlay()` method to check if their requirements are working. How to solve this?
1. Remove requirements checking in cards tests (since there are a lot of tests for `requirement.satisfy(player)` anyway)
2. Add manual requirements checking in cards tests (`&& card.requirements?.satisfy(player) !== false`)
3. Convert checking `card.canPlay(player)` to `player.canPlay(card)`. This requires updating the player MC (`player.canPlay` is running `player.canAfford()`) in every test probably.
4. Create a new function in Player that makes all `player.canPlay(card)` checks without the `canAfford` part

Which solution would be the best here?

