### PR TITLE
remove querystring and add unit tests

### DIFF
--- a/src/routes/ApiPlayer.ts
+++ b/src/routes/ApiPlayer.ts
@@ -1,6 +1,4 @@
 import * as http from 'http';
-import * as querystring from 'querystring';
-import {GameLoader} from '../database/GameLoader';
 import {Player} from '../Player';
 import {Server} from '../server/ServerModel';
 import {Handler} from './Handler';
@@ -14,27 +12,17 @@ export class ApiPlayer extends Handler {
   }
 
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
-    const qs = req.url!.substring('/api/player?'.length);
-    const queryParams = querystring.parse(qs);
-    let playerId = queryParams['id'] as string | Array<string> | undefined;
-    if (Array.isArray(playerId)) {
-      playerId = playerId[0];
-    }
-    if (playerId === undefined) {
-      playerId = '';
-    }
-    GameLoader.getInstance().getByPlayerId(playerId as string, (game) => {
+    const playerId = String(ctx.url.searchParams.get('id'));
+    ctx.gameLoader.getByPlayerId(playerId, (game) => {
       if (game === undefined) {
         ctx.route.notFound(req, res);
         return;
       }
       let player: Player | undefined;
       try {
-        player = game.getPlayerById(playerId as string);
+        player = game.getPlayerById(playerId);
       } catch (err) {
         console.warn(`unable to find player ${playerId}`, err);
-      }
-      if (player === undefined) {
         ctx.route.notFound(req, res);
         return;
       }

--- a/src/routes/ApiPlayer.ts
+++ b/src/routes/ApiPlayer.ts
@@ -1,5 +1,4 @@
 import * as http from 'http';
-import {Player} from '../Player';
 import {Server} from '../server/ServerModel';
 import {Handler} from './Handler';
 import {IContext} from './IHandler';
@@ -18,15 +17,14 @@ export class ApiPlayer extends Handler {
         ctx.route.notFound(req, res);
         return;
       }
-      let player: Player | undefined;
       try {
-        player = game.getPlayerById(playerId);
+        const player = game.getPlayerById(playerId);
+        ctx.route.writeJson(res, Server.getPlayerModel(player));
       } catch (err) {
         console.warn(`unable to find player ${playerId}`, err);
         ctx.route.notFound(req, res);
         return;
       }
-      ctx.route.writeJson(res, Server.getPlayerModel(player));
     });
   }
 }

--- a/src/routes/Handler.ts
+++ b/src/routes/Handler.ts
@@ -1,5 +1,4 @@
 import * as http from 'http';
-import * as querystring from 'querystring';
 import {IHandler, IContext} from './IHandler';
 
 export namespace Handler {
@@ -14,11 +13,11 @@ export abstract class Handler implements IHandler {
     this.validateServerId = options?.validateServerId === true;
   }
 
-  private isServerIdValid(req: http.IncomingMessage, ctx: IContext): boolean {
-    const queryParams = querystring.parse(req.url!.replace(/^.*\?/, ''));
+  private isServerIdValid(ctx: IContext): boolean {
+    const serverId = ctx.url.searchParams.get('serverId');
     if (
-      queryParams.serverId === undefined ||
-      queryParams.serverId !== ctx.serverId
+      serverId === null ||
+      serverId !== ctx.serverId
     ) {
       console.warn('No or invalid serverId given');
       return false;
@@ -27,7 +26,7 @@ export abstract class Handler implements IHandler {
   }
 
   processRequest(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
-    if (this.validateServerId && !this.isServerIdValid(req, ctx)) {
+    if (this.validateServerId && !this.isServerIdValid(ctx)) {
       ctx.route.notAuthorized(req, res);
       return;
     }


### PR DESCRIPTION
Removes a few usages of `querystring` as we are parsing the query string twice. Adds unit tests to verify.