### PR TITLE
Refactor the MIlestoneAward selelctor

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -63,6 +63,7 @@ import {IMoonData} from './moon/IMoonData';
 import {MoonExpansion} from './moon/MoonExpansion';
 import {TurmoilHandler} from './turmoil/TurmoilHandler';
 import {Random} from './Random';
+import {MilestoneAwardSelector} from './MilestoneAwardSelector';
 
 export type GameId = string;
 
@@ -265,7 +266,7 @@ export class Game implements ISerializable<SerializedGame> {
       game.aresData = AresSetup.initialData(gameOptions.aresExtension, gameOptions.aresHazards, players);
     }
 
-    const milestonesAwards = GameSetup.chooseMilestonesAndAwards(gameOptions);
+    const milestonesAwards = MilestoneAwardSelector.chooseMilestonesAndAwards(gameOptions);
     game.milestones = milestonesAwards.milestones;
     game.awards = milestonesAwards.awards;
 

--- a/src/GameSetup.ts
+++ b/src/GameSetup.ts
@@ -7,7 +7,7 @@ import {HellasBoard} from './boards/HellasBoard';
 import {ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from './milestones/Milestones';
 import {OriginalBoard} from './boards/OriginalBoard';
 import {RandomMAOptionType} from './RandomMAOptionType';
-import {getRandomMilestonesAndAwards} from './MilestoneAwardSelector';
+import {MilestoneAwardSelector} from './MilestoneAwardSelector';
 import {IDrawnMilestonesAndAwards} from './IDrawnMilestonesAndAwards';
 import {Player} from './Player';
 import {Resources} from './Resources';
@@ -50,10 +50,10 @@ export class GameSetup {
 
       break;
     case RandomMAOptionType.LIMITED:
-      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty);
+      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty);
       break;
     case RandomMAOptionType.UNLIMITED:
-      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty, 100, 100, 100, 100);
+      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty, 100, 100, 100, 100);
       break;
     }
 

--- a/src/GameSetup.ts
+++ b/src/GameSetup.ts
@@ -50,10 +50,10 @@ export class GameSetup {
 
       break;
     case RandomMAOptionType.LIMITED:
-      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(includeVenus, requiredQty);
+      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty);
       break;
     case RandomMAOptionType.UNLIMITED:
-      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(includeVenus, requiredQty, 100, 100, 100, 100);
+      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty, 100, 100, 100, 100);
       break;
     }
 

--- a/src/GameSetup.ts
+++ b/src/GameSetup.ts
@@ -1,68 +1,17 @@
-import {ELYSIUM_AWARDS, HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS} from './awards/Awards';
 import {Board} from './boards/Board';
 import {BoardName} from './boards/BoardName';
 import {ElysiumBoard} from './boards/ElysiumBoard';
 import {Game, GameId, GameOptions} from './Game';
 import {HellasBoard} from './boards/HellasBoard';
-import {ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from './milestones/Milestones';
 import {OriginalBoard} from './boards/OriginalBoard';
-import {RandomMAOptionType} from './RandomMAOptionType';
-import {MilestoneAwardSelector} from './MilestoneAwardSelector';
-import {IDrawnMilestonesAndAwards} from './IDrawnMilestonesAndAwards';
 import {Player} from './Player';
 import {Resources} from './Resources';
 import {ColonyName} from './colonies/ColonyName';
 import {Color} from './Color';
-import {AresSetup} from './ares/AresSetup';
 import {TileType} from './TileType';
 import {Random} from './Random';
 
 export class GameSetup {
-  public static chooseMilestonesAndAwards = function(gameOptions: GameOptions): IDrawnMilestonesAndAwards {
-    let drawnMilestonesAndAwards: IDrawnMilestonesAndAwards = {
-      milestones: [],
-      awards: [],
-    };
-
-    const includeVenus = gameOptions.venusNextExtension && gameOptions.includeVenusMA;
-    const requiredQty = includeVenus ? 6 : 5;
-
-    switch (gameOptions.randomMA) {
-    case RandomMAOptionType.NONE:
-      switch (gameOptions.boardName) {
-      case BoardName.ORIGINAL:
-        drawnMilestonesAndAwards.milestones.push(...ORIGINAL_MILESTONES);
-        drawnMilestonesAndAwards.awards.push(...ORIGINAL_AWARDS);
-        break;
-      case BoardName.HELLAS:
-        drawnMilestonesAndAwards.milestones.push(...HELLAS_MILESTONES);
-        drawnMilestonesAndAwards.awards.push(...HELLAS_AWARDS);
-        break;
-      case BoardName.ELYSIUM:
-        drawnMilestonesAndAwards.milestones.push(...ELYSIUM_MILESTONES);
-        drawnMilestonesAndAwards.awards.push(...ELYSIUM_AWARDS);
-        break;
-      }
-      if (includeVenus) {
-        drawnMilestonesAndAwards.milestones.push(...VENUS_MILESTONES);
-        drawnMilestonesAndAwards.awards.push(...VENUS_AWARDS);
-      }
-
-      break;
-    case RandomMAOptionType.LIMITED:
-      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty);
-      break;
-    case RandomMAOptionType.UNLIMITED:
-      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty, 100, 100, 100, 100);
-      break;
-    }
-
-    if (gameOptions.aresExtension) {
-      AresSetup.setupMilestonesAwards(drawnMilestonesAndAwards);
-    };
-    return drawnMilestonesAndAwards;
-  };
-
   // Function to construct the board and milestones/awards list
   public static newBoard(boardName: BoardName, shuffle: boolean, rng: Random, includeVenus: boolean): Board {
     if (boardName === BoardName.ELYSIUM) {

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -40,17 +40,24 @@ import {Tycoon} from './milestones/Tycoon';
 import {RandomMAOptionType} from './RandomMAOptionType';
 
 export namespace MilestoneAwardSelector {
-  // exported for testing.
-  export const MA_ITEMS = [
+  const MILESTONES = [
     ...ORIGINAL_MILESTONES,
     ...ELYSIUM_MILESTONES,
     ...HELLAS_MILESTONES,
     ...VENUS_MILESTONES,
+  ];
 
+  const AWARDS = [
     ...ORIGINAL_AWARDS,
     ...ELYSIUM_AWARDS,
     ...HELLAS_AWARDS,
     ...VENUS_AWARDS,
+  ];
+
+  // exported for testing.
+  export const MA_ITEMS = [
+    ...MILESTONES,
+    ...AWARDS,
   ];
 
   function buildSynergies(): Array<Array<number>> {

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -82,8 +82,16 @@ export namespace MilestoneAwardSelector {
     }
   }
   class Synergies {
-    // This map uses keys "X|Y" and of course stores strings as both
-    // "Y|X" and "X|X"
+    // This map uses keys of the format "X|Y" where X and Y are MA names.
+    // Entries are stored as "X|Y" and also "Y|X"; it just makes searching
+    // slightly faster. There will also be entries of the type "X|X".
+    //
+    // I honestly don't remember why "X|X" is useful, and it's possible
+    // it's no longer necessary. That's something that should be carefully conisdered
+    // and possibly removed, and not just propagated because that's what we had to begin with.
+    // In other words, someone figure out why, and preserve it, and document why, or
+    // be certain it's unnecessary and remove this paragraph and the code below that sets "X|X" to 1000.
+    // 
     private static map: Map<string, number> = Synergies.makeMap();
 
     private constructor() {

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -82,16 +82,14 @@ export namespace MilestoneAwardSelector {
     }
   }
   class Synergies {
-    // This map uses keys of the format "X|Y" where X and Y are MA names.
-    // Entries are stored as "X|Y" and also "Y|X"; it just makes searching
-    // slightly faster. There will also be entries of the type "X|X".
+    // This map uses keys of the format "X|Y" where X and Y are MA names. Entries are stored as "X|Y"
+    // and also "Y|X"; it just makes searching slightly faster. There will also be entries of the type "X|X".
     //
-    // I honestly don't remember why "X|X" is useful, and it's possible
-    // it's no longer necessary. That's something that should be carefully conisdered
-    // and possibly removed, and not just propagated because that's what we had to begin with.
-    // In other words, someone figure out why, and preserve it, and document why, or
-    // be certain it's unnecessary and remove this paragraph and the code below that sets "X|X" to 1000.
-    // 
+    // I honestly don't remember why "X|X" is useful, and it's possible it's no longer necessary. That's
+    // something that should be carefully conisdered and possibly removed, and not just propagated because
+    // it's what we had to begin with. In other words, someone figure out why, and preserve it, and document
+    // why, or be certain it's unnecessary and remove this paragraph and the code below that sets "X|X" to 1000.
+    //
     private static map: Map<string, number> = Synergies.makeMap();
 
     private constructor() {

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -36,285 +36,287 @@ import {Tactician} from './milestones/Tactician';
 import {Terraformer} from './milestones/Terraformer';
 import {Tycoon} from './milestones/Tycoon';
 
-// exported for testing.
-export const MA_ITEMS = [
-  ...ORIGINAL_MILESTONES,
-  ...ELYSIUM_MILESTONES,
-  ...HELLAS_MILESTONES,
-  ...VENUS_MILESTONES,
+export namespace MilestoneAwardSelector {
+  // exported for testing.
+  export const MA_ITEMS = [
+    ...ORIGINAL_MILESTONES,
+    ...ELYSIUM_MILESTONES,
+    ...HELLAS_MILESTONES,
+    ...VENUS_MILESTONES,
 
-  ...ORIGINAL_AWARDS,
-  ...ELYSIUM_AWARDS,
-  ...HELLAS_AWARDS,
-  ...VENUS_AWARDS,
-];
+    ...ORIGINAL_AWARDS,
+    ...ELYSIUM_AWARDS,
+    ...HELLAS_AWARDS,
+    ...VENUS_AWARDS,
+  ];
 
-export function buildSynergies(): Array<Array<number>> {
-  const array: Array<Array<number>> = new Array(MA_ITEMS.length);
-  for (let idx = 0; idx < MA_ITEMS.length; idx++) {
-    array[idx] = new Array(MA_ITEMS.length).fill(0);
-    array[idx][idx] = 1000;
-  }
-
-  // Higher synergies represent similar milestones or awards. For instance, Terraformer rewards for high TR
-  // and the Benefactor award is given to the player with the highets TR. Their synergy weight is 9, very high.
-  function bind(First: { new(): IMilestone | IAward }, Second: { new(): IMilestone | IAward }, weight: number) {
-    const row = MA_ITEMS.findIndex((ma) => new First().name === ma.name);
-    const col = MA_ITEMS.findIndex((ma) => new Second().name === ma.name);
-    array[row][col] = weight;
-    array[col][row] = weight;
-  }
-  bind(Terraformer, Benefactor, 9);
-  bind(Gardener, Cultivator, 9);
-  bind(Builder, Contractor, 9);
-  bind(EstateDealer, Cultivator, 8);
-  bind(Landlord, Cultivator, 8);
-  bind(Landlord, DesertSettler, 7);
-  bind(Landlord, EstateDealer, 7);
-  bind(DesertSettler, Cultivator, 7);
-  bind(Miner, Industrialist, 7);
-  bind(Energizer, Industrialist, 6);
-  bind(Gardener, Landlord, 6);
-  bind(Mayor, Landlord, 6);
-  bind(Mayor, Cultivator, 6);
-  bind(Gardener, EstateDealer, 5);
-  bind(Builder, Magnate, 5);
-  bind(Tycoon, Magnate, 5);
-  bind(PolarExplorer, DesertSettler, 5);
-  bind(Hoverlord, Excentric, 5);
-  bind(Hoverlord, Venuphile, 5);
-  bind(DesertSettler, EstateDealer, 5);
-  bind(Builder, Tycoon, 4);
-  bind(Specialist, Energizer, 4);
-  bind(Mayor, PolarExplorer, 4);
-  bind(Mayor, DesertSettler, 4);
-  bind(Mayor, EstateDealer, 4);
-  bind(Gardener, PolarExplorer, 4);
-  bind(Gardener, DesertSettler, 4);
-  bind(Ecologist, Excentric, 4);
-  bind(PolarExplorer, Landlord, 4);
-  bind(Mayor, Gardener, 3);
-  bind(Tycoon, Excentric, 3);
-  bind(PolarExplorer, Cultivator, 3);
-  bind(Energizer, Thermalist, 3);
-  bind(RimSettler, SpaceBaron, 3);
-  bind(Celebrity, SpaceBaron, 3);
-  bind(Benefactor, Cultivator, 3);
-  bind(Gardener, Benefactor, 2);
-  bind(Specialist, Banker, 2);
-  bind(Ecologist, Tycoon, 2);
-  bind(Ecologist, Diversifier, 2);
-  bind(Tycoon, Scientist, 2);
-  bind(Tycoon, Contractor, 2);
-  bind(Tycoon, Venuphile, 2);
-  bind(PolarExplorer, EstateDealer, 2);
-  bind(RimSettler, Celebrity, 2);
-  bind(Scientist, Magnate, 2);
-  bind(Magnate, SpaceBaron, 2);
-  bind(Excentric, Venuphile, 2);
-  bind(Terraformer, Cultivator, 2);
-  bind(Terraformer, Gardener, 2);
-  bind(Builder, Miner, 1);
-  bind(Builder, Industrialist, 1);
-  bind(Planner, Scientist, 1);
-  bind(Generalist, Miner, 1);
-  bind(Specialist, Thermalist, 1);
-  bind(Specialist, Miner, 1);
-  bind(Specialist, Industrialist, 1);
-  bind(Ecologist, Cultivator, 1);
-  bind(Ecologist, Magnate, 1);
-  bind(Tycoon, Diversifier, 1);
-  bind(Tycoon, Tactician, 1);
-  bind(Tycoon, RimSettler, 1);
-  bind(Tycoon, SpaceBaron, 1);
-  bind(Diversifier, Magnate, 1);
-  bind(Tactician, Scientist, 1);
-  bind(Tactician, Magnate, 1);
-  bind(RimSettler, Magnate, 1);
-  bind(Banker, Benefactor, 1);
-  bind(Celebrity, Magnate, 1);
-  bind(DesertSettler, Benefactor, 1);
-  bind(EstateDealer, Benefactor, 1);
-  bind(Terraformer, Landlord, 1);
-  bind(Terraformer, Thermalist, 1);
-  bind(Terraformer, DesertSettler, 1);
-  bind(Terraformer, EstateDealer, 1);
-  bind(Gardener, Ecologist, 1);
-  return array;
-}
-
-const SYNERGIES = buildSynergies();
-
-function shuffleArray(arr: Array<number>) {
-  arr = arr.slice();
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const temp = arr[i];
-    arr[i] = arr[j];
-    arr[j] = temp;
-  }
-  return arr;
-}
-
-// Returns an array from [start... end]
-// eg (4, 11) returns [4, 5, 6, 7, 8, 9, 10, 11]
-function getNumbersRange(start: number, end: number): Array<number> {
-  return Array.from(Array(end + 1 - start).keys()).map((n) => n + start);
-}
-
-// Function to compute max synergy of a given set of milestones and awards.
-export function computeSynergy(indexes: Array<number>) : number {
-  let max = 0;
-  for (let i = 0; i<indexes.length - 1; i++) {
-    for (let j = i + 1; j<indexes.length; j++) {
-      const synergy = SYNERGIES[indexes[i]][indexes[j]];
-      max = Math.max(synergy, max);
-    }
-  }
-  return max;
-}
-
-// Limited Synergy Constants
-const MAX_RANDOM_ATTEMPTS = 5;
-export const MAX_SYNERGY_ALLOWED_RULE = 6;
-export const TOTAL_SYNERGY_ALLOWED_RULE = 20;
-export const NUM_HIGH_ALLOWED_RULE = 20;
-export const HIGH_THRESHOLD_RULE = 4;
-
-// Selects |numberMARequested| milestones and |numberMARequested| awards from all available awards and milestones (optionally including
-// Venusian.) It does this by following these rules:
-// 1) No pair with synergy above |maxSynergyAllowed|.
-// 2) Total synergy is |totalSynergyAllowed| or below.
-// 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
-export function getRandomMilestonesAndAwards(gameOptions: GameOptions,
-  numberMARequested: number,
-  maxSynergyAllowed: number = MAX_SYNERGY_ALLOWED_RULE,
-  totalSynergyAllowed: number = TOTAL_SYNERGY_ALLOWED_RULE,
-  numberOfHighAllowed: number = NUM_HIGH_ALLOWED_RULE,
-  highThreshold: number = HIGH_THRESHOLD_RULE,
-  attempt: number = 1): IDrawnMilestonesAndAwards {
-  const withVenusian = gameOptions.venusNextExtension && gameOptions.includeVenusMA;
-
-  if (attempt > MAX_RANDOM_ATTEMPTS) {
-    throw new Error('No limited synergy milestones and awards set was generated after ' + MAX_RANDOM_ATTEMPTS + ' attempts. Please try again.');
-  }
-
-  // Shuffled arrays on milestones and awards once
-  const shuffled_milestones = shuffleArray(getNumbersRange(0, withVenusian ? 15: 14));
-  const shuffled_awards = shuffleArray(getNumbersRange(16, withVenusian ? 31: 30));
-
-  const pickedMA = new MASynergyArray(maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold);
-  let milestoneCount = 0;
-  let awardCount = 0;
-
-  // Keep adding milestone or award until there are enough as requested
-  while (milestoneCount + awardCount < numberMARequested*2) {
-    // If there is enough award, add a milestone. And vice versa. If still need both, flip a coin to decide which to add.
-    if (awardCount === numberMARequested || (milestoneCount !== numberMARequested && Math.round(Math.random()))) {
-      const newMilestone = shuffled_milestones.splice(0, 1)[0];
-      // If need to add more milestone, but not enough milestone left, restart the function with a recursive call.
-      if (newMilestone === undefined) {
-        return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
-      }
-      const milestoneAddSuccess = pickedMA.addNewMA(newMilestone);
-      if (milestoneAddSuccess) milestoneCount++;
-    } else {
-      const newAward = shuffled_awards.splice(0, 1)[0];
-      // If need to add more award, but not enough award left, restart the function with a recursive call.
-      if (newAward === undefined) {
-        return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
-      }
-      const awardAddSuccess = pickedMA.addNewMA(newAward);
-      if (awardAddSuccess) awardCount++;
-    }
-  }
-
-  if (!verifySynergyRules(pickedMA.currentMA, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold)) {
-    throw new Error('The randomized milestones and awards set does not satisfy the given synergy rules.');
-  }
-
-  const finalItems = pickedMA.currentMA.map((n) => MA_ITEMS[n]);
-  return {
-    milestones: finalItems.slice(0, numberMARequested) as Array<IMilestone>,
-    awards: finalItems.slice(numberMARequested) as Array<IAward>,
-  };
-}
-
-// Verify whether a given array of |milestoneAwardArray| satisfies the following these rules:
-// 1) No pair with synergy above |maxSynergyAllowed|.
-// 2) Total synergy is |totalSynergyAllowed| or below.
-// 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
-export function verifySynergyRules(
-  milestoneAwardArray: Array<number>,
-  maxSynergyAllowed: number = MAX_SYNERGY_ALLOWED_RULE,
-  totalSynergyAllowed: number = TOTAL_SYNERGY_ALLOWED_RULE,
-  numberOfHighAllowed: number = NUM_HIGH_ALLOWED_RULE,
-  highThreshold: number = HIGH_THRESHOLD_RULE): Boolean {
-  let max = 0;
-  let totalSynergy = 0;
-  let numberOfHigh = 0;
-  for (let i = 0; i < milestoneAwardArray.length - 1; i++) {
-    for (let j = i + 1; j < milestoneAwardArray.length; j++) {
-      const synergy = SYNERGIES[milestoneAwardArray[i]][milestoneAwardArray[j]];
-      max = Math.max(synergy, max);
-      totalSynergy += synergy;
-      if (synergy >= highThreshold) numberOfHigh++;
-    }
-  }
-  return (max <= maxSynergyAllowed && totalSynergy <= totalSynergyAllowed && numberOfHigh <= numberOfHighAllowed);
-}
-
-class MASynergyArray {
-    currentMA: Array<number>;
-    maxSynergyAllowed: number;
-    totalSynergyAllowed: number;
-    numberOfHighAllowed: number;
-    highThreshold: number;
-
-    currentNumberOfHigh: number;
-    currentTotalSynergy: number;
-
-    constructor(maxSynergyAllowed: number, totalSynergyAllowed: number, numberOfHighAllowed: number, highThreshold:number) {
-      this.currentMA = [];
-      this.maxSynergyAllowed = maxSynergyAllowed;
-      this.totalSynergyAllowed = totalSynergyAllowed;
-      this.numberOfHighAllowed = numberOfHighAllowed;
-      this.highThreshold = highThreshold;
-      this.currentNumberOfHigh = 0;
-      this.currentTotalSynergy = 0;
+  export function buildSynergies(): Array<Array<number>> {
+    const array: Array<Array<number>> = new Array(MA_ITEMS.length);
+    for (let idx = 0; idx < MA_ITEMS.length; idx++) {
+      array[idx] = new Array(MA_ITEMS.length).fill(0);
+      array[idx][idx] = 1000;
     }
 
-    // A class function for adding a new milestone or award index
-    // Return true if adding successfully without violating any rule.
-    addNewMA(newMAIndex: number): boolean {
-      let tempTotalSynergy = this.currentTotalSynergy;
-      let tempNumberOfHigh = this.currentNumberOfHigh;
-      let max = 0;
+    // Higher synergies represent similar milestones or awards. For instance, Terraformer rewards for high TR
+    // and the Benefactor award is given to the player with the highets TR. Their synergy weight is 9, very high.
+    function bind(First: { new(): IMilestone | IAward }, Second: { new(): IMilestone | IAward }, weight: number) {
+      const row = MA_ITEMS.findIndex((ma) => new First().name === ma.name);
+      const col = MA_ITEMS.findIndex((ma) => new Second().name === ma.name);
+      array[row][col] = weight;
+      array[col][row] = weight;
+    }
+    bind(Terraformer, Benefactor, 9);
+    bind(Gardener, Cultivator, 9);
+    bind(Builder, Contractor, 9);
+    bind(EstateDealer, Cultivator, 8);
+    bind(Landlord, Cultivator, 8);
+    bind(Landlord, DesertSettler, 7);
+    bind(Landlord, EstateDealer, 7);
+    bind(DesertSettler, Cultivator, 7);
+    bind(Miner, Industrialist, 7);
+    bind(Energizer, Industrialist, 6);
+    bind(Gardener, Landlord, 6);
+    bind(Mayor, Landlord, 6);
+    bind(Mayor, Cultivator, 6);
+    bind(Gardener, EstateDealer, 5);
+    bind(Builder, Magnate, 5);
+    bind(Tycoon, Magnate, 5);
+    bind(PolarExplorer, DesertSettler, 5);
+    bind(Hoverlord, Excentric, 5);
+    bind(Hoverlord, Venuphile, 5);
+    bind(DesertSettler, EstateDealer, 5);
+    bind(Builder, Tycoon, 4);
+    bind(Specialist, Energizer, 4);
+    bind(Mayor, PolarExplorer, 4);
+    bind(Mayor, DesertSettler, 4);
+    bind(Mayor, EstateDealer, 4);
+    bind(Gardener, PolarExplorer, 4);
+    bind(Gardener, DesertSettler, 4);
+    bind(Ecologist, Excentric, 4);
+    bind(PolarExplorer, Landlord, 4);
+    bind(Mayor, Gardener, 3);
+    bind(Tycoon, Excentric, 3);
+    bind(PolarExplorer, Cultivator, 3);
+    bind(Energizer, Thermalist, 3);
+    bind(RimSettler, SpaceBaron, 3);
+    bind(Celebrity, SpaceBaron, 3);
+    bind(Benefactor, Cultivator, 3);
+    bind(Gardener, Benefactor, 2);
+    bind(Specialist, Banker, 2);
+    bind(Ecologist, Tycoon, 2);
+    bind(Ecologist, Diversifier, 2);
+    bind(Tycoon, Scientist, 2);
+    bind(Tycoon, Contractor, 2);
+    bind(Tycoon, Venuphile, 2);
+    bind(PolarExplorer, EstateDealer, 2);
+    bind(RimSettler, Celebrity, 2);
+    bind(Scientist, Magnate, 2);
+    bind(Magnate, SpaceBaron, 2);
+    bind(Excentric, Venuphile, 2);
+    bind(Terraformer, Cultivator, 2);
+    bind(Terraformer, Gardener, 2);
+    bind(Builder, Miner, 1);
+    bind(Builder, Industrialist, 1);
+    bind(Planner, Scientist, 1);
+    bind(Generalist, Miner, 1);
+    bind(Specialist, Thermalist, 1);
+    bind(Specialist, Miner, 1);
+    bind(Specialist, Industrialist, 1);
+    bind(Ecologist, Cultivator, 1);
+    bind(Ecologist, Magnate, 1);
+    bind(Tycoon, Diversifier, 1);
+    bind(Tycoon, Tactician, 1);
+    bind(Tycoon, RimSettler, 1);
+    bind(Tycoon, SpaceBaron, 1);
+    bind(Diversifier, Magnate, 1);
+    bind(Tactician, Scientist, 1);
+    bind(Tactician, Magnate, 1);
+    bind(RimSettler, Magnate, 1);
+    bind(Banker, Benefactor, 1);
+    bind(Celebrity, Magnate, 1);
+    bind(DesertSettler, Benefactor, 1);
+    bind(EstateDealer, Benefactor, 1);
+    bind(Terraformer, Landlord, 1);
+    bind(Terraformer, Thermalist, 1);
+    bind(Terraformer, DesertSettler, 1);
+    bind(Terraformer, EstateDealer, 1);
+    bind(Gardener, Ecologist, 1);
+    return array;
+  }
 
-      // Find synergy of this new item with all previous ones
-      for (const indexPicked of this.currentMA) {
-        const synergy = SYNERGIES[indexPicked][newMAIndex];
-        tempTotalSynergy += synergy;
-        if (synergy >= this.highThreshold) {
-          tempNumberOfHigh++;
-        }
+  const SYNERGIES = buildSynergies();
+
+  function shuffleArray(arr: Array<number>) {
+    arr = arr.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = temp;
+    }
+    return arr;
+  }
+
+  // Returns an array from [start... end]
+  // eg (4, 11) returns [4, 5, 6, 7, 8, 9, 10, 11]
+  function getNumbersRange(start: number, end: number): Array<number> {
+    return Array.from(Array(end + 1 - start).keys()).map((n) => n + start);
+  }
+
+  // Function to compute max synergy of a given set of milestones and awards.
+  export function computeSynergy(indexes: Array<number>) : number {
+    let max = 0;
+    for (let i = 0; i<indexes.length - 1; i++) {
+      for (let j = i + 1; j<indexes.length; j++) {
+        const synergy = SYNERGIES[indexes[i]][indexes[j]];
         max = Math.max(synergy, max);
       }
-      // Check whether the addition violate any rule.
-      if (max <= this.maxSynergyAllowed && tempNumberOfHigh <= this.numberOfHighAllowed && tempTotalSynergy <= this.totalSynergyAllowed) {
-        // If it is an award, push to the end of the array.
-        if (newMAIndex > 15) {
-          this.currentMA.push(newMAIndex);
-        } else {
-          // If it is a milestone, add to the front of the array
-          this.currentMA.unshift(newMAIndex);
+    }
+    return max;
+  }
+
+  // Limited Synergy Constants
+  const MAX_RANDOM_ATTEMPTS = 5;
+  export const MAX_SYNERGY_ALLOWED_RULE = 6;
+  export const TOTAL_SYNERGY_ALLOWED_RULE = 20;
+  export const NUM_HIGH_ALLOWED_RULE = 20;
+  export const HIGH_THRESHOLD_RULE = 4;
+
+  // Selects |numberMARequested| milestones and |numberMARequested| awards from all available awards and milestones (optionally including
+  // Venusian.) It does this by following these rules:
+  // 1) No pair with synergy above |maxSynergyAllowed|.
+  // 2) Total synergy is |totalSynergyAllowed| or below.
+  // 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
+  export function getRandomMilestonesAndAwards(gameOptions: GameOptions,
+    numberMARequested: number,
+    maxSynergyAllowed: number = MAX_SYNERGY_ALLOWED_RULE,
+    totalSynergyAllowed: number = TOTAL_SYNERGY_ALLOWED_RULE,
+    numberOfHighAllowed: number = NUM_HIGH_ALLOWED_RULE,
+    highThreshold: number = HIGH_THRESHOLD_RULE,
+    attempt: number = 1): IDrawnMilestonesAndAwards {
+    const withVenusian = gameOptions.venusNextExtension && gameOptions.includeVenusMA;
+
+    if (attempt > MAX_RANDOM_ATTEMPTS) {
+      throw new Error('No limited synergy milestones and awards set was generated after ' + MAX_RANDOM_ATTEMPTS + ' attempts. Please try again.');
+    }
+
+    // Shuffled arrays on milestones and awards once
+    const shuffled_milestones = shuffleArray(getNumbersRange(0, withVenusian ? 15: 14));
+    const shuffled_awards = shuffleArray(getNumbersRange(16, withVenusian ? 31: 30));
+
+    const pickedMA = new MASynergyArray(maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold);
+    let milestoneCount = 0;
+    let awardCount = 0;
+
+    // Keep adding milestone or award until there are enough as requested
+    while (milestoneCount + awardCount < numberMARequested*2) {
+      // If there is enough award, add a milestone. And vice versa. If still need both, flip a coin to decide which to add.
+      if (awardCount === numberMARequested || (milestoneCount !== numberMARequested && Math.round(Math.random()))) {
+        const newMilestone = shuffled_milestones.splice(0, 1)[0];
+        // If need to add more milestone, but not enough milestone left, restart the function with a recursive call.
+        if (newMilestone === undefined) {
+          return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
         }
-        // Update the stats
-        this.currentNumberOfHigh = tempNumberOfHigh;
-        this.currentTotalSynergy = tempTotalSynergy;
-        return true;
+        const milestoneAddSuccess = pickedMA.addNewMA(newMilestone);
+        if (milestoneAddSuccess) milestoneCount++;
       } else {
-        return false;
+        const newAward = shuffled_awards.splice(0, 1)[0];
+        // If need to add more award, but not enough award left, restart the function with a recursive call.
+        if (newAward === undefined) {
+          return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
+        }
+        const awardAddSuccess = pickedMA.addNewMA(newAward);
+        if (awardAddSuccess) awardCount++;
       }
     }
+
+    if (!verifySynergyRules(pickedMA.currentMA, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold)) {
+      throw new Error('The randomized milestones and awards set does not satisfy the given synergy rules.');
+    }
+
+    const finalItems = pickedMA.currentMA.map((n) => MA_ITEMS[n]);
+    return {
+      milestones: finalItems.slice(0, numberMARequested) as Array<IMilestone>,
+      awards: finalItems.slice(numberMARequested) as Array<IAward>,
+    };
+  }
+
+  // Verify whether a given array of |milestoneAwardArray| satisfies the following these rules:
+  // 1) No pair with synergy above |maxSynergyAllowed|.
+  // 2) Total synergy is |totalSynergyAllowed| or below.
+  // 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
+  export function verifySynergyRules(
+    milestoneAwardArray: Array<number>,
+    maxSynergyAllowed: number = MAX_SYNERGY_ALLOWED_RULE,
+    totalSynergyAllowed: number = TOTAL_SYNERGY_ALLOWED_RULE,
+    numberOfHighAllowed: number = NUM_HIGH_ALLOWED_RULE,
+    highThreshold: number = HIGH_THRESHOLD_RULE): Boolean {
+    let max = 0;
+    let totalSynergy = 0;
+    let numberOfHigh = 0;
+    for (let i = 0; i < milestoneAwardArray.length - 1; i++) {
+      for (let j = i + 1; j < milestoneAwardArray.length; j++) {
+        const synergy = SYNERGIES[milestoneAwardArray[i]][milestoneAwardArray[j]];
+        max = Math.max(synergy, max);
+        totalSynergy += synergy;
+        if (synergy >= highThreshold) numberOfHigh++;
+      }
+    }
+    return (max <= maxSynergyAllowed && totalSynergy <= totalSynergyAllowed && numberOfHigh <= numberOfHighAllowed);
+  }
+
+  class MASynergyArray {
+      currentMA: Array<number>;
+      maxSynergyAllowed: number;
+      totalSynergyAllowed: number;
+      numberOfHighAllowed: number;
+      highThreshold: number;
+
+      currentNumberOfHigh: number;
+      currentTotalSynergy: number;
+
+      constructor(maxSynergyAllowed: number, totalSynergyAllowed: number, numberOfHighAllowed: number, highThreshold:number) {
+        this.currentMA = [];
+        this.maxSynergyAllowed = maxSynergyAllowed;
+        this.totalSynergyAllowed = totalSynergyAllowed;
+        this.numberOfHighAllowed = numberOfHighAllowed;
+        this.highThreshold = highThreshold;
+        this.currentNumberOfHigh = 0;
+        this.currentTotalSynergy = 0;
+      }
+
+      // A class function for adding a new milestone or award index
+      // Return true if adding successfully without violating any rule.
+      addNewMA(newMAIndex: number): boolean {
+        let tempTotalSynergy = this.currentTotalSynergy;
+        let tempNumberOfHigh = this.currentNumberOfHigh;
+        let max = 0;
+
+        // Find synergy of this new item with all previous ones
+        for (const indexPicked of this.currentMA) {
+          const synergy = SYNERGIES[indexPicked][newMAIndex];
+          tempTotalSynergy += synergy;
+          if (synergy >= this.highThreshold) {
+            tempNumberOfHigh++;
+          }
+          max = Math.max(synergy, max);
+        }
+        // Check whether the addition violate any rule.
+        if (max <= this.maxSynergyAllowed && tempNumberOfHigh <= this.numberOfHighAllowed && tempTotalSynergy <= this.totalSynergyAllowed) {
+          // If it is an award, push to the end of the array.
+          if (newMAIndex > 15) {
+            this.currentMA.push(newMAIndex);
+          } else {
+            // If it is a milestone, add to the front of the array
+            this.currentMA.unshift(newMAIndex);
+          }
+          // Update the stats
+          this.currentNumberOfHigh = tempNumberOfHigh;
+          this.currentTotalSynergy = tempTotalSynergy;
+          return true;
+        } else {
+          return false;
+        }
+      }
+  }
 }

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -16,6 +16,7 @@ import {Scientist} from './awards/Scientist';
 import {SpaceBaron} from './awards/SpaceBaron';
 import {Thermalist} from './awards/Thermalist';
 import {Venuphile} from './awards/Venuphile';
+import {GameOptions} from './Game';
 import {IDrawnMilestonesAndAwards} from './IDrawnMilestonesAndAwards';
 import {Builder} from './milestones/Builder';
 import {Diversifier} from './milestones/Diversifier';
@@ -174,24 +175,26 @@ export function computeSynergy(indexes: Array<number>) : number {
 }
 
 // Limited Synergy Constants
-const MAX_RANDOM_ATTEMPTS: number = 5;
-export const MAX_SYNERGY_ALLOWED_RULE: number= 6;
-export const TOTAL_SYNERGY_ALLOWED_RULE: number= 20;
-export const NUM_HIGH_ALLOWED_RULE: number= 20;
-export const HIGH_THRESHOLD_RULE: number= 4;
+const MAX_RANDOM_ATTEMPTS = 5;
+export const MAX_SYNERGY_ALLOWED_RULE = 6;
+export const TOTAL_SYNERGY_ALLOWED_RULE = 20;
+export const NUM_HIGH_ALLOWED_RULE = 20;
+export const HIGH_THRESHOLD_RULE = 4;
 
 // Selects |numberMARequested| milestones and |numberMARequested| awards from all available awards and milestones (optionally including
 // Venusian.) It does this by following these rules:
 // 1) No pair with synergy above |maxSynergyAllowed|.
 // 2) Total synergy is |totalSynergyAllowed| or below.
 // 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
-export function getRandomMilestonesAndAwards(withVenusian: boolean = true,
+export function getRandomMilestonesAndAwards(gameOptions: GameOptions,
   numberMARequested: number,
   maxSynergyAllowed: number = MAX_SYNERGY_ALLOWED_RULE,
   totalSynergyAllowed: number = TOTAL_SYNERGY_ALLOWED_RULE,
   numberOfHighAllowed: number = NUM_HIGH_ALLOWED_RULE,
   highThreshold: number = HIGH_THRESHOLD_RULE,
   attempt: number = 1): IDrawnMilestonesAndAwards {
+  const withVenusian = gameOptions.venusNextExtension && gameOptions.includeVenusMA;
+
   if (attempt > MAX_RANDOM_ATTEMPTS) {
     throw new Error('No limited synergy milestones and awards set was generated after ' + MAX_RANDOM_ATTEMPTS + ' attempts. Please try again.');
   }
@@ -211,7 +214,7 @@ export function getRandomMilestonesAndAwards(withVenusian: boolean = true,
       const newMilestone = shuffled_milestones.splice(0, 1)[0];
       // If need to add more milestone, but not enough milestone left, restart the function with a recursive call.
       if (newMilestone === undefined) {
-        return getRandomMilestonesAndAwards(withVenusian, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
+        return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
       }
       const milestoneAddSuccess = pickedMA.addNewMA(newMilestone);
       if (milestoneAddSuccess) milestoneCount++;
@@ -219,7 +222,7 @@ export function getRandomMilestonesAndAwards(withVenusian: boolean = true,
       const newAward = shuffled_awards.splice(0, 1)[0];
       // If need to add more award, but not enough award left, restart the function with a recursive call.
       if (newAward === undefined) {
-        return getRandomMilestonesAndAwards(withVenusian, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
+        return getRandomMilestonesAndAwards(gameOptions, numberMARequested, maxSynergyAllowed, totalSynergyAllowed, numberOfHighAllowed, highThreshold, attempt+1);
       }
       const awardAddSuccess = pickedMA.addNewMA(newAward);
       if (awardAddSuccess) awardCount++;

--- a/src/MilestoneAwardSelector.ts
+++ b/src/MilestoneAwardSelector.ts
@@ -1,5 +1,5 @@
 import {AresSetup} from './ares/AresSetup';
-import {ELYSIUM_AWARDS, HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS} from './awards/Awards';
+import {ALL_AWARDS, ELYSIUM_AWARDS, HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS} from './awards/Awards';
 import {Banker} from './awards/Banker';
 import {Benefactor} from './awards/Benefactor';
 import {Celebrity} from './awards/Celebrity';
@@ -29,7 +29,7 @@ import {Generalist} from './milestones/Generalist';
 import {Hoverlord} from './milestones/Hoverlord';
 import {IMilestone} from './milestones/IMilestone';
 import {Mayor} from './milestones/Mayor';
-import {ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from './milestones/Milestones';
+import {ALL_MILESTONES, ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from './milestones/Milestones';
 import {Planner} from './milestones/Planner';
 import {PolarExplorer} from './milestones/PolarExplorer';
 import {RimSettler} from './milestones/RimSettler';
@@ -40,123 +40,155 @@ import {Tycoon} from './milestones/Tycoon';
 import {RandomMAOptionType} from './RandomMAOptionType';
 
 export namespace MilestoneAwardSelector {
-  const MILESTONES = [
-    ...ORIGINAL_MILESTONES,
-    ...ELYSIUM_MILESTONES,
-    ...HELLAS_MILESTONES,
-    ...VENUS_MILESTONES,
-  ];
+  class MAs {
+    private static readonly milestones = [
+      ...ORIGINAL_MILESTONES,
+      ...ELYSIUM_MILESTONES,
+      ...HELLAS_MILESTONES,
+      ...VENUS_MILESTONES,
+    ];
+    private static readonly awards = [
+      ...ORIGINAL_AWARDS,
+      ...ELYSIUM_AWARDS,
+      ...HELLAS_AWARDS,
+      ...VENUS_AWARDS,
+    ];
+    public static readonly ALL = [
+      ...ORIGINAL_MILESTONES,
+      ...ELYSIUM_MILESTONES,
+      ...HELLAS_MILESTONES,
+      ...VENUS_MILESTONES,
+      ...ORIGINAL_AWARDS,
+      ...ELYSIUM_AWARDS,
+      ...HELLAS_AWARDS,
+      ...VENUS_AWARDS,
+    ];
 
-  const AWARDS = [
-    ...ORIGINAL_AWARDS,
-    ...ELYSIUM_AWARDS,
-    ...HELLAS_AWARDS,
-    ...VENUS_AWARDS,
-  ];
 
-  // exported for testing.
-  export const MA_ITEMS = [
-    ...MILESTONES,
-    ...AWARDS,
-  ];
-
-  function buildSynergies(): Array<Array<number>> {
-    const array: Array<Array<number>> = new Array(MA_ITEMS.length);
-    for (let idx = 0; idx < MA_ITEMS.length; idx++) {
-      array[idx] = new Array(MA_ITEMS.length).fill(0);
-      array[idx][idx] = 1000;
+    public static getMilestone(name: string): IMilestone {
+      const milestone = this.milestones.find((m) => m.name === name);
+      if (milestone) {
+        return milestone;
+      }
+      throw (`Milestone ${name} not found.`);
     }
 
-    // Higher synergies represent similar milestones or awards. For instance, Terraformer rewards for high TR
-    // and the Benefactor award is given to the player with the highets TR. Their synergy weight is 9, very high.
-    function bind(First: { new(): IMilestone | IAward }, Second: { new(): IMilestone | IAward }, weight: number) {
-      const row = MA_ITEMS.findIndex((ma) => new First().name === ma.name);
-      const col = MA_ITEMS.findIndex((ma) => new Second().name === ma.name);
-      array[row][col] = weight;
-      array[col][row] = weight;
+    public static getAward(name: string): IAward {
+      const award = this.awards.find((a) => a.name === name);
+      if (award) {
+        return award;
+      }
+      throw (`Award ${name} not found.`);
     }
-    bind(Terraformer, Benefactor, 9);
-    bind(Gardener, Cultivator, 9);
-    bind(Builder, Contractor, 9);
-    bind(EstateDealer, Cultivator, 8);
-    bind(Landlord, Cultivator, 8);
-    bind(Landlord, DesertSettler, 7);
-    bind(Landlord, EstateDealer, 7);
-    bind(DesertSettler, Cultivator, 7);
-    bind(Miner, Industrialist, 7);
-    bind(Energizer, Industrialist, 6);
-    bind(Gardener, Landlord, 6);
-    bind(Mayor, Landlord, 6);
-    bind(Mayor, Cultivator, 6);
-    bind(Gardener, EstateDealer, 5);
-    bind(Builder, Magnate, 5);
-    bind(Tycoon, Magnate, 5);
-    bind(PolarExplorer, DesertSettler, 5);
-    bind(Hoverlord, Excentric, 5);
-    bind(Hoverlord, Venuphile, 5);
-    bind(DesertSettler, EstateDealer, 5);
-    bind(Builder, Tycoon, 4);
-    bind(Specialist, Energizer, 4);
-    bind(Mayor, PolarExplorer, 4);
-    bind(Mayor, DesertSettler, 4);
-    bind(Mayor, EstateDealer, 4);
-    bind(Gardener, PolarExplorer, 4);
-    bind(Gardener, DesertSettler, 4);
-    bind(Ecologist, Excentric, 4);
-    bind(PolarExplorer, Landlord, 4);
-    bind(Mayor, Gardener, 3);
-    bind(Tycoon, Excentric, 3);
-    bind(PolarExplorer, Cultivator, 3);
-    bind(Energizer, Thermalist, 3);
-    bind(RimSettler, SpaceBaron, 3);
-    bind(Celebrity, SpaceBaron, 3);
-    bind(Benefactor, Cultivator, 3);
-    bind(Gardener, Benefactor, 2);
-    bind(Specialist, Banker, 2);
-    bind(Ecologist, Tycoon, 2);
-    bind(Ecologist, Diversifier, 2);
-    bind(Tycoon, Scientist, 2);
-    bind(Tycoon, Contractor, 2);
-    bind(Tycoon, Venuphile, 2);
-    bind(PolarExplorer, EstateDealer, 2);
-    bind(RimSettler, Celebrity, 2);
-    bind(Scientist, Magnate, 2);
-    bind(Magnate, SpaceBaron, 2);
-    bind(Excentric, Venuphile, 2);
-    bind(Terraformer, Cultivator, 2);
-    bind(Terraformer, Gardener, 2);
-    bind(Builder, Miner, 1);
-    bind(Builder, Industrialist, 1);
-    bind(Planner, Scientist, 1);
-    bind(Generalist, Miner, 1);
-    bind(Specialist, Thermalist, 1);
-    bind(Specialist, Miner, 1);
-    bind(Specialist, Industrialist, 1);
-    bind(Ecologist, Cultivator, 1);
-    bind(Ecologist, Magnate, 1);
-    bind(Tycoon, Diversifier, 1);
-    bind(Tycoon, Tactician, 1);
-    bind(Tycoon, RimSettler, 1);
-    bind(Tycoon, SpaceBaron, 1);
-    bind(Diversifier, Magnate, 1);
-    bind(Tactician, Scientist, 1);
-    bind(Tactician, Magnate, 1);
-    bind(RimSettler, Magnate, 1);
-    bind(Banker, Benefactor, 1);
-    bind(Celebrity, Magnate, 1);
-    bind(DesertSettler, Benefactor, 1);
-    bind(EstateDealer, Benefactor, 1);
-    bind(Terraformer, Landlord, 1);
-    bind(Terraformer, Thermalist, 1);
-    bind(Terraformer, DesertSettler, 1);
-    bind(Terraformer, EstateDealer, 1);
-    bind(Gardener, Ecologist, 1);
-    return array;
+  }
+  class Synergies {
+    // This map uses keys "X|Y" and of course stores strings as both
+    // "Y|X" and "X|X"
+    private static map: Map<string, number> = Synergies.makeMap();
+
+    private constructor() {
+    }
+
+    private static makeMap(): Map<string, number> {
+      const synergies: Map<string, number> = new Map();
+      MAs.ALL.forEach((ma) => {
+        synergies.set(ma.name + '|' + ma.name, 1000);
+      });
+
+      // Higher synergies represent similar milestones or awards. For instance, Terraformer rewards for high TR
+      // and the Benefactor award is given to the player with the highets TR. Their synergy weight is 9, very high.
+      function bind(First: { new(): IMilestone | IAward }, Second: { new(): IMilestone | IAward }, weight: number) {
+        const aName = new First().name;
+        const bName = new Second().name;
+        synergies.set(aName + '|' + bName, weight);
+        synergies.set(bName + '|' + aName, weight);
+      }
+      bind(Terraformer, Benefactor, 9);
+      bind(Gardener, Cultivator, 9);
+      bind(Builder, Contractor, 9);
+      bind(EstateDealer, Cultivator, 8);
+      bind(Landlord, Cultivator, 8);
+      bind(Landlord, DesertSettler, 7);
+      bind(Landlord, EstateDealer, 7);
+      bind(DesertSettler, Cultivator, 7);
+      bind(Miner, Industrialist, 7);
+      bind(Energizer, Industrialist, 6);
+      bind(Gardener, Landlord, 6);
+      bind(Mayor, Landlord, 6);
+      bind(Mayor, Cultivator, 6);
+      bind(Gardener, EstateDealer, 5);
+      bind(Builder, Magnate, 5);
+      bind(Tycoon, Magnate, 5);
+      bind(PolarExplorer, DesertSettler, 5);
+      bind(Hoverlord, Excentric, 5);
+      bind(Hoverlord, Venuphile, 5);
+      bind(DesertSettler, EstateDealer, 5);
+      bind(Builder, Tycoon, 4);
+      bind(Specialist, Energizer, 4);
+      bind(Mayor, PolarExplorer, 4);
+      bind(Mayor, DesertSettler, 4);
+      bind(Mayor, EstateDealer, 4);
+      bind(Gardener, PolarExplorer, 4);
+      bind(Gardener, DesertSettler, 4);
+      bind(Ecologist, Excentric, 4);
+      bind(PolarExplorer, Landlord, 4);
+      bind(Mayor, Gardener, 3);
+      bind(Tycoon, Excentric, 3);
+      bind(PolarExplorer, Cultivator, 3);
+      bind(Energizer, Thermalist, 3);
+      bind(RimSettler, SpaceBaron, 3);
+      bind(Celebrity, SpaceBaron, 3);
+      bind(Benefactor, Cultivator, 3);
+      bind(Gardener, Benefactor, 2);
+      bind(Specialist, Banker, 2);
+      bind(Ecologist, Tycoon, 2);
+      bind(Ecologist, Diversifier, 2);
+      bind(Tycoon, Scientist, 2);
+      bind(Tycoon, Contractor, 2);
+      bind(Tycoon, Venuphile, 2);
+      bind(PolarExplorer, EstateDealer, 2);
+      bind(RimSettler, Celebrity, 2);
+      bind(Scientist, Magnate, 2);
+      bind(Magnate, SpaceBaron, 2);
+      bind(Excentric, Venuphile, 2);
+      bind(Terraformer, Cultivator, 2);
+      bind(Terraformer, Gardener, 2);
+      bind(Builder, Miner, 1);
+      bind(Builder, Industrialist, 1);
+      bind(Planner, Scientist, 1);
+      bind(Generalist, Miner, 1);
+      bind(Specialist, Thermalist, 1);
+      bind(Specialist, Miner, 1);
+      bind(Specialist, Industrialist, 1);
+      bind(Ecologist, Cultivator, 1);
+      bind(Ecologist, Magnate, 1);
+      bind(Tycoon, Diversifier, 1);
+      bind(Tycoon, Tactician, 1);
+      bind(Tycoon, RimSettler, 1);
+      bind(Tycoon, SpaceBaron, 1);
+      bind(Diversifier, Magnate, 1);
+      bind(Tactician, Scientist, 1);
+      bind(Tactician, Magnate, 1);
+      bind(RimSettler, Magnate, 1);
+      bind(Banker, Benefactor, 1);
+      bind(Celebrity, Magnate, 1);
+      bind(DesertSettler, Benefactor, 1);
+      bind(EstateDealer, Benefactor, 1);
+      bind(Terraformer, Landlord, 1);
+      bind(Terraformer, Thermalist, 1);
+      bind(Terraformer, DesertSettler, 1);
+      bind(Terraformer, EstateDealer, 1);
+      bind(Gardener, Ecologist, 1);
+      return synergies;
+    }
+
+    public static get(a: string, b: string): number {
+      const tmp = Synergies.map.get(a + '|' + b);
+      return tmp || 0;
+    }
   }
 
-  const SYNERGIES = buildSynergies();
-
-  function shuffleArray(arr: Array<number>) {
+  function shuffle<T>(arr: Array<T>) {
     arr = arr.slice();
     for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -167,25 +199,18 @@ export namespace MilestoneAwardSelector {
     return arr;
   }
 
-  // Returns an array from [start... end]
-  // eg (4, 11) returns [4, 5, 6, 7, 8, 9, 10, 11]
-  function getNumbersRange(start: number, end: number): Array<number> {
-    return Array.from(Array(end + 1 - start).keys()).map((n) => n + start);
-  }
-
   // Function to compute max synergy of a given set of milestones and awards.
   // Exported for testing
-  export function computeSynergy(indexes: Array<number>) : number {
+  export function maximumSynergy(names: Array<string>) : number {
     let max = 0;
-    for (let i = 0; i<indexes.length - 1; i++) {
-      for (let j = i + 1; j<indexes.length; j++) {
-        const synergy = SYNERGIES[indexes[i]][indexes[j]];
+    for (let i = 0; i < names.length - 1; i++) {
+      for (let j = i + 1; j < names.length; j++) {
+        const synergy = Synergies.get(names[i], names[j]);
         max = Math.max(synergy, max);
       }
     }
     return max;
   }
-
 
   export interface Constraints {
     maxSynergyAllowed: number;
@@ -194,8 +219,6 @@ export namespace MilestoneAwardSelector {
     highThreshold: number;
   }
 
-  // Limited Synergy Constants
-  const MAX_RANDOM_ATTEMPTS = 5;
   export const LIMITED_SYNERGY: Constraints = {
     maxSynergyAllowed: 6,
     totalSynergyAllowed: 20,
@@ -242,10 +265,10 @@ export namespace MilestoneAwardSelector {
 
       break;
     case RandomMAOptionType.LIMITED:
-      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty, LIMITED_SYNERGY);
+      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty, LIMITED_SYNERGY);
       break;
     case RandomMAOptionType.UNLIMITED:
-      drawnMilestonesAndAwards = MilestoneAwardSelector.getRandomMilestonesAndAwards(gameOptions, requiredQty, UNLIMITED_SYNERGY);
+      drawnMilestonesAndAwards = getRandomMilestonesAndAwards(gameOptions, requiredQty, UNLIMITED_SYNERGY);
       break;
     }
 
@@ -260,54 +283,55 @@ export namespace MilestoneAwardSelector {
   // 1) No pair with synergy above |maxSynergyAllowed|.
   // 2) Total synergy is |totalSynergyAllowed| or below.
   // 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
-  export function getRandomMilestonesAndAwards(gameOptions: GameOptions,
+  function getRandomMilestonesAndAwards(gameOptions: GameOptions,
     numberMARequested: number,
     constraints: Constraints,
     attempt: number = 1): IDrawnMilestonesAndAwards {
     const withVenusian = gameOptions.venusNextExtension && gameOptions.includeVenusMA;
 
-    if (attempt > MAX_RANDOM_ATTEMPTS) {
-      throw new Error('No limited synergy milestones and awards set was generated after ' + MAX_RANDOM_ATTEMPTS + ' attempts. Please try again.');
+    const maxAttempts = 5;
+    if (attempt > maxAttempts) {
+      throw new Error('No limited synergy milestones and awards set was generated after ' + maxAttempts + ' attempts. Please try again.');
     }
 
-    // Shuffled arrays on milestones and awards once
-    const shuffled_milestones = shuffleArray(getNumbersRange(0, withVenusian ? 15: 14));
-    const shuffled_awards = shuffleArray(getNumbersRange(16, withVenusian ? 31: 30));
+    const candidateMilestones = ALL_MILESTONES.map((ma) => ma.name);
+    const candidateAwards = ALL_AWARDS.map((ma) => ma.name);
+    if (withVenusian) {
+      candidateMilestones.push(...VENUS_MILESTONES.map((ma) => ma.name));
+      candidateAwards.push(...VENUS_AWARDS.map((ma) => ma.name));
+    }
+    const shuffledMilestones = shuffle(candidateMilestones);
+    const shuffledAwards = shuffle(candidateAwards);
 
-    const pickedMA = new MASynergyArray(constraints);
-    let milestoneCount = 0;
-    let awardCount = 0;
+    const accum = new Accumulator(constraints);
 
-    // Keep adding milestone or award until there are enough as requested
-    while (milestoneCount + awardCount < numberMARequested*2) {
+    // Keep adding milestones or awards until there are as many as requested
+    while (accum.milestones.length + accum.awards.length < numberMARequested * 2) {
       // If there is enough award, add a milestone. And vice versa. If still need both, flip a coin to decide which to add.
-      if (awardCount === numberMARequested || (milestoneCount !== numberMARequested && Math.round(Math.random()))) {
-        const newMilestone = shuffled_milestones.splice(0, 1)[0];
+      if (accum.awards.length === numberMARequested || (accum.milestones.length !== numberMARequested && Math.round(Math.random()))) {
+        const newMilestone = shuffledMilestones.splice(0, 1)[0];
         // If need to add more milestone, but not enough milestone left, restart the function with a recursive call.
         if (newMilestone === undefined) {
           return getRandomMilestonesAndAwards(gameOptions, numberMARequested, constraints, attempt+1);
         }
-        const milestoneAddSuccess = pickedMA.addNewMA(newMilestone);
-        if (milestoneAddSuccess) milestoneCount++;
+        accum.add(newMilestone, true);
       } else {
-        const newAward = shuffled_awards.splice(0, 1)[0];
+        const newAward = shuffledAwards.splice(0, 1)[0];
         // If need to add more award, but not enough award left, restart the function with a recursive call.
         if (newAward === undefined) {
           return getRandomMilestonesAndAwards(gameOptions, numberMARequested, constraints, attempt+1);
         }
-        const awardAddSuccess = pickedMA.addNewMA(newAward);
-        if (awardAddSuccess) awardCount++;
+        accum.add(newAward, false);
       }
     }
 
-    if (!verifySynergyRules(pickedMA.currentMA, constraints)) {
+    if (!verifySynergyRules(accum.milestones.concat(accum.awards), constraints)) {
       throw new Error('The randomized milestones and awards set does not satisfy the given synergy rules.');
     }
 
-    const finalItems = pickedMA.currentMA.map((n) => MA_ITEMS[n]);
     return {
-      milestones: finalItems.slice(0, numberMARequested) as Array<IMilestone>,
-      awards: finalItems.slice(numberMARequested) as Array<IAward>,
+      milestones: accum.milestones.map((name) => MAs.getMilestone(name)),
+      awards: accum.awards.map((name) => MAs.getAward(name)),
     };
   }
 
@@ -316,14 +340,14 @@ export namespace MilestoneAwardSelector {
   // 2) Total synergy is |totalSynergyAllowed| or below.
   // 3) Limited a number of pair with synergy at |highThreshold| or above to |numberOfHighAllowed| or below.
   export function verifySynergyRules(
-    milestoneAwardArray: Array<number>,
-    constraints: Constraints): Boolean {
+    mas: Array<string>,
+    constraints: Constraints): boolean {
     let max = 0;
     let totalSynergy = 0;
     let numberOfHigh = 0;
-    for (let i = 0; i < milestoneAwardArray.length - 1; i++) {
-      for (let j = i + 1; j < milestoneAwardArray.length; j++) {
-        const synergy = SYNERGIES[milestoneAwardArray[i]][milestoneAwardArray[j]];
+    for (let i = 0; i < mas.length - 1; i++) {
+      for (let j = i + 1; j < mas.length; j++) {
+        const synergy = Synergies.get(mas[i], mas[j]);
         max = Math.max(synergy, max);
         totalSynergy += synergy;
         if (synergy >= constraints.highThreshold) numberOfHigh++;
@@ -334,52 +358,55 @@ export namespace MilestoneAwardSelector {
       numberOfHigh <= constraints.numberOfHighAllowed;
   }
 
-  class MASynergyArray {
-      currentMA: Array<number>;
+  class Accumulator {
+    milestones: Array<string> = [];
+    awards: Array<string> = [];
 
-      currentNumberOfHigh: number;
-      currentTotalSynergy: number;
+    private accumulatedHighCount: number = 0;
+    private accumulatedTotalSynergy: number = 0;
 
-      constructor(private constraints: Constraints) {
-        this.currentMA = [];
-        this.currentNumberOfHigh = 0;
-        this.currentTotalSynergy = 0;
-      }
+    constructor(private constraints: Constraints) {
+    }
 
-      // A class function for adding a new milestone or award index
-      // Return true if adding successfully without violating any rule.
-      addNewMA(newMAIndex: number): boolean {
-        let tempTotalSynergy = this.currentTotalSynergy;
-        let tempNumberOfHigh = this.currentNumberOfHigh;
-        let max = 0;
+    // Conditionally add a milestone or award when it doesn't
+    // violate synergy constraints.
+    //
+    // |ma| is the milestone or award, |milestone| is true when
+    // |ma| represents a milestone and false when it represents
+    // an award.
+    //
+    // Returns true when successful, false otherwise.
+    //
+    add(candidate: string, milestone: boolean): boolean {
+      let totalSynergy = this.accumulatedTotalSynergy;
+      let highCount = this.accumulatedHighCount;
+      let max = 0;
 
-        // Find synergy of this new item with all previous ones
-        for (const indexPicked of this.currentMA) {
-          const synergy = SYNERGIES[indexPicked][newMAIndex];
-          tempTotalSynergy += synergy;
-          if (synergy >= this.constraints.highThreshold) {
-            tempNumberOfHigh++;
-          }
-          max = Math.max(synergy, max);
+      // Find maximum synergy of this new item compared to the others
+      this.milestones.concat(this.awards).forEach((ma) => {
+        const synergy = Synergies.get(ma, candidate);
+        totalSynergy += synergy;
+        if (synergy >= this.constraints.highThreshold) {
+          highCount++;
         }
-        // Check whether the addition violate any rule.
-        if (max <= this.constraints.maxSynergyAllowed &&
-          tempNumberOfHigh <= this.constraints.numberOfHighAllowed &&
-          tempTotalSynergy <= this.constraints.totalSynergyAllowed) {
-          // If it is an award, push to the end of the array.
-          if (newMAIndex > 15) {
-            this.currentMA.push(newMAIndex);
-          } else {
-            // If it is a milestone, add to the front of the array
-            this.currentMA.unshift(newMAIndex);
-          }
-          // Update the stats
-          this.currentNumberOfHigh = tempNumberOfHigh;
-          this.currentTotalSynergy = tempTotalSynergy;
-          return true;
+        max = Math.max(synergy, max);
+      });
+      // Check whether the addition violates any rule.
+      if (max <= this.constraints.maxSynergyAllowed &&
+        highCount <= this.constraints.numberOfHighAllowed &&
+        totalSynergy <= this.constraints.totalSynergyAllowed) {
+        if (milestone) {
+          this.milestones.push(candidate);
         } else {
-          return false;
+          this.awards.push(candidate);
         }
+        // Update the stats
+        this.accumulatedHighCount = highCount;
+        this.accumulatedTotalSynergy = totalSynergy;
+        return true;
+      } else {
+        return false;
       }
+    }
   }
 }

--- a/tests/MilestoneAwardSelector.spec.ts
+++ b/tests/MilestoneAwardSelector.spec.ts
@@ -37,10 +37,7 @@ describe('MilestoneAwardSelector', function() {
     // Tharsis milestones and awards has total synergy of 21 and break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
       getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS),
-      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
-      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(false);
+      MilestoneAwardSelector.LIMITED_SYNERGY)).eq(false);
   });
 
   it('Elysium\'s milestones and awards do not break limited synergy rules', function() {
@@ -48,26 +45,25 @@ describe('MilestoneAwardSelector', function() {
     // This set does not break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
       getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS),
-      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
-      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(true);
+      MilestoneAwardSelector.LIMITED_SYNERGY)).eq(true);
   });
 
   it('Hellas\'s milestones and awards do not break limited synergy rules', function() {
     // Hellas milestones and awards has total synergy of 11 and no high pair. It does not break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
       getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
-      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
-      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
-      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(true);
+      MilestoneAwardSelector.LIMITED_SYNERGY)).eq(true);
   });
 
   it('Hellas\'s milestones and awards break stringent limited synergy rules', function() {
     // Hellas milestones and awards break rules if allowed no synergy whatsoever.
     expect(MilestoneAwardSelector.verifySynergyRules(
       getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
-      0, 0, 0, MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(false);
+      {
+        highThreshold: 10,
+        maxSynergyAllowed: 0,
+        numberOfHighAllowed: 0,
+        totalSynergyAllowed: 0,
+      })).eq(false);
   });
 });

--- a/tests/MilestoneAwardSelector.spec.ts
+++ b/tests/MilestoneAwardSelector.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {ELYSIUM_AWARDS, HELLAS_AWARDS, ORIGINAL_AWARDS, VENUS_AWARDS} from '../src/awards/Awards';
 import {IAward} from '../src/awards/IAward';
-import {MA_ITEMS, computeSynergy, verifySynergyRules, MAX_SYNERGY_ALLOWED_RULE, TOTAL_SYNERGY_ALLOWED_RULE, NUM_HIGH_ALLOWED_RULE, HIGH_THRESHOLD_RULE} from '../src/MilestoneAwardSelector';
+import {MilestoneAwardSelector} from '../src/MilestoneAwardSelector';
 import {IMilestone} from '../src/milestones/IMilestone';
 import {ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from '../src/milestones/Milestones';
 
 function getMAIndices(...entries: Array<IMilestone | IAward>): Array<number> {
-  const idxs = entries.map((entry) => MA_ITEMS.findIndex((ma) => entry.name === ma.name));
+  const idxs = entries.map((entry) => MilestoneAwardSelector.MA_ITEMS.findIndex((ma) => entry.name === ma.name));
   return idxs;
 }
 
@@ -16,41 +16,58 @@ describe('MilestoneAwardSelector', function() {
 
   it('Tharsis\'s milestones and awards have high synergy', function() {
     // Gardener / Landlord have synergy 6.
-    expect(computeSynergy(getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS))).eq(6);
+    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS))).eq(6);
   });
 
   it('Elysium\'s milestones and awards have high synergy', function() {
     // DesertSettler / Estate Dealer has synergy 5.
-    expect(computeSynergy(getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS))).eq(5);
+    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS))).eq(5);
   });
   it('Hellas\'s milestones and awards have high synergy', function() {
     // Both pairs Polar Explorer / Cultivator and Rim Settler / Space Baron
     // have synergy 3.
-    expect(computeSynergy(getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS))).eq(3);
+    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS))).eq(3);
   });
   it('Venus\'s milestones and awards have high synergy', function() {
     // Hoverlord / Venuphine have synergy 5.
-    expect(computeSynergy(getMAIndices(...VENUS_MILESTONES, ...VENUS_AWARDS))).eq(5);
+    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...VENUS_MILESTONES, ...VENUS_AWARDS))).eq(5);
   });
 
   it('Tharsis\'s milestones and awards break limited synergy rules', function() {
     // Tharsis milestones and awards has total synergy of 21 and break the rules.
-    expect(verifySynergyRules(getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS), MAX_SYNERGY_ALLOWED_RULE, TOTAL_SYNERGY_ALLOWED_RULE, NUM_HIGH_ALLOWED_RULE, HIGH_THRESHOLD_RULE)).eq(false);
+    expect(MilestoneAwardSelector.verifySynergyRules(
+      getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS),
+      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
+      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(false);
   });
 
   it('Elysium\'s milestones and awards do not break limited synergy rules', function() {
     // Elysium milestones and awards has total synergy of 13 and two high pairs of 4 and 5.
     // This set does not break the rules.
-    expect(verifySynergyRules(getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS), MAX_SYNERGY_ALLOWED_RULE, TOTAL_SYNERGY_ALLOWED_RULE, NUM_HIGH_ALLOWED_RULE, HIGH_THRESHOLD_RULE)).eq(true);
+    expect(MilestoneAwardSelector.verifySynergyRules(
+      getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS),
+      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
+      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(true);
   });
 
   it('Hellas\'s milestones and awards do not break limited synergy rules', function() {
     // Hellas milestones and awards has total synergy of 11 and no high pair. It does not break the rules.
-    expect(verifySynergyRules(getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS), MAX_SYNERGY_ALLOWED_RULE, TOTAL_SYNERGY_ALLOWED_RULE, NUM_HIGH_ALLOWED_RULE, HIGH_THRESHOLD_RULE)).eq(true);
+    expect(MilestoneAwardSelector.verifySynergyRules(
+      getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
+      MilestoneAwardSelector.MAX_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.TOTAL_SYNERGY_ALLOWED_RULE,
+      MilestoneAwardSelector.NUM_HIGH_ALLOWED_RULE,
+      MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(true);
   });
 
   it('Hellas\'s milestones and awards break stringent limited synergy rules', function() {
     // Hellas milestones and awards break rules if allowed no synergy whatsoever.
-    expect(verifySynergyRules(getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS), 0, 0, 0, HIGH_THRESHOLD_RULE)).eq(false);
+    expect(MilestoneAwardSelector.verifySynergyRules(
+      getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
+      0, 0, 0, MilestoneAwardSelector.HIGH_THRESHOLD_RULE)).eq(false);
   });
 });

--- a/tests/MilestoneAwardSelector.spec.ts
+++ b/tests/MilestoneAwardSelector.spec.ts
@@ -10,7 +10,7 @@ function getMAIndices(...entries: Array<IMilestone | IAward>): Array<number> {
   return idxs;
 }
 
-describe('MilestoneAwardSelecter', function() {
+describe('MilestoneAwardSelector', function() {
   // These aren't particularly excellent tests as much as they help demonstrate
   // what the original maps, if selected in full, would have as a synergy.
 

--- a/tests/MilestoneAwardSelector.spec.ts
+++ b/tests/MilestoneAwardSelector.spec.ts
@@ -5,60 +5,59 @@ import {MilestoneAwardSelector} from '../src/MilestoneAwardSelector';
 import {IMilestone} from '../src/milestones/IMilestone';
 import {ELYSIUM_MILESTONES, HELLAS_MILESTONES, ORIGINAL_MILESTONES, VENUS_MILESTONES} from '../src/milestones/Milestones';
 
-function getMAIndices(...entries: Array<IMilestone | IAward>): Array<number> {
-  const idxs = entries.map((entry) => MilestoneAwardSelector.MA_ITEMS.findIndex((ma) => entry.name === ma.name));
-  return idxs;
+function toNames(list: Array<IMilestone | IAward>): Array<string> {
+  return list.map((e) => e.name);
 }
 
 describe('MilestoneAwardSelector', function() {
   // These aren't particularly excellent tests as much as they help demonstrate
   // what the original maps, if selected in full, would have as a synergy.
 
-  it('Tharsis\'s milestones and awards have high synergy', function() {
+  it('Tharsis milestones and awards have high synergy', function() {
     // Gardener / Landlord have synergy 6.
-    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS))).eq(6);
+    expect(MilestoneAwardSelector.maximumSynergy(toNames([...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS]))).eq(6);
   });
 
-  it('Elysium\'s milestones and awards have high synergy', function() {
+  it('Elysium milestones and awards have high synergy', function() {
     // DesertSettler / Estate Dealer has synergy 5.
-    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS))).eq(5);
+    expect(MilestoneAwardSelector.maximumSynergy(toNames([...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS]))).eq(5);
   });
-  it('Hellas\'s milestones and awards have high synergy', function() {
+  it('Hellas milestones and awards have high synergy', function() {
     // Both pairs Polar Explorer / Cultivator and Rim Settler / Space Baron
     // have synergy 3.
-    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS))).eq(3);
+    expect(MilestoneAwardSelector.maximumSynergy(toNames([...HELLAS_MILESTONES, ...HELLAS_AWARDS]))).eq(3);
   });
-  it('Venus\'s milestones and awards have high synergy', function() {
+  it('Venus milestones and awards have high synergy', function() {
     // Hoverlord / Venuphine have synergy 5.
-    expect(MilestoneAwardSelector.computeSynergy(getMAIndices(...VENUS_MILESTONES, ...VENUS_AWARDS))).eq(5);
+    expect(MilestoneAwardSelector.maximumSynergy(toNames([...VENUS_MILESTONES, ...VENUS_AWARDS]))).eq(5);
   });
 
-  it('Tharsis\'s milestones and awards break limited synergy rules', function() {
+  it('Tharsis milestones and awards break limited synergy rules', function() {
     // Tharsis milestones and awards has total synergy of 21 and break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
-      getMAIndices(...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS),
+      toNames([...ORIGINAL_MILESTONES, ...ORIGINAL_AWARDS]),
       MilestoneAwardSelector.LIMITED_SYNERGY)).eq(false);
   });
 
-  it('Elysium\'s milestones and awards do not break limited synergy rules', function() {
+  it('Elysium milestones and awards do not break limited synergy rules', function() {
     // Elysium milestones and awards has total synergy of 13 and two high pairs of 4 and 5.
     // This set does not break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
-      getMAIndices(...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS),
+      toNames([...ELYSIUM_MILESTONES, ...ELYSIUM_AWARDS]),
       MilestoneAwardSelector.LIMITED_SYNERGY)).eq(true);
   });
 
-  it('Hellas\'s milestones and awards do not break limited synergy rules', function() {
+  it('Hellas milestones and awards do not break limited synergy rules', function() {
     // Hellas milestones and awards has total synergy of 11 and no high pair. It does not break the rules.
     expect(MilestoneAwardSelector.verifySynergyRules(
-      getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
+      toNames([...HELLAS_MILESTONES, ...HELLAS_AWARDS]),
       MilestoneAwardSelector.LIMITED_SYNERGY)).eq(true);
   });
 
-  it('Hellas\'s milestones and awards break stringent limited synergy rules', function() {
+  it('Hellas milestones and awards break stringent limited synergy rules', function() {
     // Hellas milestones and awards break rules if allowed no synergy whatsoever.
     expect(MilestoneAwardSelector.verifySynergyRules(
-      getMAIndices(...HELLAS_MILESTONES, ...HELLAS_AWARDS),
+      toNames([...HELLAS_MILESTONES, ...HELLAS_AWARDS]),
       {
         highThreshold: 10,
         maxSynergyAllowed: 0,


### PR DESCRIPTION
This in part starts to make #2577 easier, but mostly it's so I can integrate the Moon's milestones and awards into this without too much trouble. It also clarifies and simplifies a few changes.

This change is best reviewed commit-by-commit.

I have a few more changes coming, but this is a good starting point.