### PR TITLE
Fix viz for the steel/titanium market monopolists

### DIFF
--- a/src/cards/moon/SteelMarketMonopolists.ts
+++ b/src/cards/moon/SteelMarketMonopolists.ts
@@ -26,7 +26,7 @@ export class SteelMarketMonopolists extends MarketCard {
             }).br;
             b.or().br;
             b.action('Spend X steel to gain 3X M€ (max 3 steel).', (eb) => {
-              eb.text('X').steel(0).startAction.text('x').megacredits(3).asterix();
+              eb.text('X').steel(1).startAction.text('x').megacredits(3).asterix();
             });
           }),
         },

--- a/src/cards/moon/TitaniumMarketMonopolists.ts
+++ b/src/cards/moon/TitaniumMarketMonopolists.ts
@@ -26,7 +26,7 @@ export class TitaniumMarketMonopolists extends MarketCard {
             }).br;
             b.or().br;
             b.action('Spend X titanium to gain 4X M€ [max 4 titanium].', (eb) => {
-              eb.text('X').titanium(0).startAction.text('X').megacredits(4).asterix();
+              eb.text('X').titanium(1).startAction.text('X').megacredits(4).asterix();
             });
           }),
         },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/413481/117656540-7903ba00-b166-11eb-8dc7-b24dd35fcf1c.png)

(The titanium and steel units on the bottom of the card were absent)