### PR TITLE
Add Desperate Measures test

### DIFF
--- a/tests/cards/ares/DesperateMeasures.spec.ts
+++ b/tests/cards/ares/DesperateMeasures.spec.ts
@@ -46,7 +46,7 @@ describe('DesperateMeasures', function() {
     expect(game.getTemperature()).eq(priorTemp + 2);
   });
 
-  it('hazard tile with player marker can\'t be played on', function() {
+  it('hazard tile with player marker cannot be played on', function() {
     const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
     expect(game.board.getAvailableSpacesOnLand(player).map((s) => s.id)).contains(protectedDustStorm.id);
@@ -54,5 +54,25 @@ describe('DesperateMeasures', function() {
     card.play(player).cb(protectedDustStorm);
 
     expect(game.board.getAvailableSpacesOnLand(player).map((s) => s.id)).not.contains(protectedDustStorm.id);
+  });
+
+  it('hazard tile with player marker is not removed after placing the sixth ocean', function() {
+    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
+    card.play(player).cb(protectedDustStorm);
+
+    // The sixth ocean removes dust storms.
+    AresTestHelper.addOcean(game, player);
+    AresTestHelper.addOcean(game, player);
+    AresTestHelper.addOcean(game, player);
+    AresTestHelper.addOcean(game, player);
+    AresTestHelper.addOcean(game, player);
+
+    let mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(game)).get(TileType.DUST_STORM_MILD);
+    expect(mildDustStorms).has.length(3);
+    AresTestHelper.addOcean(game, player);
+    mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(game)).get(TileType.DUST_STORM_MILD);
+    expect(mildDustStorms).has.length(1);
+    expect(mildDustStorms![0].id).eq(protectedDustStorm.id);
   });
 });


### PR DESCRIPTION
hazard tile with player marker is not removed after placing the sixth ocean

I wrote this to track down bug #2904 but it is not reoccurring, even via manual test.