### PR TITLE
set usedUndo synchronously

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1669,6 +1669,7 @@ export class Player implements ISerializable<SerializedPlayer> {
         // We need a mechanism to tell the user this has failed. By now the `res` has been sent.
         // For now we will keep this player instance going and hope player discovers what has happened.
         if (err) {
+          this.game.log('Unable to perform undo operation', () => {}, {reservedFor: this});
           this.usedUndo = false;
           this.takeAction();
           return;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1669,6 +1669,7 @@ export class Player implements ISerializable<SerializedPlayer> {
         // We need a mechanism to tell the user this has failed. By now the `res` has been sent.
         // For now we will keep this player instance going and hope player discovers what has happened.
         if (err) {
+          this.usedUndo = false;
           this.takeAction();
           return;
         }
@@ -1811,8 +1812,13 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public takeAction(): void {
+    /**
+     * Once an undo has been used we switch to
+     * a different instance of `Player` pulled from
+     * database. The instance where the undo was performed
+     * should no longer take actions
+     */
     if (this.usedUndo) {
-      this.usedUndo = false;
       return;
     }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1663,6 +1663,12 @@ export class Player implements ISerializable<SerializedPlayer> {
   // Propose a new action to undo last action
   private undoTurnOption(): PlayerInput {
     return new SelectOption('Undo last action', 'Undo', () => {
+      /**
+       * The usedUndo flag is used as a kill switch. Once this flag
+       * is set on an instance we don't expect that instance to take
+       * further action or be used. We assume the `GameLoader` is going
+       * to create a new `Player` instance to use with the a `Game`.
+       */
       this.usedUndo = true; // To prevent going back into takeAction()
       GameLoader.getInstance().restoreGameAt(this.game.id, this.game.lastSaveId - 2, (err) => {
         // If there is an error with restoring the game from the database this undo action has failed.
@@ -1815,9 +1821,9 @@ export class Player implements ISerializable<SerializedPlayer> {
   public takeAction(): void {
     /**
      * Once an undo has been used we switch to
-     * a different instance of `Player` pulled from
-     * database. The instance where the undo was performed
-     * should no longer take actions
+     * the new instance of `Player` pulled from
+     * database. This instance, where the undo was performed,
+     * should no longer take actions.
      */
     if (this.usedUndo) {
       return;

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -94,14 +94,18 @@ export const WaitingFor = Vue.component('waiting-for', {
             if (result.result === 'GO') {
               root.updatePlayer();
 
-              if (Notification.permission !== 'granted') {
-                Notification.requestPermission();
-              }
-              if (Notification.permission === 'granted') {
-                new Notification(constants.APP_NAME, {
-                  icon: '/favicon.ico',
-                  body: 'It\'s your turn!',
-                });
+              // Only show notification for multi-player games
+              // todo bafolts remove once undo refactor complete
+              if (this.player.players.length > 1) {
+                if (Notification.permission !== 'granted') {
+                  Notification.requestPermission();
+                }
+                if (Notification.permission === 'granted') {
+                  new Notification(constants.APP_NAME, {
+                    icon: '/favicon.ico',
+                    body: 'It\'s your turn!',
+                  });
+                }
               }
               const soundsEnabled = PreferencesManager.loadValue('enable_sounds') === '1';
               if (soundsEnabled) SoundManager.playActivePlayerSound();
@@ -130,7 +134,12 @@ export const WaitingFor = Vue.component('waiting-for', {
     window.clearInterval(documentTitleTimer);
     if (this.waitingfor === undefined) {
       this.waitForUpdate();
-      return createElement('div', $t('Not your turn to take any actions'));
+      let message = 'Not your turn to take any actions';
+      // todo bafolts remove once undo refactor complete
+      if (this.players.length === 1) {
+        message = '';
+      }
+      return createElement('div', $t(message));
     }
     if (this.player.players.length > 1 && this.player.waitingFor !== undefined) {
       documentTitleTimer = window.setInterval(() => this.animateTitle(), 1000);

--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -116,23 +116,21 @@ export class GameLoader implements IGameLoader {
     this.getByParticipantId(spectatorId, cb);
   }
 
-  public restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void {
-    try {
-      Database.getInstance().restoreGame(gameId, saveId, (err, game) => {
-        if (game !== undefined) {
-          Database.getInstance().deleteGameNbrSaves(gameId, 1);
-          this.add(game);
-          game.undoCount++;
-          cb(game);
-        } else {
-          console.log(err);
-          cb(undefined);
-        }
-      });
-    } catch (error) {
-      console.log(error);
-      cb(undefined);
-    }
+  public restoreGameAt(gameId: GameId, saveId: number, cb: (err?: any) => void): void {
+    Database.getInstance().restoreGame(gameId, saveId, (err, game) => {
+      if (err) {
+        console.error('error while restoring game', err);
+        cb(err);
+      } else if (game !== undefined) {
+        Database.getInstance().deleteGameNbrSaves(gameId, 1);
+        this.add(game);
+        game.undoCount++;
+        cb();
+      } else {
+        console.error('game not found while restoring game', err);
+        cb(new Error('game not found'));
+      }
+    });
   }
 
   private loadGame(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void {

--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -117,20 +117,25 @@ export class GameLoader implements IGameLoader {
   }
 
   public restoreGameAt(gameId: GameId, saveId: number, cb: (err?: any) => void): void {
-    Database.getInstance().restoreGame(gameId, saveId, (err, game) => {
-      if (err) {
-        console.error('error while restoring game', err);
-        cb(err);
-      } else if (game !== undefined) {
-        Database.getInstance().deleteGameNbrSaves(gameId, 1);
-        this.add(game);
-        game.undoCount++;
-        cb();
-      } else {
-        console.error('game not found while restoring game', err);
-        cb(new Error('game not found'));
-      }
-    });
+    try {
+      Database.getInstance().restoreGame(gameId, saveId, (err, game) => {
+        if (err) {
+          console.error('error while restoring game', err);
+          cb(err);
+        } else if (game !== undefined) {
+          Database.getInstance().deleteGameNbrSaves(gameId, 1);
+          this.add(game);
+          game.undoCount++;
+          cb();
+        } else {
+          console.error('game not found while restoring game', err);
+          cb(new Error('game not found'));
+        }
+      });
+    } catch (error) {
+      console.log(error);
+      cb(error);
+    }
   }
 
   private loadGame(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void {

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -18,6 +18,8 @@ import {GlobalParameter} from '../src/GlobalParameter';
 import {TestingUtils} from './TestingUtils';
 import {Units} from '../src/Units';
 import {SelfReplicatingRobots} from '../src/cards/promo/SelfReplicatingRobots';
+import {OrOptions} from '../src/inputs/OrOptions';
+import {GameLoader} from '../src/database/GameLoader';
 
 describe('Player', function() {
   it('should initialize with right defaults', function() {
@@ -287,6 +289,43 @@ describe('Player', function() {
     player.playedCards.push(srr);
     srr.targetCards.push({card: new LunarBeam(), resourceCount: 0});
     expect(player.getSelfReplicatingRobotsTargetCards().length).eq(1);
+  });
+  it('uses undo', function() {
+    const player = TestPlayers.BLUE.newPlayer();
+    player.beginner = true;
+    const game = Game.newInstance('foo', [player], player);
+    game.gameOptions.undoOption = true;
+    player.process([['1'], ['Power Plant:SP']]);
+    const options = player.getWaitingFor() as OrOptions;
+    expect((player as any).usedUndo).is.false;
+    player.process([[String(options.options.length - 1)], ['']]);
+    expect((player as any).usedUndo).is.true;
+    expect(player.getWaitingFor()).is.undefined;
+  });
+  it('progresses game if undo operation fails', function() {
+    const player = TestPlayers.BLUE.newPlayer();
+    player.beginner = true;
+    const game = Game.newInstance('foo', [player], player);
+    game.gameOptions.undoOption = true;
+    player.process([['1'], ['Power Plant:SP']]);
+    const options = player.getWaitingFor() as OrOptions;
+    expect((player as any).usedUndo).is.false;
+    const instance = GameLoader.getInstance();
+    const originRestore = instance.restoreGameAt;
+    let restoreGameCb: ((err: any) => void) | undefined = undefined;
+    instance.restoreGameAt = function(_gameId: string, _saveId: number, cb: (err: any) => void) {
+      restoreGameCb = cb;
+      instance.restoreGameAt = originRestore;
+    };
+    player.process([[String(options.options.length - 1)], ['']]);
+    expect((player as any).usedUndo).is.true;
+    if (restoreGameCb === undefined) {
+      throw new Error('did not call to restore game');
+    }
+    expect(player.getWaitingFor()).is.undefined;
+    (restoreGameCb as (err: any) => void)('unable to restore game');
+    expect((player as any).usedUndo).is.false;
+    expect(player.getWaitingFor()).not.is.undefined;
   });
 });
 


### PR DESCRIPTION
This is part 2 (of 3 or 4) on a quest to have undo work without needing to click refresh. After this change after performing an undo the user will see the message "Not your turn to take any actions". Seconds later once we again query for the updated player the latest player object will be returned. This is still not perfect but better. In the change after this I plan to wait to send the updated player response until the database has rolled back. Once all of these commits are in when a player performs the undo last action they wont have to remember to click refresh.