### PR TITLE
allow curiosity ii to be copied by robotic workforce

### DIFF
--- a/src/cards/community/CuriosityII.ts
+++ b/src/cards/community/CuriosityII.ts
@@ -16,6 +16,7 @@ import {DrawCards} from '../../deferredActions/DrawCards';
 import {SpaceType} from '../../SpaceType';
 import {SpaceBonus} from '../../SpaceBonus';
 import {Phase} from '../../Phase';
+import {Units} from '../../Units';
 
 export class CuriosityII extends Card implements CorporationCard {
   constructor() {
@@ -24,6 +25,7 @@ export class CuriosityII extends Card implements CorporationCard {
       name: CardName.CURIOSITY_II,
       tags: [Tags.SCIENCE, Tags.BUILDING],
       startingMegaCredits: 40,
+      productionBox: Units.of({steel: 2}),
 
       metadata: {
         cardNumber: '',


### PR DESCRIPTION
This PR fixes the issue that Curiosity production cannot be copied by Robotic Workforce.

![image](https://user-images.githubusercontent.com/14239220/113022418-93ec1300-9152-11eb-9b90-a67add107fd4.png)
