### PR TITLE
Fixing Hellas Map ocean bonus

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const ENERGY_TRADE_COST: number = 3;
 export const TITANIUM_TRADE_COST: number = 3;
 // Turmoil
 export const PLAYER_DELEGATES_COUNT: number = 7;
+export const GREENS_RULING_POLICY_REBATE: number = 4;
 export const REDS_RULING_POLICY_COST: number = 3;
 export const POLITICAL_AGENDAS_MAX_ACTION_USES: number = 3;
 // Map specific

--- a/src/turmoil/parties/Greens.ts
+++ b/src/turmoil/parties/Greens.ts
@@ -19,7 +19,7 @@ import {ResourceType} from '../../ResourceType';
 import {Phase} from '../../Phase';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
-import {POLITICAL_AGENDAS_MAX_ACTION_USES} from '../../constants';
+import {POLITICAL_AGENDAS_MAX_ACTION_USES, GREENS_RULING_POLICY_REBATE} from '../../constants';
 import {TurmoilPolicy} from '../TurmoilPolicy';
 
 export class Greens extends Party implements IParty {
@@ -65,7 +65,7 @@ class GreensPolicy01 implements Policy {
 
   onTilePlaced(player: Player, space: ISpace) {
     if (space.tile?.tileType === TileType.GREENERY && player.game.phase === Phase.ACTION) {
-      player.setResource(Resources.MEGACREDITS, 4);
+      player.setResource(Resources.MEGACREDITS, GREENS_RULING_POLICY_REBATE);
     }
   }
 }


### PR DESCRIPTION
This should reduce the cost of the ocean bonus spot so that canAfford becomes true. From console.log that happens, so it seems the space got filtered out even before Hellas.filter somehow.

In theory this code should work. I am not sure what part I am missing.