### PR TITLE
Fix resource logging

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1375,13 +1375,13 @@ export class Game implements ISerializable<SerializedGame> {
     if (spaceBonus === SpaceBonus.DRAW_CARD) {
       player.drawCard(count);
     } else if (spaceBonus === SpaceBonus.PLANT) {
-      player.plants += count;
+      player.addResource(Resources.PLANTS, count, {log: true});
     } else if (spaceBonus === SpaceBonus.STEEL) {
-      player.steel += count;
+      player.addResource(Resources.STEEL, count, {log: true});
     } else if (spaceBonus === SpaceBonus.TITANIUM) {
-      player.titanium += count;
+      player.addResource(Resources.TITANIUM, count, {log: true});
     } else if (spaceBonus === SpaceBonus.HEAT) {
-      player.heat += count;
+      player.addResource(Resources.HEAT, count, {log: true});
     }
   }
 

--- a/src/cards/promo/CrashSiteCleanup.ts
+++ b/src/cards/promo/CrashSiteCleanup.ts
@@ -53,6 +53,15 @@ export class CrashSiteCleanup extends Card implements IProjectCard {
     return new OrOptions(gainTitanium, gain2Steel);
   }
 
+  public static resourceHook(player: Player, resource: Resources, amount: number, from: Player) {
+    if (from === player || amount >= 0) {
+      return;
+    }
+    if (resource === Resources.PLANTS && amount < 0) {
+      player.game.someoneHasRemovedOtherPlayersPlants = true;
+    }
+  }
+
   public getVictoryPoints() {
     return 1;
   }

--- a/src/cards/promo/LawSuit.ts
+++ b/src/cards/promo/LawSuit.ts
@@ -46,5 +46,14 @@ export class LawSuit extends Card implements IProjectCard {
   public getVictoryPoints() {
     return -1;
   }
+
+  public static resourceHook(player: Player, _resource: Resources, amount: number, from: Player) {
+    if (from === player || amount >= 0) {
+      return;
+    }
+    if (player.removingPlayers.includes(from.id) === false) {
+      player.removingPlayers.push(from.id);
+    }
+  }
 }
 

--- a/tests/cards/promo/LawSuit.spec.ts
+++ b/tests/cards/promo/LawSuit.spec.ts
@@ -21,6 +21,7 @@ describe('LawSuit', () => {
   });
 
   it('Can play if resources removed this turn by other player', () => {
+    player.megaCredits = 1;
     player.addResource(Resources.MEGACREDITS, -1, {log: true, from: player2});
     expect(card.canPlay(player)).is.true;
   });


### PR DESCRIPTION
What started as an easy fix for #2586 fixed a few more things.

1. `addResource` and `addProduction` logging is now in one place. It's also managed to remove most repetition without sacrificing readability.
2. Moved the CrashSiteCleanup and LawSuit hooks to their own cards.
3. Fixed a small bug when removing a resource -- when the overall delta of removed resources is zero, despite the inbound amount, it triggered LawSuit. Now it will not.
4. addResource did not for standard resource gains (like placement bonuses) but only when it had to do with other players.

This could use a little more manual testing, or better, some automated tests.

(Although I kind of think we should rewrite this logging anyway: "You's plants resources increased by 2" should really just be "You gained 2 plaints" Right?)