### PR TITLE
remove prev-game-age for good

### DIFF
--- a/src/routes/ApiWaitingFor.ts
+++ b/src/routes/ApiWaitingFor.ts
@@ -22,8 +22,7 @@ export class ApiWaitingFor extends Handler {
 
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
     const playerId = String(ctx.url.searchParams.get('id'));
-    // TODO bafolts remove prev-game-age by 2020-04-01
-    const gameAge = Number(ctx.url.searchParams.get('gameAge') ?? ctx.url.searchParams.get('prev-game-age'));
+    const gameAge = Number(ctx.url.searchParams.get('gameAge'));
     const undoCount = Number(ctx.url.searchParams.get('undoCount'));
     ctx.gameLoader.getByPlayerId(playerId, (game) => {
       if (game === undefined) {

--- a/tests/routes/ApiWaitingFor.spec.ts
+++ b/tests/routes/ApiWaitingFor.spec.ts
@@ -25,7 +25,7 @@ describe('ApiWaitingFor', function() {
   });
 
   it('fails when game not found', () => {
-    req.url = '/api/waitingfor?id=game-id&prev-game-age=123';
+    req.url = '/api/waitingfor?id=game-id&gameAge=123&undoCount=0';
     ctx.url = new URL('http://boo.com' + req.url);
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
     expect(res.content).eq('Not found: cannot find game for that player');
@@ -33,7 +33,7 @@ describe('ApiWaitingFor', function() {
 
   it('fails when player not found', () => {
     const player = TestPlayers.BLACK.newPlayer();
-    req.url = '/api/waitingfor?id=' + player.id + '&prev-game-age=50';
+    req.url = '/api/waitingfor?id=' + player.id + '&gameAge=50&undoCount=0';
     ctx.url = new URL('http://boo.com' + req.url);
     const game = Game.newInstance('game-id', [player], player);
     ctx.gameLoader.add(game);
@@ -46,7 +46,7 @@ describe('ApiWaitingFor', function() {
 
   it('sends model', () => {
     const player = TestPlayers.BLACK.newPlayer();
-    req.url = '/api/waitingfor?id=' + player.id + '&prev-game-age=50';
+    req.url = '/api/waitingfor?id=' + player.id + '&gameAge=50&undoCount=0';
     ctx.url = new URL('http://boo.com' + req.url);
     const game = Game.newInstance('game-id', [player], player);
     ctx.gameLoader.add(game);


### PR DESCRIPTION
I was dual writing `prev-game-age` and `gameAge` to handle the transition for clients which may had been polling with `prev-game-age`. Removing for good now.