### PR TITLE
Move buffer gas out of Prelude Manifest

### DIFF
--- a/src/cards/StandardCardManifests.ts
+++ b/src/cards/StandardCardManifests.ts
@@ -230,6 +230,7 @@ import {AsteroidStandardProject} from './base/standardProjects/AsteroidStandardP
 import {SellPatentsStandardProject} from './base/standardProjects/SellPatentsStandardProject';
 import {ConvertPlants} from './base/standardActions/ConvertPlants';
 import {ConvertHeat} from './base/standardActions/ConvertHeat';
+import {BufferGasStandardProject} from './prelude/BufferGasStandardProject';
 
 export const BASE_CARD_MANIFEST = new CardManifest({
   module: GameModule.Base,
@@ -392,6 +393,7 @@ export const BASE_CARD_MANIFEST = new CardManifest({
     {cardName: CardName.GREENERY_STANDARD_PROJECT, Factory: GreeneryStandardProject},
     {cardName: CardName.ASTEROID_STANDARD_PROJECT, Factory: AsteroidStandardProject},
     {cardName: CardName.SELL_PATENTS_STANDARD_PROJECT, Factory: SellPatentsStandardProject},
+    {cardName: CardName.BUFFER_GAS_STANDARD_PROJECT, Factory: BufferGasStandardProject},
   ],
   standardActions: [
     {cardName: CardName.CONVERT_PLANTS, Factory: ConvertPlants},

--- a/src/cards/prelude/PreludeCardManifest.ts
+++ b/src/cards/prelude/PreludeCardManifest.ts
@@ -7,7 +7,6 @@ import {AquiferTurbines} from './AquiferTurbines';
 import {Biofuels} from './Biofuels';
 import {Biolab} from './Biolab';
 import {BiosphereSupport} from './BiosphereSupport';
-import {BufferGasStandardProject} from './BufferGasStandardProject';
 import {BusinessEmpire} from './BusinessEmpire';
 import {CheungShingMARS} from './CheungShingMARS';
 import {DomeFarming} from './DomeFarming';
@@ -106,8 +105,5 @@ export const PRELUDE_CARD_MANIFEST = new CardManifest({
     {cardName: CardName.ECCENTRIC_SPONSOR, Factory: EccentricSponsor},
     {cardName: CardName.ECOLOGY_EXPERTS, Factory: EcologyExperts},
     {cardName: CardName.EXPERIMENTAL_FOREST, Factory: ExperimentalForest},
-  ],
-  standardProjects: [
-    {cardName: CardName.BUFFER_GAS_STANDARD_PROJECT, Factory: BufferGasStandardProject},
   ],
 });


### PR DESCRIPTION
This PR can close #2788 . It allows buffer gas to be available when Prelude is not used, as long as 63TR mode is on.