### PR TITLE
use searchParams for player input

### DIFF
--- a/src/routes/PlayerInput.ts
+++ b/src/routes/PlayerInput.ts
@@ -12,10 +12,13 @@ export class PlayerInput extends Handler {
   }
 
   public post(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
-    // I made this req.url! We know at this point url is not null. But moving to using ctx.url will help.
-    const playerId: string = req.url!.substring(
-      '/player/input?id='.length,
-    );
+    const playerId = ctx.url.searchParams.get('id');
+
+    if (playerId === null) {
+      ctx.route.badRequest(req, res, 'must provide id');
+      return;
+    }
+
     // This is the exact same code as in `ApiPlayer`. I bet it's not the only place.
     GameLoader.getInstance().getByPlayerId(playerId, (game) => {
       if (game === undefined) {

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,0 +1,31 @@
+import * as http from 'http';
+import {expect} from 'chai';
+import {PlayerInput} from '../../src/routes/PlayerInput';
+import {Route} from '../../src/routes/Route';
+import {MockResponse} from './HttpMocks';
+import {IContext} from '../../src/routes/IHandler';
+import {FakeGameLoader} from './FakeGameLoader';
+
+describe('PlayerInput', function() {
+  let req: http.IncomingMessage;
+  let res: MockResponse;
+  let ctx: IContext;
+
+  beforeEach(() => {
+    req = {} as http.IncomingMessage;
+    res = new MockResponse();
+    ctx = {
+      route: new Route(),
+      serverId: '1',
+      url: new URL('http://boo.com'),
+      gameLoader: new FakeGameLoader(),
+    };
+  });
+
+  it('fails when id not provided', () => {
+    req.url = '/player/input';
+    ctx.url = new URL('http://boo.com' + req.url);
+    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
+    expect(res.content).eq('Bad request: must provide id');
+  });
+});


### PR DESCRIPTION
I plan to start improving the action we currently know as undo. On my quest I stumbled upon this small clean up. Uses the search params instead of parsing the id out of the query string. Added unit test for the route to verify my addition of added bad request response.