### PR TITLE
Make SelectHowToPayForProjectCard work with Moon cards.

### DIFF
--- a/src/PlayerInput.ts
+++ b/src/PlayerInput.ts
@@ -1,4 +1,4 @@
-
+import {ICard} from './cards/ICard';
 import {Message} from './Message';
 import {PlayerInputTypes} from './PlayerInputTypes';
 
@@ -8,4 +8,15 @@ export interface PlayerInput {
     options?: Array<PlayerInput>;
     title: string | Message;
     cb: (...item: any) => PlayerInput | undefined;
+}
+
+export namespace PlayerInput {
+  export function getCard<T extends ICard>(cards: Array<T>, cardName: string): {card: T, idx: number} {
+    const idx = cards.findIndex((card) => card.name === cardName);
+    if (idx === -1) {
+      throw new Error(`Card ${cardName} not found`);
+    }
+    const card = cards[idx];
+    return {card, idx};
+  }
 }

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -44,7 +44,7 @@ export const PaymentWidgetMixin = {
     },
     addValue: function(target: string, to: number, max?: number): void {
       const currentValue: number = (this as any)[target];
-      let maxValue: number = max !== undefined ? max : (this as any).player[target];
+      let maxValue: number = max ?? (this as any).player[target];
 
       if (target === 'megaCredits') {
         maxValue = this.getMegaCreditsMax();

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -77,7 +77,7 @@ export const PaymentWidgetMixin = {
     setMaxValue: function(target: string, max?: number): void {
       let currentValue: number = (this as any)[target];
       const cardCost: number = (this as any).$data.cost;
-      let amountHave: number = max !== undefined ? max : (this as any).player[target];
+      let amountHave: number = max ?? (this as any).player[target];
 
       let amountNeed: number = cardCost;
       if (['titanium', 'steel', 'microbes', 'floaters'].includes(target)) {

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -42,9 +42,9 @@ export const PaymentWidgetMixin = {
 
       this.setRemainingMCValue();
     },
-    addValue: function(target: string, to: number): void {
+    addValue: function(target: string, to: number, max?: number): void {
       const currentValue: number = (this as any)[target];
-      let maxValue: number = (this as any).player[target];
+      let maxValue: number = max !== undefined ? max : (this as any).player[target];
 
       if (target === 'megaCredits') {
         maxValue = this.getMegaCreditsMax();
@@ -74,10 +74,10 @@ export const PaymentWidgetMixin = {
 
       (this as any)['megaCredits'] = Math.max(0, Math.min(this.getMegaCreditsMax(), remainingMC));
     },
-    setMaxValue: function(target: string): void {
+    setMaxValue: function(target: string, max?: number): void {
       let currentValue: number = (this as any)[target];
       const cardCost: number = (this as any).$data.cost;
-      let amountHave: number = (this as any).player[target];
+      let amountHave: number = max !== undefined ? max : (this as any).player[target];
 
       let amountNeed: number = cardCost;
       if (['titanium', 'steel', 'microbes', 'floaters'].includes(target)) {
@@ -91,7 +91,7 @@ export const PaymentWidgetMixin = {
       }
 
       while (currentValue < amountHave && currentValue < amountNeed) {
-        this.addValue(target, 1);
+        this.addValue(target, 1, max);
         currentValue++;
       }
     },

--- a/src/inputs/SelectHowToPayForProjectCard.ts
+++ b/src/inputs/SelectHowToPayForProjectCard.ts
@@ -2,11 +2,11 @@ import {PlayerInput} from '../PlayerInput';
 import {PlayerInputTypes} from '../PlayerInputTypes';
 import {HowToPay} from './HowToPay';
 import {IProjectCard} from '../cards/IProjectCard';
-import {CardName} from '../CardName';
 import {Units} from '../Units';
 import {MoonExpansion} from '../moon/MoonExpansion';
 import {Player} from '../Player';
 
+// TODO(kberg): Rename to SelectProjectCardToPlay
 export class SelectHowToPayForProjectCard implements PlayerInput {
   public inputType: PlayerInputTypes = PlayerInputTypes.SELECT_HOW_TO_PAY_FOR_PROJECT_CARD;
   public title = 'Play project card';
@@ -14,7 +14,7 @@ export class SelectHowToPayForProjectCard implements PlayerInput {
   public microbes: number;
   public floaters: number;
   public canUseHeat: boolean;
-  public reserveUnitsMap: Map<CardName, Units>;
+  public reserveUnits: Array<Units>;
 
   constructor(
     player: Player,
@@ -23,11 +23,8 @@ export class SelectHowToPayForProjectCard implements PlayerInput {
     this.microbes = player.getMicrobesCanSpend();
     this.floaters = player.getFloatersCanSpend();
     this.canUseHeat = player.canUseHeatAsMegaCredits;
-    this.reserveUnitsMap = new Map(this.cards.map((card) => {
-      if (card.reserveUnits === undefined) {
-        return [card.name, Units.EMPTY];
-      }
-      return [card.name, MoonExpansion.adjustedReserveCosts(player, card)];
-    }));
+    this.reserveUnits = this.cards.map((card) => {
+      return card.reserveUnits ? MoonExpansion.adjustedReserveCosts(player, card) : Units.EMPTY;
+    });
   }
 }

--- a/src/server/ServerModel.ts
+++ b/src/server/ServerModel.ts
@@ -38,7 +38,6 @@ import {SelectProductionToLose} from '../inputs/SelectProductionToLose';
 import {ShiftAresGlobalParameters} from '../inputs/ShiftAresGlobalParameters';
 import {SpectatorModel} from '../models/SpectatorModel';
 import {MoonModel} from '../models/MoonModel';
-import {CardName} from '../CardName';
 import {Units} from '../Units';
 import {SelectPartyToSendDelegate} from '../inputs/SelectPartyToSendDelegate';
 
@@ -264,7 +263,7 @@ function getWaitingFor(
     break;
   case PlayerInputTypes.SELECT_HOW_TO_PAY_FOR_PROJECT_CARD:
     const shtpfpc: SelectHowToPayForProjectCard = waitingFor as SelectHowToPayForProjectCard;
-    playerInputModel.cards = getCards(player, shtpfpc.cards, {showNewCost: true, reserveUnitMap: shtpfpc.reserveUnitsMap});
+    playerInputModel.cards = getCards(player, shtpfpc.cards, {showNewCost: true, reserveUnits: shtpfpc.reserveUnits});
     playerInputModel.microbes = shtpfpc.microbes;
     playerInputModel.floaters = shtpfpc.floaters;
     playerInputModel.canUseHeat = shtpfpc.canUseHeat;
@@ -351,7 +350,7 @@ function getCards(
   options: {
     showResources?: boolean,
     showNewCost?: boolean,
-    reserveUnitMap?: Map<CardName, Units>,
+    reserveUnits?: Array<Units>,
     enabled?: Array<boolean>, // If provided, then the cards with false in `enabled` are not selectable and grayed out
   } = {},
 ): Array<CardModel> {
@@ -363,7 +362,7 @@ function getCards(
     cardType: card.cardType,
     isDisabled: options.enabled?.[index] === false,
     warning: card.warning,
-    reserveUnits: options.reserveUnitMap?.get(card.name) || Units.EMPTY,
+    reserveUnits: options.reserveUnits ? options.reserveUnits[index] : Units.EMPTY,
     bonusResource: (card as IProjectCard).bonusResource,
     discount: card.cardDiscount,
   }));


### PR DESCRIPTION
This commit does a few things: it deals with keeping track of what the
proper remaining steel and titanium a player may use and applies it
throughout the algorithm. That was the most complicated part -- no --
writing the tests was the most complicated part.

There's a bit of code in SHPTFPC which uses the player's played cards,
and includes the self replicating robots as its source for card data.
That just seems wrong. Of the many changes in this commit, that's the
one I'm most surprised is in the code, and the one I most want someone
to scrutinize and evaluate.

I rewrote the tests, but just a bit -- to take advantage of things like
Partial<>.

Finally, there's a server-side change which verifies that someone can't
overspend their steel, consequently, they can't go negative. Now, this
won't be possible anymore because of all the client-side changes, but
I have manually verified this with Luna Train Station.