### PR TITLE
Move Agendas Scientists P4 code to correct place

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -672,11 +672,6 @@ export class Player implements ISerializable<SerializedPlayer> {
       tagCount += this.scienceTagCount;
     }
 
-    // PoliticalAgendas Scientists P4 hook
-    if (tag === Tags.SCIENCE && this.hasTurmoilScienceTagBonus) {
-      tagCount += 1;
-    }
-
     if (includeTagSubstitutions) {
       // Earth Embassy hook
       if (tag === Tags.EARTH && this.playedCards.some((c) => c.name === CardName.EARTH_EMBASSY)) {

--- a/src/cards/CardRequirement.ts
+++ b/src/cards/CardRequirement.ts
@@ -175,7 +175,11 @@ export class TagCardRequirement extends CardRequirement {
     return firstLetterUpperCase(this.tag);
   }
   public satisfies(player: Player): boolean {
-    return this.satisfiesInequality(player.getTagCount(this.tag));
+    let tagCount = player.getTagCount(this.tag);
+    // PoliticalAgendas Scientists P4 hook
+    if (this.tag === Tags.SCIENCE && player.hasTurmoilScienceTagBonus) tagCount += 1;
+
+    return this.satisfiesInequality(tagCount);
   }
 }
 


### PR DESCRIPTION
From Discord:

`About fan expansion Agenda: When the Scientists rule and their Ruling Policy is 'Cards with :tag_science: requirements may be played with 1 :tag_science: less', 1 additional :tag_science: is here (which is a good thing) but Orbital Cleanup should not take this tag into account I think :smiley:`