### PR TITLE
fix version text

### DIFF
--- a/make_static_json.js
+++ b/make_static_json.js
@@ -41,7 +41,7 @@ function getAllTranslations() {
 function generateAppVersion() {
     // assumes SOURCE_VERSION is git hash
     if (process.env.SOURCE_VERSION) {
-        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toUTCString();
+        return "deployed: " + new Date().toUTCString();
     }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -41,7 +41,7 @@ function getAllTranslations() {
 function generateAppVersion() {
     // assumes SOURCE_VERSION is git hash
     if (process.env.SOURCE_VERSION) {
-        return "deployed: " + new Date().toUTCString();
+        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toUTCString();
     }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -41,7 +41,7 @@ function getAllTranslations() {
 function generateAppVersion() {
     // assumes SOURCE_VERSION is git hash
     if (process.env.SOURCE_VERSION) {
-        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toString();
+        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toUTCString();
     }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -41,7 +41,7 @@ function getAllTranslations() {
 function generateAppVersion() {
     // assumes SOURCE_VERSION is git hash
     if (process.env.SOURCE_VERSION) {
-        return process.env.SOURCE_VERSION.substring(0, 7) + " deployed " + new Date().toISOString();
+        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toString();
     }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();

--- a/make_static_json.js
+++ b/make_static_json.js
@@ -41,7 +41,7 @@ function getAllTranslations() {
 function generateAppVersion() {
     // assumes SOURCE_VERSION is git hash
     if (process.env.SOURCE_VERSION) {
-        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toUTCString();
+        return process.env.SOURCE_VERSION.substring(0, 7) + " " + new Date().toUTCString().replace(/ \(.+\)/, '');
     }
     try {
         return child_process.execSync(`git log -1 --pretty=format:"%h %cD"`).toString();


### PR DESCRIPTION
Fix the version text when built on Heroku. This PR can close #2384.

Before
<img width="302" alt="Screen Shot 2021-02-02 at 1 32 58 PM" src="https://user-images.githubusercontent.com/14239220/106647657-3b870380-655d-11eb-8c0a-739c03c90871.png">

After
<img width="459" alt="Screen Shot 2021-02-02 at 1 41 46 PM" src="https://user-images.githubusercontent.com/14239220/106647644-37f37c80-655d-11eb-87e6-4fc519dd5ce7.png">

This problem does not happen when build locally. Not sure how to safely get rid of the `(Coordinated Universal Time)` at the end. Also do we want GMT +0? Probably right.