### PR TITLE
only show buffer gas for solo games

### DIFF
--- a/src/CardLoader.ts
+++ b/src/CardLoader.ts
@@ -69,8 +69,7 @@ export class CardLoader {
     return this.getCards((manifest) => manifest.projectCards);
   }
   public getStandardProjects() {
-    return this.getCards((manifest) => manifest.standardProjects)
-      .filter((card) => card.name !== CardName.BUFFER_GAS_STANDARD_PROJECT || this.gameOptions.soloTR);
+    return this.getCards((manifest) => manifest.standardProjects);
   }
   public getCorporationCards() {
     return this.getCards((manifest) => manifest.corporationCards)

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1665,12 +1665,21 @@ export class Player implements ISerializable<SerializedPlayer> {
   private getStandardProjects(): Array<StandardProjectCard> {
     return new CardLoader(this.game.gameOptions)
       .getStandardProjects()
-      .filter((card) => card.name !== CardName.SELL_PATENTS_STANDARD_PROJECT)
+      .filter((card) => {
+        // sell patents is not displayed as a card
+        if (card.name === CardName.SELL_PATENTS_STANDARD_PROJECT) {
+          return false;
+        }
+        // only show buffer gas in solo mode
+        if (card.name === CardName.BUFFER_GAS_STANDARD_PROJECT && this.game.isSoloMode()) {
+          return false;
+        }
+        return true;
+      })
       .sort((a, b) => a.cost - b.cost);
   }
 
-  // Public for testing. TODO: make protected using the TestPlayer class.
-  public getStandardProjectOption(): SelectCard<StandardProjectCard> {
+  protected getStandardProjectOption(): SelectCard<StandardProjectCard> {
     const standardProjects: Array<StandardProjectCard> = this.getStandardProjects();
 
     return new SelectCard(

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -125,6 +125,21 @@ describe('Player', function() {
     player.process([['1']]);
     expect(player.getWaitingFor()).to.be.undefined;
   });
+  it('Includes buffer gas for non solo games', function() {
+    const player = TestPlayers.BLUE.newPlayer();
+    const player2= TestPlayers.RED.newPlayer();
+    Game.newInstance('foobar', [player, player2], player);
+    const option = player.getStandardProjectOption();
+    const bufferGas = option.cards.find((card) => card.name === CardName.BUFFER_GAS_STANDARD_PROJECT);
+    expect(bufferGas).not.to.be.undefined;
+  });
+  it('Omits buffer gas for non solo games', function() {
+    const player = TestPlayers.BLUE.newPlayer();
+    Game.newInstance('foobar', [player], player);
+    const option = player.getStandardProjectOption();
+    const bufferGas = option.cards.find((card) => card.name === CardName.BUFFER_GAS_STANDARD_PROJECT);
+    expect(bufferGas).to.be.undefined;
+  });
   it('serialization test for pickedCorporationCard', () => {
     const player = TestPlayers.BLUE.newPlayer();
     player.pickedCorporationCard = new SaturnSystems();

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -31,6 +31,10 @@ export class TestPlayer extends Player {
 
   public tagsForTest: Partial<TagsForTest> | undefined = undefined;
 
+  public getStandardProjectOption() {
+    return super.getStandardProjectOption();
+  }
+
   public getTagCount(tag: Tags, includeEventsTags:boolean = false, includeWildcardTags:boolean = true): number {
     if (this.tagsForTest !== undefined) {
       return this.tagsForTest[tag] || 0;

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -8,6 +8,7 @@ import {OrOptions} from '../../src/inputs/OrOptions';
 import {SelectSpace} from '../../src/inputs/SelectSpace';
 import {SpaceBonus} from '../../src/SpaceBonus';
 import {Turmoil} from '../../src/turmoil/Turmoil';
+import {TestPlayer} from '../TestPlayer';
 import {TestingUtils, setCustomGameOptions, TestPlayers} from '../TestingUtils';
 import {Reds} from '../../src/turmoil/parties/Reds';
 import {ReleaseOfInertGases} from '../../src/cards/base/ReleaseOfInertGases';
@@ -27,7 +28,7 @@ import {IParty} from '../../src/turmoil/parties/IParty';
 import {GreeneryStandardProject} from '../../src/cards/base/standardProjects/GreeneryStandardProject';
 
 describe('Turmoil', function() {
-  let player : Player; let player2 : Player; let game : Game; let turmoil: Turmoil;
+  let player : TestPlayer; let player2 : Player; let game : Game; let turmoil: Turmoil;
 
   beforeEach(function() {
     player = TestPlayers.BLUE.newPlayer();


### PR DESCRIPTION
The check to show buffer gas was relying on the game option versus checking for solo mode. This moves the check to `Player` and looks for solo mode. Unit test was added to verify this logic.