### PR TITLE
Fix promo card on end game page

### DIFF
--- a/src/VictoryPointsBreakdown.ts
+++ b/src/VictoryPointsBreakdown.ts
@@ -11,7 +11,7 @@ export class VictoryPointsBreakdown {
     public moonRoads: number = 0;
     public victoryPoints = 0;
     public total = 0;
-    public detailsCards: Array<string> = [];
+    public detailsCards: Array<{cardName: string, victoryPoint: number}> = [];
     public detailsMilestones: Array<string> = [];
     public detailsAwards: Array<string> = [];
 
@@ -49,7 +49,7 @@ export class VictoryPointsBreakdown {
         break;
       case 'victoryPoints':
         this.victoryPoints += points;
-        if (message !== undefined) this.detailsCards.push(message+':'+points);
+        if (message !== undefined) this.detailsCards.push({cardName: message, victoryPoint: points});
         break;
       case 'moon colony':
         this.moonColonies += points;

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -157,9 +157,8 @@ export const GameEnd = Vue.component('game-end', {
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsCards">
                               <div class="game-end-column-row">
-                                <div v-if="v.split(':').length === 3" class="game-end-column-vp">{{v.split(':', 3)[2]}}</div>
-                                <div v-else class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
-                                <div class="game-end-column-text">{{v.split(':', 2)[0]}}</div>
+                                <div class="game-end-column-vp">{{v.victoryPoint}}</div>
+                                <div class="game-end-column-text">{{v.cardName}}</div>
                               </div>
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsMilestones">

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -157,7 +157,8 @@ export const GameEnd = Vue.component('game-end', {
                             </div>
                             <div v-for="v in p.victoryPointsBreakdown.detailsCards">
                               <div class="game-end-column-row">
-                                <div class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
+                                <div v-if="v.split(':').length === 3" class="game-end-column-vp">{{v.split(':', 3)[2]}}</div>
+                                <div v-else class="game-end-column-vp">{{v.split(':', 2)[1]}}</div>
                                 <div class="game-end-column-text">{{v.split(':', 2)[0]}}</div>
                               </div>
                             </div>


### PR DESCRIPTION
This PR closes #3027 .

<img width="564" alt="Screen Shot 2021-03-30 at 1 49 31 PM" src="https://user-images.githubusercontent.com/14239220/113034035-a882d800-915f-11eb-8e7e-17d244c66b2e.png">

<img width="532" alt="Screen Shot 2021-03-30 at 1 43 34 PM" src="https://user-images.githubusercontent.com/14239220/113034048-ab7dc880-915f-11eb-878f-a1dad3aaff49.png">

![image](https://user-images.githubusercontent.com/14239220/113034011-a3be2400-915f-11eb-98aa-7bb0d1b0b580.png)

It would be better if we rename the promo cards to `Great Dam (promo)` instead of `Great Dam:  promo`, but that will breaks existing games.