### PR TITLE
Fully separate player's public and private models.

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -119,7 +119,7 @@ export const mainAppSettings = {
         if (xhr.status === 200) {
           app.player = xhr.response as PlayerModel;
           app.playerkey++;
-          const playerId = app.player.players[app.player.playersIndex].id;
+          const playerId = app.player.privateModel.id;
 
           if (
             app.player.game.phase === 'end' &&

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -119,6 +119,8 @@ export const mainAppSettings = {
         if (xhr.status === 200) {
           app.player = xhr.response as PlayerModel;
           app.playerkey++;
+          const playerId = app.player.players[app.player.playersIndex].id;
+
           if (
             app.player.game.phase === 'end' &&
                         window.location.search.includes('&noredirect') === false
@@ -128,7 +130,7 @@ export const mainAppSettings = {
               window.history.replaceState(
                 xhr.response,
                 `${constants.APP_NAME} - Player`,
-                '/the-end?id=' + app.player.id,
+                '/the-end?id=' + playerId,
               );
             }
           } else {
@@ -137,7 +139,7 @@ export const mainAppSettings = {
               window.history.replaceState(
                 xhr.response,
                 `${constants.APP_NAME} - Game`,
-                '/player?id=' + app.player.id,
+                '/player?id=' + playerId,
               );
             }
           }

--- a/src/components/CardOrderStorage.ts
+++ b/src/components/CardOrderStorage.ts
@@ -1,12 +1,13 @@
-
 import {CardModel} from '../models/CardModel';
 
 const STORAGE_PREFIX = 'cardOrder';
 
 export class CardOrderStorage {
-  public static getCardOrder(playerId: string): {[x: string]: number} {
+  public static getCardOrder(playerColor: string): {[x: string]: number} {
     try {
-      const order = typeof localStorage === 'undefined' ? null : localStorage.getItem(`${STORAGE_PREFIX}${playerId}`);
+      const order = typeof localStorage === 'undefined' ?
+        null :
+        localStorage.getItem(`${STORAGE_PREFIX}${playerColor}`);
       if (order === null) {
         return {};
       }
@@ -24,9 +25,9 @@ export class CardOrderStorage {
     });
     return hits.concat(misses);
   }
-  public static updateCardOrder(playerId: string, order: {[x: string]: number}): void {
+  public static updateCardOrder(playerColor: string, order: {[x: string]: number}): void {
     try {
-      localStorage.setItem(`${STORAGE_PREFIX}${playerId}`, JSON.stringify(order));
+      localStorage.setItem(`${STORAGE_PREFIX}${playerColor}`, JSON.stringify(order));
     } catch (err) {
       console.warn('unable to update card order with local storage', err);
     }

--- a/src/components/GameEnd.ts
+++ b/src/components/GameEnd.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import {PlayerModel, PublicPlayerModel} from '../models/PlayerModel';
+import {PlayerModel, publicModelOf, PublicPlayerModel} from '../models/PlayerModel';
 import {Board} from './Board';
 import {LogPanel} from './LogPanel';
 import {Button} from '../components/common/Button';
@@ -12,6 +12,11 @@ export const GameEnd = Vue.component('game-end', {
   props: {
     player: {
       type: Object as () => PlayerModel,
+    },
+  },
+  computed: {
+    publicPlayer: function(): PublicPlayerModel {
+      return publicModelOf(this.player);
     },
   },
   data: function() {
@@ -74,7 +79,7 @@ export const GameEnd = Vue.component('game-end', {
                             <ul class="game_end_list">
                                 <li v-i18n>Try to win with expansions enabled</li>
                                 <li v-i18n>Try to win before the last generation comes</li>
-                                <li><span v-i18n>Can you get</span> {{ player.victoryPointsBreakdown.total + 10 }}<span v-i18n>+ Victory Points?</span></li>
+                                <li><span v-i18n>Can you get</span> {{ this.publicPlayer.victoryPointsBreakdown.total + 10 }}<span v-i18n>+ Victory Points?</span></li>
                             </ul>
                         </div>
                     </div>
@@ -194,7 +199,7 @@ export const GameEnd = Vue.component('game-end', {
                         :temperature="player.game.temperature"></board>
                 </div>
                 <div class="game_end_block--log game-end-column">
-                  <log-panel :color="player.color" :generation="player.game.generation" :id="player.id" :lastSoloGeneration="player.game.lastSoloGeneration" :players="player.players"></log-panel>
+                  <log-panel :color="this.publicPlayer.color" :generation="player.game.generation" :id="this.publicPlayer.id" :lastSoloGeneration="player.game.lastSoloGeneration" :players="player.players"></log-panel>
                 </div>
               </div>
             </div>

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -101,7 +101,7 @@ export const LogPanel = Vue.component('log-panel', {
       switch (data.type) {
       case LogMessageDataType.PLAYER:
         for (const player of this.players) {
-          if (data.value === player.color || data.value === player.id) {
+          if (data.value === player.color) {
             return '<span class="log-player player_bg_color_'+player.color+'">'+player.name+'</span>';
           }
         }

--- a/src/components/LogPanel.ts
+++ b/src/components/LogPanel.ts
@@ -4,7 +4,7 @@ import {LogMessage} from '../LogMessage';
 import {LogMessageType} from '../LogMessageType';
 import {LogMessageData} from '../LogMessageData';
 import {LogMessageDataType} from '../LogMessageDataType';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {Card} from './card/Card';
 import {$t} from '../directives/i18n';
 import {CardFinder} from './../CardFinder';
@@ -35,7 +35,7 @@ export const LogPanel = Vue.component('log-panel', {
       type: Number,
     },
     players: {
-      type: Array as () => Array<PlayerModel>,
+      type: Array as () => Array<PublicPlayerModel>,
     },
     color: {
       type: String as () => Color,
@@ -188,7 +188,6 @@ export const LogPanel = Vue.component('log-panel', {
       return '';
     },
     messageClicked: function(message: LogMessage) {
-      // TODO(kberg): add global event here, too.
       const datas = message.data;
       datas.forEach((data: LogMessageData) => {
         if (data.value === undefined) {

--- a/src/components/OtherPlayer.ts
+++ b/src/components/OtherPlayer.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 
 import {StackedCards} from './StackedCards';
 import {PlayerMixin} from './PlayerMixin';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {hidePlayerData} from './overview/PlayerStatus';
 import {mainAppSettings} from './App';
 import {Card} from './card/Card';
@@ -10,7 +10,7 @@ import {Card} from './card/Card';
 export const OtherPlayer = Vue.component('other-player', {
   props: {
     player: {
-      type: Object as () => PlayerModel,
+      type: Object as () => PublicPlayerModel,
     },
     playerIndex: {
       type: Number,

--- a/src/components/PlayerHome.ts
+++ b/src/components/PlayerHome.ts
@@ -201,7 +201,7 @@ export const PlayerHome = Vue.component('player-home', {
             <div v-if="player.game.phase === 'end'">
                 <div class="player_home_block">
                     <dynamic-title title="This game is over!" :color="publicPlayer().color"/>
-                    <a :href="'/the-end?id='+ publicPlayer().id" v-i18n>Go to game results</a>
+                    <a :href="'/the-end?id='+ player.privateModel.id" v-i18n>Go to game results</a>
                 </div>
             </div>
 
@@ -251,7 +251,7 @@ export const PlayerHome = Vue.component('player-home', {
                 <players-overview class="player_home_block player_home_block--players nofloat:" :player="player" v-trim-whitespace id="shortkey-playersoverview"/>
 
                 <div class="player_home_block nofloat">
-                    <log-panel :id="publicPlayer().id" :players="player.players" :generation="player.game.generation" :lastSoloGeneration="player.game.lastSoloGeneration" :color="publicPlayer().color"></log-panel>
+                    <log-panel :id="player.privateModel.id" :players="player.players" :generation="player.game.generation" :lastSoloGeneration="player.game.lastSoloGeneration" :color="publicPlayer().color"></log-panel>
                 </div>
 
                 <div class="player_home_block player_home_block--actions nofloat">
@@ -270,7 +270,7 @@ export const PlayerHome = Vue.component('player-home', {
                 <a name="cards" class="player_home_anchor"></a>
                 <div class="player_home_block player_home_block--hand" v-if="player.privateModel.cardsInHand.length + player.privateModel.preludeCardsInHand.length > 0" id="shortkey-hand">
                     <dynamic-title title="Cards In Hand" :color="publicPlayer().color" :withAdditional="true" :additional="(publicPlayer().cardsInHandNbr + player.privateModel.preludeCardsInHand.length).toString()" />
-                    <sortable-cards :playerId="publicPlayer().id" :cards="player.privateModel.preludeCardsInHand.concat(player.privateModel.cardsInHand)" />
+                    <sortable-cards :playerId="player.privateModel.id" :cards="player.privateModel.preludeCardsInHand.concat(player.privateModel.cardsInHand)" />
                 </div>
 
                 <div class="player_home_block player_home_block--cards"">

--- a/src/components/PlayerMixin.ts
+++ b/src/components/PlayerMixin.ts
@@ -1,6 +1,6 @@
 import {CardModel} from '../models/CardModel';
 import {CardType} from '../cards/CardType';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {sortActiveCards} from '../components/ActiveCardsSortingOrder';
 
 // Common code for player layouts
@@ -22,7 +22,7 @@ export const PlayerMixin = {
       return cards.reverse();
     },
     getPlayerCardsPlayed: function(
-      player: PlayerModel,
+      player: PublicPlayerModel,
       withCorp: boolean,
     ): number {
       const playedCardsNr = player.playedCards.length || 0;
@@ -41,14 +41,16 @@ export const PlayerMixin = {
       return CardType.PRELUDE;
     },
     isCardActivated: function(
-      card: CardModel,
-      player: PlayerModel,
+      // TODO(kberg): The | undefined was added because PlayerHomeView uses publicPlayer(),
+      // which makes it hard to elegaently rely on Typescript's compiler to know that the
+      // incoming corporation card is certainly defined.
+      card: CardModel | undefined,
+      player: PublicPlayerModel,
     ): boolean {
-      return (
-        (player !== undefined &&
-                player.actionsThisGeneration !== undefined &&
-                player.actionsThisGeneration.includes(card.name)) || card.isDisabled
-      );
+      return card !== undefined &&
+          ((player.actionsThisGeneration !== undefined &&
+            player.actionsThisGeneration.includes(card.name)) ||
+          card.isDisabled);
     },
   },
 };

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import {Button} from '../components/common/Button';
 import {Message} from '../Message';
 import {CardOrderStorage} from './CardOrderStorage';
-import {PlayerModel} from '../models/PlayerModel';
+import {PlayerModel, publicModelOf} from '../models/PlayerModel';
 import {VueModelCheckbox, VueModelRadio} from './VueTypes';
 import {Card} from './card/Card';
 import {CardModel} from '../models/CardModel';
@@ -73,7 +73,7 @@ export const SelectCard = Vue.component('select-card', {
         return sortActiveCards(this.playerinput.cards);
       } else {
         return CardOrderStorage.getOrdered(
-          CardOrderStorage.getCardOrder(this.player.id),
+          CardOrderStorage.getCardOrder(publicModelOf(this.player).id),
           this.playerinput.cards,
         );
       }

--- a/src/components/SelectCard.ts
+++ b/src/components/SelectCard.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import {Button} from '../components/common/Button';
 import {Message} from '../Message';
 import {CardOrderStorage} from './CardOrderStorage';
-import {PlayerModel, publicModelOf} from '../models/PlayerModel';
+import {PlayerModel} from '../models/PlayerModel';
 import {VueModelCheckbox, VueModelRadio} from './VueTypes';
 import {Card} from './card/Card';
 import {CardModel} from '../models/CardModel';
@@ -73,7 +73,7 @@ export const SelectCard = Vue.component('select-card', {
         return sortActiveCards(this.playerinput.cards);
       } else {
         return CardOrderStorage.getOrdered(
-          CardOrderStorage.getCardOrder(publicModelOf(this.player).id),
+          CardOrderStorage.getCardOrder(this.player.privateModel.id),
           this.playerinput.cards,
         );
       }

--- a/src/components/SelectHowToPay.ts
+++ b/src/components/SelectHowToPay.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import {HowToPay} from '../inputs/HowToPay';
 import {PaymentWidgetMixin} from './PaymentWidgetMixin';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {PreferencesManager} from './PreferencesManager';
 import {Button} from '../components/common/Button';
 import {TranslateMixin} from './TranslateMixin';
@@ -22,7 +22,7 @@ interface SelectHowToPayModel {
 export const SelectHowToPay = Vue.component('select-how-to-pay', {
   props: {
     player: {
-      type: Object as () => PlayerModel,
+      type: Object as () => PublicPlayerModel,
     },
     playerinput: {
       type: Object as () => PlayerInputModel,

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -56,7 +56,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
             this.playerinput.cards !== undefined &&
             this.playerinput.cards.length > 0) {
       cards = CardOrderStorage.getOrdered(
-        CardOrderStorage.getCardOrder(this.player.id),
+        CardOrderStorage.getCardOrder(this.player.color),
         this.playerinput.cards,
       );
       card = cards[0];

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -1,4 +1,3 @@
-
 import Vue from 'vue';
 import {Button} from './common/Button';
 
@@ -27,7 +26,7 @@ import {CardModel} from '../models/CardModel';
 import {CardOrderStorage} from './CardOrderStorage';
 import {PaymentWidgetMixin} from './PaymentWidgetMixin';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {PreferencesManager} from './PreferencesManager';
 import {TranslateMixin} from './TranslateMixin';
 import {CardName} from '../CardName';
@@ -35,7 +34,7 @@ import {CardName} from '../CardName';
 export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for-project-card', {
   props: {
     player: {
-      type: Object as () => PlayerModel,
+      type: Object as () => PublicPlayerModel,
     },
     playerinput: {
       type: Object as () => PlayerInputModel,

--- a/src/components/SelectPartyPlayer.ts
+++ b/src/components/SelectPartyPlayer.ts
@@ -3,14 +3,14 @@ import Vue from 'vue';
 import {Button} from '../components/common/Button';
 import {ColorWithNeutral} from '../Color';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {SelectPlayerRow} from './SelectPlayerRow';
 import {TranslateMixin} from './TranslateMixin';
 
 export const SelectPartyPlayer = Vue.component('select-party-player', {
   props: {
     players: {
-      type: Array as () => Array<PlayerModel>,
+      type: Array as () => Array<PublicPlayerModel>,
     },
     playerinput: {
       type: Object as () => PlayerInputModel,

--- a/src/components/SelectPlayer.ts
+++ b/src/components/SelectPlayer.ts
@@ -3,7 +3,7 @@ import Vue from 'vue';
 import {Button} from './common/Button';
 import {ColorWithNeutral} from '../Color';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 import {SelectPlayerRow} from './SelectPlayerRow';
 import {VueModelRadio} from './VueTypes';
 import {TranslateMixin} from './TranslateMixin';
@@ -11,7 +11,7 @@ import {TranslateMixin} from './TranslateMixin';
 export const SelectPlayer = Vue.component('select-player', {
   props: {
     players: {
-      type: Array as () => Array<PlayerModel>,
+      type: Array as () => Array<PublicPlayerModel>,
     },
     playerinput: {
       type: Object as () => PlayerInputModel,

--- a/src/components/SelectPlayerRow.ts
+++ b/src/components/SelectPlayerRow.ts
@@ -1,11 +1,11 @@
 
 import Vue from 'vue';
-import {PlayerModel} from '../models/PlayerModel';
+import {PublicPlayerModel} from '../models/PlayerModel';
 
 export const SelectPlayerRow = Vue.component('select-player-row', {
   props: {
     player: {
-      type: Object as () => PlayerModel | undefined,
+      type: Object as () => PublicPlayerModel | undefined,
     },
   },
   methods: {

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -16,7 +16,7 @@ import {$t} from '../directives/i18n';
 import {SelectPartyPlayer} from './SelectPartyPlayer';
 import {SelectPartyToSendDelegate} from './SelectPartyToSendDelegate';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel} from '../models/PlayerModel';
+import {PlayerModel, publicModelOf} from '../models/PlayerModel';
 import {PreferencesManager} from './PreferencesManager';
 import {SoundManager} from './SoundManager';
 import {SelectColony} from './SelectColony';
@@ -132,7 +132,7 @@ export const WaitingFor = Vue.component('waiting-for', {
       this.waitForUpdate();
       return createElement('div', $t('Not your turn to take any actions'));
     }
-    if (this.player.players.length > 1 && this.player.waitingFor !== undefined) {
+    if (this.player.players.length > 1 && this.player.privateModel.waitingFor !== undefined) {
       documentTitleTimer = window.setInterval(() => this.animateTitle(), 1000);
     }
     const input = new PlayerInputFactory().getPlayerInput(createElement, this.players, this.player, this.waitingfor, (out: Array<Array<string>>) => {
@@ -145,7 +145,7 @@ export const WaitingFor = Vue.component('waiting-for', {
       }
 
       root.isServerSideRequestInProgress = true;
-      xhr.open('POST', '/player/input?id=' + this.player.id);
+      xhr.open('POST', '/player/input?id=' + publicModelOf(this.player).id);
       xhr.responseType = 'json';
       xhr.onload = () => {
         if (xhr.status === 200) {

--- a/src/components/WaitingFor.ts
+++ b/src/components/WaitingFor.ts
@@ -16,7 +16,7 @@ import {$t} from '../directives/i18n';
 import {SelectPartyPlayer} from './SelectPartyPlayer';
 import {SelectPartyToSendDelegate} from './SelectPartyToSendDelegate';
 import {PlayerInputModel} from '../models/PlayerInputModel';
-import {PlayerModel, publicModelOf} from '../models/PlayerModel';
+import {PlayerModel} from '../models/PlayerModel';
 import {PreferencesManager} from './PreferencesManager';
 import {SoundManager} from './SoundManager';
 import {SelectColony} from './SelectColony';
@@ -145,7 +145,7 @@ export const WaitingFor = Vue.component('waiting-for', {
       }
 
       root.isServerSideRequestInProgress = true;
-      xhr.open('POST', '/player/input?id=' + publicModelOf(this.player).id);
+      xhr.open('POST', '/player/input?id=' + this.player.privateModel.id);
       xhr.responseType = 'json';
       xhr.onload = () => {
         if (xhr.status === 200) {

--- a/src/components/overview/PlayerInfo.ts
+++ b/src/components/overview/PlayerInfo.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import {PlayerModel} from '../../models/PlayerModel';
+import {PlayerModel, publicModelOf, PublicPlayerModel} from '../../models/PlayerModel';
 import {PlayerResources} from './PlayerResources';
 import {PlayerTags} from './PlayerTags';
 import {PlayerStatus} from './PlayerStatus';
@@ -23,7 +23,7 @@ export const PlayerInfo = Vue.component('player-info', {
       type: Object as () => PlayerModel,
     },
     activePlayer: {
-      type: Object as () => PlayerModel,
+      type: Object as () => PublicPlayerModel,
     },
     firstForGen: {
       type: Boolean,
@@ -38,6 +38,11 @@ export const PlayerInfo = Vue.component('player-info', {
       type: Boolean,
     },
   },
+  computed: {
+    publicPlayer: function(): PublicPlayerModel {
+      return publicModelOf(this.player);
+    },
+  },
   components: {
     'player-resources': PlayerResources,
     'player-tags': PlayerTags,
@@ -47,7 +52,7 @@ export const PlayerInfo = Vue.component('player-info', {
   methods: {
     getClasses: function(): string {
       const classes = ['player-info'];
-      classes.push(playerColorClass(this.player.color, 'bg_transparent'));
+      classes.push(playerColorClass(this.publicPlayer.color, 'bg_transparent'));
       return classes.join(' ');
     },
     getPlayerStatusAndResClasses: function(): string {
@@ -55,14 +60,14 @@ export const PlayerInfo = Vue.component('player-info', {
       return classes.join(' ');
     },
     getIsActivePlayer: function(): boolean {
-      return this.player.color === this.activePlayer.color;
+      return this.publicPlayer.color === this.activePlayer.color;
     },
     pinPlayer: function() {
       let hiddenPlayersIndexes: Array<Number> = [];
       const playerPinned = isPinned(this.$root, this.playerIndex);
 
       // if player is already pinned, add to hidden players (toggle)
-      hiddenPlayersIndexes = range(this.activePlayer.players.length - 1);
+      hiddenPlayersIndexes = range(this.player.players.length - 1);
       if (!playerPinned) {
         showPlayerData(this.$root, this.playerIndex);
         hiddenPlayersIndexes = hiddenPlayersIndexes.filter(
@@ -80,7 +85,7 @@ export const PlayerInfo = Vue.component('player-info', {
     },
     togglePlayerDetails: function() {
       // for active player => scroll to cards UI
-      if (this.player.color === this.activePlayer.color) {
+      if (this.publicPlayer.color === this.activePlayer.color) {
         const el: HTMLElement = document.getElementsByClassName(
           'preferences_icon--cards',
         )[0] as HTMLElement;
@@ -92,10 +97,10 @@ export const PlayerInfo = Vue.component('player-info', {
       this.pinPlayer();
     },
     getNrPlayedCards: function(): number {
-      return this.player.playedCards.length;
+      return this.publicPlayer.playedCards.length;
     },
     getAvailableBlueActionCount: function(): number {
-      return this.player.availableBlueCardActionCount;
+      return this.publicPlayer.availableBlueCardActionCount;
     },
   },
   template: `
@@ -103,9 +108,9 @@ export const PlayerInfo = Vue.component('player-info', {
         <div :class="getPlayerStatusAndResClasses()">
         <div class="player-status">
           <div class="player-info-details">
-            <div class="player-info-name">{{ player.name }}</div>
-            <div class="icon-first-player" v-if="firstForGen && activePlayer.players.length > 1">1st</div>
-            <div class="player-info-corp" v-if="player.corporationCard !== undefined" :title="player.corporationCard.name">{{ player.corporationCard.name }}</div>
+            <div class="player-info-name">{{ this.publicPlayer.name }}</div>
+            <div class="icon-first-player" v-if="firstForGen && player.players.length > 1">1st</div>
+            <div class="player-info-corp" v-if="this.publicPlayer.corporationCard !== undefined" :title="this.publicPlayer.corporationCard.name">{{ this.publicPlayer.corporationCard.name }}</div>
           </div>
           <player-status :player="player" :activePlayer="activePlayer" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" :playerIndex="playerIndex"/>
         </div>

--- a/src/components/overview/PlayerResources.ts
+++ b/src/components/overview/PlayerResources.ts
@@ -1,13 +1,17 @@
 import Vue from 'vue';
 import {CardName} from '../../CardName';
-import {PlayerModel} from '../../models/PlayerModel';
+import {PublicPlayerModel} from '../../models/PlayerModel';
 import {PlayerResource} from './PlayerResource';
 import {Resources} from '../../Resources';
+import {TurmoilModel} from '../../models/TurmoilModel';
 
 export const PlayerResources = Vue.component('player-resources', {
   props: {
     player: {
-      type: Object as () => PlayerModel,
+      type: Object as () => PublicPlayerModel,
+    },
+    turmoil: {
+      type: Object as () => TurmoilModel | undefined,
     },
   },
   data: function() {
@@ -27,7 +31,7 @@ export const PlayerResources = Vue.component('player-resources', {
         <div class="resource_items_cont">
             <player-resource :type="resources.MEGACREDITS" :count="player.megaCredits" :production="player.megaCreditProduction"></player-resource>
             <player-resource :type="resources.STEEL" :count="player.steel" :production="player.steelProduction" :steelValue="player.steelValue"></player-resource>
-            <player-resource :type="resources.TITANIUM" :count="player.titanium" :production="player.titaniumProduction" :titaniumValue="player.titaniumValue" :turmoil="player.game.turmoil"></player-resource>
+            <player-resource :type="resources.TITANIUM" :count="player.titanium" :production="player.titaniumProduction" :titaniumValue="player.titaniumValue" :turmoil="turmoil"></player-resource>
             <player-resource :type="resources.PLANTS" :count="player.plants" :production="player.plantProduction" :plantsAreProtected="player.plantsAreProtected"></player-resource>
             <player-resource :type="resources.ENERGY" :count="player.energy" :production="player.energyProduction"></player-resource>
             <player-resource :type="resources.HEAT" :count="player.heat" :production="player.heatProduction" :canUseHeatAsMegaCredits="canUseHeatAsMegaCredits()"></player-resource>

--- a/src/components/overview/PlayerStatus.ts
+++ b/src/components/overview/PlayerStatus.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import {ActionLabel} from './ActionLabel';
 import {Button} from '../common/Button';
 import {mainAppSettings} from '../App';
-import {PlayerModel} from '../../models/PlayerModel';
+import {PlayerModel, publicModelOf, PublicPlayerModel} from '../../models/PlayerModel';
 import {PlayerTimer} from './PlayerTimer';
 
 export const hidePlayerData = (root: typeof mainAppSettings.methods, playerIndex: number) => {
@@ -25,6 +25,11 @@ export const PlayerStatus = Vue.component('player-status', {
     },
     playerIndex: {
       type: Number,
+    },
+  },
+  computed: {
+    publicPlayer: function(): PublicPlayerModel {
+      return publicModelOf(this.player);
     },
   },
   components: {
@@ -59,7 +64,7 @@ export const PlayerStatus = Vue.component('player-status', {
         <div class="player-status-bottom">
           <div :class="getLabelAndTimerClasses()">
             <div :class="getActionStatusClasses()">{{ actionLabel }}</div>
-            <div class="player-status-timer" v-if="player.game.gameOptions.showTimers"><player-timer :timer="player.timer"/></div>
+            <div class="player-status-timer" v-if="player.game.gameOptions.showTimers"><player-timer :timer="this.publicPlayer.timer"/></div>
           </div>
         </div>
       </div>

--- a/src/components/overview/PlayersOverview.ts
+++ b/src/components/overview/PlayersOverview.ts
@@ -111,14 +111,14 @@ export const PlayersOverview = Vue.component('players-overview', {
         <div class="players-overview" v-if="hasPlayers()">
             <overview-settings />
             <div class="other_player" v-if="player.players.length > 1">
-                <div v-for="(otherPlayer, index) in getPlayersInOrder()" :key="otherPlayer.id">
-                    <other-player v-if="otherPlayer.id !== publicPlayer().id" :player="otherPlayer" :playerIndex="index"/>
+                <div v-for="(otherPlayer, index) in getPlayersInOrder()" :key="otherPlayer.color">
+                    <other-player v-if="otherPlayer.color !== publicPlayer().color" :player="otherPlayer" :playerIndex="index"/>
                 </div>
             </div>
             <player-info v-for="(p, index) in getPlayersInOrder()"
               :activePlayer="player"
               :player="p"
-              :key="p.id"
+              :key="p.color"
               :firstForGen="getIsFirstForGen(p)"
               :actionLabel="getActionLabel(p)"
               :playerIndex="index"/>

--- a/src/components/overview/PlayersOverview.ts
+++ b/src/components/overview/PlayersOverview.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import {PlayerInfo} from './PlayerInfo';
 import {OverviewSettings} from './OverviewSettings';
 import {OtherPlayer} from '../OtherPlayer';
-import {PlayerModel, PublicPlayerModel} from '../../models/PlayerModel';
+import {PlayerModel, publicModelOf, PublicPlayerModel} from '../../models/PlayerModel';
 import {ActionLabel} from './ActionLabel';
 import {Phase} from '../../Phase';
 import {Color} from '../../Color';
@@ -37,12 +37,15 @@ export const PlayersOverview = Vue.component('players-overview', {
     return {};
   },
   methods: {
+    publicPlayer: function() {
+      return publicModelOf(this.player);
+    },
     hasPlayers: function(): boolean {
       return this.player.players.length > 0;
     },
     getPlayerOnFocus: function(): PublicPlayerModel {
       return this.player.players.filter(
-        (p: PublicPlayerModel) => p.color === this.player.color,
+        (p: PublicPlayerModel) => p.color === this.publicPlayer().color,
       )[0];
     },
     getIsFirstForGen: function(player: PublicPlayerModel): boolean {
@@ -53,7 +56,7 @@ export const PlayersOverview = Vue.component('players-overview', {
       let result: Array<PublicPlayerModel> = [];
       let currentPlayerOffset: number = 0;
       const currentPlayerIndex: number = getCurrentPlayerIndex(
-        this.player.color,
+        this.publicPlayer().color,
         this.player.players,
       );
 
@@ -109,7 +112,7 @@ export const PlayersOverview = Vue.component('players-overview', {
             <overview-settings />
             <div class="other_player" v-if="player.players.length > 1">
                 <div v-for="(otherPlayer, index) in getPlayersInOrder()" :key="otherPlayer.id">
-                    <other-player v-if="otherPlayer.id !== player.id" :player="otherPlayer" :playerIndex="index"/>
+                    <other-player v-if="otherPlayer.id !== publicPlayer().id" :player="otherPlayer" :playerIndex="index"/>
                 </div>
             </div>
             <player-info v-for="(p, index) in getPlayersInOrder()"
@@ -124,8 +127,8 @@ export const PlayersOverview = Vue.component('players-overview', {
               :player="getPlayerOnFocus()"
               :activePlayer="player"
               :key="player.players.length - 1"
-              :firstForGen="getIsFirstForGen(player)"
-              :actionLabel="getActionLabel(player)"
+              :firstForGen="getIsFirstForGen(publicPlayer())"
+              :actionLabel="getActionLabel(publicPlayer())"
               :playerIndex="-1"/>
         </div>
     `,

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -6,7 +6,7 @@ import {PlayerInputModel} from './PlayerInputModel';
 import {SerializedTimer} from '../SerializedTimer';
 import {GameModel} from './GameModel';
 
-export interface PublicPlayerModel extends GameModel {
+export interface PublicPlayerModel {
   actionsTakenThisRound: number;
   actionsThisGeneration: Array<string /* CardName */>;
   availableBlueCardActionCount: number;

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -5,6 +5,7 @@ import {ITagCount} from '../ITagCount';
 import {PlayerInputModel} from './PlayerInputModel';
 import {SerializedTimer} from '../SerializedTimer';
 import {GameModel} from './GameModel';
+import {PlayerId} from '../Player';
 
 export interface PublicPlayerModel {
   actionsTakenThisRound: number;
@@ -21,7 +22,7 @@ export interface PublicPlayerModel {
   fleetSize: number;
   heat: number;
   heatProduction: number;
-  id: string; // PlayerId
+  id: PlayerId | 'invalid',
   influence: number;
   isActive: boolean;
   megaCredits: number;
@@ -57,7 +58,7 @@ export interface PrivatePlayerModel {
   dealtPreludeCards: Array<CardModel>;
   dealtProjectCards: Array<CardModel>;
   draftedCards: Array<CardModel>;
-  game: GameModel;
+  id: PlayerId;
   influence: number;
   pickedCorporationCard: Array<CardModel>; // Why Array?
   preludeCardsInHand: Array<CardModel>;

--- a/src/models/PlayerModel.ts
+++ b/src/models/PlayerModel.ts
@@ -34,7 +34,6 @@ export interface PublicPlayerModel {
   plantProduction: number;
   plantsAreProtected: boolean;
   playedCards: Array<CardModel>;
-  preludeCardsInHand: Array<CardModel>;
   selfReplicatingRobotsCards: Array<CardModel>;
   steel: number;
   steelProduction: number;
@@ -49,7 +48,7 @@ export interface PublicPlayerModel {
   victoryPointsBreakdown: VictoryPointsBreakdown;
 }
 
-export interface PlayerModel extends PublicPlayerModel {
+export interface PrivatePlayerModel {
   availableBlueCardActionCount: number;
   cardCost: number;
   cardsInHand: Array<CardModel>;
@@ -61,8 +60,21 @@ export interface PlayerModel extends PublicPlayerModel {
   game: GameModel;
   influence: number;
   pickedCorporationCard: Array<CardModel>; // Why Array?
-  players: Array<PublicPlayerModel>;
   preludeCardsInHand: Array<CardModel>;
   timer: SerializedTimer;
   waitingFor: PlayerInputModel | undefined;
+}
+
+// A player's view of the game includes public game information,
+// public information about all the players,
+// your private information, and your index in the public players array.
+export interface PlayerModel {
+  game: GameModel;
+  players: Array<PublicPlayerModel>;
+  privateModel: PrivatePlayerModel;
+  playersIndex: number,
+}
+
+export function publicModelOf(playerModel: PlayerModel): PublicPlayerModel {
+  return playerModel.players[playerModel.playersIndex];
 }

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -91,8 +91,6 @@ export class Server {
     const game = player.game;
     const turmoil = getTurmoil(game);
 
-    const gameModel = this.getCommonGameModel(game);
-
     return {
       actionsTakenThisRound: player.actionsTakenThisRound,
       actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
@@ -143,30 +141,6 @@ export class Server {
       tradesThisGeneration: player.tradesThisGeneration,
       victoryPointsBreakdown: player.getVictoryPoints(),
       waitingFor: this.getWaitingFor(player, player.getWaitingFor()),
-
-      // Remove these after 2021-05-05
-      aresData: gameModel.aresData,
-      awards: gameModel.awards,
-      colonies: gameModel.colonies,
-      deckSize: gameModel.deckSize,
-      gameAge: gameModel.gameAge,
-      gameOptions: gameModel.gameOptions,
-      generation: gameModel.generation,
-      isSoloModeWin: gameModel.isSoloModeWin,
-      lastSoloGeneration: gameModel.lastSoloGeneration,
-      milestones: gameModel.milestones,
-      moon: gameModel.moon,
-      oceans: gameModel.oceans,
-      oxygenLevel: gameModel.oxygenLevel,
-      passedPlayers: gameModel.passedPlayers,
-      phase: gameModel.phase,
-      spaces: gameModel.spaces,
-      spectatorId: gameModel.spectatorId,
-      temperature: gameModel.temperature,
-      isTerraformed: gameModel.isTerraformed,
-      turmoil: gameModel.turmoil,
-      undoCount: gameModel.undoCount,
-      venusScaleLevel: gameModel.venusScaleLevel,
     };
   }
 

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -87,8 +87,8 @@ export class Server {
     };
   }
   public static getPlayerModel(player: Player): PlayerModel {
-    const players = this.getPlayers(player.game);
-    const playersIndex = players.findIndex((p) => p.id = player.id);
+    const players = player.game.getPlayers().map((p) => this.getPlayer(p));
+    const playersIndex = players.findIndex((p) => p.color = player.color);
     return {
       game: this.getCommonGameModel(player.game),
       players,
@@ -106,11 +106,11 @@ export class Server {
       cardCost: player.cardCost,
       cardsInHand: this.getCards(player, player.cardsInHand, {showNewCost: true}),
       corporationCard: this.getCorporationCard(player),
-      game: this.getCommonGameModel(player.game),
       dealtCorporationCards: this.getCards(player, player.dealtCorporationCards),
       dealtPreludeCards: this.getCards(player, player.dealtPreludeCards),
       dealtProjectCards: this.getCards(player, player.dealtProjectCards),
       draftedCards: this.getCards(player, player.draftedCards, {showNewCost: true}),
+      id: player.id,
       influence: turmoil ? game.turmoil!.getPlayerInfluence(player) : 0,
       pickedCorporationCard: player.pickedCorporationCard ? this.getCards(player, [player.pickedCorporationCard]) : [],
       preludeCardsInHand: this.getCards(player, player.preludeCardsInHand),
@@ -365,52 +365,49 @@ export class Server {
       discount: card.cardDiscount,
     }));
   }
-  private static getPlayers(game: Game): Array<PublicPlayerModel> {
-    const players = game.getPlayers();
-    return players.map((player) => {
-      return {
-        actionsTakenThisRound: player.actionsTakenThisRound,
-        actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
-        availableBlueCardActionCount: player.getAvailableBlueActionCount(),
-        cardCost: player.cardCost,
-        cardsInHandNbr: player.cardsInHand.length,
-        citiesCount: player.getCitiesCount(),
-        coloniesCount: player.getColoniesCount(),
-        color: player.color,
-        corporationCard: this.getCorporationCard(player),
-        energy: player.energy,
-        energyProduction: player.getProduction(Resources.ENERGY),
-        fleetSize: player.getFleetSize(),
-        heat: player.heat,
-        heatProduction: player.getProduction(Resources.HEAT),
-        id: game.phase === Phase.END ? player.id : player.color,
-        influence: game.turmoil?.getPlayerInfluence(player) ?? 0,
-        isActive: player.id === game.activePlayer,
-        megaCredits: player.megaCredits,
-        megaCreditProduction: player.getProduction(Resources.MEGACREDITS),
-        name: player.name,
-        needsToDraft: player.needsToDraft,
-        needsToResearch: !game.hasResearched(player),
-        noTagsCount: player.getNoTagsCount(),
-        plants: player.plants,
-        plantProduction: player.getProduction(Resources.PLANTS),
-        plantsAreProtected: player.plantsAreProtected(),
-        playedCards: this.getCards(player, player.playedCards, {showResources: true}),
-        preludeCardsInHand: '',
-        selfReplicatingRobotsCards: this.getSelfReplicatingRobotsTargetCards(player),
-        steel: player.steel,
-        steelProduction: player.getProduction(Resources.STEEL),
-        steelValue: player.getSteelValue(),
-        tags: player.getAllTags(),
-        terraformRating: player.getTerraformRating(),
-        timer: player.timer.serialize(),
-        titanium: player.titanium,
-        titaniumProduction: player.getProduction(Resources.TITANIUM),
-        titaniumValue: player.getTitaniumValue(),
-        tradesThisGeneration: player.tradesThisGeneration,
-        victoryPointsBreakdown: player.getVictoryPoints(),
-      };
-    });
+
+  private static getPlayer(player: Player): PublicPlayerModel {
+    return {
+      actionsTakenThisRound: player.actionsTakenThisRound,
+      actionsThisGeneration: Array.from(player.getActionsThisGeneration()),
+      availableBlueCardActionCount: player.getAvailableBlueActionCount(),
+      cardCost: player.cardCost,
+      cardsInHandNbr: player.cardsInHand.length,
+      citiesCount: player.getCitiesCount(),
+      coloniesCount: player.getColoniesCount(),
+      color: player.color,
+      corporationCard: this.getCorporationCard(player),
+      energy: player.energy,
+      energyProduction: player.getProduction(Resources.ENERGY),
+      fleetSize: player.getFleetSize(),
+      heat: player.heat,
+      heatProduction: player.getProduction(Resources.HEAT),
+      id: player.game.phase === Phase.END ? player.id : 'invalid',
+      influence: player.game.turmoil?.getPlayerInfluence(player) ?? 0,
+      isActive: player.id === player.game.activePlayer,
+      megaCredits: player.megaCredits,
+      megaCreditProduction: player.getProduction(Resources.MEGACREDITS),
+      name: player.name,
+      needsToDraft: player.needsToDraft,
+      needsToResearch: !player.game.hasResearched(player),
+      noTagsCount: player.getNoTagsCount(),
+      plants: player.plants,
+      plantProduction: player.getProduction(Resources.PLANTS),
+      plantsAreProtected: player.plantsAreProtected(),
+      playedCards: this.getCards(player, player.playedCards, {showResources: true}),
+      selfReplicatingRobotsCards: this.getSelfReplicatingRobotsTargetCards(player),
+      steel: player.steel,
+      steelProduction: player.getProduction(Resources.STEEL),
+      steelValue: player.getSteelValue(),
+      tags: player.getAllTags(),
+      terraformRating: player.getTerraformRating(),
+      timer: player.timer.serialize(),
+      titanium: player.titanium,
+      titaniumProduction: player.getProduction(Resources.TITANIUM),
+      titaniumValue: player.getTitaniumValue(),
+      tradesThisGeneration: player.tradesThisGeneration,
+      victoryPointsBreakdown: player.getVictoryPoints(),
+    };
   }
 
   public static getColonies(game: Game): Array<ColonyModel> {

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -5,7 +5,7 @@ import {CardName} from '../../src/CardName';
 import {CardType} from '../../src/cards/CardType';
 import {SelectHowToPayForProjectCard} from '../../src/components/SelectHowToPayForProjectCard';
 import {PlayerInputModel} from '../../src/models/PlayerInputModel';
-import {PlayerModel} from '../../src/models/PlayerModel';
+import {PublicPlayerModel} from '../../src/models/PlayerModel';
 import {Units} from '../../src/Units';
 
 describe('SelectHowToPayForProjectCard', function() {
@@ -313,11 +313,11 @@ describe('SelectHowToPayForProjectCard', function() {
   const setupCardForPurchase = function(
     cardName: CardName,
     cardCost: number,
-    playerFields: Partial<PlayerModel>,
+    playerFields: Partial<PublicPlayerModel>,
     playerInputFields: Partial<PlayerInputModel>,
     reserveUnits: Units = Units.EMPTY) {
-    const player: Partial<PlayerModel> = Object.assign({
-      cards: [{name: cardName, calculatedCost: cardCost}],
+    const player: Partial<PublicPlayerModel> = Object.assign({
+      cardsInHand: [{name: cardName, calculatedCost: cardCost}],
       id: 'foo',
       steel: 0,
       titanium: 0,

--- a/tests/components/SelectInitialCards.spec.ts
+++ b/tests/components/SelectInitialCards.spec.ts
@@ -17,10 +17,9 @@ describe('SelectInitialCards', function() {
       localVue: getLocalVue(),
       propsData: {
         player: {
-          playersIndex: 0,
-          players: [{
+          privateModel: {
             id: 'foo',
-          }],
+          },
         },
         playerinput: {
           title: 'foo',
@@ -41,8 +40,8 @@ describe('SelectInitialCards', function() {
     expect(component).not.is.undefined;
     const selectCards = component.findAllComponents({name: 'select-card'});
     expect(selectCards.length).to.eq(2);
-    await selectCards.at(0).vm.$emit('cardschanged', [CardName.ECOLINE]);
-    await selectCards.at(1).vm.$emit('cardschanged', [CardName.ANTS]);
+    selectCards.at(0).vm.$emit('cardschanged', [CardName.ECOLINE]);
+    selectCards.at(1).vm.$emit('cardschanged', [CardName.ANTS]);
     const buttons = component.findAllComponents({name: 'Button'});
     await buttons.at(0).findAllComponents({
       name: 'button',
@@ -55,10 +54,11 @@ describe('SelectInitialCards', function() {
       localVue: getLocalVue(),
       propsData: {
         player: {
-          playersIndex: 0,
-          players: [{
-            id: 'foo',
-          }],
+          player: {
+            privateModel: {
+              id: 'foo',
+            },
+          },
         },
         playerinput: {
           title: 'foo',
@@ -82,9 +82,9 @@ describe('SelectInitialCards', function() {
     expect(component).not.is.undefined;
     const selectCards = component.findAllComponents({name: 'select-card'});
     expect(selectCards.length).to.eq(3);
-    await selectCards.at(0).vm.$emit('cardschanged', [CardName.ECOLINE]);
-    await selectCards.at(1).vm.$emit('cardschanged', [CardName.ALLIED_BANKS]);
-    await selectCards.at(2).vm.$emit('cardschanged', [CardName.ANTS]);
+    selectCards.at(0).vm.$emit('cardschanged', [CardName.ECOLINE]);
+    selectCards.at(1).vm.$emit('cardschanged', [CardName.ALLIED_BANKS]);
+    selectCards.at(2).vm.$emit('cardschanged', [CardName.ANTS]);
     const buttons = component.findAllComponents({name: 'Button'});
     await buttons.at(0).findAllComponents({
       name: 'button',

--- a/tests/components/SelectInitialCards.spec.ts
+++ b/tests/components/SelectInitialCards.spec.ts
@@ -17,7 +17,10 @@ describe('SelectInitialCards', function() {
       localVue: getLocalVue(),
       propsData: {
         player: {
-          id: 'foo',
+          playersIndex: 0,
+          players: [{
+            id: 'foo',
+          }],
         },
         playerinput: {
           title: 'foo',
@@ -52,7 +55,10 @@ describe('SelectInitialCards', function() {
       localVue: getLocalVue(),
       propsData: {
         player: {
-          id: 'foo',
+          playersIndex: 0,
+          players: [{
+            id: 'foo',
+          }],
         },
         playerinput: {
           title: 'foo',

--- a/tests/routes/ApiPlayers.spec.ts
+++ b/tests/routes/ApiPlayers.spec.ts
@@ -40,6 +40,6 @@ describe('ApiPlayer', function() {
     ctx.gameLoader.add(game);
     ApiPlayer.INSTANCE.get(req, res.hide(), ctx);
     const response: PlayerModel = JSON.parse(res.content);
-    expect(response.id).eq(player.id);
+    expect(response.players[0].id).eq(player.id);
   });
 });

--- a/tests/routes/ApiPlayers.spec.ts
+++ b/tests/routes/ApiPlayers.spec.ts
@@ -40,6 +40,6 @@ describe('ApiPlayer', function() {
     ctx.gameLoader.add(game);
     ApiPlayer.INSTANCE.get(req, res.hide(), ctx);
     const response: PlayerModel = JSON.parse(res.content);
-    expect(response.players[0].id).eq(player.id);
+    expect(response.players[0].color).eq('black');
   });
 });


### PR DESCRIPTION
This is still a prototype, it doesn't fully build yet. But I'm calling for comments.

Once this is done, a spectator link is easy and generally safer: it's a model with no private data. (NB that player ids are still in the public data model /shrug.)
The impetus for this change was for adding some data related to tracking whether the host has peeked at everyone's cards; this will be easier to work with, now.