### PR TITLE
Add dangerous button and fix optional button

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -170,7 +170,7 @@ generateVueClass(
     'ui', 'hide_hand', 'hide_awards_and_milestones',
     'hide_top_bar', 'small_cards', 'remove_background', 'magnify_cards',
     'show_alerts', 'lang', 'langs', 'enable_sounds', 'hide_tile_confirmation', 
-    'show_card_number', 'hide_discount_on_cards', 'learner_mode', 'hide_animated_sidebar',
+    'show_card_number', 'hide_discount_on_cards', 'learner_mode', 'hide_animated_sidebar', 'color_label_buttons'
   ],
 );
 generateVueClass(

--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -170,7 +170,7 @@ generateVueClass(
     'ui', 'hide_hand', 'hide_awards_and_milestones',
     'hide_top_bar', 'small_cards', 'remove_background', 'magnify_cards',
     'show_alerts', 'lang', 'langs', 'enable_sounds', 'hide_tile_confirmation', 
-    'show_card_number', 'hide_discount_on_cards', 'learner_mode', 'hide_animated_sidebar', 'color_label_buttons'
+    'show_card_number', 'hide_discount_on_cards', 'learner_mode', 'hide_animated_sidebar', 'hide_color_code_buttons'
   ],
 );
 generateVueClass(

--- a/src/PlayerInput.ts
+++ b/src/PlayerInput.ts
@@ -5,6 +5,7 @@ import {PlayerInputTypes} from './PlayerInputTypes';
 export interface PlayerInput {
     inputType: PlayerInputTypes;
     buttonLabel: string;
+    buttonDanger?: boolean;
     options?: Array<PlayerInput>;
     title: string | Message;
     cb: (...item: any) => PlayerInput | undefined;

--- a/src/cards/base/MarsUniversity.ts
+++ b/src/cards/base/MarsUniversity.ts
@@ -40,14 +40,18 @@ export class MarsUniversity extends Card implements IProjectCard {
           if (player.cardsInHand.length === 0) {
             return undefined;
           }
+
+          const selectCardToDiscard = new SelectCard('Select a card to discard', 'Discard', player.cardsInHand, (foundCards: Array<IProjectCard>) => {
+            player.cardsInHand.splice(player.cardsInHand.indexOf(foundCards[0]), 1);
+            player.game.dealer.discard(foundCards[0]);
+            player.game.log('${0} is using their ${1} effect to draw a card.', (b) => b.player(player).card(this));
+            player.drawCard();
+            return undefined;
+          });
+          selectCardToDiscard.buttonDanger = true;
+
           return new OrOptions(
-            new SelectCard('Select a card to discard', 'Discard', player.cardsInHand, (foundCards: Array<IProjectCard>) => {
-              player.cardsInHand.splice(player.cardsInHand.indexOf(foundCards[0]), 1);
-              player.game.dealer.discard(foundCards[0]);
-              player.game.log('${0} is using their ${1} effect to draw a card.', (b) => b.player(player).card(this));
-              player.drawCard();
-              return undefined;
-            }),
+            selectCardToDiscard,
             new SelectOption('Do nothing', 'Confirm', () => {
               return undefined;
             }),

--- a/src/cards/base/standardProjects/SellPatentsStandardProject.ts
+++ b/src/cards/base/standardProjects/SellPatentsStandardProject.ts
@@ -30,7 +30,7 @@ export class SellPatentsStandardProject extends StandardProjectCard {
   }
 
   public action(player: Player): SelectCard<IProjectCard> {
-    return new SelectCard(
+    const select = new SelectCard(
       'Sell patents',
       'Sell',
       player.cardsInHand,
@@ -50,5 +50,7 @@ export class SellPatentsStandardProject extends StandardProjectCard {
         return undefined;
       }, player.cardsInHand.length,
     );
+    select.buttonDanger = true;
+    return select;
   }
 }

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -148,6 +148,7 @@ export const OrOptions = Vue.component('or-options', {
                     onClick: () => {
                       this.saveData();
                     },
+                    danger: this.playerinput.buttonDanger,
                   },
                 }),
               ],

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -148,7 +148,7 @@ export const OrOptions = Vue.component('or-options', {
                     onClick: () => {
                       this.saveData();
                     },
-                    danger: this.playerinput.buttonDanger,
+                    danger: option.buttonDanger,
                   },
                 }),
               ],

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -311,7 +311,7 @@ export const Preferences = Vue.component('preferences', {
                     <div class="preferences_panel_item">
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="color_label_buttons" />
-                            <i class="form-icon"></i> <span v-i18n>Color label dangerous buttons</span>
+                            <i class="form-icon"></i> <span v-i18n>Color label skip/discard/sell buttons</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item">

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -73,6 +73,7 @@ export const Preferences = Vue.component('preferences', {
       'hide_discount_on_cards': false as boolean | unknown[],
       'learner_mode': true as boolean | unknown[],
       'hide_animated_sidebar': false as boolean | unknown[],
+      'color_label_buttons': false as boolean | unknown[],
     };
   },
   methods: {
@@ -305,6 +306,12 @@ export const Preferences = Vue.component('preferences', {
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="show_alerts" />
                             <i class="form-icon"></i> <span v-i18n>Show in-game alerts</span>
+                        </label>
+                    </div>
+                    <div class="preferences_panel_item">
+                        <label class="form-switch">
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="color_label_buttons" />
+                            <i class="form-icon"></i> <span v-i18n>Color label dangerous buttons</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item">

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -73,7 +73,7 @@ export const Preferences = Vue.component('preferences', {
       'hide_discount_on_cards': false as boolean | unknown[],
       'learner_mode': true as boolean | unknown[],
       'hide_animated_sidebar': false as boolean | unknown[],
-      'color_label_buttons': false as boolean | unknown[],
+      'hide_color_code_buttons': false as boolean | unknown[],
     };
   },
   methods: {
@@ -310,8 +310,8 @@ export const Preferences = Vue.component('preferences', {
                     </div>
                     <div class="preferences_panel_item">
                         <label class="form-switch">
-                            <input type="checkbox" v-on:change="updatePreferences" v-model="color_label_buttons" />
-                            <i class="form-icon"></i> <span v-i18n>Color label skip/discard/sell buttons</span>
+                            <input type="checkbox" v-on:change="updatePreferences" v-model="hide_color_code_buttons" />
+                            <i class="form-icon"></i> <span v-i18n>Hide label skip/discard/sell buttons</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item">

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -311,7 +311,7 @@ export const Preferences = Vue.component('preferences', {
                     <div class="preferences_panel_item">
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="hide_color_code_buttons" />
-                            <i class="form-icon"></i> <span v-i18n>Hide label skip/discard/sell buttons</span>
+                            <i class="form-icon"></i> <span v-i18n>Hide button color coding</span>
                         </label>
                     </div>
                     <div class="preferences_panel_item">

--- a/src/components/PreferencesManager.ts
+++ b/src/components/PreferencesManager.ts
@@ -18,6 +18,7 @@ export class PreferencesManager {
       'hide_discount_on_cards',
       'learner_mode',
       'hide_animated_sidebar',
+      'color_label_buttons',
     ];
 
     static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();

--- a/src/components/PreferencesManager.ts
+++ b/src/components/PreferencesManager.ts
@@ -18,7 +18,7 @@ export class PreferencesManager {
       'hide_discount_on_cards',
       'learner_mode',
       'hide_animated_sidebar',
-      'color_label_buttons',
+      'hide_color_code_buttons',
     ];
 
     static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -127,7 +127,7 @@ export const SelectCard = Vue.component('select-card', {
         </label>
         <div v-if="hasCardWarning()" class="card-warning">{{ $t(warning) }}</div>
         <div v-if="showsave === true" class="nofloat">
-            <Button :disabled="isSelectionOptional() && cardsSelected() === 0" type="submit" :onClick="saveData" :title="buttonLabel()"/>
+            <Button :disabled="isSelectionOptional() && cardsSelected() === 0" type="submit" :onClick="saveData" :danger="playerinput.buttonDanger" :title="buttonLabel()" />
             <Button :disabled="isSelectionOptional() && cardsSelected() > 0" v-if="isSelectionOptional()" :onClick="saveData" type="submit" :danger="true" :title="$t('Skip this action')" />
         </div>
     </div>`,

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -42,7 +42,6 @@ export const SelectCard = Vue.component('select-card', {
   },
   data: function() {
     return {
-      // Preselect the card if there is only one card as an option
       cards: [],
       warning: undefined,
     } as SelectCardModel;

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -42,6 +42,7 @@ export const SelectCard = Vue.component('select-card', {
   },
   data: function() {
     return {
+      // Preselect the card if there is only one card as an option
       cards: [],
       warning: undefined,
     } as SelectCardModel;
@@ -87,10 +88,8 @@ export const SelectCard = Vue.component('select-card', {
       }
       return false;
     },
-    isOptionalToManyCards: function(): boolean {
-      return this.playerinput.maxCardsToSelect !== undefined &&
-             this.playerinput.maxCardsToSelect > 1 &&
-             this.playerinput.minCardsToSelect === 0;
+    isSelectionOptional: function(): boolean {
+      return this.playerinput.minCardsToSelect === 0;
     },
     getData: function(): Array<CardName> {
       return Array.isArray(this.$data.cards) ? this.$data.cards.map((card) => card.name) : [this.$data.cards.name];
@@ -128,8 +127,8 @@ export const SelectCard = Vue.component('select-card', {
         </label>
         <div v-if="hasCardWarning()" class="card-warning">{{ $t(warning) }}</div>
         <div v-if="showsave === true" class="nofloat">
-            <Button :disabled="isOptionalToManyCards() && cardsSelected() === 0" type="submit" :onClick="saveData" :title="buttonLabel()" />
-            <Button :disabled="isOptionalToManyCards() && cardsSelected() > 0" v-if="isOptionalToManyCards()" :onClick="saveData" type="submit" :title="$t('Skip this action')" />
+            <Button :disabled="isSelectionOptional() && cardsSelected() === 0" type="submit" :onClick="saveData" :title="buttonLabel()"/>
+            <Button :disabled="isSelectionOptional() && cardsSelected() > 0" v-if="isSelectionOptional()" :onClick="saveData" type="submit" :danger="true" :title="$t('Skip this action')" />
         </div>
     </div>`,
 });

--- a/src/components/common/Button.ts
+++ b/src/components/common/Button.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import {PreferencesManager} from '../PreferencesManager';
 
 export const Button = Vue.component('Button', {
   props: {
@@ -74,8 +75,10 @@ export const Button = Vue.component('Button', {
         classes.push('btn-submit');
       }
 
-      if (this.danger || this.title === 'Discard' || this.title === 'Sell') {
-        classes.push('btn-dangerous');
+      if (this.danger || this.title.includes('Discard' || this.title === 'Sell')) {
+        if (PreferencesManager.loadBooleanValue('color_label_buttons')) {
+          classes.push('btn-dangerous');
+        }
       }
 
       // align

--- a/src/components/common/Button.ts
+++ b/src/components/common/Button.ts
@@ -75,8 +75,8 @@ export const Button = Vue.component('Button', {
         classes.push('btn-submit');
       }
 
-      if (this.danger || this.title.includes('Discard' || this.title === 'Sell')) {
-        if (PreferencesManager.loadBooleanValue('color_label_buttons')) {
+      if (this.danger || this.title === 'Discard' || this.title === 'Sell') {
+        if (!PreferencesManager.loadBooleanValue('hide_color_code_buttons')) {
           classes.push('btn-dangerous');
         }
       }

--- a/src/components/common/Button.ts
+++ b/src/components/common/Button.ts
@@ -40,6 +40,10 @@ export const Button = Vue.component('Button', {
           'plus',
         ].includes(item),
     },
+    danger: {
+      type: Boolean,
+      default: false,
+    },
     onClick: {
       type: Function,
       default: () => {},
@@ -68,6 +72,10 @@ export const Button = Vue.component('Button', {
         classes.push('btn-action');
       } else if (this.type === 'submit') {
         classes.push('btn-submit');
+      }
+
+      if (this.danger || this.title === 'Discard' || this.title === 'Sell') {
+        classes.push('btn-dangerous');
       }
 
       // align

--- a/src/components/common/Button.ts
+++ b/src/components/common/Button.ts
@@ -75,7 +75,7 @@ export const Button = Vue.component('Button', {
         classes.push('btn-submit');
       }
 
-      if (this.danger || this.title === 'Discard' || this.title === 'Sell') {
+      if (this.danger) {
         if (!PreferencesManager.loadBooleanValue('hide_color_code_buttons')) {
           classes.push('btn-dangerous');
         }

--- a/src/deferredActions/DiscardCards.ts
+++ b/src/deferredActions/DiscardCards.ts
@@ -17,7 +17,7 @@ export class DiscardCards implements DeferredAction {
       cards.forEach((card) => this.player.game.dealer.discard(card));
       return undefined;
     }
-    return new SelectCard(
+    const select = new SelectCard(
       this.title,
       'Discard',
       this.player.cardsInHand,
@@ -31,5 +31,7 @@ export class DiscardCards implements DeferredAction {
       this.count,
       this.count,
     );
+    select.buttonDanger = true;
+    return select;
   }
 }

--- a/src/inputs/SelectCard.ts
+++ b/src/inputs/SelectCard.ts
@@ -5,7 +5,7 @@ import {PlayerInputTypes} from '../PlayerInputTypes';
 
 export class SelectCard<T> implements PlayerInput {
     public inputType: PlayerInputTypes = PlayerInputTypes.SELECT_CARD;
-
+    public buttonDanger?: boolean;
     constructor(
         public title: string | Message,
         public buttonLabel: string = 'Save',

--- a/src/models/PlayerInputModel.ts
+++ b/src/models/PlayerInputModel.ts
@@ -27,6 +27,7 @@ export interface PlayerInputModel {
     players: Array<ColorWithNeutral> | undefined;
     title: string | Message;
     buttonLabel: string;
+    buttonDanger?: boolean;
     coloniesModel : Array<ColonyModel> | undefined;
     payProduction?: IPayProductionModel;
     aresData?: IAresData;

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -223,7 +223,7 @@ function getWaitingFor(
   const playerInputModel: PlayerInputModel = {
     title: waitingFor.title,
     buttonLabel: waitingFor.buttonLabel,
-    buttonDanger: waitingFor.buttonLabel === 'Sell' || waitingFor.buttonLabel === 'Discard' ? true : undefined,
+    buttonDanger: waitingFor.buttonDanger,
     inputType: waitingFor.inputType,
     amount: undefined,
     options: undefined,

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -223,6 +223,7 @@ function getWaitingFor(
   const playerInputModel: PlayerInputModel = {
     title: waitingFor.title,
     buttonLabel: waitingFor.buttonLabel,
+    buttonDanger: waitingFor.buttonLabel === 'Sell' || waitingFor.buttonLabel === 'Discard' ? true : undefined,
     inputType: waitingFor.inputType,
     amount: undefined,
     options: undefined,

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -13,11 +13,11 @@ body {
 .btn {
     color: @text_action !important;
     background: @bg_action !important;
-    border-color: @boder_action !important;
+    border-color: @border_action !important;
 }
 .btn-tiny {
-    background: rgb(87, 85, 217);
-    border-color: rgb(75, 72, 214);
+    background: @bg_action;
+    border-color: @border_action;
     color: #fff;
     cursor: pointer;
     height: 1.5rem;

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -16,8 +16,8 @@ body {
     border-color: @boder_action !important;
 }
 .btn-tiny {
-    background: #5755d9;
-    border-color: #4b48d6;
+    background: rgb(87, 85, 217);
+    border-color: rgb(75, 72, 214);
     color: #fff;
     cursor: pointer;
     height: 1.5rem;
@@ -31,6 +31,10 @@ body {
     height: 50px;
     font-size: 20px;
     margin: 10px 0 30px 0;
+}
+.btn-dangerous {
+    background-color: @bg_dangerous_action !important;
+    border-color: @border_dangerous_action !important;;
 }
 .flex {
     display: flex;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -5,7 +5,7 @@
 @bg_action: rgb(87, 85, 217);
 @bg_dangerous_action: rgb(167, 77, 77);
 //borders
-@boder_action: rgb(75, 72, 214);
+@border_action: rgb(75, 72, 214);
 @border_dangerous_action: rgb(168, 62, 62);
 //text
 @text_action: rgb(255, 255, 255);

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -3,8 +3,10 @@
 @bg_main: rgb(48, 48, 48);
 @bg_dynamic: rgb(34, 34, 34);
 @bg_action: rgb(87, 85, 217);
+@bg_dangerous_action: rgb(167, 77, 77);
 //borders
 @boder_action: rgb(75, 72, 214);
+@border_dangerous_action: rgb(168, 62, 62);
 //text
 @text_action: rgb(255, 255, 255);
 @text_main: rgb(221, 221, 221);


### PR DESCRIPTION
This PR can close #3010. It does two main things.
1) When you are allowed to select zero card, it offers two buttons one for buy and one for skipping like during the research phase. I remove the restriction so that it applies to Business Network and Inventor Guild.
2) It labels certain buttons RED as a warning to the users that this can action is dangerous such as 'Skip', 'Discard', and 'Sell'. Sometimes users do not know that they are discarding a card due to Pluto trade or a global event. A red button will pauses them for a sec to notice what action they are doing.

Problem: It reads the title directly from Button. If I do it only in Selectcard, it will not apply to Sell and some forms of Discard. Not sure where the translation of the button title happened.

Discarding a card from Mars U
![image](https://user-images.githubusercontent.com/14239220/113463219-a4bab400-93f2-11eb-8776-6494e5994f7a.png)

Business Network Action
![image](https://user-images.githubusercontent.com/14239220/113463228-ae441c00-93f2-11eb-8a2e-b0e0e2e044a6.png)

Selling a card
![image](https://user-images.githubusercontent.com/14239220/113463521-1b0be600-93f4-11eb-829d-c1026d5cdce1.png)


Pluto does not work due to the number label
![image](https://user-images.githubusercontent.com/14239220/113463319-24488300-93f3-11eb-9fb2-a525ee610017.png)

Sell does not work in another language
![image](https://user-images.githubusercontent.com/14239220/113463537-31b23d00-93f4-11eb-8400-7d1b67344fb2.png)



