### PR TITLE
Fixed showing resources on cards

### DIFF
--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -281,7 +281,7 @@ function getWaitingFor(
   case PlayerInputTypes.SELECT_CARD:
     playerInputModel.cards = getCardsAsCardModel(
       (waitingFor as SelectCard<ICard>).cards,
-      false,
+      true,
       (waitingFor as SelectCard<ICard>).enabled,
     );
     playerInputModel.maxCardsToSelect = (waitingFor as SelectCard<


### PR DESCRIPTION
Fixed discord bug (created when added displaying Standard Projects):
```
regolith eaters no longer shows how many resources it has under perform an action from a played card
thats kinda annoying
```