### PR TITLE
Rework the preferences API.

### DIFF
--- a/src/components/Award.ts
+++ b/src/components/Award.ts
@@ -47,7 +47,7 @@ export const Award = Vue.component('award', {
       return AWARD_COSTS.slice(numFundedAwards);
     },
     isLearnerModeOn: function(): boolean {
-      return PreferencesManager.loadBooleanValue('learner_mode');
+      return PreferencesManager.loadBoolean('learner_mode');
     },
   },
   template: `

--- a/src/components/Board.ts
+++ b/src/components/Board.ts
@@ -63,7 +63,7 @@ export const Board = Vue.component('board', {
     };
   },
   mounted: function() {
-    if (this.marsIsTerraformed() && this.shouldNotify && AlertDialog.shouldAlert && PreferencesManager.loadValue('show_alerts') === '1') {
+    if (this.marsIsTerraformed() && this.shouldNotify && AlertDialog.shouldAlert && PreferencesManager.load('show_alerts') === '1') {
       alert('Mars is Terraformed!');
       AlertDialog.shouldAlert = false;
     };
@@ -230,14 +230,14 @@ export const Board = Vue.component('board', {
                     <line x1="38" y1="20" x2="88" y2="26" class="board-line"></line>
                     <text x="86" y="29" class="board-caption board_caption--black">●</text>
                 </g>
-                
+
                 <g v-if="boardName === 'tharsis'" id="pavonis_mons" transform="translate(90, 230)">
                     <text class="board-caption">
                         <tspan dy="15">Pavonis</tspan>
                         <tspan x="4" dy="12">Mons</tspan>
                     </text>
                     <line x1="35" y1="25" x2="72" y2="30" class="board-line" />
-                    <text x="66" y="33" class="board-caption board_caption--black">●</text>              
+                    <text x="66" y="33" class="board-caption board_caption--black">●</text>
                 </g>
 
 
@@ -247,7 +247,7 @@ export const Board = Vue.component('board', {
                         <tspan x="-2" dy="12">Mons</tspan>
                     </text>
                     <line x1="25" y1="20" x2="49" y2="26" class="board-line" />
-                    <text x="47" y="29" class="board-caption board_caption--black">●</text>              
+                    <text x="47" y="29" class="board-caption board_caption--black">●</text>
                 </g>
 
                 <g v-if="boardName === 'tharsis'" id="tharsis_tholus" transform="translate(85, 175)">
@@ -258,7 +258,7 @@ export const Board = Vue.component('board', {
                     <line y1="-3" x2="160" y2="2" class="board-line" x1="90"></line>
                     <text x="158" y="5" class="board-caption board_caption--black">&#x25cf;</text>
                 </g>
-                
+
                 <g v-if="boardName === 'tharsis'" id="noctis_city" transform="translate(85, 320)">
                     <text class="board-caption">
                         <tspan dy="15">Noctis</tspan>

--- a/src/components/DebugUI.ts
+++ b/src/components/DebugUI.ts
@@ -166,7 +166,7 @@ export const DebugUI = Vue.component('debug-ui', {
       }
     },
     getLanguageCssClass() {
-      const language = PreferencesManager.loadValue('lang') || 'en';
+      const language = PreferencesManager.load('lang') || 'en';
       return 'language-' + language;
     },
   },

--- a/src/components/LanguageSwitcher.ts
+++ b/src/components/LanguageSwitcher.ts
@@ -10,16 +10,16 @@ export const LanguageSwitcher = Vue.component('language-switcher', {
   },
   methods: {
     switchLanguageTo: function(langId: string, reloadThePage: boolean = false) {
-      PreferencesManager.saveValue('lang', langId);
+      PreferencesManager.save('lang', langId);
       if (reloadThePage) window.location = window.location;
     },
   },
   template: `
         <div class="language-switcher">
-            <div 
-                v-for="lang in languages" 
-                :class="'language-icon language-icon--'+lang.id" 
-                :title="lang.title" 
+            <div
+                v-for="lang in languages"
+                :class="'language-icon language-icon--'+lang.id"
+                :title="lang.title"
                 v-on:click="switchLanguageTo(lang.id, true)"></div>
         </div>
     `,

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -209,7 +209,7 @@ export const LogPanel = Vue.component('log-panel', {
         if (xhr.status === 200) {
           messages.splice(0, messages.length);
           messages.push(...xhr.response);
-          if (PreferencesManager.loadBooleanValue('enable_sounds') && window.location.search.includes('experimental=1') ) {
+          if (PreferencesManager.loadBoolean('enable_sounds') && window.location.search.includes('experimental=1') ) {
             SoundManager.newLog();
           }
           if (generation === this.generation) {

--- a/src/components/Milestone.ts
+++ b/src/components/Milestone.ts
@@ -42,7 +42,7 @@ export const Milestone = Vue.component('milestone', {
       return Array(MAX_MILESTONES - count).fill(MILESTONE_COST);
     },
     isLearnerModeOn: function(): boolean {
-      return PreferencesManager.loadValue('learner_mode') === '1';
+      return PreferencesManager.load('learner_mode') === '1';
     },
   },
   template: `

--- a/src/components/OrOptions.ts
+++ b/src/components/OrOptions.ts
@@ -123,7 +123,7 @@ export const OrOptions = Vue.component('or-options', {
 
       // Show all option by default unless it is told to show only in learner mode
       let showOption = true;
-      if (option.showOnlyInLearnerMode && !PreferencesManager.loadBooleanValue('learner_mode')) {
+      if (option.showOnlyInLearnerMode && !PreferencesManager.loadBoolean('learner_mode')) {
         showOption = false;
       }
 

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -25,28 +25,28 @@ import {Phase} from '../../src/Phase';
 import * as raw_settings from '../genfiles/settings.json';
 
 export interface PlayerHomeModel {
-  hideActiveCards: boolean;
-  hideAutomatedCards: boolean;
-  hideEventCards: boolean;
+  showActiveCards: boolean;
+  showAutomatedCards: boolean;
+  showEventCards: boolean;
 }
 
 export const PlayerHome = Vue.component('player-home', {
   data: function(): PlayerHomeModel {
     return {
-      hideActiveCards: PreferencesManager.loadBoolean('hide_active_cards'),
-      hideAutomatedCards: PreferencesManager.loadBoolean('hide_automated_cards'),
-      hideEventCards: PreferencesManager.loadBoolean('hide_event_cards'),
+      showActiveCards: !PreferencesManager.loadBoolean('hide_active_cards'),
+      showAutomatedCards: !PreferencesManager.loadBoolean('hide_automated_cards'),
+      showEventCards: !PreferencesManager.loadBoolean('hide_event_cards'),
     };
   },
   watch: {
     hide_active_cards: function() {
-      PreferencesManager.save('hide_active_cards', this.hideActiveCards);
+      PreferencesManager.save('hide_active_cards', !this.showActiveCards);
     },
     hide_automated_cards: function() {
-      PreferencesManager.save('hide_automated_cards', this.hideAutomatedCards);
+      PreferencesManager.save('hide_automated_cards', !this.showAutomatedCards);
     },
     hide_event_cards: function() {
-      PreferencesManager.save('hide_event_cards', this.hideEventCards);
+      PreferencesManager.save('hide_event_cards', !this.showEventCards);
     },
   },
   props: {
@@ -126,34 +126,40 @@ export const PlayerHome = Vue.component('player-home', {
       }
       return fleetsRange;
     },
-    toggleActiveCardsHiding() {
-      this.hideActiveCards = this.isActiveCardShown();
+    toggle(type: string): void {
+      switch (type) {
+      case 'ACTIVE':
+        this.showActiveCards = !this.showActiveCards;
+        break;
+      case 'AUTOMATED':
+        this.showAutomatedCards = !this.showAutomatedCards;
+        break;
+      case 'EVENT':
+        this.showEventCards = !this.showEventCards;
+        break;
+      }
     },
-    toggleAutomatedCardsHiding() {
-      this.hideAutomatedCards = this.isAutomatedCardShown();
-    },
-    toggleEventCardsHiding() {
-      this.hideEventCards = this.isEventCardShown();
-    },
-    isActiveCardShown(): boolean {
-      return !this.hideActiveCards;
-    },
-    isAutomatedCardShown(): boolean {
-      return !this.hideAutomatedCards;
-    },
-    isEventCardShown(): boolean {
-      return !this.hideEventCards;
+    isVisible(type: string): boolean {
+      switch (type) {
+      case 'ACTIVE':
+        return this.showActiveCards;
+      case 'AUTOMATED':
+        return this.showAutomatedCards;
+      case 'EVENT':
+        return this.showEventCards;
+      }
+      return false;
     },
     isInitialDraftingPhase(): boolean {
       return (this.player.phase === Phase.INITIALDRAFTING) && this.player.gameOptions.initialDraftVariant;
     },
     getToggleLabel: function(hideType: string): string {
       if (hideType === 'ACTIVE') {
-        return (this.isActiveCardShown() ? '✔' : '');
+        return (this.showActiveCards? '✔' : '');
       } else if (hideType === 'AUTOMATED') {
-        return (this.isAutomatedCardShown() ? '✔' : '');
+        return (this.showAutomatedCards ? '✔' : '');
       } else if (hideType === 'EVENT') {
-        return (this.isEventCardShown() ? '✔' : '');
+        return (this.showEventCards ? '✔' : '');
       } else {
         return '';
       }
@@ -161,11 +167,11 @@ export const PlayerHome = Vue.component('player-home', {
     getHideButtonClass: function(hideType: string): string {
       const prefix = 'hiding-card-button ';
       if (hideType === 'ACTIVE') {
-        return prefix + (this.isActiveCardShown() ? 'active' : 'active-transparent');
+        return prefix + (this.showActiveCards ? 'active' : 'active-transparent');
       } else if (hideType === 'AUTOMATED') {
-        return prefix + (this.isAutomatedCardShown() ? 'automated' : 'automated-transparent');
+        return prefix + (this.showAutomatedCards ? 'automated' : 'automated-transparent');
       } else if (hideType === 'EVENT') {
-        return prefix + (this.isEventCardShown() ? 'event' : 'event-transparent');
+        return prefix + (this.showEventCards ? 'event' : 'event-transparent');
       } else {
         return '';
       }
@@ -260,15 +266,15 @@ export const PlayerHome = Vue.component('player-home', {
                     <div class="hiding-card-button-row">
                         <dynamic-title title="Played Cards" :color="player.color" />
                         <div class="played-cards-filters">
-                          <div :class="getHideButtonClass('ACTIVE')" v-on:click.prevent="toggleActiveCardsHiding()">
+                          <div :class="getHideButtonClass('ACTIVE')" v-on:click.prevent="toggle('ACTIVE')">
                             <div class="played-cards-count">{{getCardsByType(player.playedCards, [getActiveCardType()]).length.toString()}}</div>
                             <div class="played-cards-selection" v-i18n>{{ getToggleLabel('ACTIVE')}}</div>
                           </div>
-                          <div :class="getHideButtonClass('AUTOMATED')" v-on:click.prevent="toggleAutomatedCardsHiding()">
+                          <div :class="getHideButtonClass('AUTOMATED')" v-on:click.prevent="toggle('AUTOMATED')">
                             <div class="played-cards-count">{{getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()]).length.toString()}}</div>
                             <div class="played-cards-selection" v-i18n>{{ getToggleLabel('AUTOMATED')}}</div>
                           </div>
-                          <div :class="getHideButtonClass('EVENT')" v-on:click.prevent="toggleEventCardsHiding()">
+                          <div :class="getHideButtonClass('EVENT')" v-on:click.prevent="toggle('EVENT')">
                             <div class="played-cards-count">{{getCardsByType(player.playedCards, [getEventCardType()]).length.toString()}}</div>
                             <div class="played-cards-selection" v-i18n>{{ getToggleLabel('EVENT')}}</div>
                           </div>
@@ -278,13 +284,13 @@ export const PlayerHome = Vue.component('player-home', {
                     <div v-if="player.corporationCard !== undefined" class="cardbox">
                         <Card :card="player.corporationCard" :actionUsed="isCardActivated(player.corporationCard, player)"/>
                     </div>
-                    <div v-show="isActiveCardShown()" v-for="card in sortActiveCards(getCardsByType(player.playedCards, [getActiveCardType()]))" :key="card.name" class="cardbox">
+                    <div v-show="isVisible('ACTIVE')" v-for="card in sortActiveCards(getCardsByType(player.playedCards, [getActiveCardType()]))" :key="card.name" class="cardbox">
                         <Card :card="card" :actionUsed="isCardActivated(card, player)"/>
                     </div>
 
-                    <stacked-cards v-show="isAutomatedCardShown()" :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" ></stacked-cards>
+                    <stacked-cards v-show="isVisible('AUTOMATED')" :cards="getCardsByType(player.playedCards, [getAutomatedCardType(), getPreludeCardType()])" ></stacked-cards>
 
-                    <stacked-cards v-show="isEventCardShown()" :cards="getCardsByType(player.playedCards, [getEventCardType()])" ></stacked-cards>
+                    <stacked-cards v-show="isVisible('EVENT')" :cards="getCardsByType(player.playedCards, [getEventCardType()])" ></stacked-cards>
 
                 </div>
 

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -25,28 +25,28 @@ import {Phase} from '../../src/Phase';
 import * as raw_settings from '../genfiles/settings.json';
 
 export interface PlayerHomeModel {
-  hide_active_cards: string;
-  hide_automated_cards: string;
-  hide_event_cards: string;
+  hideActiveCards: boolean;
+  hideAutomatedCards: boolean;
+  hideEventCards: boolean;
 }
 
 export const PlayerHome = Vue.component('player-home', {
   data: function(): PlayerHomeModel {
     return {
-      hide_active_cards: PreferencesManager.loadValue('hide_active_cards'),
-      hide_automated_cards: PreferencesManager.loadValue('hide_automated_cards'),
-      hide_event_cards: PreferencesManager.loadValue('hide_event_cards'),
+      hideActiveCards: PreferencesManager.loadBoolean('hide_active_cards'),
+      hideAutomatedCards: PreferencesManager.loadBoolean('hide_automated_cards'),
+      hideEventCards: PreferencesManager.loadBoolean('hide_event_cards'),
     };
   },
   watch: {
     hide_active_cards: function() {
-      PreferencesManager.saveValue('hide_active_cards', this.hide_active_cards);
+      PreferencesManager.save('hide_active_cards', this.hideActiveCards);
     },
     hide_automated_cards: function() {
-      PreferencesManager.saveValue('hide_automated_cards', this.hide_automated_cards);
+      PreferencesManager.save('hide_automated_cards', this.hideAutomatedCards);
     },
     hide_event_cards: function() {
-      PreferencesManager.saveValue('hide_event_cards', this.hide_event_cards);
+      PreferencesManager.save('hide_event_cards', this.hideEventCards);
     },
   },
   props: {
@@ -127,22 +127,22 @@ export const PlayerHome = Vue.component('player-home', {
       return fleetsRange;
     },
     toggleActiveCardsHiding() {
-      this.hide_active_cards = this.isActiveCardShown() ? '1': '';
+      this.hideActiveCards = this.isActiveCardShown();
     },
     toggleAutomatedCardsHiding() {
-      this.hide_automated_cards = this.isAutomatedCardShown() ? '1': '';
+      this.hideAutomatedCards = this.isAutomatedCardShown();
     },
     toggleEventCardsHiding() {
-      this.hide_event_cards = this.isEventCardShown() ? '1': '';
+      this.hideEventCards = this.isEventCardShown();
     },
     isActiveCardShown(): boolean {
-      return this.hide_active_cards !== '1';
+      return !this.hideActiveCards;
     },
     isAutomatedCardShown(): boolean {
-      return this.hide_automated_cards !== '1';
+      return !this.hideAutomatedCards;
     },
     isEventCardShown(): boolean {
-      return this.hide_event_cards !== '1';
+      return !this.hideEventCards;
     },
     isInitialDraftingPhase(): boolean {
       return (this.player.phase === Phase.INITIALDRAFTING) && this.player.gameOptions.initialDraftVariant;

--- a/src/components/Preferences.ts
+++ b/src/components/Preferences.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import {Color} from '../Color';
-import {PreferencesManager} from './PreferencesManager';
+import {preferences, PreferencesManager} from './PreferencesManager';
 import {LANGUAGES} from '../constants';
 import {MAX_OCEAN_TILES, MAX_TEMPERATURE, MAX_OXYGEN_LEVEL, MAX_VENUS_SCALE} from '../constants';
 import {TurmoilModel} from '../models/TurmoilModel';
@@ -96,8 +96,8 @@ export const Preferences = Vue.component('preferences', {
             string,
             boolean | string
             > {
-      for (const k of PreferencesManager.keys) {
-        const val = PreferencesManager.loadValue(k);
+      for (const k of preferences) {
+        const val = PreferencesManager.load(k);
         if (k === 'lang') {
           PreferencesManager.preferencesValues.set(k, this.$data[k]);
           this[k] = val || 'en';
@@ -112,7 +112,7 @@ export const Preferences = Vue.component('preferences', {
     },
     updatePreferences: function(_evt: any): void {
       let strVal: string = '';
-      for (const k of PreferencesManager.keys) {
+      for (const k of preferences) {
         const val = PreferencesManager.preferencesValues.get(k);
         if (val !== this.$data[k]) {
           if (k === 'lang') {
@@ -120,23 +120,23 @@ export const Preferences = Vue.component('preferences', {
           } else {
             strVal = this.$data[k] ? '1' : '0';
           }
-          PreferencesManager.saveValue(k, strVal);
+          PreferencesManager.save(k, strVal);
           PreferencesManager.preferencesValues.set(k, this.$data[k]);
           this.setPreferencesCSS(this.$data[k], k);
         }
       }
     },
     syncPreferences: function(): void {
-      for (const k of PreferencesManager.keys) {
+      for (const k of preferences) {
         this.$data[k] = PreferencesManager.preferencesValues.get(k);
         this.setPreferencesCSS(this.$data[k], k);
       }
     },
     getPlayerColorCubeClass: function(): string {
-      return this.acting_player && (PreferencesManager.loadBooleanValue('hide_animated_sidebar') === false) ? 'preferences_player_inner active' : 'preferences_player_inner';
+      return this.acting_player && (PreferencesManager.loadBoolean('hide_animated_sidebar') === false) ? 'preferences_player_inner active' : 'preferences_player_inner';
     },
     getSideBarClass: function(): string {
-      return this.acting_player && (PreferencesManager.loadBooleanValue('hide_animated_sidebar') === false) ? 'preferences_acting_player' : 'preferences_nonacting_player';
+      return this.acting_player && (PreferencesManager.loadBoolean('hide_animated_sidebar') === false) ? 'preferences_acting_player' : 'preferences_nonacting_player';
     },
     getGenMarker: function(): string {
       return `${this.generation}`;
@@ -328,7 +328,7 @@ export const Preferences = Vue.component('preferences', {
                     <div class="preferences_panel_item">
                         <label class="form-switch">
                             <input type="checkbox" v-on:change="updatePreferences" v-model="learner_mode" />
-                            <i class="form-icon"></i> 
+                            <i class="form-icon"></i>
                             <span v-i18n>Learner Mode (req. refresh)</span>
                             <span class="tooltip tooltip-left" data-tooltip="Show information that can be helpful\n to players who are still learning the games">&#9432;</span>
                         </label>

--- a/src/components/PreferencesManager.ts
+++ b/src/components/PreferencesManager.ts
@@ -1,44 +1,49 @@
+export const preferences = [
+  'hide_hand',
+  'hide_awards_and_milestones',
+  'hide_top_bar',
+  'small_cards',
+  'remove_background',
+  'magnify_cards',
+  'magnify_card_descriptions',
+  'show_alerts',
+  'hide_active_cards',
+  'hide_automated_cards',
+  'hide_event_cards',
+  'lang',
+  'enable_sounds',
+  'hide_tile_confirmation',
+  'show_card_number',
+  'hide_discount_on_cards',
+  'learner_mode',
+  'hide_animated_sidebar',
+] as const;
+
+export type Key = typeof preferences[number];
+
 export class PreferencesManager {
-    static keys: Array<string> = [
-      'hide_hand',
-      'hide_awards_and_milestones',
-      'hide_top_bar',
-      'small_cards',
-      'remove_background',
-      'magnify_cards',
-      'magnify_card_descriptions',
-      'show_alerts',
-      'hide_active_cards',
-      'hide_automated_cards',
-      'hide_event_cards',
-      'lang',
-      'enable_sounds',
-      'hide_tile_confirmation',
-      'show_card_number',
-      'hide_discount_on_cards',
-      'learner_mode',
-      'hide_animated_sidebar',
-    ];
+  static preferencesValues: Map<Key, boolean | string> = new Map<Key, boolean | string>();
+  private static localStorageSupported(): boolean {
+    return typeof localStorage !== 'undefined';
+  }
 
-    static preferencesValues: Map<string, boolean | string> = new Map<string, boolean | string>();
-    private static localStorageSupported(): boolean {
-      return typeof localStorage !== 'undefined';
-    }
-
-    static saveValue(name: string, val: string): void {
-      if ( ! PreferencesManager.localStorageSupported()) return;
+  static save(name: Key, val: string | boolean): void {
+    if (!this.localStorageSupported()) return;
+    if (typeof(val) === 'string') {
       localStorage.setItem(name, val);
+    } else {
+      localStorage.setItem(name, val ? '0' : '1');
     }
+  }
 
-    static loadValue(name: string): string {
-      if ( ! PreferencesManager.localStorageSupported()) return '';
-      const value = localStorage.getItem(name);
-      if (value === null) return '';
-      return value;
-    }
+  static load(name: Key, defaultValue = ''): string {
+    if (!this.localStorageSupported()) return defaultValue;
+    const value = localStorage.getItem(name);
+    return value ?? defaultValue;
+  }
 
-    static loadBooleanValue(name: string): boolean {
-      if ( ! PreferencesManager.localStorageSupported()) return false;
-      return localStorage.getItem(name) === '1';
-    }
+  static loadBoolean(name: Key, defaultValue = false): boolean {
+    if (!this.localStorageSupported()) return defaultValue;
+    return localStorage.getItem(name) === '1';
+  }
 }

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -201,7 +201,7 @@ export const SelectHowToPay = Vue.component('select-how-to-pay', {
         }
       }
 
-      const showAlert = PreferencesManager.loadValue('show_alerts') === '1';
+      const showAlert = PreferencesManager.load('show_alerts') === '1';
 
       if (requiredAmt > 0 && totalSpentAmt > requiredAmt && showAlert) {
         const diff = totalSpentAmt - requiredAmt;

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -319,7 +319,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
         }
       }
 
-      const showAlert = PreferencesManager.loadValue('show_alerts') === '1';
+      const showAlert = PreferencesManager.load('show_alerts') === '1';
 
       if (totalSpentAmt > this.cost && showAlert) {
         const diff = totalSpentAmt - this.cost;

--- a/src/components/SelectInitialCards.ts
+++ b/src/components/SelectInitialCards.ts
@@ -152,7 +152,7 @@ export const SelectInitialCards = Vue.component('select-initial-cards', {
       return starting;
     },
     saveIfConfirmed: function() {
-      if (PreferencesManager.loadValue('show_alerts') === '1' && this.selectedCards.length === 0) {
+      if (PreferencesManager.load('show_alerts') === '1' && this.selectedCards.length === 0) {
         (this.$refs['confirmation'] as any).show();
       } else {
         this.saveData();

--- a/src/components/SelectSpace.ts
+++ b/src/components/SelectSpace.ts
@@ -95,14 +95,14 @@ export const SelectSpace = Vue.component('select-space', {
       return spaces;
     },
     hideDialog: function(hide: boolean) {
-      PreferencesManager.saveValue('hide_tile_confirmation', hide === true ? '1' : '0');
+      PreferencesManager.save('hide_tile_confirmation', hide);
     },
     onTileSelected: function(tile: HTMLElement) {
       this.selectedTile = tile;
       this.disableAvailableSpaceAnimation();
       this.animateSpace(tile, true);
       tile.classList.remove('board-space--available');
-      const hideTileConfirmation = PreferencesManager.loadValue('hide_tile_confirmation') === '1';
+      const hideTileConfirmation = PreferencesManager.load('hide_tile_confirmation') === '1';
       if (hideTileConfirmation) {
         this.confirmPlacement();
       } else {

--- a/src/components/TopBar.ts
+++ b/src/components/TopBar.ts
@@ -22,13 +22,12 @@ export const TopBar = Vue.component('top-bar', {
       this.componentKey += 1;
     },
     toggleBar() {
-      const newVal = this.isExpanded() ? '1': '';
-      PreferencesManager.saveValue('hide_top_bar', newVal);
+      PreferencesManager.save('hide_top_bar', this.isExpanded());
       PreferencesManager.preferencesValues.set('hide_top_bar', this.isExpanded());
       this.forceRerender();
     },
     isExpanded(): boolean {
-      const val = PreferencesManager.loadValue('hide_top_bar');
+      const val = PreferencesManager.load('hide_top_bar');
       return val !== '1';
     },
     formatCssClass(): string {

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -103,7 +103,7 @@ export const WaitingFor = Vue.component('waiting-for', {
                   body: 'It\'s your turn!',
                 });
               }
-              const soundsEnabled = PreferencesManager.loadValue('enable_sounds') === '1';
+              const soundsEnabled = PreferencesManager.load('enable_sounds') === '1';
               if (soundsEnabled) SoundManager.playActivePlayerSound();
 
               // We don't need to wait anymore - it's our turn

--- a/src/components/card/Card.ts
+++ b/src/components/card/Card.ts
@@ -123,7 +123,7 @@ export const Card = Vue.component('card', {
       if (this.isStandardProject()) {
         classes.push('card-standard-project');
       }
-      const learnerModeOff = PreferencesManager.loadValue('learner_mode') === '0';
+      const learnerModeOff = PreferencesManager.load('learner_mode') === '0';
       if (learnerModeOff && this.isStandardProject() && card.isDisabled) {
         classes.push('card-hide');
       }

--- a/src/components/card/CardCost.ts
+++ b/src/components/card/CardCost.ts
@@ -19,7 +19,7 @@ export const CardCost = Vue.component('CardCost', {
       return classes.join(' ');
     },
     displayTwoCosts: function(): boolean {
-      const hideDiscount = PreferencesManager.loadBooleanValue('hide_discount_on_cards');
+      const hideDiscount = PreferencesManager.loadBoolean('hide_discount_on_cards');
       return this.newCost !== undefined && this.newCost !== this.amount && !hideDiscount;
     },
   },

--- a/src/components/card/CardNumber.ts
+++ b/src/components/card/CardNumber.ts
@@ -10,7 +10,7 @@ export const CardNumber = Vue.component('CardNumber', {
   },
   methods: {
     showCardNumber: function(): boolean {
-      return PreferencesManager.loadValue('show_card_number') === '1';
+      return PreferencesManager.load('show_card_number') === '1';
     },
   },
   template: `

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -99,10 +99,10 @@ export const PlayerInfo = Vue.component('player-info', {
       return this.player.availableBlueCardActionCount;
     },
     isLearnerModeOff: function(): boolean {
-      return PreferencesManager.loadBooleanValue('learner_mode') === false;
+      return PreferencesManager.loadBoolean('learner_mode') === false;
     },
   },
-  template: ` 
+  template: `
       <div :class="getClasses()">
         <div :class="getPlayerStatusAndResClasses()">
         <div class="player-status">
@@ -120,8 +120,8 @@ export const PlayerInfo = Vue.component('player-info', {
                 <div class="played-cards-icon hiding-card-button active"></div>
                 <div class="played-cards-icon hiding-card-button automated"></div>
                 <div class="played-cards-icon hiding-card-button event"></div>
-                <div class="played-cards-count"> 
-                  {{ 
+                <div class="played-cards-count">
+                  {{
                     getNrPlayedCards()
                   }}
                 </div>
@@ -129,7 +129,7 @@ export const PlayerInfo = Vue.component('player-info', {
             </div>
             <Button class="played-cards-button" size="tiny" :onClick="togglePlayerDetails" :title="buttonLabel()" />
           </div>
-          <div v-if="isLearnerModeOff()" class="tag-display player-board-blue-action-counter tooltip tooltip-top" data-tooltip="The number of available active card actions">
+          <div v-if="isLearnerModeOff()" class="tag-display player-board-blue-action-counter tooltip tooltip-top" data-tooltip="The number of available actions on active cards">
             <div class="tag-count tag-action-card">
               <div class="blue-stripe"></div>
               <div class="red-arrow"></div>

--- a/src/components/overview/PlayerResource.ts
+++ b/src/components/overview/PlayerResource.ts
@@ -58,7 +58,7 @@ export const PlayerResource = Vue.component('player-resource', {
       return this.type === Resources.PLANTS && this.plantsAreProtected;
     },
     showResourceValue: function(): boolean {
-      const learnerModeOn = PreferencesManager.loadValue('learner_mode') === '1';
+      const learnerModeOn = PreferencesManager.load('learner_mode') === '1';
       switch (this.type) {
       case Resources.STEEL:
         return learnerModeOn || this.steelValue > DEFAULT_STEEL_VALUE;

--- a/src/directives/i18n.ts
+++ b/src/directives/i18n.ts
@@ -18,7 +18,7 @@ export function translateMessage(message: Message): string {
 
 export function translateText(englishText: string): string {
   let translatedText = englishText;
-  const lang = PreferencesManager.loadValue('lang') || 'en';
+  const lang = PreferencesManager.load('lang') || 'en';
   if (lang === 'en') return englishText;
 
   englishText = normalizeText(englishText);


### PR DESCRIPTION
1. Limit valid fields to a key type. Avoiding using the namespace/enum solution as it seems namespaces and enums are deprecated. Huh.

2. Shortened the method names. Shorter and easier to read. 

3. Added default value parameters. These will help us standardize on `show` versus `hide` as a parameter name. In the long run.

4. Encompassed boolean management inside PreferencesManager. Each bit of code did their own thing, but all of them used `1` as a true, so it was easy to internalize.