### PR TITLE
should only show Buffer Gas for solo games

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1676,7 +1676,7 @@ export class Player implements ISerializable<SerializedPlayer> {
           return false;
         }
         // only show buffer gas in solo mode
-        if (card.name === CardName.BUFFER_GAS_STANDARD_PROJECT && this.game.isSoloMode()) {
+        if (card.name === CardName.BUFFER_GAS_STANDARD_PROJECT && this.game.isSoloMode() === false) {
           return false;
         }
         return true;

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -125,20 +125,20 @@ describe('Player', function() {
     player.process([['1']]);
     expect(player.getWaitingFor()).to.be.undefined;
   });
-  it('Includes buffer gas for non solo games', function() {
+  it('Omits buffer gas for non solo games', function() {
     const player = TestPlayers.BLUE.newPlayer();
     const player2= TestPlayers.RED.newPlayer();
     Game.newInstance('foobar', [player, player2], player);
     const option = player.getStandardProjectOption();
     const bufferGas = option.cards.find((card) => card.name === CardName.BUFFER_GAS_STANDARD_PROJECT);
-    expect(bufferGas).not.to.be.undefined;
+    expect(bufferGas).to.be.undefined;
   });
-  it('Omits buffer gas for non solo games', function() {
+  it('Includes buffer gas for non solo games', function() {
     const player = TestPlayers.BLUE.newPlayer();
     Game.newInstance('foobar', [player], player);
     const option = player.getStandardProjectOption();
     const bufferGas = option.cards.find((card) => card.name === CardName.BUFFER_GAS_STANDARD_PROJECT);
-    expect(bufferGas).to.be.undefined;
+    expect(bufferGas).not.to.be.undefined;
   });
   it('serialization test for pickedCorporationCard', () => {
     const player = TestPlayers.BLUE.newPlayer();


### PR DESCRIPTION
The logic implemented with unit tests for Buffer Gas I had completely backwards and only showed Buffer Gas for multi player games. This shows buffer gas only for solo games. Closes #2961 