### PR TITLE
check name when comparing award and milestone

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -491,7 +491,7 @@ export class Game implements ISerializable<SerializedGame> {
 
   public milestoneClaimed(milestone: IMilestone): boolean {
     return this.claimedMilestones.find(
-      (claimedMilestone) => claimedMilestone.milestone === milestone,
+      (claimedMilestone) => claimedMilestone.milestone.name === milestone.name,
     ) !== undefined;
   }
 
@@ -583,7 +583,7 @@ export class Game implements ISerializable<SerializedGame> {
 
   public hasBeenFunded(award: IAward): boolean {
     return this.fundedAwards.find(
-      (fundedAward) => fundedAward.award === award,
+      (fundedAward) => fundedAward.award.name === award.name,
     ) !== undefined;
   }
 


### PR DESCRIPTION
While trying to recreate #3116 I noticed we compare `milestone` and `award` with the `===` operator. I don't think this is causing the bug in the ticket but it requires us to pass the same instance of the `milestone` and `award` when calling to see if a milestone or award has been claimed or funded. This changes to check the `name` property.