### PR TITLE
try removing ended games again

### DIFF
--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -116,6 +116,10 @@ export class GameLoader implements IGameLoader {
     this.getByParticipantId(spectatorId, cb);
   }
 
+  public remove(gameId: GameId): void {
+    this.games.set(gameId, undefined);
+  }
+
   public restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void {
     try {
       Database.getInstance().restoreGame(gameId, saveId, (err, game) => {

--- a/src/database/IGameLoader.ts
+++ b/src/database/IGameLoader.ts
@@ -19,5 +19,6 @@ export interface IGameLoader {
   getByGameId(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void;
   getByPlayerId(playerId: PlayerId, cb: LoadCallback): void;
   getBySpectatorId(spectatorId: SpectatorId, cb: LoadCallback): void;
+  remove(gameId: GameId): void;
   restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void;
 }

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -223,4 +223,13 @@ describe('GameLoader', function() {
       done();
     });
   });
+
+  it('removes', function(done) {
+    GameLoader.getInstance().add(game);
+    GameLoader.getInstance().remove(game.id);
+    GameLoader.getInstance().getByGameId(game.id, false, (game) => {
+      expect(game).is.undefined;
+      done();
+    });
+  });
 });

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -29,6 +29,9 @@ export class FakeGameLoader implements IGameLoader {
   getBySpectatorId(_spectatorId: string, _cb: (game: Game | undefined) => void): void {
     throw new Error('Method not implemented.');
   }
+  remove(_gameId: string): void {
+    throw new Error('Method not implemented.');
+  }
   restoreGameAt(_gameId: string, _saveId: number, _cb: (game: Game | undefined) => void): void {
     throw new Error('Method not implemented.');
   }

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,6 +1,7 @@
 import * as http from 'http';
 import * as EventEmitter from 'events';
 import {expect} from 'chai';
+import {Phase} from '../../src/Phase';
 import {PlayerInput} from '../../src/routes/PlayerInput';
 import {Route} from '../../src/routes/Route';
 import {MockResponse} from './HttpMocks';
@@ -90,5 +91,24 @@ describe('PlayerInput', function() {
     req.emit('data', '}{');
     req.emit('end');
     expect(res.content).eq('{"message":"Unexpected token } in JSON at position 0"}');
+  });
+
+  it('schedules game removal when game ends', (done) => {
+    const player = TestPlayers.BLUE.newPlayer();
+    req.url = '/player/input?id=' + player.id;
+    ctx.url = new URL('http://boo.com' + req.url);
+    const game = Game.newInstance('foo', [player], player);
+    ctx.gameLoader.add(game);
+    ctx.gameLoader.remove = function(gameId) {
+      expect(gameId).to.equal(game.id);
+      done();
+    };
+    player.process = function() {
+      player.game.phase = Phase.END;
+    };
+    PlayerInput.INSTANCE.setRemoveTimeout(0);
+    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
+    req.emit('data', JSON.stringify([]));
+    req.emit('end');
   });
 });


### PR DESCRIPTION
The first try with garbage collection I ended up blocking the main thread iterating through every game. The strategy this time is to set a timeout when the game transitions to the end phase. This will avoid having to iterate through thousands of games at once. It will also allow for a finished game to remain in javascript memory for an hour.

The goal of this ticket is to cut down on the amount of memory being used on the heroku instance. With no process in place today to every free memory we eventually use enough that heroku tries to restart the dyno. We have seen in the past that when it restarts the dyno it sometimes fails to start.