### PR TITLE
Add log for final greenery placement.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1062,6 +1062,8 @@ export class Game implements ISerializable<SerializedGame> {
   }
 
   private gotoFinalGreeneryPlacement(): void {
+    this.log('Final greenery placement', (b) => b.forNewGeneration());
+
     const players: Player[] = [];
 
     this.players.forEach((player) => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/413481/116796681-6a553d00-aaac-11eb-81be-c5f583b14687.png)

This seems to work with @bafolts by-generation log filter just because it happens to be the last one.