### PR TITLE
show metal selection for mining cards

### DIFF
--- a/src/components/card/CardExtraContent.ts
+++ b/src/components/card/CardExtraContent.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import {CardModel} from '../../models/CardModel';
 import {CardName} from '../../CardName';
+import {Resources} from '../../Resources';
 
 export const CardExtraContent = Vue.component('CardExtraContent', {
   props: {
@@ -13,8 +14,26 @@ export const CardExtraContent = Vue.component('CardExtraContent', {
     lifeFound: function(card: CardModel): boolean {
       return card.name === CardName.SEARCH_FOR_LIFE && card.resources !== undefined && card.resources > 0;
     },
+    miningTileOnMetal: function(card: CardModel, metal: string): boolean {
+      const miningCard = [CardName.MINING_RIGHTS, CardName.MINING_AREA, CardName.MINING_RIGHTS_ARES, CardName.MINING_AREA_ARES];
+      if (miningCard.includes(card.name)) {
+        if (metal === 'titanium') {
+          return card.bonusResource === Resources.TITANIUM;
+        } else if (metal === 'steel') {
+          return card.bonusResource === Resources.STEEL;
+        }
+      }
+      return false;
+    },
+    miningTileOnTitanium: function(card: CardModel): boolean {
+      return card.name === CardName.SEARCH_FOR_LIFE && card.resources !== undefined && card.resources > 0;
+    },
   },
   template: `
-        <img v-if="lifeFound(card)" class="little-green-men" src="assets/martian.png" />
+        <div class="card-extra-content-container">
+          <img v-if="lifeFound(card)" class="little-green-men" src="assets/martian.png" />
+          <div v-if="miningTileOnMetal(card,'steel')" class="mined-steel"/>
+          <div v-if="miningTileOnMetal(card,'titanium')" class="mined-titanium"/>
+        </div>
     `,
 });

--- a/src/models/CardModel.ts
+++ b/src/models/CardModel.ts
@@ -3,6 +3,7 @@ import {CardType} from '../cards/CardType';
 import {ResourceType} from '../ResourceType';
 import {Units} from '../Units';
 import {CardName} from '../CardName';
+import {Resources} from '../Resources';
 
 export interface CardModel {
     name: CardName;
@@ -13,4 +14,5 @@ export interface CardModel {
     isDisabled: boolean;
     warning?: string | Message;
     reserveUnits: Readonly<Units>;
+    bonusResource?: Resources | undefined;
 }

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -350,6 +350,7 @@ function getCards(
     isDisabled: options.enabled?.[index] === false,
     warning: card.warning,
     reserveUnits: options.reserveUnitMap?.get(card.name) || Units.EMPTY,
+    bonusResource: (card as IProjectCard).bonusResource,
   }));
 }
 

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -2085,6 +2085,26 @@ input[type="radio"]:checked + .filterDiv::after {
     left: 70px;
 }
 
+.mined-steel {
+    position: absolute;
+    z-index: 1000;
+    top: 142px;
+    left: 64px;
+    width: 35px;
+    height: 35px;
+    border: 5px dashed #FFFACD;
+}
+
+.mined-titanium {
+    position: absolute;
+    z-index: 1000;
+    top: 142px;
+    left: 122px;
+    width: 35px;
+    height: 35px;
+    border: 5px dashed #FFFACD;
+}
+
 .card-domed-crater {
     .content {
         .description {


### PR DESCRIPTION
Does not show anything in hand.

<img width="483" alt="Screen Shot 2021-02-11 at 2 25 47 PM" src="https://user-images.githubusercontent.com/14239220/107688072-3c164d00-6c75-11eb-80d3-4562d59cb26d.png">

But once they are placed

![image](https://user-images.githubusercontent.com/14239220/107688129-4a646900-6c75-11eb-834c-a8327076ae90.png)

steel is selected

<img width="173" alt="Screen Shot 2021-02-11 at 2 26 12 PM" src="https://user-images.githubusercontent.com/14239220/107688145-4df7f000-6c75-11eb-8140-a395b211fe31.png">

or titanium is selected

<img width="171" alt="Screen Shot 2021-02-11 at 2 26 21 PM" src="https://user-images.githubusercontent.com/14239220/107688183-58b28500-6c75-11eb-883b-439fa9e31d2f.png">

What does it look like when trying to copy with Robotic Workforce:
![image](https://user-images.githubusercontent.com/14239220/107688740-f8701300-6c75-11eb-9f3e-d6caa59c193c.png)


I rely on the cardExtraContent like Search For Life.

What I would like to improve:
- I don't want to make bonusResource property for all CardModel but I don't know how to fetch IProjectCard given a CardName.
- The box is slightly off for the Ares t cards. Just a little off center but definitely look okay.