### PR TITLE
Hidable animated side bar

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -172,7 +172,7 @@ checkComponent(
     'hide_turnorder', 'hide_corporation_names', , 'hide_top_bar', 'small_cards', 'remove_background', 'magnify_cards',
     'magnify_card_descriptions', 'show_alerts', 'hide_ma_scores', 'hide_non_blue_cards', 'hide_log',
     'lang', 'langs', 'enable_sounds', 'smooth_scrolling', 'hide_tile_confirmation', 'show_card_number', 'show_discount_on_cards',
-    'learner_mode',
+    'learner_mode', 'hide_animated_sidebar',
   ],
 );
 checkComponent(

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -82,6 +82,7 @@ export const Preferences = Vue.component('preferences', {
       'show_card_number': false as boolean | unknown[],
       'show_discount_on_cards': true as boolean | unknown[],
       'learner_mode': true as boolean | unknown[],
+      'hide_animated_sidebar': false as boolean | unknown[],
     };
   },
   methods: {
@@ -141,8 +142,11 @@ export const Preferences = Vue.component('preferences', {
         this.setPreferencesCSS(this.$data[k], k);
       }
     },
-    getActingPlayerClass: function(): string {
-      return this.acting_player ? 'preferences_acting_player' : 'preferences_nonacting_player';
+    getPlayerColorCubeClass: function(): string {
+      return this.acting_player && (PreferencesManager.loadBooleanValue('hide_animated_sidebar') === false) ? 'preferences_player_inner active' : 'preferences_player_inner';
+    },
+    getSideBarClass: function(): string {
+      return this.acting_player && (PreferencesManager.loadBooleanValue('hide_animated_sidebar') === false) ? 'preferences_acting_player' : 'preferences_nonacting_player';
     },
     getGenMarker: function(): string {
       return `${this.generation}`;
@@ -199,7 +203,7 @@ export const Preferences = Vue.component('preferences', {
     this.updatePreferencesFromStorage();
   },
   template: `
-        <div :class="'preferences_cont '+getActingPlayerClass()" :data="syncPreferences()">
+        <div :class="'preferences_cont '+getSideBarClass()" :data="syncPreferences()">
                 <div class="preferences_tm">
                     <div class="preferences-gen-text">GEN</div>
                     <div class="preferences-gen-marker">{{ getGenMarker() }}</div>
@@ -220,7 +224,7 @@ export const Preferences = Vue.component('preferences', {
                   </div>
                 </div>
                 <div class="preferences_item preferences_player">
-                  <div class="preferences_player_inner" :class="'player_bg_color_' + player_color"></div>
+                  <div :class="getPlayerColorCubeClass()+' player_bg_color_' + player_color"></div>
                 </div>
                 <a  href="#board">
                     <div class="preferences_item preferences_item_shortcut">
@@ -371,6 +375,12 @@ export const Preferences = Vue.component('preferences', {
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="hide_tile_confirmation" />
                             <i class="form-icon"></i> <span v-i18n>Hide tile confirmation</span>
+                        </label>
+                    </div>
+                    <div class="preferences_panel_item">
+                        <label class="form-switch">
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="hide_animated_sidebar" />
+                            <i class="form-icon"></i> <span v-i18n>Hide sidebar notification</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item">

--- a/src/components/PreferencesManager.ts
+++ b/src/components/PreferencesManager.ts
@@ -26,6 +26,7 @@ export class PreferencesManager {
       'show_card_number',
       'show_discount_on_cards',
       'learner_mode',
+      'hide_animated_sidebar',
     ];
 
     static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -93,6 +93,7 @@
     &.active {
         -webkit-animation: rotation 8s infinite linear;
         animation: rotation 8s infinite linear;
+        box-shadow: 0 0 5px 2px #fff;
     }
 }
 

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -11,7 +11,7 @@
     height: 100%;
 }
 .preferences_acting_player {
-    background: #4a4033;
+    background: linear-gradient(180deg, #303030 0%, #303030 25%, #745B54 80%, #745B54 100%);
 }
 .preferences_nonacting_player {
     background: #303030;
@@ -90,6 +90,28 @@
     width: 26px;
     height: 26px;
     border-radius: 3px;
+    &.active {
+        -webkit-animation: rotation 8s infinite linear;
+        animation: rotation 8s infinite linear;
+    }
+}
+
+@-webkit-keyframes rotation {
+    from {
+        -webkit-transform: rotate(0deg);
+    }
+    to {
+        -webkit-transform: rotate(359deg);
+    }
+}
+
+@keyframes rotation {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(359deg);
+    }
 }
 
 .preferences_global_params {


### PR DESCRIPTION
This PR improves on #2969 .

![image](https://user-images.githubusercontent.com/14239220/112772446-dc92b780-8ffe-11eb-9832-86edab1cb4fa.png)

It makes the color brighter but with gradient toward the bottom so the text on the top are not impossible to see. It also rotates the player cube slowly as movement should get attention of users.

It is possible to hide this animation from the Preferences panel.

Example

https://user-images.githubusercontent.com/14239220/112772426-b79e4480-8ffe-11eb-892c-cf326012b8e8.mov


