### PR TITLE
add standard project colony, separate into sections

### DIFF
--- a/src/components/help/Help.ts
+++ b/src/components/help/Help.ts
@@ -30,6 +30,7 @@ export const Help = Vue.component('help', {
   },
   template: `
     <div class="help-container">
+
         <div class="help-tabs">
             <input type="radio" name="help-tab" id="radio-symbols" checked>
             <label for="radio-symbols" v-on:click="setTab('iconology')">
@@ -48,9 +49,13 @@ export const Help = Vue.component('help', {
                 <span v-i18n>Hot Keys</span>
             </label>
         </div>
+
         <help-iconology v-if="isOpen('iconology')"></help-iconology>
+
         <help-standard-projects v-if="isOpen('standard projects')"></help-standard-projects>
+
         <help-phases v-if="isOpen('phases')"></help-phases>
+
         <div v-if="isOpen('hotkeys')">
           <div class="help-hotkeys">
             <div class="keys">
@@ -62,6 +67,7 @@ export const Help = Vue.component('help', {
           </div>
           <div class="help-hotkeys-example"></div>
         </div>
+        
     </div>
     `,
 });

--- a/src/components/help/HelpStandardProjects.ts
+++ b/src/components/help/HelpStandardProjects.ts
@@ -33,19 +33,16 @@ export const HelpStandardProjects = Vue.component('help-standard-projects', {
       <div class="cardbox" v-for="card in getBasicStandardProjects()">
         <Card :card="{'name': card}" />
       </div>
-      <br>
 
       <h2 v-i18n>Standard Projects from Expansions and Solo Mode</h2>
       <div class="cardbox" v-for="card in getExpansionStandardProjects()">
         <Card :card="{'name': card}" />
       </div>
-      <br>
 
       <h2 v-i18n>Standard Project from Fan-made Expansions</h2>
       <div class="cardbox" v-for="card in getFanMadeStandardProjects()">
         <Card :card="{'name': card}" />
       </div>
-      <br>
 
     </div>
     `,

--- a/src/components/help/HelpStandardProjects.ts
+++ b/src/components/help/HelpStandardProjects.ts
@@ -7,15 +7,20 @@ export const HelpStandardProjects = Vue.component('help-standard-projects', {
     Card,
   },
   methods: {
-    getStandardProjects: () => [
+    getBasicStandardProjects: () => [
       CardName.SELL_PATENTS_STANDARD_PROJECT,
       CardName.POWER_PLANT_STANDARD_PROJECT,
       CardName.ASTEROID_STANDARD_PROJECT,
       CardName.AQUIFER_STANDARD_PROJECT,
       CardName.GREENERY_STANDARD_PROJECT,
       CardName.CITY_STANDARD_PROJECT,
+    ],
+    getExpansionStandardProjects: () => [
       CardName.AIR_SCRAPPING_STANDARD_PROJECT,
+      CardName.BUILD_COLONY_STANDARD_PROJECT,
       CardName.BUFFER_GAS_STANDARD_PROJECT,
+    ],
+    getFanMadeStandardProjects: () => [
       CardName.MOON_COLONY_STANDARD_PROJECT,
       CardName.MOON_MINE_STANDARD_PROJECT,
       CardName.MOON_ROAD_STANDARD_PROJECT,
@@ -23,9 +28,25 @@ export const HelpStandardProjects = Vue.component('help-standard-projects', {
   },
   template: `
     <div class="help-standard-projects-container">
-      <div class="cardbox" v-for="card in getStandardProjects()">
+
+      <h2 v-i18n>Standard Projects</h2>
+      <div class="cardbox" v-for="card in getBasicStandardProjects()">
         <Card :card="{'name': card}" />
       </div>
+      <br>
+
+      <h2 v-i18n>Standard Projects from Expansions and Solo Mode</h2>
+      <div class="cardbox" v-for="card in getExpansionStandardProjects()">
+        <Card :card="{'name': card}" />
+      </div>
+      <br>
+
+      <h2 v-i18n>Standard Project from Fan-made Expansions</h2>
+      <div class="cardbox" v-for="card in getFanMadeStandardProjects()">
+        <Card :card="{'name': card}" />
+      </div>
+      <br>
+
     </div>
     `,
 });

--- a/src/styles/help.less
+++ b/src/styles/help.less
@@ -51,6 +51,10 @@
 
 .help-standard-projects-container {
     padding-bottom: 40px;
+    h2 {
+        padding-top: 25px;
+        margin-bottom: 0px;
+    }
 }
 
 .help-icons-column {

--- a/src/styles/help.less
+++ b/src/styles/help.less
@@ -280,6 +280,18 @@
     background: url(assets/help/hotkeys.png);
     width: 608px;
     height: 436px;
+    background-size: 608px 436px;
+    color: white;
+    font-family: Prototype;
+    font-weight: normal;
+    text-align: left;
+    margin-left: 250px;
+    line-height: 38px;
+    .keys{
+        position: relative;
+        left: -245px;
+        margin-top: 263px;
+    }
 }
 
 .help-hotkeys-example {


### PR DESCRIPTION
Added the missing standard project colonies. Separate the projects into sections.

![image](https://user-images.githubusercontent.com/14239220/108624953-24c62500-7416-11eb-95fc-4cd3227f21f6.png)
