### PR TITLE
Prelude cards filter; Create game form page styling fixes

### DIFF
--- a/compile-vue-templates.js
+++ b/compile-vue-templates.js
@@ -54,8 +54,8 @@ generateVueClass(
   [],
 );
 generateVueClass(
-  'src/components/CardsFilter',
-  require('./build/src/components/CardsFilter').CardsFilter,
+  'src/components/create/CardsFilter',
+  require('./build/src/components/create/CardsFilter').CardsFilter,
   ['selectedCardNames', 'foundCardNames', 'searchTerm'],
 );
 generateVueClass(

--- a/src/components/create/CardsFilter.ts
+++ b/src/components/create/CardsFilter.ts
@@ -1,9 +1,9 @@
 import Vue from 'vue';
-import {CardName} from '../CardName';
-import {ALL_PROJECT_CARD_NAMES} from '../cards/AllCards';
-import {TranslateMixin} from './TranslateMixin';
+import {CardName} from '../../CardName';
+import {ALL_PRELUDE_CARD_NAMES, ALL_PROJECT_CARD_NAMES} from '../../cards/AllCards';
+import {TranslateMixin} from '../TranslateMixin';
 
-const allItems: Array<CardName> = ALL_PROJECT_CARD_NAMES.sort();
+const allItems: Array<CardName> = ALL_PROJECT_CARD_NAMES.concat(ALL_PRELUDE_CARD_NAMES).sort();
 
 interface CardsFilterModel {
     selectedCardNames: Array<CardName>;
@@ -22,6 +22,9 @@ export const CardsFilter = Vue.component('cards-filter', {
   },
   mixins: [TranslateMixin],
   methods: {
+    isPrelude: function(cardName: CardName) {
+      return ALL_PRELUDE_CARD_NAMES.includes(cardName);
+    },
     removeCard: function(cardNameToRemove: CardName) {
       this.selectedCardNames = this.selectedCardNames.filter((curCardName) => curCardName !== cardNameToRemove).sort();
     },
@@ -61,7 +64,7 @@ export const CardsFilter = Vue.component('cards-filter', {
         <h2 v-i18n>Cards to exclude from the game</h2>
         <div class="cards-filter-results-cont" v-if="selectedCardNames.length">
             <div class="cards-filter-result" v-for="cardName in selectedCardNames">
-                <label>{{ cardName }}</label>
+                <label>{{ cardName }}<i class="create-game-expansion-icon expansion-icon-prelude" title="This card is prelude" v-if="isPrelude(cardName)"></i></label>
                 <Button size="small" type="close" :onClick="_=>removeCard(cardName)" /> 
             </div>
         </div>
@@ -71,7 +74,10 @@ export const CardsFilter = Vue.component('cards-filter', {
             </div>
             <div class="cards-filter-suggest" v-if="foundCardNames.length">
                 <div class="cards-filter-suggest-item" v-for="cardName in foundCardNames">
-                    <a href="#" v-on:click.prevent="addCard(cardName)">{{ cardName }}</a> 
+                    <a href="#" v-on:click.prevent="addCard(cardName)">
+                      {{ cardName }}
+                      <i class="create-game-expansion-icon expansion-icon-prelude" title="This card is prelude" v-if="isPrelude(cardName)"></i>
+                    </a> 
                 </div>
             </div>
         </div>

--- a/src/components/create/CreateGameForm.ts
+++ b/src/components/create/CreateGameForm.ts
@@ -7,7 +7,7 @@ import {translateTextWithParams} from '../../directives/i18n';
 import {IGameData} from '../../database/IDatabase';
 import {ColoniesFilter} from './ColoniesFilter';
 import {ColonyName} from '../../colonies/ColonyName';
-import {CardsFilter} from '../CardsFilter';
+import {CardsFilter} from './CardsFilter';
 import {Button} from '../common/Button';
 import {playerColorClass} from '../../utils/utils';
 import {RandomMAOptionType} from '../../RandomMAOptionType';
@@ -511,13 +511,13 @@ export const CreateGameForm = Vue.component('create-game-form', {
   template: `
         <div id="create-game">
             <h1><span v-i18n>{{ constants.APP_NAME }}</span> — <span v-i18n>Create New Game</span></h1>
-            <div class="create-game-discord-invite" v-if="playersCount===1" v-i18n>
-              (<span v-i18n>Looking for people to play with</span>? <a href="https://discord.gg/VR8TbrD" class="tooltip" target="_blank"><u>Join us on Discord</u></a>.)
+            <div class="create-game-discord-invite" v-if="playersCount===1">
+              (<span v-i18n>Looking for people to play with</span>? <a href="https://discord.gg/VR8TbrD" class="tooltip" target="_blank"><u v-i18n>Join us on Discord</u></a>.)
             </div>
 
-            <div class="create-game-form create-game--block">
+            <div class="create-game-form create-game-panel create-game--block">
 
-                <div class="container create-game-options">
+                <div class="create-game-options">
 
                     <div class="create-game-solo-player form-group" v-if="isSoloModePage" v-for="newPlayer in getPlayers()">
                         <div>
@@ -812,7 +812,7 @@ export const CreateGameForm = Vue.component('create-game-form', {
                             <div class="container">
                                 <div class="columns">
                                     <template v-for="newPlayer in getPlayers()">
-                                    <div :class="'form-group col6 create-game-player create-game--block '+getPlayerContainerColorClass(newPlayer.color)">
+                                    <div :class="'form-group col6 create-game-player '+getPlayerContainerColorClass(newPlayer.color)">
                                         <div>
                                             <input class="form-input form-inline create-game-player-name" :placeholder="getPlayerNamePlaceholder(newPlayer)" v-model="newPlayer.name" />
                                         </div>
@@ -865,35 +865,37 @@ export const CreateGameForm = Vue.component('create-game-form', {
             </div>
 
 
+            <div class="create-game--block" v-if="showCorporationList">
+              <corporations-filter
+                  ref="corporationsFilter"
+                  v-on:corporation-list-changed="updateCustomCorporationsList"
+                  v-bind:corporateEra="corporateEra"
+                  v-bind:prelude="prelude"
+                  v-bind:venusNext="venusNext"
+                  v-bind:colonies="colonies"
+                  v-bind:turmoil="turmoil"
+                  v-bind:promoCardsOption="promoCardsOption"
+                  v-bind:communityCardsOption="communityCardsOption"
+                  v-bind:moonExpansion="moonExpansion"
+              ></corporations-filter>
+            </div>
 
-            <corporations-filter
-                ref="corporationsFilter"
-                v-if="showCorporationList"
-                v-on:corporation-list-changed="updateCustomCorporationsList"
-                v-bind:corporateEra="corporateEra"
-                v-bind:prelude="prelude"
-                v-bind:venusNext="venusNext"
-                v-bind:colonies="colonies"
-                v-bind:turmoil="turmoil"
-                v-bind:promoCardsOption="promoCardsOption"
-                v-bind:communityCardsOption="communityCardsOption"
-                v-bind:moonExpansion="moonExpansion"
-            ></corporations-filter>
+            <div class="create-game--block" v-if="showColoniesList">
+              <colonies-filter
+                  ref="coloniesFilter"
+                  v-on:colonies-list-changed="updateCustomColoniesList"
+                  v-bind:venusNext="venusNext"
+                  v-bind:turmoil="turmoil"
+                  v-bind:communityCardsOption="communityCardsOption"
+              ></colonies-filter>
+            </div>
 
-            <colonies-filter
-                ref="coloniesFilter"
-                v-if="showColoniesList"
-                v-on:colonies-list-changed="updateCustomColoniesList"
-                v-bind:venusNext="venusNext"
-                v-bind:turmoil="turmoil"
-                v-bind:communityCardsOption="communityCardsOption"
-            ></colonies-filter>
-
-            <cards-filter
-                ref="cardsFilter"
-                v-if="showCardsBlackList"
-                v-on:cards-list-changed="updateCardsBlackList"
-            ></cards-filter>
+            <div class="create-game--block" v-if="showCardsBlackList">
+              <cards-filter
+                  ref="cardsFilter"
+                  v-on:cards-list-changed="updateCardsBlackList"
+              ></cards-filter>
+            </div>
         </div>
     `,
 });

--- a/src/styles/corporations_filter.less
+++ b/src/styles/corporations_filter.less
@@ -1,8 +1,3 @@
-.corporations-filter {
-    margin-left: -25px;
-
-}
-
 .corporations-filter-group {
     display: inline-block;
     vertical-align: top;
@@ -27,6 +22,10 @@
         a {
             padding: 0 5px;
         }
+    }
+
+    .corporations-filter-toolbox--topmost {
+        margin: -63px 0 0 200px;
     }
 }
 

--- a/src/styles/create_game_form.less
+++ b/src/styles/create_game_form.less
@@ -20,6 +20,10 @@
     .create-game-color {
         padding: 0px 50px 0px 26px;
     }
+
+    .main-container {
+        margin: 0 40px 0 40px;
+    }
 }
 
 .create-game-player {
@@ -37,8 +41,10 @@
 }
 
 .create-game--block {	 
-    padding: 10px;	    
+    margin: 16px 16px 0 18px;
+    padding: 20px;
     border-radius: 10px;
+    background: black;
 }
 
 .create-game-form {
@@ -251,8 +257,8 @@
 }
 
 .create-game-player-name:focus {
- border: none;
- box-shadow: none;
+    border: none;
+    box-shadow: none;
 }
 
 .create-game-page-color-row {


### PR DESCRIPTION
Backend already supports prelude filtering via cardsBlackList, so i've done only client side part.
Added small visual hint to distinguish project cards and preludes in cards filter widget: 
![prelude_filter](https://user-images.githubusercontent.com/394311/116217097-c34a6b80-a762-11eb-9e7a-7ac7e69f86c3.png)
