### PR TITLE
remove unused property in polling

### DIFF
--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -21,6 +21,7 @@ import {playActivePlayerSound} from '../SoundManager';
 import {SelectColony} from './SelectColony';
 import {SelectProductionToLose} from './SelectProductionToLose';
 import {ShiftAresGlobalParameters} from './ShiftAresGlobalParameters';
+import {WaitingForModel} from '../models/WaitingForModel';
 
 import * as raw_settings from '../genfiles/settings.json';
 
@@ -75,8 +76,8 @@ export const WaitingFor = Vue.component('waiting-for', {
         };
         xhr.onload = () => {
           if (xhr.status === 200) {
-            const result = xhr.response;
-            if (result['result'] === 'GO') {
+            const result = xhr.response as WaitingForModel;
+            if (result.result === 'GO') {
               root.updatePlayer();
 
               if (Notification.permission !== 'granted') {
@@ -93,7 +94,7 @@ export const WaitingFor = Vue.component('waiting-for', {
 
               // We don't need to wait anymore - it's our turn
               return;
-            } else if (result['result'] === 'REFRESH') {
+            } else if (result.result === 'REFRESH') {
               // Something changed, let's refresh UI
               root.updatePlayer();
               return;

--- a/src/models/WaitingForModel.ts
+++ b/src/models/WaitingForModel.ts
@@ -1,0 +1,4 @@
+
+export interface WaitingForModel {
+  result: 'GO' | 'REFRESH' | 'WAIT'
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,6 @@ import {Game, GameId} from './Game';
 import {GameLoader} from './database/GameLoader';
 import {GameLogs} from './routes/GameLogs';
 import {Route} from './routes/Route';
-import {Phase} from './Phase';
 import {Player} from './Player';
 import {Database} from './database/Database';
 import {Server} from './server/ServerModel';
@@ -319,17 +318,7 @@ function apiGetWaitingFor(
     }
 
     res.setHeader('Content-Type', 'application/json');
-    const answer = {
-      'result': 'WAIT',
-      'player': game.getPlayerById(game.activePlayer).name,
-    };
-    if (player.getWaitingFor() !== undefined || game.phase === Phase.END) {
-      answer['result'] = 'GO';
-    } else if (game.gameAge > prevGameAge) {
-      answer['result'] = 'REFRESH';
-    }
-    res.write(JSON.stringify(answer));
-    res.end();
+    res.end(JSON.stringify(Server.getWaitingForModel(player, prevGameAge)));
   });
 }
 

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -39,6 +39,7 @@ import {ShiftAresGlobalParameters} from '../inputs/ShiftAresGlobalParameters';
 import {MoonModel} from '../models/MoonModel';
 import {CardName} from '../CardName';
 import {Units} from '../Units';
+import {WaitingForModel} from '../models/WaitingForModel';
 
 export class Server {
   public static getGameModel(game: Game): GameHomeModel {
@@ -125,6 +126,18 @@ export class Server {
       victoryPointsBreakdown: player.getVictoryPoints(),
       waitingFor: getWaitingFor(player.getWaitingFor()),
     };
+  }
+
+  public static getWaitingForModel(player: Player, prevGameAge: number): WaitingForModel {
+    const result: WaitingForModel = {
+      result: 'WAIT',
+    };
+    if (player.getWaitingFor() !== undefined || player.game.phase === Phase.END) {
+      result.result = 'GO';
+    } else if (player.game.gameAge > prevGameAge) {
+      result.result = 'REFRESH';
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
I have been taking a closer look at the data we send between client and server in an attempt to minimize the bandwidth we use. When looking at the request we use for polling in multiplayer games I discovered a property we aren't using. Eventually I want to minimize this response body to rely on HTTP status codes versus sending any response data as it quickly adds up. Right now we send back roughly 150 bytes every 5 seconds. Over time this quickly becomes megabytes of data. Should be able to use status codes to map to `GO`, `WAIT`, and `REFRESH`. Will do that in separate PR.