### PR TITLE
add log for multiplier production cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -356,6 +356,16 @@ export class Player implements ISerializable<SerializedPlayer> {
 
     const modifier = amount > 0 ? 'increased' : 'decreased';
 
+    // Gaining production from multiplier cards
+    if (game !== undefined && fromPlayer === undefined && amount > 0) {
+      game.log('${0}\'s ${1} production ${2} by ${3}', (b) =>
+        b.player(this)
+          .string(resource)
+          .string(modifier)
+          .number(Math.abs(amount)));
+    }
+
+    // Production reduced by other players
     if (game !== undefined && fromPlayer !== undefined && amount < 0) {
       if (fromPlayer !== this && this.removingPlayers.includes(fromPlayer.id) === false) {
         this.removingPlayers.push(fromPlayer.id);

--- a/src/cards/base/Cartel.ts
+++ b/src/cards/base/Cartel.ts
@@ -26,7 +26,7 @@ export class Cartel extends Card implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH) + 1);
+    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH) + 1, player.game);
     return undefined;
   }
 }

--- a/src/cards/base/EnergySaving.ts
+++ b/src/cards/base/EnergySaving.ts
@@ -28,7 +28,7 @@ export class EnergySaving extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.addProduction(Resources.ENERGY, player.game.getCitiesInPlay());
+    player.addProduction(Resources.ENERGY, player.game.getCitiesInPlay(), player.game);
     return undefined;
   }
 }

--- a/src/cards/base/Insects.ts
+++ b/src/cards/base/Insects.ts
@@ -27,7 +27,7 @@ export class Insects extends Card implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.PLANTS, player.getTagCount(Tags.PLANT));
+    player.addProduction(Resources.PLANTS, player.getTagCount(Tags.PLANT), player.game);
     return undefined;
   }
 }

--- a/src/cards/base/MirandaResort.ts
+++ b/src/cards/base/MirandaResort.ts
@@ -29,7 +29,7 @@ export class MirandaResort extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH));
+    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH), player.game);
     return undefined;
   }
   public getVictoryPoints() {

--- a/src/cards/base/PowerGrid.ts
+++ b/src/cards/base/PowerGrid.ts
@@ -26,7 +26,7 @@ export class PowerGrid extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    player.addProduction(Resources.ENERGY, 1 + player.getTagCount(Tags.ENERGY));
+    player.addProduction(Resources.ENERGY, 1 + player.getTagCount(Tags.ENERGY), player.game);
     return undefined;
   }
 }

--- a/src/cards/base/Satellites.ts
+++ b/src/cards/base/Satellites.ts
@@ -27,7 +27,7 @@ export class Satellites extends Card implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, 1 + player.getTagCount(Tags.SPACE));
+    player.addProduction(Resources.MEGACREDITS, 1 + player.getTagCount(Tags.SPACE), player.game);
     return undefined;
   }
 }

--- a/src/cards/base/TollStation.ts
+++ b/src/cards/base/TollStation.ts
@@ -31,7 +31,7 @@ export class TollStation extends Card implements IProjectCard {
       .filter((aPlayer) => aPlayer !== player)
       .map((opponent) => opponent.getTagCount(Tags.SPACE, false, false))
       .reduce((a, c) => a + c, 0);
-    player.addProduction(Resources.MEGACREDITS, amount);
+    player.addProduction(Resources.MEGACREDITS, amount, player.game);
     return undefined;
   }
 }

--- a/src/cards/base/Zeppelins.ts
+++ b/src/cards/base/Zeppelins.ts
@@ -30,7 +30,7 @@ export class Zeppelins extends Card implements IProjectCard {
     });
   }
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, player.game.getCitiesInPlayOnMars());
+    player.addProduction(Resources.MEGACREDITS, player.game.getCitiesInPlayOnMars(), player.game);
     return undefined;
   }
   public getVictoryPoints() {

--- a/src/cards/colonies/EcologyResearch.ts
+++ b/src/cards/colonies/EcologyResearch.ts
@@ -32,7 +32,7 @@ export class EcologyResearch extends Card implements IProjectCard {
 
   public play(player: Player) {
     const coloniesCount = player.getColoniesCount();
-    player.addProduction(Resources.PLANTS, coloniesCount);
+    player.addProduction(Resources.PLANTS, coloniesCount, player.game);
 
     const animalCards = player.getResourceCards(ResourceType.ANIMAL);
     if (animalCards.length) {

--- a/src/cards/colonies/QuantumCommunications.ts
+++ b/src/cards/colonies/QuantumCommunications.ts
@@ -39,7 +39,7 @@ export class QuantumCommunications extends Card implements IProjectCard {
     player.game.colonies.forEach((colony) => {
       coloniesCount += colony.colonies.length;
     });
-    player.addProduction(Resources.MEGACREDITS, coloniesCount);
+    player.addProduction(Resources.MEGACREDITS, coloniesCount, player.game);
     return undefined;
   }
 

--- a/src/cards/venusNext/Gyropolis.ts
+++ b/src/cards/venusNext/Gyropolis.ts
@@ -36,7 +36,7 @@ export class Gyropolis extends Card {
   public play(player: Player) {
     const tags: Array<Tags> = [Tags.VENUS, Tags.EARTH];
     player.addProduction(Resources.ENERGY, -2);
-    player.addProduction(Resources.MEGACREDITS, player.getMultipleTagCount(tags));
+    player.addProduction(Resources.MEGACREDITS, player.getMultipleTagCount(tags), player.game);
     return new SelectSpace('Select space for city tile', player.game.board.getAvailableSpacesForCity(player), (space: ISpace) => {
       player.game.addCityTile(player, space.id);
       return undefined;

--- a/src/cards/venusNext/LunaMetropolis.ts
+++ b/src/cards/venusNext/LunaMetropolis.ts
@@ -28,7 +28,7 @@ export class LunaMetropolis extends Card {
     });
   };
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH) + 1);
+    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.EARTH) + 1, player.game);
     player.game.addCityTile(player, SpaceName.LUNA_METROPOLIS, SpaceType.COLONY);
     return undefined;
   }

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -38,7 +38,7 @@ export class SulphurExports extends Card {
   }
 
   public play(player: Player) {
-    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.VENUS) + 1 );
+    player.addProduction(Resources.MEGACREDITS, player.getTagCount(Tags.VENUS) + 1, player.game);
     player.game.increaseVenusScaleLevel(player, 1);
     return undefined;
   }

--- a/tests/cards/base/Cartel.spec.ts
+++ b/tests/cards/base/Cartel.spec.ts
@@ -3,16 +3,20 @@ import {Cartel} from '../../../src/cards/base/Cartel';
 import {ImportedHydrogen} from '../../../src/cards/base/ImportedHydrogen';
 import {InterstellarColonyShip} from '../../../src/cards/base/InterstellarColonyShip';
 import {LunarBeam} from '../../../src/cards/base/LunarBeam';
+import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Cartel', function() {
-  let card : Cartel; let player : Player;
+  let card : Cartel; let player : Player; let game : Game;
 
   beforeEach(function() {
     card = new Cartel();
     player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+    game = Game.newInstance('foobar', [player, redPlayer], player);
+    player.game = game;
   });
 
   it('Should play', function() {

--- a/tests/cards/base/MirandaResort.spec.ts
+++ b/tests/cards/base/MirandaResort.spec.ts
@@ -3,11 +3,16 @@ import {BusinessNetwork} from '../../../src/cards/base/BusinessNetwork';
 import {MirandaResort} from '../../../src/cards/base/MirandaResort';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
+import {Game} from '../../../src/Game';
 
 describe('MirandaResort', function() {
   it('Should play', function() {
     const card = new MirandaResort();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = Game.newInstance('foobar', [player, redPlayer], player);
+    player.game = game;
+
     player.playedCards.push(new BusinessNetwork());
     const action = card.play(player);
     expect(action).is.undefined;

--- a/tests/cards/base/PowerGrid.spec.ts
+++ b/tests/cards/base/PowerGrid.spec.ts
@@ -2,11 +2,15 @@ import {expect} from 'chai';
 import {PowerGrid} from '../../../src/cards/base/PowerGrid';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
+import {Game} from '../../../src/Game';
 
 describe('PowerGrid', function() {
   it('Should play', function() {
     const card = new PowerGrid();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = Game.newInstance('foobar', [player, redPlayer], player);
+    player.game = game;
     const action = card.play(player);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.ENERGY)).to.eq(1);

--- a/tests/cards/base/Satellites.spec.ts
+++ b/tests/cards/base/Satellites.spec.ts
@@ -2,11 +2,15 @@ import {expect} from 'chai';
 import {Satellites} from '../../../src/cards/base/Satellites';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
+import {Game} from '../../../src/Game';
 
 describe('Satellites', function() {
   it('Should play', function() {
     const card = new Satellites();
     const player = TestPlayers.BLUE.newPlayer();
+    const redPlayer = TestPlayers.RED.newPlayer();
+    const game = Game.newInstance('foobar', [player, redPlayer], player);
+    player.game = game;
     const action = card.play(player);
     expect(action).is.undefined;
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(1);


### PR DESCRIPTION
This closes #2956.

Only log the production gain for card with variable gain such as Cartel, Miranda Resorts, etc.