### PR TITLE
Fix the problem with selectHowToPay

### DIFF
--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -186,7 +186,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
         // We need not try to save heat since heat is paid last at value 1. We will never overspend in heat.
         // We do not need to save Ti either because Ti is paid last before heat. If we overspend, it is because of Ti.
         // We cannot reduce the amount of Ti and still pay enough.
-        this.steel -= saveOverSpendingUnits(this.availableSteel, this.player.steelValue);
+        this.steel -= saveOverSpendingUnits(this.steel, this.player.steelValue);
         this.floaters -= saveOverSpendingUnits(this.floaters, 3);
         this.microbes -= saveOverSpendingUnits(this.microbes, 2);
         this.megaCredits -= saveOverSpendingUnits(this.megaCredits, 1);

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -285,6 +285,31 @@ describe('SelectHowToPayForProjectCard', function() {
     expect(vm.steel).eq(2);
   });
 
+  it('select how to pay uses titanium metal bonus without using steel', async function() {
+    // Io Mining Industries cost 41 mc. Player has 10 MC, 2 Steel and 13 Ti.
+    // The steel is artificially inflated to be worth 4 MC each.
+    // The titanium is artificially inflated to be worth 5 MC each.
+    // The algorithm will try to spend 10 mc. Then spend as much Ti as possible.
+    // This will come down to 10 MC and 7 Ti (at value 5). So we are effectively spending 45 MC.
+    // That is overspending by 4 mc. The algorithm will try to spend 4 mc less if possible.
+    // IT WILL NOT TRY TO SPEND LESS STEEL EVEN IF IT HAS STEEL AND STEEL VALUE IS 4.
+    // It will reduce the amount of MC.
+    // The final answer should be 6mc and 7 Ti (at value 5).
+    const wrapper = setupCardForPurchase(
+      CardName.IO_MINING_INDUSTRIES, 41,
+      {megaCredits: 10, titanium: 13, titaniumValue: 5, steel: 2, steelValue: 4},
+      {canUseTitanium: true});
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.megaCredits).eq(6);
+    expect(vm.titanium).eq(7);
+    expect(vm.steel).eq(0);
+    const titaniumTextBox = wrapper.find('[title~=Titanium] ~ input').element as HTMLInputElement;
+    expect(titaniumTextBox.value).eq('7');
+  });
+
   const setupCardForPurchase = function(
     cardName: CardName,
     cardCost: number,


### PR DESCRIPTION
This can close #3042.

When the app tries to reduce overspending, it should save steel only if it is actually spending steel. 

The bug was introduced by #3025. When the app sees that it is overspending by 2 mc and the player has steel, it tries to reduce the amount of spending steel by 1 even if that amount is already 0. As a result, the player is trying to pay with negative one steel forcing the player to have to overspend by 2 mc to cover that deficit.