### PR TITLE
Add alert when the server version updates.

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -42,6 +42,7 @@ interface MainAppData {
     isServerSideRequestInProgress: boolean;
     componentsVisibility: {[x: string]: boolean};
     game: GameHomeModel | undefined;
+    lastServedVersion: string;
 }
 
 export const mainAppSettings = {
@@ -64,6 +65,7 @@ export const mainAppSettings = {
     } as {[x: string]: boolean},
     game: undefined as GameHomeModel | undefined,
     logPaused: false,
+    lastServedVersion: raw_settings.version,
   } as MainAppData,
   'components': {
     'start-screen': StartScreen,
@@ -118,6 +120,7 @@ export const mainAppSettings = {
       xhr.onload = () => {
         if (xhr.status === 200) {
           app.player = xhr.response as PlayerModel;
+          this.testServerVersion(app.player.version);
           app.playerkey++;
           if (
             app.player.phase === 'end' &&
@@ -147,6 +150,19 @@ export const mainAppSettings = {
       };
       xhr.responseType = 'json';
       xhr.send();
+    },
+    testServerVersion: function(version: string) {
+      const app = this as unknown as typeof mainAppSettings.data;
+      const player = app.player;
+      if (player === undefined) {
+        return;
+      }
+      if (version !== undefined && version.length > 0) {
+        if (app.lastServedVersion !== version) {
+          app.lastServedVersion = version;
+          alert('A new version of the app is available. Please refresh your browser so it remains compatible with the server.');
+        }
+      }
     },
   },
   'mounted': function() {

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -91,6 +91,7 @@ export const WaitingFor = Vue.component('waiting-for', {
         xhr.onload = () => {
           if (xhr.status === 200) {
             const result = xhr.response as WaitingForModel;
+            root.testServerVersion(result.version);
             if (result.result === 'GO') {
               root.updatePlayer();
 

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -82,6 +82,7 @@ export interface PlayerModel {
     turmoil: TurmoilModel | undefined;
     undoCount: number;
     venusScaleLevel: number;
+    version: string;
     victoryPointsBreakdown: VictoryPointsBreakdown;
     waitingFor: PlayerInputModel | undefined;
 }

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -40,6 +40,7 @@ import {SpectatorModel} from './SpectatorModel';
 import {MoonModel} from './MoonModel';
 import {Units} from '../Units';
 import {SelectPartyToSendDelegate} from '../inputs/SelectPartyToSendDelegate';
+import * as raw_settings from '../genfiles/settings.json';
 
 export class Server {
   public static getGameModel(game: Game): GameHomeModel {
@@ -128,6 +129,7 @@ export class Server {
       tradesThisGeneration: player.tradesThisGeneration,
       turmoil: turmoil,
       undoCount: game.undoCount,
+      version: raw_settings.version,
       venusScaleLevel: game.getVenusScaleLevel(),
       victoryPointsBreakdown: player.getVictoryPoints(),
       waitingFor: getWaitingFor(player, player.getWaitingFor()),

--- a/src/models/WaitingForModel.ts
+++ b/src/models/WaitingForModel.ts
@@ -1,4 +1,5 @@
 
 export interface WaitingForModel {
-  result: 'GO' | 'REFRESH' | 'WAIT'
+  result: 'GO' | 'REFRESH' | 'WAIT',
+  version: string
 }

--- a/src/routes/ApiWaitingFor.ts
+++ b/src/routes/ApiWaitingFor.ts
@@ -5,6 +5,8 @@ import {Phase} from '../Phase';
 import {Player} from '../Player';
 import {WaitingForModel} from '../models/WaitingForModel';
 
+import * as raw_settings from '../genfiles/settings.json';
+
 export class ApiWaitingFor extends Handler {
   public static readonly INSTANCE = new ApiWaitingFor();
   private constructor() {
@@ -17,11 +19,11 @@ export class ApiWaitingFor extends Handler {
 
   private getWaitingForModel(player: Player, gameAge: number, undoCount: number): WaitingForModel {
     if (this.timeToGo(player)) {
-      return {result: 'GO'};
+      return {result: 'GO', version: raw_settings.version};
     } else if (player.game.gameAge > gameAge || player.game.undoCount > undoCount) {
-      return {result: 'REFRESH'};
+      return {result: 'REFRESH', version: raw_settings.version};
     }
-    return {result: 'WAIT'};
+    return {result: 'WAIT', version: raw_settings.version};
   }
 
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {

--- a/tests/routes/ApiWaitingFor.spec.ts
+++ b/tests/routes/ApiWaitingFor.spec.ts
@@ -54,6 +54,6 @@ describe('ApiWaitingFor', function() {
     ctx.gameLoader.add(game);
     ApiWaitingFor.INSTANCE.get(req, res.hide(), ctx);
     expect(res.statusCode).eq(200);
-    expect(res.content).eq('{"result":"GO"}');
+    expect(res.content).matches(/{"result":"GO","version":"[^"].*"}/);
   });
 });


### PR DESCRIPTION
What do you think? Something more sophisticated would suggest a refresh when the server model changes, but I think that's probably not ideal.

Testing this was interesting -- I finally had to do it by editing `make_static_json.js`. But it works well. Refreshing the page does what you expect, and the server restarting with a new version does what you would expect.