### PR TITLE
Placing a tile on top of another one should not trigger space bonus.

### DIFF
--- a/src/ares/AresHazards.ts
+++ b/src/ares/AresHazards.ts
@@ -56,6 +56,10 @@ export class _AresHazardPlacement {
   }
 
   private static testToPlaceErosionTiles(aresData: IAresData, player: Player) {
+    if (player.game.gameOptions.aresHazards === false) {
+      return;
+    }
+
     this.testConstraint(
       aresData.hazardData.erosionOceanCount,
       player.game.board.getOceansOnBoard(),

--- a/src/cards/ares/OceanCity.ts
+++ b/src/cards/ares/OceanCity.ts
@@ -52,7 +52,6 @@ export class OceanCity extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.removeTile(space.id);
         player.game.addTile(player, space.spaceType, space, tile);
         return undefined;
       },

--- a/src/cards/ares/OceanFarm.ts
+++ b/src/cards/ares/OceanFarm.ts
@@ -49,7 +49,6 @@ export class OceanFarm extends Card implements IProjectCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.removeTile(space.id);
         player.game.addTile(player, space.spaceType, space, tile);
         space.adjacency = {bonus: [SpaceBonus.PLANT]};
         return undefined;

--- a/src/cards/ares/OceanSanctuary.ts
+++ b/src/cards/ares/OceanSanctuary.ts
@@ -51,7 +51,6 @@ export class OceanSanctuary extends Card implements IResourceCard {
           card: this.name,
           covers: space.tile,
         };
-        player.game.removeTile(space.id);
         player.game.addTile(player, space.spaceType, space, tile);
         space.adjacency = {bonus: [SpaceBonus.ANIMAL]};
         return undefined;

--- a/tests/cards/ares/OceanCity.spec.ts
+++ b/tests/cards/ares/OceanCity.spec.ts
@@ -8,6 +8,7 @@ import {TileType} from '../../../src/TileType';
 import {SpaceType} from '../../../src/SpaceType';
 import {TestPlayers} from '../../TestPlayers';
 import {Capital} from '../../../src/cards/base/Capital';
+import {SpaceBonus} from '../../../src/SpaceBonus';
 
 describe('OceanCity', function() {
   let card: OceanCity; let player: Player; let game: Game;
@@ -153,5 +154,25 @@ describe('OceanCity', function() {
     expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_CITY);
 
     expect(player.getVictoryPoints().victoryPoints).to.eq(1);
+  });
+
+  it('Placing Ocean City does not grant underlying space bonus', () => {
+    const oceanSpace = game.board.spaces.filter((space) => {
+      return space.bonus.length === 1 && space.bonus[0] === SpaceBonus.PLANT && space.spaceType === SpaceType.OCEAN;
+    })[0];
+
+    player.plants = 0;
+    game.addOceanTile(player, oceanSpace.id);
+    expect(player.plants).eq(1);
+
+    const action = card.play(player);
+
+    expect(player.plants).eq(1);
+
+    action.cb(oceanSpace);
+
+    expect(oceanSpace.player).to.eq(player);
+    expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_CITY);
+    expect(player.plants).eq(1);
   });
 });

--- a/tests/cards/ares/OceanFarm.spec.ts
+++ b/tests/cards/ares/OceanFarm.spec.ts
@@ -9,17 +9,17 @@ import {Resources} from '../../../src/Resources';
 import {SpaceType} from '../../../src/SpaceType';
 import {TestPlayers} from '../../TestPlayers';
 
-describe('OceanFarm', function() {
+describe('OceanFarm', () => {
   let card : OceanFarm; let player : Player; let otherPlayer: Player; let game : Game;
 
-  beforeEach(function() {
+  beforeEach(() => {
     card = new OceanFarm();
     player = TestPlayers.BLUE.newPlayer();
     otherPlayer = TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, otherPlayer], player, ARES_OPTIONS_NO_HAZARDS);
   });
 
-  it('Can play', function() {
+  it('Can play', () => {
     AresTestHelper.addOcean(game, player);
     expect(card.canPlay(player)).is.false;
 
@@ -33,7 +33,7 @@ describe('OceanFarm', function() {
     expect(card.canPlay(player)).is.true;
   });
 
-  it('Play', function() {
+  it('Play', () => {
     expect(player.getProduction(Resources.HEAT)).eq(0);
     expect(player.getProduction(Resources.PLANTS)).eq(0);
 
@@ -50,8 +50,7 @@ describe('OceanFarm', function() {
     expect(oceanSpace.adjacency).to.deep.eq({bonus: [SpaceBonus.PLANT]});
   });
 
-
-  it('Ocean Farm counts as ocean for adjacency', function() {
+  it('Ocean Farm counts as ocean for adjacency', () => {
     const oceanSpace = AresTestHelper.addOcean(game, player);
     const action = card.play(player);
     action.cb(oceanSpace);
@@ -62,5 +61,25 @@ describe('OceanFarm', function() {
     game.addGreenery(otherPlayer, greenery.id);
 
     expect(otherPlayer.megaCredits).eq(2);
+  });
+
+  it('Placing Ocean Farm does not grant underlying space bonus', () => {
+    const oceanSpace = game.board.spaces.filter((space) => {
+      return space.bonus.length === 1 && space.bonus[0] === SpaceBonus.PLANT && space.spaceType === SpaceType.OCEAN;
+    })[0];
+
+    player.plants = 0;
+    game.addOceanTile(player, oceanSpace.id);
+    expect(player.plants).eq(1);
+
+    const action = card.play(player);
+
+    expect(player.plants).eq(1);
+
+    action.cb(oceanSpace);
+
+    expect(oceanSpace.player).to.eq(player);
+    expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_FARM);
+    expect(player.plants).eq(1);
   });
 });

--- a/tests/cards/ares/OceanSanctuary.spec.ts
+++ b/tests/cards/ares/OceanSanctuary.spec.ts
@@ -62,4 +62,24 @@ describe('OceanSanctuary', function() {
     card.resourceCount = 7;
     expect(card.getVictoryPoints()).eq(7);
   });
+
+  it('Placing Ocean Sanctuary does not grant underlying space bonus', () => {
+    const oceanSpace = game.board.spaces.filter((space) => {
+      return space.bonus.length === 1 && space.bonus[0] === SpaceBonus.PLANT && space.spaceType === SpaceType.OCEAN;
+    })[0];
+
+    player.plants = 0;
+    game.addOceanTile(player, oceanSpace.id);
+    expect(player.plants).eq(1);
+
+    const action = card.play(player);
+
+    expect(player.plants).eq(1);
+
+    action.cb(oceanSpace);
+
+    expect(oceanSpace.player).to.eq(player);
+    expect(oceanSpace.tile!.tileType).to.eq(TileType.OCEAN_SANCTUARY);
+    expect(player.plants).eq(1);
+  });
 });

--- a/tests/cards/base/RoboticWorkforce.spec.ts
+++ b/tests/cards/base/RoboticWorkforce.spec.ts
@@ -155,7 +155,7 @@ describe('RoboticWorkforce', function() {
 
   const testCard = function(card: ICard) {
     const researchCoordination = new ResearchCoordination();
-    const gameOptions = TestingUtils.setCustomGameOptions({moonExpansion: true});
+    const gameOptions = TestingUtils.setCustomGameOptions({aresExtension: true, aresHazards: false, moonExpansion: true});
     const productions = [Resources.MEGACREDITS, Resources.STEEL, Resources.TITANIUM, Resources.PLANTS, Resources.ENERGY, Resources.HEAT];
 
     if ((card.tags.includes(Tags.BUILDING) || card.tags.includes(Tags.WILDCARD)) && card.play !== undefined) {

--- a/tests/cards/community/CuriosityII.spec.ts
+++ b/tests/cards/community/CuriosityII.spec.ts
@@ -16,7 +16,7 @@ describe('CuriosityII', function() {
     card = new CuriosityII();
     player = TestPlayers.BLUE.newPlayer();
     player2 = TestPlayers.RED.newPlayer();
-    game = Game.newInstance('foobar', [player, player2], player);
+    game = Game.newInstance('foobar', [player, player2], player, TestingUtils.setCustomGameOptions({aresExtension: true, aresHazards: false}));
     game.phase = Phase.ACTION;
 
     player.corporationCard = card;


### PR DESCRIPTION
The existing solution doesn't work. Oh, it might have at the beginning. But the bits of code in Ocean* that remove a tile before placing another one introduced this regression.

Turns out this was easy to fix, but it impacted a few tests along the way.

Fixes #2843