### PR TITLE
Make max amount by default for TitanShuttles and SEB

### DIFF
--- a/src/PlayerInput.ts
+++ b/src/PlayerInput.ts
@@ -8,6 +8,7 @@ export interface PlayerInput {
     options?: Array<PlayerInput>;
     title: string | Message;
     cb: (...item: any) => PlayerInput | undefined;
+    maxByDefault?: boolean;
 }
 
 export namespace PlayerInput {

--- a/src/cards/colonies/TitanShuttles.ts
+++ b/src/cards/colonies/TitanShuttles.ts
@@ -65,6 +65,7 @@ export class TitanShuttles extends Card implements IProjectCard, IResourceCard {
         },
         1,
         this.resourceCount,
+        true,
       ),
     );
   }

--- a/src/cards/venusNext/SulphurEatingBacteria.ts
+++ b/src/cards/venusNext/SulphurEatingBacteria.ts
@@ -49,7 +49,7 @@ export class SulphurEatingBacteria extends Card implements IActionCard, IResourc
     const opts: Array<SelectOption | SelectAmount> = [];
 
     const addResource = new SelectOption('Add 1 microbe to this card', 'Add microbe', () => this.addResource(player));
-    const spendResource = new SelectAmount('Remove any number of microbes to gain 3 MC per microbe removed', 'Remove microbes', (amount: number) => this.spendResource(player, amount), 1, this.resourceCount);
+    const spendResource = new SelectAmount('Remove any number of microbes to gain 3 MC per microbe removed', 'Remove microbes', (amount: number) => this.spendResource(player, amount), 1, this.resourceCount, true);
 
     opts.push(addResource);
 

--- a/src/components/SelectAmount.ts
+++ b/src/components/SelectAmount.ts
@@ -24,7 +24,7 @@ export const SelectAmount = Vue.component('select-amount', {
   },
   data: function() {
     return {
-      amount: String(this.playerinput.min),
+      amount: this.playerinput.maxByDefault ? String(this.playerinput.max) : String(this.playerinput.min),
     };
   },
   methods: {

--- a/src/inputs/SelectAmount.ts
+++ b/src/inputs/SelectAmount.ts
@@ -11,6 +11,7 @@ export class SelectAmount implements PlayerInput {
         public cb: (amount: number) => undefined | PlayerInput,
         public min: number,
         public max: number,
+        public maxByDefault?: boolean,
     ) {
       this.buttonLabel = buttonLabel;
     }

--- a/src/models/PlayerInputModel.ts
+++ b/src/models/PlayerInputModel.ts
@@ -20,6 +20,7 @@ export interface PlayerInputModel {
     options: Array<PlayerInputModel> | undefined;
     min: number | undefined;
     max: number | undefined;
+    maxByDefault?: boolean;
     maxCardsToSelect: number | undefined;
     microbes: number | undefined;
     floaters: number | undefined;

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -236,6 +236,7 @@ function getWaitingFor(
     availableSpaces: undefined,
     min: undefined,
     max: undefined,
+    maxByDefault: undefined,
     microbes: undefined,
     floaters: undefined,
     coloniesModel: undefined,
@@ -305,6 +306,7 @@ function getWaitingFor(
   case PlayerInputTypes.SELECT_AMOUNT:
     playerInputModel.min = (waitingFor as SelectAmount).min;
     playerInputModel.max = (waitingFor as SelectAmount).max;
+    playerInputModel.maxByDefault = (waitingFor as SelectAmount).maxByDefault;
     break;
   case PlayerInputTypes.SELECT_DELEGATE:
     playerInputModel.players = (waitingFor as SelectDelegate).players.map(


### PR DESCRIPTION
This PR can close #3099 .

Any sensible player should only activate these cards when they want to convert everything to MC or Ti. Current implementation make it likely someone might not convert everything or just convert 1. That would be a game-ruining move.