### PR TITLE
Game end and player board css fixes

### DIFF
--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -120,7 +120,7 @@ export const GameEnd = Vue.component('game-end', {
                                 <th><div class="vp">VP</div></th>
                                 <th class="game-end-total"><div class="game-end-total-column">Total</div></th>
                                 <th><div class="mc-icon"></div></th>
-                                <th class="game-end-clock">&#x1F551;</th>
+                                <th v-if="player.gameOptions.showTimers" class="clock-icon">&#x1F551;</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -142,7 +142,7 @@ export const GameEnd = Vue.component('game-end', {
                                 <td class="game-end-mc">
                                   <div>{{ p.megaCredits }}</div>
                                 </td>
-                                <td class="game-end-clock">
+                                <td>
                                   <div v-if="player.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
                                 </td>
                             </tr>

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -1,5 +1,5 @@
 body {
-    background: rgb(50,53,59);
+    background: rgb(53,57,63);
 }
 
 .game_end_success, .game_end_fail {
@@ -32,7 +32,6 @@ body {
 
 .game_end_table {
     width: auto;
-    font-family: Prototype;
     background: #222;
 
     td, th {
@@ -58,7 +57,7 @@ body {
         height: 36px;
         background-size: 30px 36px;
         vertical-align: middle;
-        filter: drop-shadow(0px 0px 1px black);
+        filter: drop-shadow(0px 0px 1px black) brightness(0.8);
     }
     .table-city-tile {
         background-image: url(./assets/tiles/city.png);
@@ -84,6 +83,7 @@ body {
         background-size: 46px 38px;
     }
     .vp {
+        font-family: 'Prototype';
         font-size: 18px;
         color: black;
         font-weight: normal !important;
@@ -115,6 +115,8 @@ body {
         position: relative;
         vertical-align: sub;
         text-shadow: none;
+        background-repeat: no-repeat;
+        filter: brightness(0.8);
     }
     .mc-icon::after {
         position: absolute;
@@ -129,6 +131,9 @@ body {
         line-height: 27px;
         left: 0px;
         font-size: 18px;
+    }
+    .clock-icon {
+        filter: brightness(0.8);
     }
     .column-corporation {
         width: 300px;
@@ -145,8 +150,6 @@ body {
 
     .game-end-player {
         text-align: center;
-        font-family: 'Prototype';
-        letter-spacing: 1px;
         text-shadow: 0 0px 2px black, 0 1px 1px black;
         font-size: 23px;
     }

--- a/src/styles/game_end.less
+++ b/src/styles/game_end.less
@@ -100,11 +100,13 @@ body {
     .m-and-a{
         color: #ffcc64;
         width: 38px;
-        height: 38px;
-        background: #000;
-        line-height: 38px;
-        border-radius: 5px;
+        height: 36px;
+        line-height: 36px;
+        background: #444;
+        border-radius: 3px;
         cursor: context-menu;
+        text-shadow: none;
+        font-weight: bold;
     }
     .mc-icon {
         background-image: url(assets/resources/megacredit.png);

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -191,7 +191,7 @@
 
 .tag-cards {
     background-image: url("./assets/sidebar/preferences_cards.png");
-    background-color: #0008 !important;
+    background-color: #000 !important;
     background-position: 0px;
 }
 .tag-vp {

--- a/src/styles/players_overview.less
+++ b/src/styles/players_overview.less
@@ -10,11 +10,12 @@
     line-height: 24px;
     height: 26px;
     letter-spacing: 0px;
-    margin-top: 32px;
+    margin-top: 34px;
     left: -17px;
     background: linear-gradient(to right, black, #aaa,#aaa, #aaa);
     color: black;
     clip-path: polygon(85% 0%, 100% 50%, 85% 100%, 0% 100%, 0% 0%);
+    z-index: 1;
 }
 
 .player-played-cards {
@@ -102,23 +103,22 @@
 
 .player-info-details {
     white-space: nowrap;
-    letter-spacing: 1px;
-    line-height: 19px;
+    line-height: 18px;
     width: 136px;
     color: #e6e1e1;
-    font-family: 'Prototype';
     .player-info-name {
         text-shadow: 0px 1px 1px #000;
-        font-size: 20px;
-        font-family: 'Prototype';
         overflow: hidden;
         text-overflow: ellipsis;
+        font-size: 20px;
+        line-height: 24px;
+        margin-top: -4px;
     } 
     .player-info-corp { 
-        font-size: 16px;
-        margin-bottom: 5px;
+        font-size: 18px;
         overflow: hidden;
         text-overflow: ellipsis;
+        height: 26px;
     }
 }
 
@@ -135,8 +135,8 @@
             position: relative;
             .megacredits-container {
                 position: absolute;
-                left: 12px;
-                top: -17px;
+                right: -6px;
+                top: -18px;
                 z-index: 10;
                 border-radius: 8px 8px 0px 1px;
                 padding: 8px 8px 0px 8px;
@@ -149,7 +149,7 @@
                     font-size: 15px;
                     font-style: normal;
                     font-family: Prototype;
-                    line-height: 21px;
+                    line-height: 20px;
                     text-align: center;
                 }
             }


### PR DESCRIPTION
Fixes: 
- Reverted to "Ubuntu" on the game and and player boards (forgot that Prototype does not display well non-english text)
- reverted the "cards in hand" back to black (my fault for making it a bit transparent)
- fixed the discount icon position on all cards in the player board
- fixed game end table when no timer option is selected
- (hopefully haven't missed/messed now)