### PR TITLE
global event name in the log

### DIFF
--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -215,6 +215,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
 
       // 2 - Global Event
       if (this.currentGlobalEvent) {
+        game.log('Global event "' + this.currentGlobalEvent.name + '" has been resolved.');
         this.currentGlobalEvent.resolve(game, this);
       }
 

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -214,6 +214,7 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
       });
 
       // 2 - Global Event
+      // TODO: create a LogMessageDataType for Global Events, ref https://github.com/bafolts/terraforming-mars/issues/3057
       if (this.currentGlobalEvent) {
         game.log('Global event "' + this.currentGlobalEvent.name + '" has been resolved.');
         this.currentGlobalEvent.resolve(game, this);


### PR DESCRIPTION
This can close #3057, for now at least. 

We don't have a way to show the turmoil card once clicked yet. That is not how the turmoil event cards are rendered. 

For now, just showing the name of the global event that just happened should be helpful enough. Players can look them up later on Simon's database. But eventually we may want to consider rendering the global event as a unit of card.