### PR TITLE
Sabotage Global Event reduce only if has any

### DIFF
--- a/src/turmoil/globalEvents/Sabotage.ts
+++ b/src/turmoil/globalEvents/Sabotage.ts
@@ -12,8 +12,12 @@ export class Sabotage implements IGlobalEvent {
     public currentDelegate = PartyName.REDS;
     public resolve(game: Game, turmoil: Turmoil) {
       game.getPlayers().forEach((player) => {
-        player.addProduction(Resources.ENERGY, -1, game, undefined, true);
-        player.addProduction(Resources.STEEL, -1, game, undefined, true);
+        if (player.getProduction(Resources.ENERGY) >= 1) {
+          player.addProduction(Resources.ENERGY, -1, game, undefined, true);
+        }
+        if (player.getProduction(Resources.STEEL) >= 1) {
+          player.addProduction(Resources.STEEL, -1, game, undefined, true);
+        }
         player.setResource(Resources.STEEL, turmoil.getPlayerInfluence(player), game, undefined, true);
       });
     }

--- a/src/turmoil/globalEvents/Sabotage.ts
+++ b/src/turmoil/globalEvents/Sabotage.ts
@@ -12,6 +12,7 @@ export class Sabotage implements IGlobalEvent {
     public currentDelegate = PartyName.REDS;
     public resolve(game: Game, turmoil: Turmoil) {
       game.getPlayers().forEach((player) => {
+        // This conditional isn't to prevent negative production, but to prevent misleading logging when the production diff is zero.
         if (player.getProduction(Resources.ENERGY) >= 1) {
           player.addProduction(Resources.ENERGY, -1, game, undefined, true);
         }


### PR DESCRIPTION
This PR can close #2380. It should try to reduce the steel/energy production if the player has any. This prevents inaccurate log report.