### PR TITLE
Fix the top bar expansion logic

### DIFF
--- a/src/components/TopBar.ts
+++ b/src/components/TopBar.ts
@@ -26,7 +26,7 @@ export const TopBar = Vue.component('top-bar', {
       this.forceRerender();
     },
     isExpanded(): boolean {
-      return PreferencesManager.loadBoolean('hide_top_bar');
+      return !PreferencesManager.loadBoolean('hide_top_bar');
     },
     formatCssClass(): string {
       const cssClasses = ['top-bar'];


### PR DESCRIPTION
Commit` #3212 reversed the topbar logic
```
isExpanded(): boolean {
-      const val = PreferencesManager.load('hide_top_bar');
-      return val !== '1';
+      return PreferencesManager.loadBoolean('hide_top_bar');
},
```
This fixes it and works in my test.