### PR TITLE
allow CEOsFavoriteProject to select SelfReplicatingRobots cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -13,7 +13,7 @@ import {CorporationCard} from './cards/corporation/CorporationCard';
 import {Game} from './Game';
 import {HowToPay} from './inputs/HowToPay';
 import {IAward} from './awards/IAward';
-import {ICard} from './cards/ICard';
+import {ICard, IResourceCard} from './cards/ICard';
 import {Colony} from './colonies/Colony';
 import {ISerializable} from './ISerializable';
 import {IMilestone} from './milestones/IMilestone';
@@ -212,12 +212,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public getSelfReplicatingRobotsTargetCards(): Array<RobotCard> {
-    for (const card of this.playedCards) {
-      if (card instanceof SelfReplicatingRobots) {
-        return card.targetCards;
-      }
-    }
-    return [];
+    return (this.playedCards.find((card) => card instanceof SelfReplicatingRobots) as (SelfReplicatingRobots | undefined))?.targetCards ?? [];
   }
 
   public getSteelValue(): number {
@@ -652,7 +647,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       }
     }
   }
-  public addResourceTo(card: ICard, count: number = 1): void {
+  public addResourceTo(card: IResourceCard, count: number = 1): void {
     if (card.resourceCount !== undefined) {
       card.resourceCount += count;
     }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -4,7 +4,6 @@ import {AndOptions} from './inputs/AndOptions';
 import {Aridor} from './cards/colonies/Aridor';
 import {Board} from './boards/Board';
 import {CardFinder} from './CardFinder';
-import {CardModel} from './models/CardModel';
 import {CardName} from './CardName';
 import {CardType} from './cards/CardType';
 import {ColonyModel} from './models/ColonyModel';
@@ -44,7 +43,7 @@ import {SelectHowToPayForProjectCard} from './inputs/SelectHowToPayForProjectCar
 import {SelectOption} from './inputs/SelectOption';
 import {SelectPlayer} from './inputs/SelectPlayer';
 import {SelectSpace} from './inputs/SelectSpace';
-import {SelfReplicatingRobots} from './cards/promo/SelfReplicatingRobots';
+import {RobotCard, SelfReplicatingRobots} from './cards/promo/SelfReplicatingRobots';
 import {SerializedCard} from './SerializedCard';
 import {SerializedPlayer} from './SerializedPlayer';
 import {SpaceType} from './SpaceType';
@@ -210,6 +209,15 @@ export class Player implements ISerializable<SerializedPlayer> {
     if (this.titaniumValue > constants.DEFAULT_TITANIUM_VALUE) {
       this.titaniumValue--;
     }
+  }
+
+  public getSelfReplicatingRobotsTargetCards(): Array<RobotCard> {
+    for (const card of this.playedCards) {
+      if (card instanceof SelfReplicatingRobots) {
+        return card.targetCards;
+      }
+    }
+    return [];
   }
 
   public getSteelValue(): number {
@@ -909,8 +917,9 @@ export class Player implements ISerializable<SerializedPlayer> {
       }
       const mappedCards: Array<ICard> = [];
       for (const cardName of input[0]) {
-        mappedCards.push(PlayerInput.getCard(pi.cards, cardName).card);
-        if (pi.enabled?.[pi.cards.findIndex((card) => card.name === cardName)] === false) {
+        const cardIndex = PlayerInput.getCard(pi.cards, cardName);
+        mappedCards.push(cardIndex.card);
+        if (pi.enabled?.[cardIndex.idx] === false) {
           throw new Error('Selected unavailable card');
         }
       }
@@ -1189,30 +1198,6 @@ export class Player implements ISerializable<SerializedPlayer> {
 
     const action = DrawCards.choose(this, dealtCards, {paying: true});
     this.setWaitingFor(action, () => this.game.playerIsFinishedWithResearchPhase(this));
-  }
-
-  public getSelfReplicatingRobotsCards() : Array<CardModel> {
-    const card = this.playedCards.find((card) => card.name === CardName.SELF_REPLICATING_ROBOTS);
-    const cards : Array<CardModel> = [];
-    if (card instanceof SelfReplicatingRobots) {
-      if (card.targetCards.length > 0) {
-        for (const targetCard of card.targetCards) {
-          cards.push(
-            {
-              resources: targetCard.resourceCount,
-              resourceType: undefined, // Card on SRR cannot gather its own resources (if any)
-              name: targetCard.card.name,
-              calculatedCost: this.getCardCost(targetCard.card),
-              cardType: card.cardType,
-              isDisabled: false,
-              reserveUnits: Units.EMPTY, // I wonder if this could just be removed.
-            },
-          );
-        }
-        return cards;
-      }
-    }
-    return cards;
   }
 
   public getCardCost(card: IProjectCard): number {

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -27,7 +27,8 @@ export interface IActionCard {
 }
 
 export interface IResourceCard {
-    resourceCount: number;
+    resourceCount?: number;
+    resourceType?: ResourceType;
 }
 
 export interface CardDiscount {

--- a/src/cards/base/CEOsFavoriteProject.ts
+++ b/src/cards/base/CEOsFavoriteProject.ts
@@ -34,12 +34,7 @@ export class CEOsFavoriteProject extends Card implements IProjectCard {
       'Add resource',
       player.getCardsWithResources().concat(robotCards.map((c) => c.card)),
       (foundCards: Array<ICard>) => {
-        const robotCard = robotCards.find((c) => c.card.name === foundCards[0].name);
-        if (robotCard !== undefined) {
-          robotCard.resourceCount++;
-        } else {
-          player.addResourceTo(foundCards[0]);
-        }
+        player.addResourceTo(robotCards.find((c) => c.card.name === foundCards[0].name) ?? foundCards[0]);
         LogHelper.logAddResource(player, foundCards[0]);
         return undefined;
       },

--- a/src/cards/base/CEOsFavoriteProject.ts
+++ b/src/cards/base/CEOsFavoriteProject.ts
@@ -23,16 +23,23 @@ export class CEOsFavoriteProject extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    return player.getCardsWithResources().length > 0;
+    return player.getCardsWithResources().length > 0 ||
+           player.getSelfReplicatingRobotsTargetCards().length > 0;
   }
 
   public play(player: Player) {
+    const robotCards = player.getSelfReplicatingRobotsTargetCards();
     return new SelectCard(
       'Select card to add resource',
       'Add resource',
-      player.getCardsWithResources(),
+      player.getCardsWithResources().concat(robotCards.map((c) => c.card)),
       (foundCards: Array<ICard>) => {
-        player.addResourceTo(foundCards[0]);
+        const robotCard = robotCards.find((c) => c.card.name === foundCards[0].name);
+        if (robotCard !== undefined) {
+          robotCard.resourceCount++;
+        } else {
+          player.addResourceTo(foundCards[0]);
+        }
         LogHelper.logAddResource(player, foundCards[0]);
         return undefined;
       },

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -112,7 +112,7 @@ export class Server {
       playedCards: getCards(player, player.playedCards, {showResources: true}),
       players: getPlayers(game.getPlayers(), game),
       preludeCardsInHand: getCards(player, player.preludeCardsInHand),
-      selfReplicatingRobotsCards: player.getSelfReplicatingRobotsCards(),
+      selfReplicatingRobotsCards: getSelfReplicatingRobotsTargetCards(player),
       spaces: getSpaces(game.board),
       spectatorId: game.spectatorId,
       steel: player.steel,
@@ -139,6 +139,18 @@ export class Server {
       generation: game.generation,
     };
   }
+}
+
+function getSelfReplicatingRobotsTargetCards(player: Player): Array<CardModel> {
+  return player.getSelfReplicatingRobotsTargetCards().map((targetCard) => ({
+    resources: targetCard.resourceCount,
+    resourceType: undefined, // Card on SRR cannot gather its own resources (if any)
+    name: targetCard.card.name,
+    calculatedCost: player.getCardCost(targetCard.card),
+    cardType: CardType.ACTIVE,
+    isDisabled: false,
+    reserveUnits: Units.EMPTY, // I wonder if this could just be removed.
+  }));
 }
 
 function getMilestones(game: Game): Array<ClaimedMilestoneModel> {
@@ -418,7 +430,7 @@ function getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
       fleetSize: player.getFleetSize(),
       tradesThisGeneration: player.tradesThisGeneration,
       turmoil: turmoil,
-      selfReplicatingRobotsCards: player.getSelfReplicatingRobotsCards(),
+      selfReplicatingRobotsCards: getSelfReplicatingRobotsTargetCards(player),
       needsToDraft: player.needsToDraft,
       needsToResearch: !game.hasResearched(player),
       deckSize: game.dealer.getDeckSize(),

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -17,6 +17,7 @@ import {CardName} from '../src/CardName';
 import {GlobalParameter} from '../src/GlobalParameter';
 import {TestingUtils} from './TestingUtils';
 import {Units} from '../src/Units';
+import {SelfReplicatingRobots} from '../src/cards/promo/SelfReplicatingRobots';
 
 describe('Player', function() {
   it('should initialize with right defaults', function() {
@@ -278,6 +279,14 @@ describe('Player', function() {
 
     expect(newPlayer.color).eq(Color.PURPLE);
     expect(newPlayer.tradesThisGeneration).eq(100);
+  });
+  it('pulls self replicating robots target cards', function() {
+    const player = TestPlayers.BLUE.newPlayer();
+    expect(player.getSelfReplicatingRobotsTargetCards().length).eq(0);
+    const srr = new SelfReplicatingRobots();
+    player.playedCards.push(srr);
+    srr.targetCards.push({card: new LunarBeam(), resourceCount: 0});
+    expect(player.getSelfReplicatingRobotsTargetCards().length).eq(1);
   });
 });
 

--- a/tests/cards/base/CEOsFavoriteProject.spec.ts
+++ b/tests/cards/base/CEOsFavoriteProject.spec.ts
@@ -4,6 +4,7 @@ import {CEOsFavoriteProject} from '../../../src/cards/base/CEOsFavoriteProject';
 import {Decomposers} from '../../../src/cards/base/Decomposers';
 import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {SecurityFleet} from '../../../src/cards/base/SecurityFleet';
+import {SelfReplicatingRobots} from '../../../src/cards/promo/SelfReplicatingRobots';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
 import {Player} from '../../../src/Player';
@@ -46,5 +47,16 @@ describe('CEOsFavoriteProject', function() {
     expect(player.getResourcesOnCard(decomposers)).to.eq(2);
     action.cb([securityFleet]);
     expect(player.getResourcesOnCard(securityFleet)).to.eq(2);
+  });
+
+  it('Can play on SelfReplicatingRobots cards', function() {
+    const srr = new SelfReplicatingRobots();
+    const birds = new Birds();
+    player.playedCards.push(srr);
+    srr.targetCards.push({card: birds, resourceCount: 0});
+    const action = card.play(player);
+    expect(action instanceof SelectCard).is.true;
+    action.cb([birds]);
+    expect(srr.targetCards[0].resourceCount).to.eq(1);
   });
 });


### PR DESCRIPTION
Fixes #2453 . Allows `CEOsFavoriteProject` to add resources to `SelfReplicatingRobots` cards.