### PR TITLE
log uncaught exceptions

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,10 @@ import {GameLoader} from './database/GameLoader';
 import {ServeApp} from './routes/ServeApp';
 import {ServeAsset} from './routes/ServeAsset';
 
+process.on('uncaughtException', (err: any) => {
+  console.error('UNCAUGHT EXCEPTION', err);
+});
+
 const serverId = process.env.SERVER_ID || GameHandler.INSTANCE.generateRandomId('');
 const route = new Route();
 


### PR DESCRIPTION
The default uncaught exception handler stops the node process. This is a problem since heroku doesn't re-start the app. This implements an uncaught exception handler so that the node process does not stop.

https://nodejs.org/api/process.html#process_event_uncaughtexception

With this application this should only prevent one game from working versus taking down the application. This should allow us to determine what went wrong versus today where we have to hope a good willed developer redeploys the app.