### PR TITLE
Fix recruitment

### DIFF
--- a/src/deferredActions/SendDelegateToArea.ts
+++ b/src/deferredActions/SendDelegateToArea.ts
@@ -55,9 +55,10 @@ export class SendDelegateToArea implements DeferredAction {
       } else {
         for (let i = 0; i < numDelegateToSend; i++) {
           if (this.options.replace) {
-            turmoil.removeDelegateFromParty(this.options.replace, partyName, this.player.game, false);
+            turmoil.replaceDelegateFromParty(this.options.replace, this.player.id, source, partyName, this.player.game);
+          } else {
+            turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, source);
           }
-          turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, source);
         }
       }
 

--- a/src/deferredActions/SendDelegateToArea.ts
+++ b/src/deferredActions/SendDelegateToArea.ts
@@ -55,7 +55,7 @@ export class SendDelegateToArea implements DeferredAction {
       } else {
         for (let i = 0; i < numDelegateToSend; i++) {
           if (this.options.replace) {
-            turmoil.removeDelegateFromParty(this.options.replace, partyName, this.player.game);
+            turmoil.removeDelegateFromParty(this.options.replace, partyName, this.player.game, false);
           }
           turmoil.sendDelegateToParty(this.player.id, partyName, this.player.game, source);
         }

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -145,16 +145,29 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     }
 
     // Use to remove a delegate from a specific party
-    public removeDelegateFromParty(playerId: PlayerId | NeutralPlayer, partyName: PartyName, game: Game, dominanceCheck: boolean = true): void {
+    public removeDelegateFromParty(playerId: PlayerId | NeutralPlayer, partyName: PartyName, game: Game): void {
       const party = this.getPartyByName(partyName);
       if (party) {
         this.delegateReserve.push(playerId);
         party.removeDelegate(playerId, game);
+        this.checkDominantParty(party);
+      } else {
+        throw 'Party not found';
+      }
+    }
 
-        // Skip party dominant party check during removal part of Recruitment
-        if (dominanceCheck) {
-          this.checkDominantParty(party);
-        }
+    // Use to replace a delegate from a specific party with another delegate with NO DOMINANCE CHANGE
+    public replaceDelegateFromParty(
+      outgoingPlayerId: PlayerId | NeutralPlayer,
+      incomingPlayerId: PlayerId | NeutralPlayer,
+      source: 'lobby' | 'reserve' = 'lobby',
+      partyName: PartyName,
+      game: Game): void {
+      const party = this.getPartyByName(partyName);
+      if (party) {
+        this.delegateReserve.push(outgoingPlayerId);
+        party.removeDelegate(outgoingPlayerId, game);
+        this.sendDelegateToParty(incomingPlayerId, partyName, game, source);
       } else {
         throw 'Party not found';
       }

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -145,12 +145,16 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
     }
 
     // Use to remove a delegate from a specific party
-    public removeDelegateFromParty(playerId: PlayerId | NeutralPlayer, partyName: PartyName, game: Game): void {
+    public removeDelegateFromParty(playerId: PlayerId | NeutralPlayer, partyName: PartyName, game: Game, dominanceCheck: boolean = true): void {
       const party = this.getPartyByName(partyName);
       if (party) {
         this.delegateReserve.push(playerId);
         party.removeDelegate(playerId, game);
-        this.checkDominantParty(party);
+
+        // Skip party dominant party check during removal part of Recruitment
+        if (dominanceCheck) {
+          this.checkDominantParty(party);
+        }
       } else {
         throw 'Party not found';
       }


### PR DESCRIPTION
This PR can close #3114 .

Switching Mars First
<img width="567" alt="Screen Shot 2021-04-08 at 8 27 12 PM" src="https://user-images.githubusercontent.com/14239220/114112040-7d0f9400-98a9-11eb-80f4-8c2c4f5882d9.png">

Mars First still dominant
<img width="559" alt="Screen Shot 2021-04-08 at 8 27 22 PM" src="https://user-images.githubusercontent.com/14239220/114112048-813bb180-98a9-11eb-9afa-500f2069ffc1.png">

Test with Banned Delegate

<img width="621" alt="Screen Shot 2021-04-08 at 8 31 10 PM" src="https://user-images.githubusercontent.com/14239220/114112077-93b5eb00-98a9-11eb-85ba-f380785ddc4c.png">
<img width="419" alt="Screen Shot 2021-04-08 at 8 31 03 PM" src="https://user-images.githubusercontent.com/14239220/114112083-96184500-98a9-11eb-8fea-420a8cd6dec5.png">
<img width="618" alt="Screen Shot 2021-04-08 at 8 31 21 PM" src="https://user-images.githubusercontent.com/14239220/114112090-987a9f00-98a9-11eb-848f-0a3c6d2319bb.png">

In this case, dominance check happens properly.