### PR TITLE
add ETag for waiting for route

### DIFF
--- a/src/routes/ApiWaitingFor.ts
+++ b/src/routes/ApiWaitingFor.ts
@@ -29,7 +29,14 @@ export class ApiWaitingFor extends Handler {
         ctx.route.notFound(req, res, 'cannot find game for that player');
         return;
       }
+      const etag = `${playerId}:${game.gameAge}:${game.undoCount}`;
+      if (req.headers['if-none-match'] === etag) {
+        ctx.route.notModified(res);
+        return;
+      }
       try {
+        res.setHeader('Cache-Control', 'must-revalidate');
+        res.setHeader('ETag', etag);
         ctx.route.writeJson(res, this.getWaitingForModel(game.getPlayerById(playerId), gameAge, undoCount));
       } catch (err) {
         // This is basically impossible since getPlayerById ensures that the player is on that game.

--- a/tests/routes/ApiWaitingFor.spec.ts
+++ b/tests/routes/ApiWaitingFor.spec.ts
@@ -14,7 +14,7 @@ describe('ApiWaitingFor', function() {
   let ctx: IContext;
 
   beforeEach(() => {
-    req = {} as http.IncomingMessage;
+    req = {headers: {}} as http.IncomingMessage;
     res = new MockResponse();
     ctx = {
       route: new Route(),
@@ -28,6 +28,7 @@ describe('ApiWaitingFor', function() {
     req.url = '/api/waitingfor?id=game-id&gameAge=123&undoCount=0';
     ctx.url = new URL('http://boo.com' + req.url);
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.statusCode).eq(404);
     expect(res.content).eq('Not found: cannot find game for that player');
   });
 
@@ -41,6 +42,7 @@ describe('ApiWaitingFor', function() {
       throw new Error('player does not exist');
     };
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.statusCode).eq(404);
     expect(res.content).eq('Not found: player not found');
   });
 
@@ -51,6 +53,20 @@ describe('ApiWaitingFor', function() {
     const game = Game.newInstance('game-id', [player], player);
     ctx.gameLoader.add(game);
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.headers.get('ETag')).eq(`${player.id}:${game.gameAge}:${game.undoCount}`);
+    expect(res.statusCode).eq(200);
     expect(res.content).eq('{"result":"GO"}');
+  });
+
+  it('sends not modified', () => {
+    const player = TestPlayers.BLACK.newPlayer();
+    req.url = '/api/waitingfor?id=' + player.id + '&gameAge=50&undoCount=0';
+    ctx.url = new URL('http://boo.com' + req.url);
+    const game = Game.newInstance('game-id', [player], player);
+    ctx.gameLoader.add(game);
+    req.headers['if-none-match'] = `${player.id}:${game.gameAge}:${game.undoCount}`;
+    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
+    expect(res.statusCode).eq(304);
+    expect(res.content).eq('');
   });
 });

--- a/tests/routes/HttpMocks.ts
+++ b/tests/routes/HttpMocks.ts
@@ -3,7 +3,7 @@ import * as http from 'http';
 export class MockResponse {
   public headers: Map<string, string> = new Map();
   public content: string = '';
-  public statusCode: number = 0;
+  public statusCode: number = 200;
 
   public setHeader(key: string, value: string) {
     this.headers.set(key, value);


### PR DESCRIPTION
First usage of the `ETag` I think we can leverage for most routes. This implements for the waiting for route. During multi player games this should be hit often. This saves 100 bytes or so from the normal response. Over time this will add up to saved bandwidth!

![image](https://user-images.githubusercontent.com/2707843/112732660-e209d800-8f00-11eb-9484-162b22dbce3e.png)
