### PR TITLE
Game End page tables rework

### DIFF
--- a/src/VictoryPointsBreakdown.ts
+++ b/src/VictoryPointsBreakdown.ts
@@ -35,11 +35,11 @@ export class VictoryPointsBreakdown {
         break;
       case 'milestones':
         this.milestones += points;
-        if (message !== undefined) this.detailsMilestones.push(message+': '+points);
+        if (message !== undefined) this.detailsMilestones.push(message+':'+points);
         break;
       case 'awards':
         this.awards += points;
-        if (message !== undefined) this.detailsAwards.push(message+': '+points);
+        if (message !== undefined) this.detailsAwards.push(message+':'+points);
         break;
       case 'greenery':
         this.greenery += points;
@@ -49,7 +49,7 @@ export class VictoryPointsBreakdown {
         break;
       case 'victoryPoints':
         this.victoryPoints += points;
-        if (message !== undefined) this.detailsCards.push(message+': '+points);
+        if (message !== undefined) this.detailsCards.push(message+':'+points);
         break;
       case 'moon colony':
         this.moonColonies += points;

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -25,9 +25,6 @@ export const GameEnd = Vue.component('game-end', {
     'Button': Button,
   },
   methods: {
-    getEndGamePlayerHighlightColorClass: function(color: string): string {
-      return playerColorClass(color.toLowerCase(), 'bg');
-    },
     getEndGamePlayerRowColorClass: function(color: string): string {
       return playerColorClass(color.toLowerCase(), 'bg_transparent');
     },
@@ -104,33 +101,40 @@ export const GameEnd = Vue.component('game-end', {
                     </a>
                 </div>
                 <div v-if="!isSoloGame() || player.isSoloModeWin" class="game-end-winer-announcement">
-                    <span v-for="p in getWinners()"><span :class="'log-player ' + getEndGamePlayerHighlightColorClass(p.color)">{{ p.name }}</span></span> won!
+                    <span v-for="p in getWinners()"><span :class="'log-player ' + getEndGamePlayerRowColorClass(p.color)">{{ p.name }}</span></span> won!
                 </div>
                 <div class="game_end_victory_points">
                     <h2 v-i18n>Victory points breakdown after<span> {{player.generation}} </span>generations</h2>
-                    <table class="table game_end_table">
+                    <table id="table" class="table game_end_table">
                         <thead>
                             <tr v-i18n>
-                                <th>Player</th>
-                                <th>Corporation</th>
-                                <th>TR</th>
-                                <th>Milestones</th>
-                                <th>Awards</th>
-                                <th>Greenery</th>
-                                <th>City</th>
+                                <th><div class="card-delegate"></div></th>
+                                <th class="game-end-clock">&#x1F551;</th>
+                                <th><div class="mc-icon"></div></th>
+                                <th><div class="tr"></div></th>
+                                <th><div class="m-and-a" title="Milestones points">M</div></th>
+                                <th><div class="m-and-a" title="Awards points">A</div></th>
+                                <th><div class="table-forest-tile"></div></th>
+                                <th><div class="table-city-tile"></div></th>
                                 <th v-if="player.moon !== undefined">Moon Roads</th>
                                 <th v-if="player.moon !== undefined">Moon Colonies</th>
                                 <th v-if="player.moon !== undefined">Moon Mines</th>
-                                <th>VP</th>
+                                <th><div class="vp">VP</div></th>
                                 <th class="game-end-total"><div class="game-end-total-column">Total</div></th>
-                                <th>M€</th>
-                                <th v-if="player.gameOptions.showTimers">Timer</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr v-for="p in getSortedPlayers()" :class="getEndGamePlayerRowColorClass(p.color)">
-                                <td><a :href="'/player?id='+p.id+'&noredirect'">{{ p.name }}</a></td>
-                                <td v-i18n>{{ p.corporationCard === undefined ? "" : p.corporationCard.name }}</td>
+                                <td>
+                                  <a :href="'/player?id='+p.id+'&noredirect'">{{ p.name }}</a>
+                                  <div class="column-corporation">{{ p.corporationCard === undefined ? "" : p.corporationCard.name }}</div>
+                                </td>
+                                <td class="game-end-clock">
+                                  <div v-if="player.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
+                                </td>
+                                <td class="game-end-mc">
+                                  <div>{{ p.megaCredits }}</div>
+                                </td>
                                 <td>{{ p.victoryPointsBreakdown.terraformRating }}</td>
                                 <td>{{ p.victoryPointsBreakdown.milestones }}</td>
                                 <td>{{ p.victoryPointsBreakdown.awards }}</td>
@@ -141,8 +145,6 @@ export const GameEnd = Vue.component('game-end', {
                                 <td v-if="player.moon !== undefined">{{ p.victoryPointsBreakdown.moonMines }}</td>
                                 <td>{{ p.victoryPointsBreakdown.victoryPoints }}</td>
                                 <td class="game-end-total">{{ p.victoryPointsBreakdown.total }}</td>
-                                <td class="game-end-mc">{{ p.megaCredits }}M€</td>
-                                <td v-if="player.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</td>
                             </tr>
                         </tbody>
                     </table>
@@ -151,16 +153,25 @@ export const GameEnd = Vue.component('game-end', {
                     <div class="game-end-flexrow">
                         <div v-for="p in getSortedPlayers()" class="game-end-column">
                             <div class="game-end-winer-scorebreak-player-title">
-                                <span :class="'log-player ' + getEndGamePlayerHighlightColorClass(p.color)"><a :href="'/player?id='+p.id+'&noredirect'">{{p.name}}</a></span>
+                                <div :class="'game-end-player ' + getEndGamePlayerRowColorClass(p.color)"><a :href="'/player?id='+p.id+'&noredirect'">{{p.name}}</a></div>
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsCards">
-                                {{v}}
+                              <div class="game-end-column-row">
+                                <div class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
+                                <div class="game-end-column-text">{{v.split(':', 2)[0]}}</div>
+                              </div>
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsMilestones">
-                                {{v}}
+                              <div class="game-end-column-row">
+                                <div class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
+                                <div class="game-end-column-text">{{v.split(':', 2)[0]}}</div>
+                              </div>
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsAwards">
-                                {{v}}
+                              <div class="game-end-column-row">
+                                <div class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
+                                <div class="game-end-column-text">{{v.split(':', 2)[0]}}</div>
+                              </div>
                             </div>
                         </div>
                     </div>
@@ -180,10 +191,9 @@ export const GameEnd = Vue.component('game-end', {
                         :shouldNotify="false"></board>
                 </div>
                 <div class="game_end_block--log game-end-column">
-                    <h2 v-i18n>Final game log</h2>
-                    <log-panel :color="player.color" :generation="player.generation" :id="player.id" :lastSoloGeneration="player.lastSoloGeneration" :players="player.players"></log-panel>
+                  <log-panel :color="player.color" :generation="player.generation" :id="player.id" :lastSoloGeneration="player.lastSoloGeneration" :players="player.players"></log-panel>                
                 </div>
-                </div>
+              </div>
             </div>
         </div>
     `,

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -109,8 +109,6 @@ export const GameEnd = Vue.component('game-end', {
                         <thead>
                             <tr v-i18n>
                                 <th><div class="card-delegate"></div></th>
-                                <th class="game-end-clock">&#x1F551;</th>
-                                <th><div class="mc-icon"></div></th>
                                 <th><div class="tr"></div></th>
                                 <th><div class="m-and-a" title="Milestones points">M</div></th>
                                 <th><div class="m-and-a" title="Awards points">A</div></th>
@@ -121,6 +119,8 @@ export const GameEnd = Vue.component('game-end', {
                                 <th v-if="player.moon !== undefined">Moon Mines</th>
                                 <th><div class="vp">VP</div></th>
                                 <th class="game-end-total"><div class="game-end-total-column">Total</div></th>
+                                <th><div class="mc-icon"></div></th>
+                                <th class="game-end-clock">&#x1F551;</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -128,12 +128,6 @@ export const GameEnd = Vue.component('game-end', {
                                 <td>
                                   <a :href="'/player?id='+p.id+'&noredirect'">{{ p.name }}</a>
                                   <div class="column-corporation">{{ p.corporationCard === undefined ? "" : p.corporationCard.name }}</div>
-                                </td>
-                                <td class="game-end-clock">
-                                  <div v-if="player.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
-                                </td>
-                                <td class="game-end-mc">
-                                  <div>{{ p.megaCredits }}</div>
                                 </td>
                                 <td>{{ p.victoryPointsBreakdown.terraformRating }}</td>
                                 <td>{{ p.victoryPointsBreakdown.milestones }}</td>
@@ -145,6 +139,12 @@ export const GameEnd = Vue.component('game-end', {
                                 <td v-if="player.moon !== undefined">{{ p.victoryPointsBreakdown.moonMines }}</td>
                                 <td>{{ p.victoryPointsBreakdown.victoryPoints }}</td>
                                 <td class="game-end-total">{{ p.victoryPointsBreakdown.total }}</td>
+                                <td class="game-end-mc">
+                                  <div>{{ p.megaCredits }}</div>
+                                </td>
+                                <td class="game-end-clock">
+                                  <div v-if="player.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -105,7 +105,7 @@ export const GameEnd = Vue.component('game-end', {
                 </div>
                 <div class="game_end_victory_points">
                     <h2 v-i18n>Victory points breakdown after<span> {{player.generation}} </span>generations</h2>
-                    <table id="table" class="table game_end_table">
+                    <table class="table game_end_table">
                         <thead>
                             <tr v-i18n>
                                 <th><div class="card-delegate"></div></th>

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -31,18 +31,19 @@ body {
 }
 
 .game_end_table {
-    border: 2px solid #7b7b7b;
     width: auto;
     font-family: Prototype;
+    background: #222;
 
     td, th {
         text-align: center !important;
-        border-bottom: .05rem solid #7b7b7b !important;
-        padding: 5px 20px;
-        text-shadow: 0 0px 2px black, 0 2px 1px black;
+        border: none;
+        padding: 5px 10px;
+        text-shadow: 0 0px 2px black, 0 1px 1px black;
         font-weight: normal;
-        min-width: 80px;
-        max-width: 400px;
+        min-width: 60px;
+        max-width: 320px;
+        line-height: 30px;
     }
 
     a {
@@ -66,7 +67,7 @@ body {
         height: 40px;
         background-size: 34px 40px;
         vertical-align: middle;
-        margin-left: 3px;
+        margin-left: 2px;
     }
     .table-forest-tile {
         background-image: url(./assets/tiles/greenery_no_O2.png);
@@ -74,14 +75,13 @@ body {
         height: 40px;
         background-size: 34px 40px;
         vertical-align: middle;
-        margin-left: 3px;
+        margin-left: 2px;
     }
     .tr {
         background-image: url(./assets/resources/tr.png);
         width: 46px;
         height: 38px;
         background-size: 46px 38px;
-        border-radius: 10px;
     }
     .vp {
         font-size: 18px;
@@ -101,7 +101,7 @@ body {
         color: #ffcc64;
         width: 38px;
         height: 38px;
-        background: #222;
+        background: #000;
         line-height: 38px;
         border-radius: 5px;
         cursor: context-menu;
@@ -147,7 +147,7 @@ body {
         text-align: center;
         font-family: 'Prototype';
         letter-spacing: 1px;
-        text-shadow: 0 0px 2px black, 0 2px 1px black;
+        text-shadow: 0 0px 2px black, 0 1px 1px black;
         font-size: 23px;
     }
 
@@ -184,16 +184,12 @@ body {
 
 .game-end-total {
   font-size: 30px;
-  border-left: 2px solid #7b7b7b;
 }
 
 .game-end-mc {
-  font-size: smaller;
-}
-.game-end-clock {
-    border-left: 2px solid #7b7b7b;
+  opacity: 0.5;
 }
 
 .game-end-timer {
-  font-size: smaller;
+  opacity: 0.5;
 }

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -38,7 +38,7 @@ body {
     td, th {
         text-align: center !important;
         border: none;
-        padding: 5px 10px;
+        padding: 10px;
         text-shadow: 0 0px 2px black, 0 1px 1px black;
         font-weight: normal;
         min-width: 60px;

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -1,3 +1,7 @@
+body {
+    background: rgb(50,53,59);
+}
+
 .game_end_success, .game_end_fail {
     max-width: 820px;
     margin: 30px auto;
@@ -29,16 +33,105 @@
 .game_end_table {
     border: 2px solid #7b7b7b;
     width: auto;
+    font-family: Prototype;
 
     td, th {
         text-align: center !important;
         border-bottom: .05rem solid #7b7b7b !important;
-        padding: 10px 20px;
-        text-shadow: 2px 2px 4px #000000;
+        padding: 5px 20px;
+        text-shadow: 0 0px 2px black, 0 2px 1px black;
+        font-weight: normal;
+        min-width: 80px;
+        max-width: 400px;
     }
 
     a {
         text-decoration: underline;
+        font-size: 30px;
+    }
+
+    .card-delegate {
+        display: inline-block;
+        background-image: url(./assets/misc/delegate.png);
+        width: 30px;
+        height: 36px;
+        background-size: 30px 36px;
+        vertical-align: middle;
+        filter: drop-shadow(0px 0px 1px black);
+    }
+    .table-city-tile {
+        background-image: url(./assets/tiles/city.png);
+        filter: brightness(0.8) drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.5));
+        width: 34px;
+        height: 40px;
+        background-size: 34px 40px;
+        vertical-align: middle;
+        margin-left: 3px;
+    }
+    .table-forest-tile {
+        background-image: url(./assets/tiles/greenery_no_O2.png);
+        width: 34px;
+        height: 40px;
+        background-size: 34px 40px;
+        vertical-align: middle;
+        margin-left: 3px;
+    }
+    .tr {
+        background-image: url(./assets/resources/tr.png);
+        width: 46px;
+        height: 38px;
+        background-size: 46px 38px;
+        border-radius: 10px;
+    }
+    .vp {
+        font-size: 18px;
+        color: black;
+        font-weight: normal !important;
+        text-shadow: 0 0 5px darkorange;
+        width: 38px;
+        height: 38px;
+        line-height: 38px;
+        text-align: center;
+        border-radius: 50%;
+        background-color: #cda282;
+        background: linear-gradient(#cc8b00, #805700, #805700);
+        box-shadow: 0 1px 1px 0px black;
+    }
+    .m-and-a{
+        color: #ffcc64;
+        width: 38px;
+        height: 38px;
+        background: #222;
+        line-height: 38px;
+        border-radius: 5px;
+        cursor: context-menu;
+    }
+    .mc-icon {
+        background-image: url(assets/resources/megacredit.png);
+        width: 26px;
+        height: 26px;
+        display: inline-block;
+        background-size: contain;
+        position: relative;
+        vertical-align: sub;
+        text-shadow: none;
+    }
+    .mc-icon::after {
+        position: absolute;
+        content: "€";
+        color: rgba(0, 0, 0, 0.3);
+        font-style: normal;
+        font-family: Arial;
+        font-weight: bold;
+        width: 26px;
+        height: 26px;
+        text-align: center;
+        line-height: 27px;
+        left: 0px;
+        font-size: 18px;
+    }
+    .column-corporation {
+        width: 300px;
     }
 }
 .game-end-flexrow {
@@ -46,18 +139,42 @@
     flex-flow: row wrap;
 
     .game-end-column {
-        min-width: 400px;
         padding-right: 20px;
         padding-bottom: 40px;
+    }
+
+    .game-end-player {
+        text-align: center;
+        font-family: 'Prototype';
+        letter-spacing: 1px;
+        text-shadow: 0 0px 2px black, 0 2px 1px black;
+        font-size: 23px;
+    }
+
+    .game-end-column-row {
+        display: flex;
+        background: #222;
+        width: 275px;
+        font-size: 18px;
+    }
+
+    .game-end-column-vp {
+        width: 45px;
+        font-weight: bold;
+        text-align: center;
+    }
+    .game-end-column-text {
+        width: 215px;
     }
 }
 
 .game-end-winer-scorebreak-player-title {
-    font-size: 32px
+    font-size: 32px;
+    width: 275px;
 }
 
 .game-end-total-column {
-    padding: 5px 30px;
+    padding: 0px 30px;
 }
 
 .game-end-winer-announcement {
@@ -66,12 +183,15 @@
 }
 
 .game-end-total {
-  font-size: larger;
-  border-right: 0.05rem solid #7b7b7b ;
+  font-size: 30px;
+  border-left: 2px solid #7b7b7b;
 }
 
 .game-end-mc {
   font-size: smaller;
+}
+.game-end-clock {
+    border-left: 2px solid #7b7b7b;
 }
 
 .game-end-timer {


### PR DESCRIPTION
## Main goals
- icons in the table header 
- Combining the two wide cells (player+corporation) in one
- bigger numbers (so posted results in discord to be more visible without opening the original image)
- vp details columns of 4 players to fit the mobile width 
- vp details columns to easily show the points - vp are now aligned in their own sub-column
 
![tables](https://user-images.githubusercontent.com/6917565/111885617-21986780-89c9-11eb-9b13-3198495475d4.png)

![Untitled2](https://user-images.githubusercontent.com/6917565/111885492-67086500-89c8-11eb-8dc5-902eb0dded84.png)

## Further thoughts
- column MC -  I like the idea this to be completely gone and when there is a tie a MC icon with the value in it is displayed next to the Total vps for that player. E.g. 77 [50] - 77vp total and 50mc. I can't it at the moment, so I leave it for now as it is.
- time + mc columns position - I agree that those two show more of a meta info, not real VPs, but I think "Total" column being last looks better. 
- table VPs per generation - this is in the "pipeline" that will come in a different pr
![Untitled3](https://user-images.githubusercontent.com/6917565/111885778-3f1a0100-89ca-11eb-8d62-0806a734ac17.png)
A table that shows the total and gained vps per generation. The layout/visuals should be similar to the main table.


