### PR TITLE
add option not to attack

### DIFF
--- a/src/cards/base/HiredRaiders.ts
+++ b/src/cards/base/HiredRaiders.ts
@@ -69,7 +69,12 @@ export class HiredRaiders extends Card implements IProjectCard {
       }
     });
 
-    if (availableActions.options.length > 0) return availableActions;
+    if (availableActions.options.length > 0) {
+      availableActions.options.push(new SelectOption('Do not steal', 'Confirm', () => {
+        return undefined;
+      }));
+      return availableActions;
+    }
     return undefined;
   }
 }

--- a/src/cards/base/Sabotage.ts
+++ b/src/cards/base/Sabotage.ts
@@ -65,7 +65,12 @@ export class Sabotage extends Card implements IProjectCard {
       }
     });
 
-    if (availableActions.options.length > 0) return availableActions;
+    if (availableActions.options.length > 0) {
+      availableActions.options.push(new SelectOption('Do not remove resource', 'Confirm', () => {
+        return undefined;
+      }));
+      return availableActions;
+    }
     return undefined;
   }
 }

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -9,6 +9,8 @@ import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardRenderer} from '../render/CardRenderer';
 import {Card} from '../Card';
+import {OrOptions} from '../../inputs/OrOptions';
+import {SelectOption} from '../../inputs/SelectOption';
 
 export class CometForVenus extends Card {
   constructor() {
@@ -45,21 +47,29 @@ export class CometForVenus extends Card {
       return undefined;
     }
 
-    if (venusTagPlayers.length === 1) {
-      venusTagPlayers[0].setResource(Resources.MEGACREDITS, -4, player.game, player);
-      player.game.increaseVenusScaleLevel(player, 1);
-      return undefined;
+    if (venusTagPlayers.length > 0) {
+      return new OrOptions(
+        new SelectPlayer(
+          Array.from(venusTagPlayers),
+          'Select player to remove up to 4 mega credits from',
+          'Remove MC',
+          (selectedPlayer: Player) => {
+            selectedPlayer.setResource(Resources.MEGACREDITS, -4, player.game, player);
+            player.game.increaseVenusScaleLevel(player, 1);
+            return undefined;
+          },
+        ),
+        new SelectOption(
+          'Do not remove mega credits',
+          'Confirm',
+          () => {
+            player.game.increaseVenusScaleLevel(player, 1);
+            return undefined;
+          },
+        ),
+      );
     }
 
-    return new SelectPlayer(
-      venusTagPlayers,
-      'Select player to remove up to 4 mega credits from',
-      'Remove MC',
-      (selectedPlayer: Player) => {
-        selectedPlayer.setResource(Resources.MEGACREDITS, -4, player.game, player);
-        player.game.increaseVenusScaleLevel(player, 1);
-        return undefined;
-      },
-    );
+    return undefined;
   }
 }

--- a/tests/cards/base/HiredRaiders.spec.ts
+++ b/tests/cards/base/HiredRaiders.spec.ts
@@ -21,7 +21,7 @@ describe('HiredRaiders', function() {
     player2.megaCredits = 2;
 
     const action = card.play(player) as OrOptions;
-    expect(action.options).has.lengthOf(2);
+    expect(action.options).has.lengthOf(3);
     action.options[1].cb();
     expect(player2.megaCredits).to.eq(0);
     expect(player.megaCredits).to.eq(12);

--- a/tests/cards/base/Sabotage.spec.ts
+++ b/tests/cards/base/Sabotage.spec.ts
@@ -22,6 +22,8 @@ describe('Sabotage', function() {
 
     const action = card.play(player) as OrOptions;
 
+    expect(action.options).has.lengthOf(4);
+
     action.options[0].cb();
     expect(player2.titanium).to.eq(0);
 

--- a/tests/cards/moon/LunarSecurityStations.spec.ts
+++ b/tests/cards/moon/LunarSecurityStations.spec.ts
@@ -54,12 +54,12 @@ describe('LunarSecurityStations', () => {
     opponent2.playedCards = [];
     let action = hiredRaiders.play(player) as OrOptions;
     // Options for both opponents.
-    expect(action.options).has.lengthOf(2);
+    expect(action.options).has.lengthOf(3);
 
     opponent2.playedCards = [lunaSecurityStations];
     action = hiredRaiders.play(player) as OrOptions;
     // Options for only one opponent.
-    expect(action.options).has.lengthOf(1);
+    expect(action.options).has.lengthOf(2);
     action.options[0].cb();
     // And it's the one weithout Luna Security Stations.
     expect(opponent1.steel).to.eq(3);

--- a/tests/cards/venusNext/CometForVenus.spec.ts
+++ b/tests/cards/venusNext/CometForVenus.spec.ts
@@ -3,6 +3,8 @@ import {AerialMappers} from '../../../src/cards/venusNext/AerialMappers';
 import {CometForVenus} from '../../../src/cards/venusNext/CometForVenus';
 import {Game} from '../../../src/Game';
 import {TestPlayers} from '../../TestPlayers';
+import {OrOptions} from '../../../src/inputs/OrOptions';
+import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 
 describe('CometForVenus', function() {
   it('Should play', function() {
@@ -15,8 +17,15 @@ describe('CometForVenus', function() {
     player2.megaCredits = 10;
     player2.playedCards.push(card2);
 
-    const play = card.play(player);
-    expect(play).is.undefined;
+    const action = card.play(player) as OrOptions;
+
+    expect(action.options).has.lengthOf(2);
+
+    const subActionSelectPlayer: SelectPlayer = action!.options[0] as SelectPlayer;
+
+    expect(subActionSelectPlayer.players).has.lengthOf(1);
+    expect(subActionSelectPlayer.players[0]).to.eq(player2);
+    subActionSelectPlayer.cb(player2);
     expect(game.getVenusScaleLevel()).to.eq(2);
     expect(player2.megaCredits).to.eq(6);
   });


### PR DESCRIPTION
This can close #2954 . Currently, Sabotage, Hired Raiders, and Comet for Venus do not offer an option not to attack someone. The rule allows players not to attack. Players may want to do that if they are Mons Insurance or expect someone to have Law Suits.

I tried changing RemoveAnyPlants to RemoveAnyResources but it will cover just Comet for Venus and Flooding. The deferred action is not great for Hire Raiders and Sabotage which have multiple resource type targets. So I decided to go with this option instead.