### PR TITLE
Alert dialog is now in fixed position.

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -12,7 +12,7 @@
     <body id="ts-preferences-target">
         <div id="app" :class="'topmost-'+screen">
             <section>
-                <dialog id="alert-dialog">
+                <dialog id="alert-dialog" class="alert-dialog">
                     <form method="dialog">
                         <p class="title" v-i18n>Error with input</p>
                         <p id="alert-dialog-message"></p>

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -200,6 +200,10 @@ h2 {
     .player_pink_bg_translucent();
 }
 
+.alert-dialog {
+    position: fixed;
+}
+
 @import "./language_switcher.less";
 @import "./cards.less";
 @import "./cards_v2.less";


### PR DESCRIPTION
This means if, for instance, you get a server error, it won't scroll all the way to the top of the page.

Here's where this happens all the time: select "Take an action from a played card" but don't select a card. Before, the whole page scrolled up. Now the page doesn't move just to show the error dialog.
Before:
![image](https://user-images.githubusercontent.com/413481/116789901-5e9f5180-aa7f-11eb-8a13-26a81f085c6e.png)

After: 
![image](https://user-images.githubusercontent.com/413481/116789886-429bb000-aa7f-11eb-9133-f48a79d50dbc.png)
