### PR TITLE
use pointer for log-card

### DIFF
--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -79,6 +79,7 @@
 
 .log-card {
     color: #000;
+    cursor: pointer;
     padding: 2px 5px;
     border-radius: 2px;
     font-family: Ubuntu;


### PR DESCRIPTION
Uses `pointer` for `log-card`. This will indicate to users that you can click these items. Will close #2905 