### PR TITLE
Update discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,4 @@ This project is designed to run on single node servers or locally. Any change sh
 
 ## Questions?
 
-[Post an issue](https://github.com/bafolts/terraforming-mars/issues/new) or [Find us on Discord](https://discord.gg/fWXE53K)
+[Post an issue](https://github.com/bafolts/terraforming-mars/issues/new) or [Find us on Discord](https://discord.gg/VR8TbrD)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with FryxGames, Asmodee Digital or Steam in any way.**
 
 The board game is great and this repository highly recommends purchasing [it](https://www.amazon.com/Stronghold-Games-6005SG-Terraforming-Board/dp/B01GSYA4K2) for personal use.
 
-Join us on Discord [here](https://discord.gg/fWXE53K).
+Join us on Discord [here](https://discord.gg/VR8TbrD).
 
 ## Demo
 

--- a/src/components/CreateGameForm.ts
+++ b/src/components/CreateGameForm.ts
@@ -500,7 +500,7 @@ export const CreateGameForm = Vue.component('create-game-form', {
         <div id="create-game">
             <h1><span v-i18n>{{ constants.APP_NAME }}</span> — <span v-i18n>Create New Game</span></h1>
             <div class="create-game-discord-invite" v-if="playersCount===1" v-i18n>
-                (Looking for people to play with? <a href="https://discord.gg/fWXE53K" class="tooltip" target="_blank"><u>Join us on Discord</u></a>.)
+                (Looking for people to play with? <a href="https://discord.gg/VR8TbrD" class="tooltip" target="_blank"><u>Join us on Discord</u></a>.)
             </div>
 
             <div class="create-game-form create-game--block">

--- a/src/components/StartScreen.ts
+++ b/src/components/StartScreen.ts
@@ -38,7 +38,7 @@ export const StartScreen = Vue.component('start-screen', {
     <a class="start-screen-link start-screen-link--board-game" href="https://boardgamegeek.com/boardgame/167791/terraforming-mars" target="_blank" v-i18n>Board game</a>
     <a class="start-screen-link start-screen-link--about" href="https://github.com/bafolts/terraforming-mars" target="_blank" v-i18n>About us</a>
     <a class="start-screen-link start-screen-link--changelog" href="https://github.com/bafolts/terraforming-mars/wiki/Changelog" target="_blank" v-i18n>Whats new?</a>
-    <a class="start-screen-link start-screen-link--chat" href="https://discord.gg/fWXE53K" target="_blank" v-i18n>Join us on Discord</a>
+    <a class="start-screen-link start-screen-link--chat" href="https://discord.gg/VR8TbrD" target="_blank" v-i18n>Join us on Discord</a>
     <div class="start-screen-header start-screen-link--languages">
       <language-switcher />
       <div class="start-screen-version-cont">


### PR DESCRIPTION
The previous discord link direct you to #general-chat which is not accessible for a new comer, so you will just see a blank screen. You have to select the only available channel on the side bar to see anything.

The new invite link redirects the user directly to the #guidelines channel where they can read the guidelines, obtain a role, and enter the server.

![image](https://user-images.githubusercontent.com/14239220/107693278-ea24f580-6c7b-11eb-9a89-2865976f39c2.png)
![image](https://user-images.githubusercontent.com/14239220/107693292-eee9a980-6c7b-11eb-807e-a009c663a8e4.png)
