### PR TITLE
fix generous funding global event

### DIFF
--- a/src/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/turmoil/globalEvents/GenerousFunding.ts
@@ -12,7 +12,9 @@ export class GenerousFunding implements IGlobalEvent {
     public currentDelegate = PartyName.UNITY;
     public resolve(game: Game, turmoil: Turmoil) {
       game.getPlayers().forEach((player) => {
-        player.setResource(Resources.MEGACREDITS, 2 * (Math.min(5, Math.floor((player.getTerraformRating() - 15) / 5)) + turmoil.getPlayerInfluence(player)), game, undefined, true);
+        const trSet = player.getTerraformRating() > 15 ? Math.floor((player.getTerraformRating() - 15) / 5) : 0;
+        const MAXSET = 5;
+        player.setResource(Resources.MEGACREDITS, 2 * (Math.min(MAXSET, trSet) + turmoil.getPlayerInfluence(player)), game, undefined, true);
       });
     }
 }

--- a/src/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/turmoil/globalEvents/GenerousFunding.ts
@@ -12,9 +12,10 @@ export class GenerousFunding implements IGlobalEvent {
     public currentDelegate = PartyName.UNITY;
     public resolve(game: Game, turmoil: Turmoil) {
       game.getPlayers().forEach((player) => {
-        const trSet = player.getTerraformRating() > 15 ? Math.floor((player.getTerraformRating() - 15) / 5) : 0;
-        const MAXSET = 5;
-        player.setResource(Resources.MEGACREDITS, 2 * (Math.min(MAXSET, trSet) + turmoil.getPlayerInfluence(player)), game, undefined, true);
+        const trSets = Math.max(0, Math.floor((player.getTerraformRating() - 15) / 5));
+        const maxTRSets = 5;
+        const totalSets = Math.min(maxTRSets, trSets) + turmoil.getPlayerInfluence(player);
+        player.setResource(Resources.MEGACREDITS, 2 * totalSets, game, undefined, true);
       });
     }
 }

--- a/tests/globalEvents/GenerousFunding.spec.ts
+++ b/tests/globalEvents/GenerousFunding.spec.ts
@@ -30,4 +30,28 @@ describe('GenerousFunding', function() {
     expect(player.getResource(Resources.MEGACREDITS)).to.eq(14);
     expect(player2.getResource(Resources.MEGACREDITS)).to.eq(26);
   });
+
+  it('no negative mc give out if TR lower than 15', function() {
+    const card = new GenerousFunding();
+    const player = TestPlayers.BLUE.newPlayer();
+    const player2 = TestPlayers.RED.newPlayer();
+    const game = Game.newInstance('foobar', [player, player2], player);
+    const turmoil = Turmoil.newInstance(game);
+
+    turmoil.initGlobalEvent(game);
+    turmoil.chairman = player2.id;
+    turmoil.dominantParty = new Kelvinists();
+    turmoil.dominantParty.partyLeader = player2.id;
+    turmoil.dominantParty.delegates.push(player2.id);
+    turmoil.dominantParty.delegates.push(player2.id);
+
+    player.megaCredits = 10;
+    player2.megaCredits = 10;
+    player.setTerraformRating(12);
+    player2.setTerraformRating(50);
+
+    card.resolve(game, turmoil);
+    expect(player.getResource(Resources.MEGACREDITS)).to.eq(10);
+    expect(player2.getResource(Resources.MEGACREDITS)).to.eq(26);
+  });
 });


### PR DESCRIPTION
This PR can closes #3058 .

It counts zero set of 5 TR, if TR is not greater than 15, instead of negative number as before.