### PR TITLE
perform undo asynchronously

### DIFF
--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -60,6 +60,5 @@ export interface SerializedPlayer {
     // TODO(kberg): change tradesThisTurn to tradeThisGeneration later
     tradesThisTurn: number;
     turmoilPolicyActionUsed: boolean;
-    usedUndo: boolean;
     victoryPointsBreakdown: VictoryPointsBreakdown;
 }

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -94,19 +94,15 @@ export const WaitingFor = Vue.component('waiting-for', {
             if (result.result === 'GO') {
               root.updatePlayer();
 
-              // Only show notification for multi-player games
-              // todo bafolts remove once undo refactor complete
-              if (this.player.players.length > 1) {
-                if (Notification.permission !== 'granted') {
-                  Notification.requestPermission();
-                }
-                if (Notification.permission === 'granted') {
-                  new Notification(constants.APP_NAME, {
-                    icon: '/favicon.ico',
-                    body: 'It\'s your turn!',
-                  });
-                }
+              if (Notification.permission !== 'granted') {
+                Notification.requestPermission();
+              } else if (Notification.permission === 'granted') {
+                new Notification(constants.APP_NAME, {
+                  icon: '/favicon.ico',
+                  body: 'It\'s your turn!',
+                });
               }
+
               const soundsEnabled = PreferencesManager.load('enable_sounds') === '1';
               if (soundsEnabled) SoundManager.playActivePlayerSound();
 
@@ -134,12 +130,7 @@ export const WaitingFor = Vue.component('waiting-for', {
     window.clearInterval(documentTitleTimer);
     if (this.waitingfor === undefined) {
       this.waitForUpdate();
-      let message = 'Not your turn to take any actions';
-      // todo bafolts remove once undo refactor complete
-      if (this.players.length === 1) {
-        message = '';
-      }
-      return createElement('div', $t(message));
+      return createElement('div', $t('Not your turn to take any actions'));
     }
     if (this.player.players.length > 1 && this.player.waitingFor !== undefined) {
       documentTitleTimer = window.setInterval(() => this.animateTitle(), 1000);

--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -116,25 +116,25 @@ export class GameLoader implements IGameLoader {
     this.getByParticipantId(spectatorId, cb);
   }
 
-  public restoreGameAt(gameId: GameId, saveId: number, cb: (err?: any) => void): void {
+  public restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void {
     try {
       Database.getInstance().restoreGame(gameId, saveId, (err, game) => {
         if (err) {
           console.error('error while restoring game', err);
-          cb(err);
+          cb(undefined);
         } else if (game !== undefined) {
           Database.getInstance().deleteGameNbrSaves(gameId, 1);
           this.add(game);
           game.undoCount++;
-          cb();
+          cb(game);
         } else {
           console.error('game not found while restoring game', err);
-          cb(new Error('game not found'));
+          cb(undefined);
         }
       });
     } catch (error) {
       console.log(error);
-      cb(error);
+      cb(undefined);
     }
   }
 

--- a/src/inputs/UndoActionOption.ts
+++ b/src/inputs/UndoActionOption.ts
@@ -1,0 +1,7 @@
+import {SelectOption} from './SelectOption';
+
+export class UndoActionOption extends SelectOption {
+  constructor() {
+    super('Undo last action', 'Undo', () => undefined);
+  }
+}

--- a/src/routes/PlayerInput.ts
+++ b/src/routes/PlayerInput.ts
@@ -43,10 +43,8 @@ export class PlayerInput extends Handler {
 
   private isWaitingForUndo(player: Player, entity: Array<Array<string>>): boolean {
     const waitingFor = player.getWaitingFor();
-    return waitingFor instanceof OrOptions &&
-           entity.length > 0 &&
-           entity[0].length > 0 &&
-           waitingFor.options[Number(entity[0][0])] instanceof UndoActionOption;
+    return entity.length > 0 && entity[0].length > 0 &&
+           waitingFor instanceof OrOptions && waitingFor.options[Number(entity[0][0])] instanceof UndoActionOption;
   }
 
   private performUndo(res: http.ServerResponse, ctx: IContext, player: Player): void {

--- a/src/routes/PlayerInput.ts
+++ b/src/routes/PlayerInput.ts
@@ -1,9 +1,11 @@
 import * as http from 'http';
-import {GameLoader} from '../database/GameLoader';
+import {Game} from '../Game';
 import {Player} from '../Player';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {IContext} from './IHandler';
+import {OrOptions} from '../inputs/OrOptions';
+import {UndoActionOption} from '../inputs/UndoActionOption';
 
 export class PlayerInput extends Handler {
   public static readonly INSTANCE = new PlayerInput();
@@ -20,7 +22,7 @@ export class PlayerInput extends Handler {
     }
 
     // This is the exact same code as in `ApiPlayer`. I bet it's not the only place.
-    GameLoader.getInstance().getByPlayerId(playerId, (game) => {
+    ctx.gameLoader.getByPlayerId(playerId, (game) => {
       if (game === undefined) {
         ctx.route.notFound(req, res);
         return;
@@ -39,6 +41,32 @@ export class PlayerInput extends Handler {
     });
   }
 
+  private isWaitingForUndo(player: Player, entity: Array<Array<string>>): boolean {
+    const waitingFor = player.getWaitingFor();
+    return waitingFor instanceof OrOptions &&
+           entity.length > 0 &&
+           entity[0].length > 0 &&
+           waitingFor.options[Number(entity[0][0])] instanceof UndoActionOption;
+  }
+
+  private performUndo(res: http.ServerResponse, ctx: IContext, player: Player): void {
+    /**
+     * The `lastSaveId` property is incremented during every `takeAction`.
+     * The first save being decremented is the increment during `takeAction` call
+     * The second save being decremented is the action that was taken
+     */
+    const lastSaveId = player.game.lastSaveId - 2;
+    ctx.gameLoader.restoreGameAt(player.game.id, lastSaveId, (game: Game | undefined) => {
+      if (game === undefined) {
+        player.game.log('Unable to perform undo operation. Error retrieving game from database. Please try again.', () => {}, {reservedFor: player});
+      } else {
+        // pull most recent player instance
+        player = game.getPlayerById(player.id);
+      }
+      ctx.route.writeJson(res, Server.getPlayerModel(player));
+    });
+  }
+
   private processInput(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -49,9 +77,13 @@ export class PlayerInput extends Handler {
     req.on('data', function(data) {
       body += data.toString();
     });
-    req.once('end', function() {
+    req.once('end', () => {
       try {
         const entity = JSON.parse(body);
+        if (this.isWaitingForUndo(player, entity)) {
+          this.performUndo(res, ctx, player);
+          return;
+        }
         player.process(entity);
         ctx.route.writeJson(res, Server.getPlayerModel(player));
       } catch (err) {

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -18,8 +18,6 @@ import {GlobalParameter} from '../src/GlobalParameter';
 import {TestingUtils} from './TestingUtils';
 import {Units} from '../src/Units';
 import {SelfReplicatingRobots} from '../src/cards/promo/SelfReplicatingRobots';
-import {OrOptions} from '../src/inputs/OrOptions';
-import {GameLoader} from '../src/database/GameLoader';
 import {Pets} from '../src/cards/base/Pets';
 
 describe('Player', function() {
@@ -237,7 +235,6 @@ describe('Player', function() {
       playedCards: [], // TODO(kberg): these are SerializedCard.
       draftedCards: [CardName.FISH, CardName.EXTREME_COLD_FUNGUS],
       needsToDraft: false,
-      usedUndo: false,
       cardCost: 3,
       cardDiscount: 7,
       fleetSize: 99,
@@ -290,43 +287,6 @@ describe('Player', function() {
     player.playedCards.push(srr);
     srr.targetCards.push({card: new LunarBeam(), resourceCount: 0});
     expect(player.getSelfReplicatingRobotsTargetCards().length).eq(1);
-  });
-  it('uses undo', function() {
-    const player = TestPlayers.BLUE.newPlayer();
-    player.beginner = true;
-    const game = Game.newInstance('foo', [player], player);
-    game.gameOptions.undoOption = true;
-    player.process([['1'], ['Power Plant:SP']]);
-    const options = player.getWaitingFor() as OrOptions;
-    expect((player as any).usedUndo).is.false;
-    player.process([[String(options.options.length - 1)], ['']]);
-    expect((player as any).usedUndo).is.true;
-    expect(player.getWaitingFor()).is.undefined;
-  });
-  it('progresses game if undo operation fails', function() {
-    const player = TestPlayers.BLUE.newPlayer();
-    player.beginner = true;
-    const game = Game.newInstance('foo', [player], player);
-    game.gameOptions.undoOption = true;
-    player.process([['1'], ['Power Plant:SP']]);
-    const options = player.getWaitingFor() as OrOptions;
-    expect((player as any).usedUndo).is.false;
-    const instance = GameLoader.getInstance();
-    const originRestore = instance.restoreGameAt;
-    let restoreGameCb: ((err: any) => void) | undefined = undefined;
-    instance.restoreGameAt = function(_gameId: string, _saveId: number, cb: (err: any) => void) {
-      restoreGameCb = cb;
-      instance.restoreGameAt = originRestore;
-    };
-    player.process([[String(options.options.length - 1)], ['']]);
-    expect((player as any).usedUndo).is.true;
-    if (restoreGameCb === undefined) {
-      throw new Error('did not call to restore game');
-    }
-    expect(player.getWaitingFor()).is.undefined;
-    (restoreGameCb as (err: any) => void)('unable to restore game');
-    expect((player as any).usedUndo).is.false;
-    expect(player.getWaitingFor()).not.is.undefined;
   });
 
   it('has units', () => {

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,10 +1,15 @@
 import * as http from 'http';
+import * as EventEmitter from 'events';
 import {expect} from 'chai';
 import {PlayerInput} from '../../src/routes/PlayerInput';
 import {Route} from '../../src/routes/Route';
 import {MockResponse} from './HttpMocks';
 import {IContext} from '../../src/routes/IHandler';
+import {Game} from '../../src/Game';
 import {FakeGameLoader} from './FakeGameLoader';
+import {TestPlayers} from '../TestPlayers';
+import {OrOptions} from '../../src/inputs/OrOptions';
+import {UndoActionOption} from '../../src/inputs/UndoActionOption';
 
 describe('PlayerInput', function() {
   let req: http.IncomingMessage;
@@ -12,7 +17,7 @@ describe('PlayerInput', function() {
   let ctx: IContext;
 
   beforeEach(() => {
-    req = {} as http.IncomingMessage;
+    req = new EventEmitter() as http.IncomingMessage;
     res = new MockResponse();
     ctx = {
       route: new Route(),
@@ -27,5 +32,63 @@ describe('PlayerInput', function() {
     ctx.url = new URL('http://boo.com' + req.url);
     PlayerInput.INSTANCE.post(req, res.hide(), ctx);
     expect(res.content).eq('Bad request: must provide id');
+  });
+
+  it('performs undo action', () => {
+    const player = TestPlayers.BLUE.newPlayer();
+    req.url = '/player/input?id=' + player.id;
+    ctx.url = new URL('http://boo.com' + req.url);
+    player.beginner = true;
+    const game = Game.newInstance('foo', [player], player);
+    const undo = Game.newInstance('old', [player], player);
+    ctx.gameLoader.add(game);
+    game.gameOptions.undoOption = true;
+    player.process([['1'], ['Power Plant:SP']]);
+    const options = player.getWaitingFor() as OrOptions;
+    options.options.push(new UndoActionOption());
+    ctx.gameLoader.restoreGameAt = function(__gameId: string, __lastSaveId: number, cb: (game: Game | undefined) => void) {
+      cb(undo);
+    };
+    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
+    req.emit('data', JSON.stringify([[String(options.options.length - 1)], ['']]));
+    req.emit('end');
+    const model = JSON.parse(res.content);
+    expect(game.gameAge).not.eq(undo.gameAge);
+    expect(model.game.gameAge).eq(undo.gameAge);
+  });
+
+  it('reverts to old if undo fails', () => {
+    const player = TestPlayers.BLUE.newPlayer();
+    req.url = '/player/input?id=' + player.id;
+    ctx.url = new URL('http://boo.com' + req.url);
+    player.beginner = true;
+    const game = Game.newInstance('foo', [player], player);
+    const undo = Game.newInstance('old', [player], player);
+    ctx.gameLoader.add(game);
+    game.gameOptions.undoOption = true;
+    player.process([['1'], ['Power Plant:SP']]);
+    const options = player.getWaitingFor() as OrOptions;
+    options.options.push(new UndoActionOption());
+    ctx.gameLoader.restoreGameAt = function(__gameId: string, __lastSaveId: number, cb: (game: Game | undefined) => void) {
+      cb(undefined);
+    };
+    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
+    req.emit('data', JSON.stringify([[String(options.options.length - 1)], ['']]));
+    req.emit('end');
+    const model = JSON.parse(res.content);
+    expect(game.gameAge).not.eq(undo.gameAge);
+    expect(model.game.gameAge).eq(model.game.gameAge);
+  });
+
+  it('sends 400 on server error', () => {
+    const player = TestPlayers.BLUE.newPlayer();
+    req.url = '/player/input?id=' + player.id;
+    ctx.url = new URL('http://boo.com' + req.url);
+    const game = Game.newInstance('foo', [player], player);
+    ctx.gameLoader.add(game);
+    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
+    req.emit('data', '}{');
+    req.emit('end');
+    expect(res.content).eq('{"message":"Unexpected token } in JSON at position 0"}');
   });
 });

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -46,7 +46,7 @@ describe('PlayerInput', function() {
     player.process([['1'], ['Power Plant:SP']]);
     const options = player.getWaitingFor() as OrOptions;
     options.options.push(new UndoActionOption());
-    ctx.gameLoader.restoreGameAt = function(__gameId: string, __lastSaveId: number, cb: (game: Game | undefined) => void) {
+    ctx.gameLoader.restoreGameAt = function(_gameId: string, _lastSaveId: number, cb: (game: Game | undefined) => void) {
       cb(undo);
     };
     PlayerInput.INSTANCE.post(req, res.hide(), ctx);
@@ -57,7 +57,7 @@ describe('PlayerInput', function() {
     expect(model.game.gameAge).eq(undo.gameAge);
   });
 
-  it('reverts to old if undo fails', () => {
+  it('reverts to current game instance if undo fails', () => {
     const player = TestPlayers.BLUE.newPlayer();
     req.url = '/player/input?id=' + player.id;
     ctx.url = new URL('http://boo.com' + req.url);
@@ -69,7 +69,7 @@ describe('PlayerInput', function() {
     player.process([['1'], ['Power Plant:SP']]);
     const options = player.getWaitingFor() as OrOptions;
     options.options.push(new UndoActionOption());
-    ctx.gameLoader.restoreGameAt = function(__gameId: string, __lastSaveId: number, cb: (game: Game | undefined) => void) {
+    ctx.gameLoader.restoreGameAt = function(_gameId: string, _lastSaveId: number, cb: (game: Game | undefined) => void) {
       cb(undefined);
     };
     PlayerInput.INSTANCE.post(req, res.hide(), ctx);


### PR DESCRIPTION
This is a step towards a more robust and reliable undo. This change waits to send the response of the action until we have rolled the game back within the database and javascript memory. It also moves the logic out of `Player` making it clearer how this works.

I still need to update the unit tests.