### PR TITLE
move pass below standard projects

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1854,9 +1854,9 @@ export class Player implements ISerializable<SerializedPlayer> {
       action.options.push(remainingAwards);
     }
 
-    action.options.push(this.passOption());
-
     action.options.push(this.getStandardProjectOption());
+
+    action.options.push(this.passOption());
 
     // Sell patents
     const sellPatents = new SellPatentsStandardProject();


### PR DESCRIPTION
This closes #2713 .

Pass should be as low as possible but still higher than sell cards as users will pass at the end of every gen but should not sell cards unless they are forced to.

More PRs later for making minimalist mode and more player aids on the help page.