### PR TITLE
avoid collision for /game route temporarily

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -84,8 +84,13 @@ function processRequest(req: http.IncomingMessage, res: http.ServerResponse): vo
 
   const url = new URL(req.url, `http://${req.headers.host}`);
   const ctx = {url, route, serverId, gameLoader: GameLoader.getInstance()};
+  let handler: IHandler | undefined = handlers.get(url.pathname);
 
-  const handler: IHandler | undefined = handlers.get(url.pathname);
+  // TODO bafolts or kberg fix this bug with collision of POST and GET for /game
+  if (req.method === 'GET' && handler !== undefined && url.pathname === '/game') {
+    handler = undefined;
+  }
+
   if (handler !== undefined) {
     handler.processRequest(req, res, ctx);
     return;


### PR DESCRIPTION
We are starting to migrate all of the code in `src/server.ts` into separate routes. This makes them easier to unit test. While moving the `/game` route seems we have overlooked a collision where this route name is hit with both PUT and GET. This avoids the collision temporarily.