### PR TITLE
Do not use ETag header for waiting for route.

### DIFF
--- a/src/routes/ApiWaitingFor.ts
+++ b/src/routes/ApiWaitingFor.ts
@@ -34,14 +34,7 @@ export class ApiWaitingFor extends Handler {
         return;
       }
       try {
-        const etag = `${playerId}:${game.gameAge}:${game.undoCount}`;
         const player = game.getPlayerById(playerId);
-        if (req.headers['if-none-match'] === etag && this.timeToGo(player) === false) {
-          ctx.route.notModified(res);
-          return;
-        }
-        res.setHeader('Cache-Control', 'must-revalidate');
-        res.setHeader('ETag', etag);
         ctx.route.writeJson(res, this.getWaitingForModel(player, gameAge, undoCount));
       } catch (err) {
         // This is basically impossible since getPlayerById ensures that the player is on that game.

--- a/tests/routes/ApiWaitingFor.spec.ts
+++ b/tests/routes/ApiWaitingFor.spec.ts
@@ -53,32 +53,6 @@ describe('ApiWaitingFor', function() {
     const game = Game.newInstance('game-id', [player], player);
     ctx.gameLoader.add(game);
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
-    expect(res.headers.get('ETag')).eq(`${player.id}:${game.gameAge}:${game.undoCount}`);
-    expect(res.statusCode).eq(200);
-    expect(res.content).eq('{"result":"GO"}');
-  });
-
-  it('sends not modified', () => {
-    const player = TestPlayers.BLACK.newPlayer();
-    req.url = '/api/waitingfor?id=' + player.id + '&gameAge=50&undoCount=0';
-    ctx.url = new URL('http://boo.com' + req.url);
-    const game = Game.newInstance('game-id', [player], player);
-    (player as any).waitingFor = undefined;
-    ctx.gameLoader.add(game);
-    req.headers['if-none-match'] = `${player.id}:${game.gameAge}:${game.undoCount}`;
-    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
-    expect(res.statusCode).eq(304);
-    expect(res.content).eq('');
-  });
-
-  it('sends model when time to go', () => {
-    const player = TestPlayers.BLACK.newPlayer();
-    req.url = '/api/waitingfor?id=' + player.id + '&gameAge=50&undoCount=0';
-    ctx.url = new URL('http://boo.com' + req.url);
-    const game = Game.newInstance('game-id', [player], player);
-    ctx.gameLoader.add(game);
-    req.headers['if-none-match'] = `${player.id}:${game.gameAge}:${game.undoCount}`;
-    ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
     expect(res.statusCode).eq(200);
     expect(res.content).eq('{"result":"GO"}');
   });


### PR DESCRIPTION
Will need a different strategy for generating the `ETag`. The strategy I was using relied on `gameAge` being incremented. Nothing must be logged during the initial drafting phase. Without `gameAge` being updated this hashing strategy doesn't work.