### PR TITLE
blue action counter

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -905,6 +905,10 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
   }
 
+  public getAvailableBlueActionCount(): number {
+    return this.getPlayableActionCards().length;
+  }
+
   private getPlayableActionCards(): Array<ICard> {
     const result: Array<ICard> = [];
     if (

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -94,6 +94,9 @@ export const PlayerInfo = Vue.component('player-info', {
     getNrPlayedCards: function(): number {
       return this.player.playedCards.length;
     },
+    getAvailableBlueActionCount: function(): number {
+      return this.player.availableBlueCardActionCount;
+    },
   },
   template: ` 
       <div :class="getClasses()">
@@ -121,6 +124,13 @@ export const PlayerInfo = Vue.component('player-info', {
               </div>
             </div>
             <Button class="played-cards-button" size="tiny" :onClick="togglePlayerDetails" :title="buttonLabel()" />
+          </div>
+          <div class="tag-display player-board-blue-action-counter">
+            <div class="tag-count tag-action-card tag-size-big tag-type-main">
+              <div class="blue-stripe"></div>
+              <div class="red-arrow"></div>
+            </div>
+            <span class="tag-count-display">{{ getAvailableBlueActionCount() }}</span>
           </div>
         </div>
         <player-tags :player="player" v-trim-whitespace :isActivePlayer="getIsActivePlayer()" :hideZeroTags="hideZeroTags" />

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -7,6 +7,7 @@ import {playerColorClass} from '../../utils/utils';
 import {mainAppSettings} from '../App';
 import {range} from '../../utils/utils';
 import {PlayerMixin} from '../PlayerMixin';
+import {PreferencesManager} from '../PreferencesManager';
 
 const isPinned = (root: any, playerIndex: number): boolean => {
   return (root as any).getVisibilityState('pinned_player_' + playerIndex);
@@ -97,6 +98,9 @@ export const PlayerInfo = Vue.component('player-info', {
     getAvailableBlueActionCount: function(): number {
       return this.player.availableBlueCardActionCount;
     },
+    isLearnerModeOff: function(): boolean {
+      return PreferencesManager.loadBooleanValue('learner_mode') === false;
+    },
   },
   template: ` 
       <div :class="getClasses()">
@@ -125,7 +129,7 @@ export const PlayerInfo = Vue.component('player-info', {
             </div>
             <Button class="played-cards-button" size="tiny" :onClick="togglePlayerDetails" :title="buttonLabel()" />
           </div>
-          <div class="tag-display player-board-blue-action-counter tooltip tooltip-top" data-tooltip="The number of available active card actions">
+          <div v-if="isLearnerModeOff()" class="tag-display player-board-blue-action-counter tooltip tooltip-top" data-tooltip="The number of available active card actions">
             <div class="tag-count tag-action-card">
               <div class="blue-stripe"></div>
               <div class="red-arrow"></div>

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -125,7 +125,7 @@ export const PlayerInfo = Vue.component('player-info', {
             </div>
             <Button class="played-cards-button" size="tiny" :onClick="togglePlayerDetails" :title="buttonLabel()" />
           </div>
-          <div class="tag-display player-board-blue-action-counter">
+          <div class="tag-display player-board-blue-action-counter tooltip tooltip-top" data-tooltip="The number of available active card actions">
             <div class="tag-count tag-action-card">
               <div class="blue-stripe"></div>
               <div class="red-arrow"></div>

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -126,7 +126,7 @@ export const PlayerInfo = Vue.component('player-info', {
             <Button class="played-cards-button" size="tiny" :onClick="togglePlayerDetails" :title="buttonLabel()" />
           </div>
           <div class="tag-display player-board-blue-action-counter">
-            <div class="tag-count tag-action-card tag-size-big tag-type-main">
+            <div class="tag-count tag-action-card">
               <div class="blue-stripe"></div>
               <div class="red-arrow"></div>
             </div>

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -18,6 +18,7 @@ export interface PlayerModel {
     actionsTakenThisRound: number;
     actionsThisGeneration: Array<string>;
     aresData: IAresData | undefined;
+    availableBlueCardActionCount: number;
     awards: Array<FundedAwardModel>;
     cardCost: number;
     cardsInHand: Array<CardModel>;

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -66,6 +66,7 @@ export class Server {
       actionsTakenThisRound: player.actionsTakenThisRound,
       actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
       aresData: game.aresData,
+      availableBlueCardActionCount: player.getAvailableBlueActionCount(),
       awards: getAwards(game),
       cardCost: player.cardCost,
       cardsInHand: getCards(player, player.cardsInHand, {showNewCost: true}),
@@ -424,6 +425,7 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       deckSize: game.dealer.getDeckSize(),
       actionsTakenThisRound: player.actionsTakenThisRound,
       timer: player.timer.serialize(),
+      availableBlueCardActionCount: player.getAvailableBlueActionCount(),
     } as PlayerModel;
   });
 }

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -211,21 +211,30 @@
 }
 
 .tag-action-card {
+    margin-top: 0px;
+    margin-left: 0px;
+
+    border-radius: 4px;
+    border: none;
+    width: 30px;
+    height: 34px;
     background: linear-gradient(to bottom right, #ffffff, #aaaaaa, #eeeeee, #cecece, #dddddd, #eeeeee, #cccccc);
+
     .blue-stripe {
         background: linear-gradient(-60deg, #208cdf 10%, #4da3e6, #208cdf 90%);
-        height: 6px;
-        top: 4px;
+        height: 8px;
+        top: 3px;
         position: relative;
     }
     .red-arrow{
         background-image: url(./assets/misc/arrow.png);
-        background-size: 30px;
-        width: 30px;
+        background-size: 25px;
+        width: 25px;
         height: 30px;
         vertical-align: middle;
         display: inline-block;
         background-repeat: no-repeat;
+        align-self: center;
         background-position: 0px;
     }
 }

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -210,6 +210,26 @@
     left: 7px;
 }
 
+.tag-action-card {
+    background: linear-gradient(to bottom right, #ffffff, #aaaaaa, #eeeeee, #cecece, #dddddd, #eeeeee, #cccccc);
+    .blue-stripe {
+        background: linear-gradient(-60deg, #208cdf 10%, #4da3e6, #208cdf 90%);
+        height: 6px;
+        top: 4px;
+        position: relative;
+    }
+    .red-arrow{
+        background-image: url(./assets/misc/arrow.png);
+        background-size: 30px;
+        width: 30px;
+        height: 30px;
+        vertical-align: middle;
+        display: inline-block;
+        background-repeat: no-repeat;
+        background-position: 0px;
+    }
+}
+
 .tag-tr {
     background-image: url(assets/resources/tr.png);
     background-image: url(assets/resources/tr.png);
@@ -249,6 +269,9 @@
     border-radius: 0px !important;
     background-position: 0px !important;
   }
+.player-board-blue-action-counter{
+    margin-top: 8px;
+}
 
 .tag-display {
     display: flex;


### PR DESCRIPTION
This PR adds a counter for available blue card action for each player. This will help the players know who can outlast them in the generation.

![image](https://user-images.githubusercontent.com/14239220/110371760-66acb900-801b-11eb-8afc-3f1495089df8.png)

![image](https://user-images.githubusercontent.com/14239220/110371970-affd0880-801b-11eb-83c0-baccaff651df.png)

![image](https://user-images.githubusercontent.com/14239220/110371994-b8edda00-801b-11eb-9726-3c44c28ef6f2.png)
