### PR TITLE
Fixes missing Mandatory Venus Terraforming option in game setup details panel

### DIFF
--- a/src/models/GameOptionsModel.ts
+++ b/src/models/GameOptionsModel.ts
@@ -27,4 +27,5 @@ export interface GameOptionsModel {
   randomMA: RandomMAOptionType,
   turmoilExtension: boolean,
   venusNextExtension: boolean,
+  requiresVenusTrackCompletion: boolean,
 }

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -492,5 +492,6 @@ function getGameOptionsAsModel(options: GameOptions): GameOptionsModel {
     randomMA: options.randomMA,
     turmoilExtension: options.turmoilExtension,
     venusNextExtension: options.venusNextExtension,
+    requiresVenusTrackCompletion: options.requiresVenusTrackCompletion,
   };
 }


### PR DESCRIPTION
This fixes an issue where selecting "Mandatory Venus Terraforming" as a game option is not reflected in the popup panel showing the game settings. I tested by creating games with and without the mandatory Venus option and it appropriately shows the correct message (or lack thereof). 