### PR TITLE
Fix reds and chairman

### DIFF
--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -15,6 +15,7 @@ import {SerializedTurmoil} from './SerializedTurmoil';
 import {PLAYER_DELEGATES_COUNT} from '../constants';
 import {AgendaStyle, PoliticalAgendasData, PoliticalAgendas} from './PoliticalAgendas';
 import {CardName} from '../CardName';
+import {DeferredAction} from '../deferredActions/DeferredAction';
 
 export type NeutralPlayer = 'NEUTRAL';
 
@@ -313,7 +314,13 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
           const player = game.getPlayerById(this.chairman);
           // Tempest Consultancy Hook (gains an additional TR when they become chairman)
           const steps = player.corporationCard?.name === CardName.TEMPEST_CONSULTANCY ? 2 :1;
-          player.increaseTerraformRatingSteps(steps);
+
+          // Raise TR but after resolving the new policy
+          game.defer(new DeferredAction(player, () => {
+            player.increaseTerraformRatingSteps(steps);
+            return undefined;
+          }));
+
           game.log('${0} is the new chairman and gained ${1} TR', (b) => b.player(player).number(steps));
         } else {
           game.log('A neutral delegate is the new chairman.');

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -318,10 +318,9 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
           // Raise TR but after resolving the new policy
           game.defer(new DeferredAction(player, () => {
             player.increaseTerraformRatingSteps(steps);
+            game.log('${0} is the new chairman and gained ${1} TR', (b) => b.player(player).number(steps));
             return undefined;
           }));
-
-          game.log('${0} is the new chairman and gained ${1} TR', (b) => b.player(player).number(steps));
         } else {
           game.log('A neutral delegate is the new chairman.');
         }

--- a/tests/cards/moon/TempestConsultancy.spec.ts
+++ b/tests/cards/moon/TempestConsultancy.spec.ts
@@ -69,6 +69,7 @@ describe('TempestConsultancy', () => {
     expect(player.getTerraformRating()).eq(20);
 
     turmoil.setRulingParty(game);
+    game.deferredActions.runAll(() => {});
 
     expect(turmoil.chairman).eq(player.id);
     expect(player.getTerraformRating()).eq(22);

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -125,6 +125,7 @@ describe('Turmoil', function() {
 
     game.phase = Phase.SOLAR;
     turmoil.endGeneration(game);
+    game.deferredActions.runAll(() => {});
 
     expect(game.getPlayerById(turmoil.chairman!)).to.eq(player);
     // both players lose 1 TR; player gains 1 TR from Reds ruling bonus, 1 TR from chairman


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14239220/116549445-7af68f00-a8c3-11eb-9c6b-e07e96ed405a.png)

Chairman uses deferredAction to resolve the policy, so TR increase should be deferredAction too. This way TR from being a chairman is not raised until after the new ruling bonus is resolved.