### PR TITLE
add missing properties to log-panel for GameEnd

### DIFF
--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -181,7 +181,7 @@ export const GameEnd = Vue.component('game-end', {
                 </div>
                 <div class="game_end_block--log game-end-column">
                     <h2 v-i18n>Final game log</h2>
-                    <log-panel :id="player.id" :players="player.players"></log-panel>
+                    <log-panel :color="player.color" :generation="player.generation" :id="player.id" :lastSoloGeneration="player.lastSoloGeneration" :players="player.players"></log-panel>
                 </div>
                 </div>
             </div>


### PR DESCRIPTION
The new properties on `log-panel` were not added to the `log-panel` component shown on `GameEnd`. This adds the properties which are required.