### PR TITLE
Darker unavailable cards instead of grayscale

### DIFF
--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -35,7 +35,7 @@
 }
 
 .card-unavailable {
-    filter: grayscale(1);
+    filter: brightness(0.4);
 }
 
 .nofloat {
@@ -73,11 +73,6 @@
     border-right: 4px solid rgb(137, 137, 137);
     border-radius: 20px;
     box-shadow: 0 0 2px 1px black;
-}
-
-.clicked-card {
-    box-shadow: 0 0 1px 1px #444, 0 0 15px 5px white !important;
-    filter: grayscale(1);
 }
 
 input[type="checkbox"]:checked + .filterDiv,


### PR DESCRIPTION
I have trouble compiling with my eyes which cards are gray and which are not, this change makes it easier to fast notice.

They are darker now (didn't change opacity).
We could also try grayscale + darker if u want, I don't think it's necessary. 

Before:
![Screenshot from 2021-02-07 02-12-25](https://user-images.githubusercontent.com/19472604/107133601-3eca1880-68ea-11eb-8cbe-b8b4b6d888fc.png)
After:
![Screenshot from 2021-02-07 02-12-01](https://user-images.githubusercontent.com/19472604/107133602-3eca1880-68ea-11eb-8527-9666cf52bcad.png)

Note, it also changes the used blue cards (intended):
![Screenshot from 2021-02-07 02-13-05](https://user-images.githubusercontent.com/19472604/107133600-3e318200-68ea-11eb-8cdf-313faee1ed32.png)
