### PR TITLE
make runInput protected

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -888,9 +888,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
   }
 
-  // This is only public for a test. It's not great.
-  // TODO(kberg): Fix that.
-  public runInput(input: ReadonlyArray<ReadonlyArray<string>>, pi: PlayerInput): void {
+  protected runInput(input: ReadonlyArray<ReadonlyArray<string>>, pi: PlayerInput): void {
     if (pi instanceof AndOptions) {
       this.checkInputLength(input, pi.options.length);
       for (let i = 0; i < input.length; i++) {

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -1,4 +1,5 @@
 import {Player} from '../src/Player';
+import {PlayerInput} from '../src/PlayerInput';
 import {Color} from '../src/Color';
 import {Units} from '../src/Units';
 import {Tags} from '../src/cards/Tags';
@@ -40,6 +41,10 @@ export class TestPlayer extends Player {
       return this.tagsForTest[tag] || 0;
     }
     return super.getTagCount(tag, includeEventsTags, includeWildcardTags);
+  }
+
+  public runInput(input: ReadonlyArray<ReadonlyArray<string>>, pi: PlayerInput): void {
+    super.runInput(input, pi);
   }
 }
 


### PR DESCRIPTION
Moves the `public` runInput method to `TestPlayer`.