### PR TITLE
Remove check that is not needed

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1047,7 +1047,6 @@ export class Game implements ISerializable<SerializedGame> {
     });
 
     Database.getInstance().saveGameResults(this.id, this.players.length, this.generation, this.gameOptions, scores);
-    if (this.phase === Phase.END) return;
     this.phase = Phase.END;
   }
 


### PR DESCRIPTION
Was looking into when we change game phase to `Phase.END`. Spotted an unnecessary check for `Phase.END` left over from a migration. 