### PR TITLE
Fix card number on button

### DIFF
--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -113,7 +113,7 @@ export const SelectCard = Vue.component('select-card', {
       return undefined;
     },
     buttonLabel: function(): string {
-      return this.playerinput.buttonLabel + ' ' + this.cardsSelected();
+      return this.playerinput.maxCardsToSelect !== 1 ? this.playerinput.buttonLabel + ' ' + this.cardsSelected() : this.playerinput.buttonLabel;
     },
   },
   template: `<div class="wf-component wf-component--select-card">

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -112,15 +112,18 @@ export const SelectCard = Vue.component('select-card', {
       }
       return undefined;
     },
+    isSelectOnlyOneCard: function() : boolean {
+      return this.playerinput.maxCardsToSelect === 1 && this.playerinput.minCardsToSelect === 1;
+    },
     buttonLabel: function(): string {
-      return this.playerinput.maxCardsToSelect !== 1 ? this.playerinput.buttonLabel + ' ' + this.cardsSelected() : this.playerinput.buttonLabel;
+      return this.isSelectOnlyOneCard() ? this.playerinput.buttonLabel : this.playerinput.buttonLabel + ' ' + this.cardsSelected();
     },
   },
   template: `<div class="wf-component wf-component--select-card">
         <div v-if="showtitle === true" class="nofloat wf-component-title">{{ $t(playerinput.title) }}</div>
         <label v-for="card in getOrderedCards()" :key="card.name" :class="getCardBoxClass(card)">
             <template v-if="!card.isDisabled">
-              <input v-if="playerinput.maxCardsToSelect === 1 && playerinput.minCardsToSelect === 1" type="radio" v-model="cards" :value="card" />
+              <input v-if="isSelectOnlyOneCard()" type="radio" v-model="cards" :value="card" />
               <input v-else type="checkbox" v-model="cards" :value="card" :disabled="playerinput.maxCardsToSelect !== undefined && Array.isArray(cards) && cards.length >= playerinput.maxCardsToSelect && cards.includes(card) === false" />
             </template>
             <Card v-if="playerinput.showOwner && getOwner(card) !== undefined" :card="card" :owner="getOwner(card)" />


### PR DESCRIPTION
If working properly, this PR can close #3104.

It only adds a number to the button for selectCard only if selectCard allows it to select more than one card.

It works properly for 'Buy' during Research Phase.

![image](https://user-images.githubusercontent.com/14239220/113951042-c1832d00-97e0-11eb-9d84-0c91cc797f43.png)

But somehow it does not work for 'Sell'. 

![image](https://user-images.githubusercontent.com/14239220/113951195-14f57b00-97e1-11eb-87b8-e871802101b8.png)


Again it has some weird thing to do about the 'Sell' button not really being a part of SelectCard.