### PR TITLE
Remove old and out of date fields from Serialized turmoil.

### DIFF
--- a/src/turmoil/SerializedTurmoil.ts
+++ b/src/turmoil/SerializedTurmoil.ts
@@ -1,5 +1,3 @@
-import {IParty} from './parties/IParty';
-import {GlobalEventDealer} from './globalEvents/GlobalEventDealer';
 import {IGlobalEvent} from './globalEvents/IGlobalEvent';
 import {GlobalEventName} from './globalEvents/GlobalEventName';
 import {PartyName} from './parties/PartyName';
@@ -14,21 +12,18 @@ export interface SerializedParty {
     partyLeader: undefined | PlayerId | NeutralPlayer;
 }
 
-// TODO(kberg): By 2021-01-15, remove delegeate_reserve, commingGlobalEvent, and uses
-// of IParty, GlobalEventDealer, and IGlobalEvent.
 export interface SerializedTurmoil {
     chairman: undefined | PlayerId | NeutralPlayer;
-    rulingParty: IParty | PartyName;
-    dominantParty: IParty | PartyName;
+    rulingParty: PartyName;
+    dominantParty: PartyName;
     lobby: Array<string>;
-    delegate_reserve: Array<PlayerId | NeutralPlayer>; // eslint-disable-line camelcase
-    delegateReserve: Array<PlayerId | NeutralPlayer> | undefined;
-    parties: Array<IParty | SerializedParty>;
+    delegateReserve: Array<PlayerId | NeutralPlayer>;
+    parties: Array<SerializedParty>;
     playersInfluenceBonus: Array<[string, number]>;
-    globalEventDealer: GlobalEventDealer | SerializedGlobalEventDealer;
-    distantGlobalEvent: IGlobalEvent | GlobalEventName | undefined;
-    commingGlobalEvent: IGlobalEvent | undefined;
+    globalEventDealer: SerializedGlobalEventDealer;
+    distantGlobalEvent: GlobalEventName | undefined;
     comingGlobalEvent: GlobalEventName | undefined;
+    // TODO(kberg): By 2021-03-01, IGlobalEvent.
     currentGlobalEvent?: IGlobalEvent | GlobalEventName;
     politicalAgendasData: SerializedPoliticalAgendasData | undefined;
 }

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -14,6 +14,7 @@ import {ISerializable} from '../ISerializable';
 import {SerializedTurmoil} from './SerializedTurmoil';
 import {PLAYER_DELEGATES_COUNT} from '../constants';
 import {AgendaStyle, PoliticalAgendasData, PoliticalAgendas} from './PoliticalAgendas';
+import {CardName} from '../CardName';
 
 export type NeutralPlayer = 'NEUTRAL';
 
@@ -289,8 +290,10 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
         // Finally, award Chairman TR
         if (this.chairman !== 'NEUTRAL') {
           const player = game.getPlayerById(this.chairman);
-          player.increaseTerraformRating();
-          game.log('${0} is the new chairman and got 1 TR increase', (b) => b.player(player));
+          // Tempest Consultancy Hook (gains an additional TR when they become chairman)
+          const steps = player.corporationCard?.name === CardName.TEMPEST_CONSULTANCY ? 2 :1;
+          player.increaseTerraformRatingSteps(steps);
+          game.log('${0} is the new chairman and gained ${1} TR', (b) => b.player(player).number(steps));
         } else {
           game.log('A neutral delegate is the new chairman.');
         }
@@ -377,7 +380,8 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
       return Array.from(new Set(this.delegateReserve));
     }
 
-    // Return number of delegate
+    // Return number of delegates in reserve
+    // TODO(kberg): rename to getDelegatesInReserve()
     public getDelegates(playerId: PlayerId | NeutralPlayer): number {
       const delegates = this.delegateReserve.filter((p) => p === playerId).length;
       return delegates;
@@ -406,7 +410,6 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
         rulingParty: this.rulingParty.name,
         dominantParty: this.dominantParty.name,
         lobby: Array.from(this.lobby),
-        delegate_reserve: this.delegateReserve,
         delegateReserve: this.delegateReserve,
         parties: this.parties.map((p) => {
           return {
@@ -418,47 +421,22 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
         playersInfluenceBonus: Array.from(this.playersInfluenceBonus.entries()),
         globalEventDealer: this.globalEventDealer.serialize(),
         distantGlobalEvent: this.distantGlobalEvent?.name,
-        commingGlobalEvent: this.comingGlobalEvent,
         comingGlobalEvent: this.comingGlobalEvent?.name,
         politicalAgendasData: PoliticalAgendas.serialize(this.politicalAgendasData),
       };
       if (this.currentGlobalEvent !== undefined) {
-        result.currentGlobalEvent = this.currentGlobalEvent;
+        result.currentGlobalEvent = this.currentGlobalEvent.name;
       }
       return result;
     }
 
     public static deserialize(d: SerializedTurmoil): Turmoil {
-      function partyName(object: any): PartyName {
-        function instanceOfIParty(object: any): object is IParty {
-          try {
-            return 'delegates' in object;
-          } catch (typeError) {
-            return false;
-          }
-        }
-        if (instanceOfIParty(object)) {
-          return object.name;
-        } else {
-          return object;
-        }
-      }
       const dealer = GlobalEventDealer.deserialize(d.globalEventDealer);
-      const turmoil =
-        new Turmoil(
-          partyName(d.rulingParty),
-          d.chairman || 'NEUTRAL',
-          partyName(d.dominantParty),
-          dealer);
+      const turmoil = new Turmoil(d.rulingParty, d.chairman || 'NEUTRAL', d.dominantParty, dealer);
 
       turmoil.lobby = new Set(d.lobby);
-      turmoil.delegateReserve = d.delegate_reserve;
 
-      if (d.delegateReserve !== undefined) {
-        turmoil.delegateReserve = d.delegateReserve;
-      } else {
-        turmoil.delegateReserve = d.delegate_reserve;
-      }
+      turmoil.delegateReserve = d.delegateReserve;
 
       // TODO(kberg): remove this test by 2021-02-01
       turmoil.politicalAgendasData = PoliticalAgendas.deserialize(d.politicalAgendasData, turmoil);
@@ -492,12 +470,10 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
       turmoil.playersInfluenceBonus = new Map<string, number>(d.playersInfluenceBonus);
 
       if (d.distantGlobalEvent) {
-        turmoil.distantGlobalEvent = getGlobalEventByName(globalEventName(d.distantGlobalEvent));
+        turmoil.distantGlobalEvent = getGlobalEventByName(d.distantGlobalEvent);
       }
       if (d.comingGlobalEvent) {
         turmoil.comingGlobalEvent = getGlobalEventByName(d.comingGlobalEvent);
-      } else if (d.commingGlobalEvent) {
-        turmoil.comingGlobalEvent = getGlobalEventByName(d.commingGlobalEvent.name);
       }
       if (d.currentGlobalEvent) {
         turmoil.currentGlobalEvent = getGlobalEventByName(globalEventName(d.currentGlobalEvent));

--- a/src/turmoil/globalEvents/GlobalEventDealer.ts
+++ b/src/turmoil/globalEvents/GlobalEventDealer.ts
@@ -180,28 +180,14 @@ export class GlobalEventDealer implements ISerializable<SerializedGlobalEventDea
     };
   }
 
-  public static deserialize(d: GlobalEventDealer | SerializedGlobalEventDealer): GlobalEventDealer {
-    function instanceOfGlobalEventDealer(object: any): object is GlobalEventDealer {
-      return 'discardedGlobalEvents' in object;
-    }
-    if (instanceOfGlobalEventDealer(d)) {
-      const deck = d.globalEventsDeck.map((element: IGlobalEvent) => {
-        return getGlobalEventByName(element.name)!;
-      });
+  public static deserialize(d: SerializedGlobalEventDealer): GlobalEventDealer {
+    const deck = d.deck.map((element: GlobalEventName) => {
+      return getGlobalEventByName(element)!;
+    });
 
-      const discardPile = d.discardedGlobalEvents.map((element: IGlobalEvent) => {
-        return getGlobalEventByName(element.name)!;
-      });
-      return new GlobalEventDealer(deck, discardPile);
-    } else {
-      const deck = d.deck.map((element: GlobalEventName) => {
-        return getGlobalEventByName(element)!;
-      });
-
-      const discardPile = d.discarded.map((element: GlobalEventName) => {
-        return getGlobalEventByName(element)!;
-      });
-      return new GlobalEventDealer(deck, discardPile);
-    }
+    const discardPile = d.discarded.map((element: GlobalEventName) => {
+      return getGlobalEventByName(element)!;
+    });
+    return new GlobalEventDealer(deck, discardPile);
   }
 }

--- a/tests/GlobalEventsDealer.spec.ts
+++ b/tests/GlobalEventsDealer.spec.ts
@@ -5,6 +5,7 @@ import {GlobalEventDealer, getGlobalEventByName} from '../src/turmoil/globalEven
 import {GlobalEventName} from '../src/turmoil/globalEvents/GlobalEventName';
 import {IGlobalEvent} from '../src/turmoil/globalEvents/IGlobalEvent';
 import {ScientificCommunity} from '../src/turmoil/globalEvents/ScientificCommunity';
+import {SerializedGlobalEventDealer} from '../src/turmoil/globalEvents/SerializedGlobalEventDealer';
 import {SponsoredProjects} from '../src/turmoil/globalEvents/SponsoredProjects';
 import {SuccessfulOrganisms} from '../src/turmoil/globalEvents/SuccessfulOrganisms';
 import {WarOnEarth} from '../src/turmoil/globalEvents/WarOnEarth';
@@ -15,7 +16,7 @@ describe('GlobalEventsDealer', () => {
     const dealer = new GlobalEventDealer([], []);
 
     const jsonString = JSON.stringify(dealer.serialize());
-    const json = JSON.parse(jsonString) as GlobalEventDealer;
+    const json = JSON.parse(jsonString) as SerializedGlobalEventDealer;
     const newDealer = GlobalEventDealer.deserialize(json);
 
     expect(newDealer.globalEventsDeck).is.empty;
@@ -28,7 +29,7 @@ describe('GlobalEventsDealer', () => {
       [new GlobalDustStorm(), new WarOnEarth()]);
 
     const jsonString = JSON.stringify(dealer.serialize());
-    const json = JSON.parse(jsonString) as GlobalEventDealer;
+    const json = JSON.parse(jsonString) as SerializedGlobalEventDealer;
     const newDealer = GlobalEventDealer.deserialize(json);
 
     const cardName = (e: IGlobalEvent) => e.name;

--- a/tests/Turmoil.spec.ts
+++ b/tests/Turmoil.spec.ts
@@ -211,70 +211,6 @@ describe('Turmoil', function() {
     expect(nitrogenFromTitan.canPlay(player)).is.true; // 25 + 6 - 6
   });
 
-  it('backward compatible deserialization', () => {
-    const json = {
-      'chairman': 'NEUTRAL',
-      'rulingParty': {'delegates': ['blue-id', 'NEUTRAL'], 'name': 'Greens', 'description': 'All players receive 1 MC for each Plant tag, Microbe tag, and Animal tag they have.'},
-      'dominantParty': {'partyLeader': 'NEUTRAL', 'delegates': ['NEUTRAL'], 'name': 'Unity', 'description': 'All players receive 1 MC for each Venus tag, Earth tag, and Jovian tag they have.'},
-      'lobby': ['blue-id'],
-      'delegate_reserve': ['blue-id', 'red-id', 'green-id', 'NEUTRAL', 'NEUTRAL'],
-      'parties': [
-        {'partyLeader': 'NEUTRAL', 'delegates': ['NEUTRAL'], 'name': 'Mars First', 'description': 'All players receive 1 MC for each Building tag they have.'},
-        {'delegates': [], 'name': 'Scientists', 'description': 'All players receive 1 MC for each Science tag they have.'},
-        {'partyLeader': 'NEUTRAL', 'delegates': ['NEUTRAL'], 'name': 'Unity', 'description': 'All players receive 1 MC for each Venus tag, Earth tag, and Jovian tag they have.'},
-        {'delegates': [], 'name': 'Greens', 'description': 'All players receive 1 MC for each Plant tag, Microbe tag, and Animal tag they have.'},
-        {'delegates': [], 'name': 'Reds', 'description': 'The player with the lowest TR gains 1 TR. Ties are friendly.'},
-        {'delegates': [], 'name': 'Kelvinists', 'description': 'All players receive 1 MC for each Heat production they have.'},
-      ],
-      'playersInfluenceBonus': [],
-      'globalEventDealer': {
-        'globalEventsDeck': [
-          {'name': 'Scientific Community', 'description': 'Gain 1 MC for each card in hand (no limit) and influence.', 'revealedDelegate': 'Reds', 'currentDelegate': 'Scientists'},
-          {'name': 'Sponsored Projects', 'description': 'All cards with resources on them gain 1 resource. Draw 1 card for each influence.', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Greens'},
-          {'name': 'Miners Of Strike', 'description': 'Lose 1 titanium for each Jovian tag (max 5, then reduced by influence).', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Greens'},
-          {'name': 'Snow Cover', 'description': 'Decrease temperature 2 steps. Draw 1 card per influence.', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Kelvinists'},
-          {'name': 'Mud Slides', 'description': 'Lose 4 MC for each tile adjacent to ocean (max 5, then reduced by influence).', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Greens'},
-          {'name': 'Pandemic', 'description': 'Lose 3 MC for each Building tag (max 5, then reduced by influence).', 'revealedDelegate': 'Greens', 'currentDelegate': 'Mars First'},
-          {'name': 'Dry Deserts', 'description': 'First player removes 1 ocean tile from the gameboard. Gain 1 standard resource per influence.', 'revealedDelegate': 'Reds', 'currentDelegate': 'Unity'},
-          {'name': 'War on Earth', 'description': 'Reduce TR 4 steps. Each influence prevents 1 step.', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Kelvinists'},
-          {'name': 'Eco Sabotage', 'description': 'Lose all plants except 3 + influence.', 'revealedDelegate': 'Greens', 'currentDelegate': 'Reds'},
-          {'name': 'Election', 'description': 'Count your influence plus Building tags and City tiles (no limits). The player with most (or 10 in solo) gains 2 TR, the 2nd (or 5 in solo) gains 1 TR (ties are friendly).', 'revealedDelegate': 'Greens', 'currentDelegate': 'Mars First'},
-          {'name': 'Revolution', 'description': 'Count Earth tags and ADD(!) influence. The player(s) with most (at least 1) loses 2 TR, and 2nd most (at least 1) loses 1 TR. SOLO: Lose 2 TR if the sum is 4 or more.', 'revealedDelegate': 'Unity', 'currentDelegate': 'Mars First'},
-          {'name': 'Sabotage', 'description': 'Decrease steel and energy production 1 step each. Gain 1 steel per influence.', 'revealedDelegate': 'Unity', 'currentDelegate': 'Reds'},
-          {'name': 'Global Dust Storm', 'description': 'Lose all heat. Lose 2 MC for each Building tag (max 5, then reduced by influence).', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Greens'},
-          {'name': 'Solarnet Shutdown', 'description': 'Lose 3 MC for each blue card (max 5, then reduced by influence).', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Mars First'},
-          {'name': 'Volcanic Eruptions', 'description': 'Increase temperature 2 steps. Increase heat production 1 step per influence.', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Kelvinists'},
-          {'name': 'Diversity', 'description': 'Gain 10 MC if you have 9 or more different tags. Influence counts as unique tags.', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Scientists'},
-          {'name': 'Venus Infrastructure', 'description': 'Gain 2 MC per Venus tag (max 5) and influence.', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Unity'},
-          {'name': 'Celebrity Leaders', 'description': 'Gain 2 MC for each event played (max 5) and influence.', 'revealedDelegate': 'Unity', 'currentDelegate': 'Greens'},
-          {'name': 'Productivity', 'description': 'Gain 1 steel for each steel production (max 5) and influence.', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Mars First'},
-          {'name': 'Homeworld Support', 'description': 'Gain 2 MC for each Earth tag (max 5) and influence.', 'revealedDelegate': 'Reds', 'currentDelegate': 'Unity'},
-          {'name': 'Strong Society', 'description': 'Gain 2 MC for each City tile (max 5) and influence.', 'revealedDelegate': 'Reds', 'currentDelegate': 'Mars First'},
-          {'name': 'Asteroid Mining', 'description': 'Gain 1 titanium for each Jovian tag (max 5) and influence.', 'revealedDelegate': 'Reds', 'currentDelegate': 'Unity'},
-          {'name': 'Riots', 'description': 'Lose 4 MC for each City tile (max 5, then reduced by influence).', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Reds'},
-          {'name': 'Spin-Off Products', 'description': 'Gain 2 MC for each Science tag (max 5) and influence.', 'revealedDelegate': 'Greens', 'currentDelegate': 'Scientists'},
-          {'name': 'Paradigm Breakdown', 'description': 'Discard 2 cards from hand. Gain 2 MC per influence.', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Reds'},
-          {'name': 'Red Influence', 'description': 'Lose 3 MC for each set of 5 TR over 10 (max 5 sets). Increase MC production 1 step per influence.', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Reds'},
-          {'name': 'Generous Funding', 'description': 'Gain 2 MC for each influence and set of 5 TR over 15 (max 5 sets).', 'revealedDelegate': 'Kelvinists', 'currentDelegate': 'Unity'},
-          {'name': 'Improved Energy Templates', 'description': 'Increase energy production 1 step per 2 power tags (no limit). Influence counts as power tags.', 'revealedDelegate': 'Scientists', 'currentDelegate': 'Kelvinists'},
-          {'name': 'Successful Organisms', 'description': 'Gain 1 plant per plant production (max 5) and influence.', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Scientists'},
-        ],
-        'discardedGlobalEvents': [
-          {'name': 'Interplanetary Trade', 'description': 'Gain 2 MC for each space tag (max 5) and influence.', 'revealedDelegate': 'Unity', 'currentDelegate': 'Unity'},
-        ],
-      },
-      'distantGlobalEvent': {'name': 'Aquifer Released by Public Council', 'description': 'First player places an ocean tile. Gain 1 plant and 1 steel per influence.', 'revealedDelegate': 'Mars First', 'currentDelegate': 'Greens'},
-      'commingGlobalEvent': {'name': 'Solar Flare', 'description': 'Lose 3 MC for each space tag (max 5, then reduced by influence).', 'revealedDelegate': 'Unity', 'currentDelegate': 'Kelvinists'},
-      'politicalAgendasData': {'thisAgenda': {'bonusId': 'none', 'policyId': 'none'}},
-    };
-    const s: SerializedTurmoil = JSON.parse(JSON.stringify(json));
-    const t = Turmoil.deserialize(s);
-
-    expect(t.distantGlobalEvent!.name).eq('Aquifer Released by Public Council');
-    expect(t.comingGlobalEvent!.name).eq('Solar Flare');
-    expect(t.delegateReserve).deep.eq(['blue-id', 'red-id', 'green-id', 'NEUTRAL', 'NEUTRAL']);
-  });
-
   it('serializes and deserializes keeping players', function() {
     // Party delegates have to be explicitly set since game set-up draws a global event which
     // adds delegates to a party. So parties[0] can be empty or not depending on the draw.
@@ -284,13 +220,13 @@ describe('Turmoil', function() {
     expect(deserialized.parties[0].getPresentPlayers()).to.have.members(['NEUTRAL', 'fancy-pants']);
   });
 
-  it('forward compatible deserialization', () => {
+  it('deserialization', () => {
     const json = {
       'chairman': 'NEUTRAL',
       'rulingParty': 'Greens',
       'dominantParty': 'Unity',
       'lobby': ['blue-id'],
-      'delegate_reserve': ['blue-id', 'red-id', 'green-id', 'NEUTRAL', 'NEUTRAL'],
+      'delegateReserve': ['blue-id', 'red-id', 'green-id', 'NEUTRAL', 'NEUTRAL'],
       'parties': [
         {'name': 'Mars First', 'delegates': []},
         {'name': 'Scientists', 'delegates': []},


### PR DESCRIPTION
And fix current global event, which still didn't serialize efficiently.