### PR TITLE
add turmoil policy use count, fix party boolean

### DIFF
--- a/src/components/Party.ts
+++ b/src/components/Party.ts
@@ -8,10 +8,10 @@ export const Party = Vue.component('party', {
       type: Object as () => PartyModel,
     },
     isDominant: {
-      type: Object as () => boolean,
+      type: Boolean,
     },
     isAvailable: {
-      type: Object as () => boolean,
+      type: Boolean,
     },
   },
   methods: {

--- a/src/components/Turmoil.ts
+++ b/src/components/Turmoil.ts
@@ -265,6 +265,12 @@ export const Turmoil = Vue.component('turmoil', {
             <div :class="'party-name party-name--'+partyNameToCss(turmoil.ruling)" v-i18n>{{ turmoil.ruling }}</div>
           </div>
           <div class="dominant-party-bonus" v-html="getPolicy(turmoil.ruling, turmoil.politicalAgendas, true)"></div>
+          <div class="policy-user-cubes">
+            <template v-for="n in turmoil.policyActionUsers">
+              <div v-if="n.turmoilPolicyActionUsed" :class="'policy-use-marker board-cube--'+n.color"></div>
+              <div v-if="n.politicalAgendasActionUsedCount > 0" :class="'policy-use-marker board-cube--'+n.color">{{n.politicalAgendasActionUsedCount}}</div>
+            </template>
+          </div>
           <div class="chairman-spot"><div v-if="turmoil.chairman" :class="'player-token '+turmoil.chairman"></div></div>
           <div class="turmoil-reserve">
               <div class="lobby-spot" v-for="n in turmoil.reserve.length" :key="n">

--- a/src/models/TurmoilModel.ts
+++ b/src/models/TurmoilModel.ts
@@ -15,6 +15,13 @@ export interface TurmoilModel {
   coming: GlobalEventModel | undefined;
   current: GlobalEventModel | undefined;
   politicalAgendas: PoliticalAgendasModel | undefined;
+  policyActionUsers: Array<PolicyUser>;
+}
+
+export interface PolicyUser {
+  color: Color;
+  turmoilPolicyActionUsed: boolean;
+  politicalAgendasActionUsedCount: number;
 }
 
 export interface PartyModel {
@@ -141,6 +148,16 @@ export function getTurmoil(game: Game): TurmoilModel | undefined {
       };
     }
 
+    const policyActionUsers = Array.from(
+      game.getPlayers(),
+      (player) => {
+        return {
+          color: player.color,
+          turmoilPolicyActionUsed: player.turmoilPolicyActionUsed,
+          politicalAgendasActionUsedCount: player.politicalAgendasActionUsedCount} as PolicyUser;
+      },
+    );
+
     return {
       chairman: chairman,
       ruling: ruling,
@@ -155,6 +172,7 @@ export function getTurmoil(game: Game): TurmoilModel | undefined {
         currentAgenda: turmoil.politicalAgendasData.currentAgenda,
         staticAgendas: staticAgendasModel,
       },
+      policyActionUsers,
     };
   } else {
     return undefined;

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -437,6 +437,28 @@
     }
 }
 
+.policy-user-cubes {
+    position: absolute;
+    margin: 132px 0px 0 336px;
+    display: flex;
+    flex-flow: row nowrap;    
+    width: 180px;
+    justify-content: center;
+
+    .policy-use-marker {
+        display: inline-block;
+        width: 21px;
+        height: 21px;
+        filter: drop-shadow(2px 2px 3px black);
+        margin: 5px;
+
+        font-size: 14px;
+        color: white;
+        line-height: 21px;
+        text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+    }
+}
+
 .dominant-party-name {
     position: absolute;
     margin: 35px 0 0 340px;


### PR DESCRIPTION
This PR can close #2381. It adds a marker for Scientist policy use and more.

The marker will be centered align right below the ruling policy. It will only show up for Scientists policy.
<img width="607" alt="Screen Shot 2021-03-02 at 5 29 51 PM" src="https://user-images.githubusercontent.com/14239220/109725523-46927b00-7b7f-11eb-946c-9d0de3f15f0b.png">
<img width="609" alt="Screen Shot 2021-03-02 at 5 30 05 PM" src="https://user-images.githubusercontent.com/14239220/109725528-48f4d500-7b7f-11eb-8930-9c8a24b5b5bf.png">
<img width="597" alt="Screen Shot 2021-03-02 at 5 32 34 PM" src="https://user-images.githubusercontent.com/14239220/109725536-4b572f00-7b7f-11eb-8e49-9fb6de54a4bf.png">

Show nothing for standard Kelvinists policy.
![image](https://user-images.githubusercontent.com/14239220/109725938-e05a2800-7b7f-11eb-816c-76ca0e60bf4e.png)
![image](https://user-images.githubusercontent.com/14239220/109725958-e7813600-7b7f-11eb-8999-f852bf4ce871.png)

For Agendas policy that has `politicalAgendasActionUsedCount` property. It will show the number inside the cubes.
<img width="605" alt="Screen Shot 2021-03-02 at 5 44 57 PM" src="https://user-images.githubusercontent.com/14239220/109725543-4db98900-7b7f-11eb-86f2-4c1501f20094.png">
