### PR TITLE
use better key for logged cards

### DIFF
--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -161,7 +161,7 @@ export const LogPanel = Vue.component('log-panel', {
     },
     cardClicked: function(message: LogMessage) {
       const datas = message.data;
-      for (const data of datas) {
+      datas.forEach((data: LogMessageData) => {
         if (data.type !== undefined && data.value !== undefined) {
           if (data.type === LogMessageDataType.CARD) {
             const card_name = data.value;
@@ -171,10 +171,9 @@ export const LogPanel = Vue.component('log-panel', {
             } else {
               this.cards.splice(index, 1);
             }
-            break;
           }
         }
-      }
+      });
     },
     hideMe: function() {
       this.cards = [];

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -161,7 +161,7 @@ export const LogPanel = Vue.component('log-panel', {
     },
     cardClicked: function(message: LogMessage) {
       const datas = message.data;
-      datas.forEach((data: LogMessageData) => {
+      for (const data of datas) {
         if (data.type !== undefined && data.value !== undefined) {
           if (data.type === LogMessageDataType.CARD) {
             const card_name = data.value;
@@ -171,9 +171,10 @@ export const LogPanel = Vue.component('log-panel', {
             } else {
               this.cards.splice(index, 1);
             }
+            break;
           }
         }
-      });
+      }
     },
     hideMe: function() {
       this.cards = [];
@@ -274,7 +275,7 @@ export const LogPanel = Vue.component('log-panel', {
         </div>
         <div class="card-panel" v-if="cards.length > 0">
           <Button size="big" type="close" :disableOnServerBusy="false" :onClick="hideMe" align="right"/>
-          <div id="log_panel_card" class="cardbox" v-for="(card, index) in cards" :key="index">
+          <div id="log_panel_card" class="cardbox" v-for="(card, index) in cards" :key="card">
             <Card :card="{name: card}"/>
           </div>
         </div>

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -134,7 +134,7 @@ export const SelectSpace = Vue.component('select-space', {
   template: `<div>
     <confirm-dialog
         message="Place your tile here?\n(This confirmation can be disabled in preferences)."
-        enableDontShowAgainCheckbox="true"
+        :enableDontShowAgainCheckbox="true"
         ref="confirmation"
         v-on:accept="confirmPlacement"
         v-on:dismiss="cancelPlacement"


### PR DESCRIPTION
Uses a key for the displayed cards. Using only `index` was leading to the bugs seen in the video provided with the bug. This fixes #2264 . Also saw we weren't passing in a boolean as expected. Vue was logging a warning regarding the `enableDontShowAgainCheckbox`. Updated that to use a boolean.