### PR TITLE
unit tests for api/waitingfor

### DIFF
--- a/src/routes/ApiWaitingFor.ts
+++ b/src/routes/ApiWaitingFor.ts
@@ -1,6 +1,4 @@
 import * as http from 'http';
-import * as querystring from 'querystring';
-import {GameLoader} from '../database/GameLoader';
 import {Handler} from './Handler';
 import {IContext} from './IHandler';
 import {Server} from '../server/ServerModel';
@@ -11,28 +9,20 @@ export class ApiWaitingFor extends Handler {
     super();
   }
 
-
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
-    const qs: string = req.url!.substring('/api/waitingfor?'.length);
-    const queryParams = querystring.parse(qs);
-    const playerId = (queryParams as any)['id'];
-    const prevGameAge = parseInt((queryParams as any)['prev-game-age']);
-
-    GameLoader.getInstance().getByPlayerId(playerId, (game) => {
+    const playerId = String(ctx.url.searchParams.get('id'));
+    const prevGameAge = Number(ctx.url.searchParams.get('prev-game-age'));
+    ctx.gameLoader.getByPlayerId(playerId, (game) => {
       if (game === undefined) {
         ctx.route.notFound(req, res, 'cannot find game for that player');
         return;
       }
       try {
-        const player = game.getPlayerById(playerId);
-        if (player !== undefined) {
-          ctx.route.writeJson(res, Server.getWaitingForModel(player, prevGameAge));
-        } else {
-          ctx.route.notFound(req, res, 'player not found');
-        }
+        ctx.route.writeJson(res, Server.getWaitingForModel(game.getPlayerById(playerId), prevGameAge));
       } catch (err) {
         // This is basically impossible since getPlayerById ensures that the player is on that game.
         console.warn(`unable to find player ${playerId}`, err);
+        ctx.route.notFound(req, res, 'player not found');
       }
     });
   }

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -134,15 +134,12 @@ export class Server {
 
   // This is only ever used in ApiWaitingFor, and could be isolated from ServerModel.
   public static getWaitingForModel(player: Player, prevGameAge: number): WaitingForModel {
-    const result: WaitingForModel = {
-      result: 'WAIT',
-    };
     if (player.getWaitingFor() !== undefined || player.game.phase === Phase.END) {
-      result.result = 'GO';
+      return {result: 'GO'};
     } else if (player.game.gameAge > prevGameAge) {
-      result.result = 'REFRESH';
+      return {result: 'REFRESH'};
     }
-    return result;
+    return {result: 'WAIT'};
   }
 }
 

--- a/tests/routes/ApiWaitingFor.spec.ts
+++ b/tests/routes/ApiWaitingFor.spec.ts
@@ -1,0 +1,56 @@
+import * as http from 'http';
+import {expect} from 'chai';
+import {ApiWaitingFor} from '../../src/routes/ApiWaitingFor';
+import {Route} from '../../src/routes/Route';
+import {Game} from '../../src/Game';
+import {TestPlayers} from '../TestPlayers';
+import {MockResponse} from './HttpMocks';
+import {IContext} from '../../src/routes/IHandler';
+import {FakeGameLoader} from './FakeGameLoader';
+
+describe('ApiWaitingFor', function() {
+  let req: http.IncomingMessage;
+  let res: MockResponse;
+  let ctx: IContext;
+
+  beforeEach(() => {
+    req = {} as http.IncomingMessage;
+    res = new MockResponse();
+    ctx = {
+      route: new Route(),
+      serverId: '1',
+      url: new URL('http://boo.com'),
+      gameLoader: new FakeGameLoader(),
+    };
+  });
+
+  it('fails when game not found', () => {
+    req.url = '/api/waitingfor?id=game-id&prev-game-age=123';
+    ctx.url = new URL('http://boo.com' + req.url);
+    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.content).eq('Not found: cannot find game for that player');
+  });
+
+  it('fails when player not found', () => {
+    const player = TestPlayers.BLACK.newPlayer();
+    req.url = '/api/waitingfor?id=' + player.id + '&prev-game-age=50';
+    ctx.url = new URL('http://boo.com' + req.url);
+    const game = Game.newInstance('game-id', [player], player);
+    ctx.gameLoader.add(game);
+    (game as any).getPlayerById = function() {
+      throw new Error('player does not exist');
+    };
+    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.content).eq('Not found: player not found');
+  });
+
+  it('sends model', () => {
+    const player = TestPlayers.BLACK.newPlayer();
+    req.url = '/api/waitingfor?id=' + player.id + '&prev-game-age=50';
+    ctx.url = new URL('http://boo.com' + req.url);
+    const game = Game.newInstance('game-id', [player], player);
+    ctx.gameLoader.add(game);
+    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.content).eq('{"result":"GO"}');
+  });
+});


### PR DESCRIPTION
Adds unit tests for the waiting for route. Also took the opportunity to use the search params instead of parsing the query string. This route gets hit quite often so worth being efficient.