### PR TITLE
avoid ? in vue templates

### DIFF
--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -160,8 +160,8 @@ export const Card = Vue.component('card', {
             <CardResourceCounter v-if="card.resources !== undefined" :amount="getResourceAmount(card)" />
             <CardExtraContent :card="card" />
             <template v-if="owner !== undefined">
-              <div :class="'card-owner-label player_translucent_bg_color_'+ owner?.color">
-                {{owner?.name}}
+              <div :class="'card-owner-label player_translucent_bg_color_'+ owner.color">
+                {{owner.name}}
               </div>
             </template>
         </div>

--- a/src/routes/ContentType.ts
+++ b/src/routes/ContentType.ts
@@ -14,7 +14,7 @@ export class ContentType {
   public static getContentType(filename: string): string | undefined {
     const parts = filename.split('.');
     let idx = parts.length - 1;
-    if (parts[idx] === 'br' || parts[idx] === 'gzip') {
+    if (parts[idx] === 'br' || parts[idx] === 'gz') {
       idx--;
     }
     if (idx < 0) {

--- a/tests/routes/ContentType.spec.ts
+++ b/tests/routes/ContentType.spec.ts
@@ -6,7 +6,7 @@ describe('ContentType', () => {
     ['/path/to/foo.ico', 'image/x-icon'],
     ['/path/to/foo.js', 'text/javascript'],
     ['/path/to/foo.map', 'text/javascript'],
-    ['/path/to/foo.js.gzip', 'text/javascript'],
+    ['/path/to/foo.js.gz', 'text/javascript'],
     ['/path/to/foo.png.br', 'image/png'],
     ['/path/to/foo.js.zip', undefined],
     ['/path/to/foo.png.ico', 'image/x-icon'],


### PR DESCRIPTION
Seems the `?` operator can't be compiled in a vue-js template in every browser. In firefox I get an error that vue can't parse this template. Will have to upgrade the vue type checker to look for these. Generating the templates at compile time would help here too. Also spotted a bug with the extension for `css`. We use `.gz` suffix and not `.gzip` suffix when naming files for gzip.