### PR TITLE
fix cultural metropolis canPlay bug

### DIFF
--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -34,13 +34,22 @@ export class CulturalMetropolis extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
+    if ( ! super.canPlay(player)) {
+      return false;
+    }
+
+    if (player.getProduction(Resources.ENERGY) < 1) {
+      return false;
+    }
+
+    // This card requires player has 2 delegates available
     const turmoil = player.game.turmoil;
     if (turmoil !== undefined) {
-      // This card requires player has 2 delegates available
       const hasEnoughDelegates = turmoil.getDelegatesInReserve(player.id) > 1 ||
         (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id));
-      return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1 && hasEnoughDelegates;
+      return hasEnoughDelegates;
     }
+
     return false;
   }
 

--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -33,6 +33,18 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     });
   }
 
+  public canPlay(player: Player): boolean {
+    const turmoil = player.game.turmoil;
+    if (turmoil !== undefined) {
+      // This card requires player has 2 delegates available
+      return super.canPlay(player) &&
+        player.getProduction(Resources.ENERGY) >= 1 &&
+        (turmoil.getDelegatesInReserve(player.id) > 1 ||
+        (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id)));
+    }
+    return false;
+  }
+
   public play(player: Player) {
     player.addProduction(Resources.ENERGY, -1);
     player.addProduction(Resources.MEGACREDITS, 3);

--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -37,10 +37,9 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     const turmoil = player.game.turmoil;
     if (turmoil !== undefined) {
       // This card requires player has 2 delegates available
-      return super.canPlay(player) &&
-        player.getProduction(Resources.ENERGY) >= 1 &&
-        (turmoil.getDelegatesInReserve(player.id) > 1 ||
-        (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id)));
+      const hasEnoughDelegates = turmoil.getDelegatesInReserve(player.id) > 1 ||
+        (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id));
+      return super.canPlay(player) && player.getProduction(Resources.ENERGY) >= 1 && hasEnoughDelegates;
     }
     return false;
   }

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import {CulturalMetropolis} from '../../../src/cards/turmoil/CulturalMetropolis';
 import {PLAYER_DELEGATES_COUNT} from '../../../src/constants';
+import {SendDelegateToArea} from '../../../src/deferredActions/SendDelegateToArea';
 import {Game} from '../../../src/Game';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
@@ -23,28 +24,48 @@ describe('Cultural Metropolis', function() {
   });
 
   it('Can\'t play without energy production', function() {
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'lobby');
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
+    expect(card.canPlay(player)).is.not.true;
+  });
+
+
+  it('Can\'t play without two delegate in unity or unity ruling', function() {
+    player.addProduction(Resources.ENERGY, 1);
     expect(card.canPlay(player)).is.not.true;
   });
 
   it('Can\'t play without 2 delegates available', function() {
-    const reds = turmoil.getPartyByName(PartyName.REDS)!;
-
-    for (let i = 0; i < PLAYER_DELEGATES_COUNT - 1; i++) {
-      reds.sendDelegate(player.id, game);
+    player.addProduction(Resources.ENERGY, 1);
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'lobby');
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
+    for (let i = 0; i < PLAYER_DELEGATES_COUNT - 3; i++) {
+      turmoil.sendDelegateToParty(player.id, PartyName.REDS, game, 'reserve');
     }
-
+    expect(turmoil.getDelegatesInReserve(player.id)).to.equal(1);
     expect(card.canPlay(player)).is.not.true;
   });
 
   it('Should play', function() {
-    player.addProduction(Resources.ENERGY, 1);
     const unity = turmoil.getPartyByName(PartyName.UNITY)!;
-    unity.sendDelegate(player.id, game);
-    unity.sendDelegate(player.id, game);
+
+    player.addProduction(Resources.ENERGY, 1);
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'lobby');
+    turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
+
+    expect(unity.delegates).has.lengthOf(2);
+    expect(turmoil.getDelegatesInReserve(player.id)).to.equal(5);
     expect(card.canPlay(player)).is.true;
 
     card.play(player);
+    expect(game.deferredActions).has.lengthOf(2);
+    player.game.deferredActions.pop(); // Pop out the city placement deferred action
+    const action = player.game.deferredActions.pop() as SendDelegateToArea;
+    const options = action.execute();
+    options.cb(PartyName.UNITY);
+
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
+    expect(unity.delegates).has.lengthOf(4);
   });
 });

--- a/tests/cards/turmoil/CulturalMetropolis.spec.ts
+++ b/tests/cards/turmoil/CulturalMetropolis.spec.ts
@@ -48,12 +48,13 @@ describe('Cultural Metropolis', function() {
 
   it('Should play', function() {
     const unity = turmoil.getPartyByName(PartyName.UNITY)!;
+    const startingUnityDelegateCount = unity.delegates.length;
 
     player.addProduction(Resources.ENERGY, 1);
     turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'lobby');
     turmoil.sendDelegateToParty(player.id, PartyName.UNITY, game, 'reserve');
 
-    expect(unity.delegates).has.lengthOf(2);
+    expect(unity.delegates).has.lengthOf(startingUnityDelegateCount + 2);
     expect(turmoil.getDelegatesInReserve(player.id)).to.equal(5);
     expect(card.canPlay(player)).is.true;
 
@@ -66,6 +67,6 @@ describe('Cultural Metropolis', function() {
 
     expect(player.getProduction(Resources.ENERGY)).to.eq(0);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(3);
-    expect(unity.delegates).has.lengthOf(4);
+    expect(unity.delegates).has.lengthOf(startingUnityDelegateCount + 4);
   });
 });


### PR DESCRIPTION
#3252 broke this with a sloppy deletion of canPlay() from cultural metropolis.

This PR adds back the requirement check for energy and delegate count. It also improves the tests on this card.