### PR TITLE
Remove Turmoil from PlayerResources.

### DIFF
--- a/src/components/overview/PlayerResource.ts
+++ b/src/components/overview/PlayerResource.ts
@@ -1,8 +1,6 @@
 import Vue from 'vue';
 import {DEFAULT_STEEL_VALUE, DEFAULT_TITANIUM_VALUE} from '../../constants';
 import {Resources} from '../../Resources';
-import {TurmoilModel} from '../../models/TurmoilModel';
-import {PartyName} from '../../turmoil/parties/PartyName';
 import {PreferencesManager} from '../PreferencesManager';
 
 export const PlayerResource = Vue.component('player-resource', {
@@ -28,19 +26,9 @@ export const PlayerResource = Vue.component('player-resource', {
     titaniumValue: {
       type: Number,
     },
-    turmoil: {
-      type: Object as () => TurmoilModel || undefined,
-    },
   },
   data: function() {
-    // TODO: Update logic after PoliticalAgendas merge
-    const unityTitaniumBonusActive: boolean = this.turmoil !== undefined && this.turmoil.ruling === PartyName.UNITY;
-
-    let playerTitaniumValueWithOffset: number = this.titaniumValue;
-    if (unityTitaniumBonusActive) playerTitaniumValueWithOffset -= 1;
-
     return {
-      playerAdjustedTitaniumValue: playerTitaniumValueWithOffset,
     };
   },
   methods: {

--- a/src/components/overview/PlayerResources.ts
+++ b/src/components/overview/PlayerResources.ts
@@ -27,7 +27,7 @@ export const PlayerResources = Vue.component('player-resources', {
         <div class="resource_items_cont">
             <player-resource :type="resources.MEGACREDITS" :count="player.megaCredits" :production="player.megaCreditProduction"></player-resource>
             <player-resource :type="resources.STEEL" :count="player.steel" :production="player.steelProduction" :steelValue="player.steelValue"></player-resource>
-            <player-resource :type="resources.TITANIUM" :count="player.titanium" :production="player.titaniumProduction" :titaniumValue="player.titaniumValue" :turmoil="player.game.turmoil"></player-resource>
+            <player-resource :type="resources.TITANIUM" :count="player.titanium" :production="player.titaniumProduction" :titaniumValue="player.titaniumValue"></player-resource>
             <player-resource :type="resources.PLANTS" :count="player.plants" :production="player.plantProduction" :plantsAreProtected="player.plantsAreProtected"></player-resource>
             <player-resource :type="resources.ENERGY" :count="player.energy" :production="player.energyProduction"></player-resource>
             <player-resource :type="resources.HEAT" :count="player.heat" :production="player.heatProduction" :canUseHeatAsMegaCredits="canUseHeatAsMegaCredits()"></player-resource>


### PR DESCRIPTION
It's not used at all, and the code that manages increasing the alloy values is already taken into consideration when generating the player model.