### PR TITLE
move victoryPointsBreakdown property to TestPlayer

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1039,11 +1039,12 @@ export class Game implements ISerializable<SerializedGame> {
     Database.getInstance().cleanSaves(this.id, this.lastSaveId);
     const scores: Array<Score> = [];
     this.players.forEach((player) => {
-      let corponame: String = '';
+      let corponame: string = '';
+      const vpb = player.getVictoryPoints();
       if (player.corporationCard !== undefined) {
         corponame = player.corporationCard.name;
       }
-      scores.push({corporation: corponame, playerScore: player.victoryPointsBreakdown.total});
+      scores.push({corporation: corponame, playerScore: vpb.total});
     });
 
     Database.getInstance().saveGameResults(this.id, this.players.length, this.generation, this.gameOptions, scores);

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -144,7 +144,6 @@ export class Player implements ISerializable<SerializedPlayer> {
   public turmoilPolicyActionUsed: boolean = false;
   public politicalAgendasActionUsedCount: number = 0;
 
-  public victoryPointsBreakdown = new VictoryPointsBreakdown();
   public oceanBonus: number = constants.OCEAN_BONUS;
 
   // Custom cards
@@ -501,31 +500,30 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public getVictoryPoints(): VictoryPointsBreakdown {
-    // Reset victory points
-    this.victoryPointsBreakdown = new VictoryPointsBreakdown();
+    const victoryPointsBreakdown = new VictoryPointsBreakdown();
 
     // Victory points from corporations
     if (this.corporationCard !== undefined && this.corporationCard.getVictoryPoints !== undefined) {
-      this.victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.corporationCard.getVictoryPoints(this), this.corporationCard.name);
+      victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.corporationCard.getVictoryPoints(this), this.corporationCard.name);
     }
 
     // Victory points from cards
     for (const playedCard of this.playedCards) {
       if (playedCard.getVictoryPoints !== undefined) {
-        this.victoryPointsBreakdown.setVictoryPoints('victoryPoints', playedCard.getVictoryPoints(this), playedCard.name);
+        victoryPointsBreakdown.setVictoryPoints('victoryPoints', playedCard.getVictoryPoints(this), playedCard.name);
       }
     }
 
     // Victory points from TR
-    this.victoryPointsBreakdown.setVictoryPoints('terraformRating', this.terraformRating);
+    victoryPointsBreakdown.setVictoryPoints('terraformRating', this.terraformRating);
 
     // Victory points from awards
-    this.giveAwards();
+    this.giveAwards(victoryPointsBreakdown);
 
     // Victory points from milestones
     for (const milestone of this.game.claimedMilestones) {
       if (milestone.player !== undefined && milestone.player.id === this.id) {
-        this.victoryPointsBreakdown.setVictoryPoints('milestones', 5, 'Claimed '+milestone.milestone.name+' milestone');
+        victoryPointsBreakdown.setVictoryPoints('milestones', 5, 'Claimed '+milestone.milestone.name+' milestone');
       }
     }
 
@@ -533,7 +531,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     this.game.board.spaces.forEach((space) => {
       // Victory points for greenery tiles
       if (space.tile && space.tile.tileType === TileType.GREENERY && space.player !== undefined && space.player.id === this.id) {
-        this.victoryPointsBreakdown.setVictoryPoints('greenery', 1);
+        victoryPointsBreakdown.setVictoryPoints('greenery', 1);
       }
 
       // Victory points for greenery tiles adjacent to cities
@@ -541,7 +539,7 @@ export class Player implements ISerializable<SerializedPlayer> {
         const adjacent = this.game.board.getAdjacentSpaces(space);
         for (const adj of adjacent) {
           if (adj.tile && adj.tile.tileType === TileType.GREENERY) {
-            this.victoryPointsBreakdown.setVictoryPoints('city', 1);
+            victoryPointsBreakdown.setVictoryPoints('city', 1);
           }
         }
       }
@@ -551,18 +549,18 @@ export class Player implements ISerializable<SerializedPlayer> {
     const includeTurmoilVP : boolean = this.game.gameIsOver() || this.game.phase === Phase.END;
 
     if (includeTurmoilVP && this.game.gameOptions.turmoilExtension && this.game.turmoil) {
-      this.victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.game.turmoil.getPlayerVictoryPoints(this), 'Turmoil Points');
+      victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.game.turmoil.getPlayerVictoryPoints(this), 'Turmoil Points');
     }
 
     // Titania Colony VP
     if (this.colonyVictoryPoints > 0) {
-      this.victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.colonyVictoryPoints, 'Colony VP');
+      victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.colonyVictoryPoints, 'Colony VP');
     }
 
-    MoonExpansion.calculateVictoryPoints(this);
+    MoonExpansion.calculateVictoryPoints(this, victoryPointsBreakdown);
 
-    this.victoryPointsBreakdown.updateTotal();
-    return this.victoryPointsBreakdown;
+    victoryPointsBreakdown.updateTotal();
+    return victoryPointsBreakdown;
   }
 
   public cardIsInEffect(cardName: CardName): boolean {
@@ -1629,7 +1627,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     });
   }
 
-  private giveAwards(): void {
+  private giveAwards(vpb: VictoryPointsBreakdown): void {
     this.game.fundedAwards.forEach((fundedAward) => {
       // Awards are disabled for 1 player games
       if (this.game.isSoloMode()) return;
@@ -1641,19 +1639,19 @@ export class Player implements ISerializable<SerializedPlayer> {
 
       // We have one rank 1 player
       if (fundedAward.award.getScore(players[0]) > fundedAward.award.getScore(players[1])) {
-        if (players[0].id === this.id) this.victoryPointsBreakdown.setVictoryPoints('awards', 5, '1st place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
+        if (players[0].id === this.id) vpb.setVictoryPoints('awards', 5, '1st place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
         players.shift();
 
         if (players.length > 1) {
           // We have one rank 2 player
           if (fundedAward.award.getScore(players[0]) > fundedAward.award.getScore(players[1])) {
-            if (players[0].id === this.id) this.victoryPointsBreakdown.setVictoryPoints('awards', 2, '2nd place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
+            if (players[0].id === this.id) vpb.setVictoryPoints('awards', 2, '2nd place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
 
           // We have at least two rank 2 players
           } else {
             const score = fundedAward.award.getScore(players[0]);
             while (players.length > 0 && fundedAward.award.getScore(players[0]) === score) {
-              if (players[0].id === this.id) this.victoryPointsBreakdown.setVictoryPoints('awards', 2, '2nd place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
+              if (players[0].id === this.id) vpb.setVictoryPoints('awards', 2, '2nd place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
               players.shift();
             }
           }
@@ -1663,7 +1661,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       } else {
         const score = fundedAward.award.getScore(players[0]);
         while (players.length > 0 && fundedAward.award.getScore(players[0]) === score) {
-          if (players[0].id === this.id) this.victoryPointsBreakdown.setVictoryPoints('awards', 5, '1st place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
+          if (players[0].id === this.id) vpb.setVictoryPoints('awards', 5, '1st place for '+fundedAward.award.name+' award (funded by '+fundedAward.player.name+')');
           players.shift();
         }
       }
@@ -2155,7 +2153,6 @@ export class Player implements ISerializable<SerializedPlayer> {
       turmoilPolicyActionUsed: this.turmoilPolicyActionUsed,
       politicalAgendasActionUsedCount: this.politicalAgendasActionUsedCount,
       hasTurmoilScienceTagBonus: this.hasTurmoilScienceTagBonus,
-      victoryPointsBreakdown: this.victoryPointsBreakdown,
       oceanBonus: this.oceanBonus,
       // Custom cards
       // Leavitt Station.
@@ -2216,7 +2213,6 @@ export class Player implements ISerializable<SerializedPlayer> {
     player.tradesThisGeneration = d.tradesThisTurn;
     player.turmoilPolicyActionUsed = d.turmoilPolicyActionUsed;
     player.politicalAgendasActionUsedCount = d.politicalAgendasActionUsedCount;
-    player.victoryPointsBreakdown = d.victoryPointsBreakdown;
 
     player.lastCardPlayed = d.lastCardPlayed !== undefined ?
       cardFinder.getProjectCardByName(d.lastCardPlayed) :

--- a/src/SerializedPlayer.ts
+++ b/src/SerializedPlayer.ts
@@ -2,7 +2,6 @@ import {PlayerId} from './Player';
 import {CardName} from './CardName';
 import {Color} from './Color';
 import {SerializedCard} from './SerializedCard';
-import {VictoryPointsBreakdown} from './VictoryPointsBreakdown';
 import {SerializedTimer} from './SerializedTimer';
 
 export interface SerializedPlayer {
@@ -60,5 +59,4 @@ export interface SerializedPlayer {
     // TODO(kberg): change tradesThisTurn to tradeThisGeneration later
     tradesThisTurn: number;
     turmoilPolicyActionUsed: boolean;
-    victoryPointsBreakdown: VictoryPointsBreakdown;
 }

--- a/src/moon/MoonExpansion.ts
+++ b/src/moon/MoonExpansion.ts
@@ -15,6 +15,7 @@ import {MAXIMUM_COLONY_RATE, MAXIMUM_LOGISTICS_RATE, MAXIMUM_MINING_RATE} from '
 import {Resources} from '../Resources';
 import {Phase} from '../Phase';
 import {BoardType} from '../boards/BoardType';
+import {VictoryPointsBreakdown} from '../VictoryPointsBreakdown';
 
 // export interface CoOwnedSpace {
 //   spaceId: string;
@@ -319,7 +320,7 @@ export class MoonExpansion {
     return Units.of({steel, titanium});
   }
 
-  public static calculateVictoryPoints(player: Player): void {
+  public static calculateVictoryPoints(player: Player, vpb: VictoryPointsBreakdown): void {
     MoonExpansion.ifMoon(player.game, (moonData) => {
       // Each road tile on the map awards 1VP to the player owning it.
       // Each mine and colony (habitat) tile on the map awards 1VP per road tile touching them.
@@ -330,17 +331,17 @@ export class MoonExpansion {
           const type = space.tile.tileType;
           switch (type) {
           case TileType.MOON_ROAD:
-            player.victoryPointsBreakdown.setVictoryPoints('moon road', 1);
+            vpb.setVictoryPoints('moon road', 1);
             break;
           case TileType.MOON_MINE:
           case TileType.MOON_COLONY:
           case TileType.LUNAR_MINE_URBANIZATION:
             const points = moon.getAdjacentSpaces(space).filter((adj) => MoonExpansion.spaceHasType(adj, TileType.MOON_ROAD)).length;
             if (type === TileType.MOON_MINE || type === TileType.LUNAR_MINE_URBANIZATION) {
-              player.victoryPointsBreakdown.setVictoryPoints('moon mine', points);
+              vpb.setVictoryPoints('moon mine', points);
             }
             if (type === TileType.MOON_COLONY || type === TileType.LUNAR_MINE_URBANIZATION) {
-              player.victoryPointsBreakdown.setVictoryPoints('moon colony', points);
+              vpb.setVictoryPoints('moon colony', points);
             }
             break;
           }

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -3,8 +3,10 @@ import {PlayerInput} from '../src/PlayerInput';
 import {Color} from '../src/Color';
 import {Units} from '../src/Units';
 import {Tags} from '../src/cards/Tags';
+import {VictoryPointsBreakdown} from '../src/VictoryPointsBreakdown';
 
 export class TestPlayer extends Player {
+  public victoryPointsBreakdown = new VictoryPointsBreakdown();
   constructor(color: Color) {
     super('player-' + color, color, false, 0, color + '-id');
   }
@@ -28,6 +30,11 @@ export class TestPlayer extends Player {
     if (units.heat !== undefined) {
       this.heatProduction = units.heat;
     }
+  }
+
+  public getVictoryPoints(): VictoryPointsBreakdown {
+    this.victoryPointsBreakdown = super.getVictoryPoints();
+    return this.victoryPointsBreakdown;
   }
 
   public tagsForTest: Partial<TagsForTest> | undefined = undefined;

--- a/tests/cards/ares/CapitalAres.spec.ts
+++ b/tests/cards/ares/CapitalAres.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {CapitalAres} from '../../../src/cards/ares/CapitalAres';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/Game';
 import {SpaceType} from '../../../src/SpaceType';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
@@ -11,7 +11,7 @@ import {ARES_OPTIONS_NO_HAZARDS} from '../../ares/AresTestHelper';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('CapitalAres', function() {
-  let card : CapitalAres; let player : Player; let game : Game;
+  let card : CapitalAres; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new CapitalAres();

--- a/tests/cards/base/AICentral.spec.ts
+++ b/tests/cards/base/AICentral.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {AICentral} from '../../../src/cards/base/AICentral';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/Game';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('AICentral', function() {
-  let card : AICentral; let player : Player;
+  let card : AICentral; let player : TestPlayer;
 
   beforeEach(function() {
     card = new AICentral();

--- a/tests/cards/base/AdvancedEcosystems.spec.ts
+++ b/tests/cards/base/AdvancedEcosystems.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {AdvancedEcosystems} from '../../../src/cards/base/AdvancedEcosystems';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Tardigrades} from '../../../src/cards/base/Tardigrades';
 import {TundraFarming} from '../../../src/cards/base/TundraFarming';
 import {ResearchCoordination} from '../../../src/cards/prelude/ResearchCoordination';
@@ -8,7 +8,7 @@ import {ResearchNetwork} from '../../../src/cards/prelude/ResearchNetwork';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('AdvancedEcosystems', function() {
-  let card : AdvancedEcosystems; let player : Player;
+  let card : AdvancedEcosystems; let player : TestPlayer;
 
   beforeEach(function() {
     card = new AdvancedEcosystems();

--- a/tests/cards/base/AntiGravityTechnology.spec.ts
+++ b/tests/cards/base/AntiGravityTechnology.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
 import {AntiGravityTechnology} from '../../../src/cards/base/AntiGravityTechnology';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('AntiGravityTechnology', function() {
-  let card : AntiGravityTechnology; let player : Player;
+  let card : AntiGravityTechnology; let player : TestPlayer;
 
   beforeEach(function() {
     card = new AntiGravityTechnology();

--- a/tests/cards/base/ArtificialLake.spec.ts
+++ b/tests/cards/base/ArtificialLake.spec.ts
@@ -3,13 +3,13 @@ import {ArtificialLake} from '../../../src/cards/base/ArtificialLake';
 import * as constants from '../../../src/constants';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {SpaceType} from '../../../src/SpaceType';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('ArtificialLake', function() {
-  let card : ArtificialLake; let player : Player; let game : Game;
+  let card : ArtificialLake; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new ArtificialLake();

--- a/tests/cards/base/AsteroidMiningConsortium.spec.ts
+++ b/tests/cards/base/AsteroidMiningConsortium.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {AsteroidMiningConsortium} from '../../../src/cards/base/AsteroidMiningConsortium';
 import {Game} from '../../../src/Game';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('AsteroidMiningConsortium', function() {
-  let card : AsteroidMiningConsortium; let player : Player; let player2 : Player; let game : Game;
+  let card : AsteroidMiningConsortium; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new AsteroidMiningConsortium();

--- a/tests/cards/base/BeamFromAThoriumAsteroid.spec.ts
+++ b/tests/cards/base/BeamFromAThoriumAsteroid.spec.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
 import {BeamFromAThoriumAsteroid} from '../../../src/cards/base/BeamFromAThoriumAsteroid';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('BeamFromAThoriumAsteroid', function() {
-  let card : BeamFromAThoriumAsteroid; let player : Player;
+  let card : BeamFromAThoriumAsteroid; let player : TestPlayer;
 
   beforeEach(function() {
     card = new BeamFromAThoriumAsteroid();

--- a/tests/cards/base/BiomassCombustors.spec.ts
+++ b/tests/cards/base/BiomassCombustors.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {BiomassCombustors} from '../../../src/cards/base/BiomassCombustors';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('BiomassCombustors', function() {
-  let card : BiomassCombustors; let player : Player; let player2 : Player; let game : Game;
+  let card : BiomassCombustors; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new BiomassCombustors();

--- a/tests/cards/base/BreathingFilters.spec.ts
+++ b/tests/cards/base/BreathingFilters.spec.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
 import {BreathingFilters} from '../../../src/cards/base/BreathingFilters';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('BreathingFilters', function() {
-  let card : BreathingFilters; let player : Player; let game : Game;
+  let card : BreathingFilters; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new BreathingFilters();

--- a/tests/cards/base/Capital.spec.ts
+++ b/tests/cards/base/Capital.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {Capital} from '../../../src/cards/base/Capital';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Game} from '../../../src/Game';
 import {SpaceType} from '../../../src/SpaceType';
 import {TileType} from '../../../src/TileType';
@@ -11,7 +11,7 @@ import {TestPlayers} from '../../TestPlayers';
 import {Board} from '../../../src/boards/Board';
 
 describe('Capital', () => {
-  let card : Capital; let player : Player; let game : Game;
+  let card : Capital; let player : TestPlayer; let game : Game;
 
   beforeEach(() => {
     card = new Capital();

--- a/tests/cards/base/ColonizerTrainingCamp.spec.ts
+++ b/tests/cards/base/ColonizerTrainingCamp.spec.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
 import {ColonizerTrainingCamp} from '../../../src/cards/base/ColonizerTrainingCamp';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('ColonizerTrainingCamp', function() {
-  let card : ColonizerTrainingCamp; let player : Player; let game : Game;
+  let card : ColonizerTrainingCamp; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new ColonizerTrainingCamp();

--- a/tests/cards/base/CorporateStronghold.spec.ts
+++ b/tests/cards/base/CorporateStronghold.spec.ts
@@ -2,13 +2,13 @@ import {expect} from 'chai';
 import {CorporateStronghold} from '../../../src/cards/base/CorporateStronghold';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('CorporateStronghold', function() {
-  let card : CorporateStronghold; let player : Player;
+  let card : CorporateStronghold; let player : TestPlayer;
 
   beforeEach(function() {
     card = new CorporateStronghold();

--- a/tests/cards/base/DomedCrater.spec.ts
+++ b/tests/cards/base/DomedCrater.spec.ts
@@ -2,13 +2,13 @@ import {expect} from 'chai';
 import {DomedCrater} from '../../../src/cards/base/DomedCrater';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('DomedCrater', function() {
-  let card : DomedCrater; let player : Player; let game : Game;
+  let card : DomedCrater; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new DomedCrater();

--- a/tests/cards/base/DustSeals.spec.ts
+++ b/tests/cards/base/DustSeals.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {DustSeals} from '../../../src/cards/base/DustSeals';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('DustSeals', function() {
-  let card : DustSeals; let player : Player;
+  let card : DustSeals; let player : TestPlayer;
 
   beforeEach(function() {
     card = new DustSeals();

--- a/tests/cards/base/EOSChasmaNationalPark.spec.ts
+++ b/tests/cards/base/EOSChasmaNationalPark.spec.ts
@@ -4,12 +4,12 @@ import {EosChasmaNationalPark} from '../../../src/cards/base/EOSChasmaNationalPa
 import {Fish} from '../../../src/cards/base/Fish';
 import {Game} from '../../../src/Game';
 import {SelectCard} from '../../../src/inputs/SelectCard';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('EosChasmaNationalPark', () => {
-  let card : EosChasmaNationalPark; let player : Player; let game : Game;
+  let card : EosChasmaNationalPark; let player : TestPlayer; let game : Game;
 
   beforeEach(() => {
     card = new EosChasmaNationalPark();

--- a/tests/cards/base/EnergyTapping.spec.ts
+++ b/tests/cards/base/EnergyTapping.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {EnergyTapping} from '../../../src/cards/base/EnergyTapping';
 import {Game} from '../../../src/Game';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('EnergyTapping', function() {
-  let card : EnergyTapping; let player : Player; let player2 : Player; let game : Game;
+  let card : EnergyTapping; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new EnergyTapping();

--- a/tests/cards/base/Farming.spec.ts
+++ b/tests/cards/base/Farming.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {Farming} from '../../../src/cards/base/Farming';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Farming', function() {
-  let card : Farming; let player : Player; let game : Game;
+  let card : Farming; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Farming();

--- a/tests/cards/base/Flooding.spec.ts
+++ b/tests/cards/base/Flooding.spec.ts
@@ -5,13 +5,13 @@ import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {SpaceType} from '../../../src/SpaceType';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Flooding', function() {
-  let card : Flooding; let player : Player; let player2 : Player; let game : Game;
+  let card : Flooding; let player : TestPlayer; let player2 : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Flooding();

--- a/tests/cards/base/FoodFactory.spec.ts
+++ b/tests/cards/base/FoodFactory.spec.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
 import {FoodFactory} from '../../../src/cards/base/FoodFactory';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('FoodFactory', function() {
-  let card : FoodFactory; let player : Player;
+  let card : FoodFactory; let player : TestPlayer;
 
   beforeEach(function() {
     card = new FoodFactory();

--- a/tests/cards/base/GeneRepair.spec.ts
+++ b/tests/cards/base/GeneRepair.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {GeneRepair} from '../../../src/cards/base/GeneRepair';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('GeneRepair', function() {
-  let card : GeneRepair; let player : Player;
+  let card : GeneRepair; let player : TestPlayer;
 
   beforeEach(function() {
     card = new GeneRepair();

--- a/tests/cards/base/GreatDam.spec.ts
+++ b/tests/cards/base/GreatDam.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {GreatDam} from '../../../src/cards/base/GreatDam';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('GreatDam', () => {
-  let card : GreatDam; let player : Player;
+  let card : GreatDam; let player : TestPlayer;
 
   beforeEach(() => {
     card = new GreatDam();

--- a/tests/cards/base/HeatTrappers.spec.ts
+++ b/tests/cards/base/HeatTrappers.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {HeatTrappers} from '../../../src/cards/base/HeatTrappers';
 import {Game} from '../../../src/Game';
 import {SelectPlayer} from '../../../src/inputs/SelectPlayer';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('HeatTrappers', function() {
-  let card : HeatTrappers; let player : Player; let player2: Player; let game: Game;
+  let card : HeatTrappers; let player : TestPlayer; let player2: TestPlayer; let game: Game;
 
   beforeEach(function() {
     card = new HeatTrappers();

--- a/tests/cards/base/IndenturedWorkers.spec.ts
+++ b/tests/cards/base/IndenturedWorkers.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {IndenturedWorkers} from '../../../src/cards/base/IndenturedWorkers';
 import {MicroMills} from '../../../src/cards/base/MicroMills';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('IndenturedWorkers', function() {
   let card: IndenturedWorkers;
-  let player: Player;
+  let player: TestPlayer;
 
   beforeEach(() => {
     card = new IndenturedWorkers();

--- a/tests/cards/base/InterstellarColonyShip.spec.ts
+++ b/tests/cards/base/InterstellarColonyShip.spec.ts
@@ -3,11 +3,11 @@ import {GeneRepair} from '../../../src/cards/base/GeneRepair';
 import {InterstellarColonyShip} from '../../../src/cards/base/InterstellarColonyShip';
 import {Research} from '../../../src/cards/base/Research';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('InterstellarColonyShip', function() {
-  let card : InterstellarColonyShip; let player : Player;
+  let card : InterstellarColonyShip; let player : TestPlayer;
 
   beforeEach(function() {
     card = new InterstellarColonyShip();

--- a/tests/cards/base/KelpFarming.spec.ts
+++ b/tests/cards/base/KelpFarming.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {KelpFarming} from '../../../src/cards/base/KelpFarming';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('KelpFarming', function() {
-  let card : KelpFarming; let player : Player;
+  let card : KelpFarming; let player : TestPlayer;
 
   beforeEach(function() {
     card = new KelpFarming();

--- a/tests/cards/base/LakeMarineris.spec.ts
+++ b/tests/cards/base/LakeMarineris.spec.ts
@@ -2,11 +2,11 @@ import {expect} from 'chai';
 import {LakeMarineris} from '../../../src/cards/base/LakeMarineris';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('LakeMarineris', function() {
-  let card : LakeMarineris; let player : Player; let game : Game;
+  let card : LakeMarineris; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new LakeMarineris();

--- a/tests/cards/base/LargeConvoy.spec.ts
+++ b/tests/cards/base/LargeConvoy.spec.ts
@@ -4,12 +4,12 @@ import {LargeConvoy} from '../../../src/cards/base/LargeConvoy';
 import {Pets} from '../../../src/cards/base/Pets';
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('LargeConvoy', function() {
-  let card : LargeConvoy; let player : Player;
+  let card : LargeConvoy; let player : TestPlayer;
 
   beforeEach(function() {
     card = new LargeConvoy();

--- a/tests/cards/base/LightningHarvest.spec.ts
+++ b/tests/cards/base/LightningHarvest.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {GeneRepair} from '../../../src/cards/base/GeneRepair';
 import {LightningHarvest} from '../../../src/cards/base/LightningHarvest';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('LightningHarvest', function() {
-  let card : LightningHarvest; let player : Player;
+  let card : LightningHarvest; let player : TestPlayer;
 
   beforeEach(function() {
     card = new LightningHarvest();

--- a/tests/cards/base/Mangrove.spec.ts
+++ b/tests/cards/base/Mangrove.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {Mangrove} from '../../../src/cards/base/Mangrove';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Mangrove', function() {
-  let card : Mangrove; let player : Player;
+  let card : Mangrove; let player : TestPlayer;
 
   beforeEach(function() {
     card = new Mangrove();

--- a/tests/cards/base/MarsUniversity.spec.ts
+++ b/tests/cards/base/MarsUniversity.spec.ts
@@ -4,11 +4,11 @@ import {Pets} from '../../../src/cards/base/Pets';
 import {Research} from '../../../src/cards/base/Research';
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('MarsUniversity', function() {
-  let card : MarsUniversity; let player : Player; let game : Game;
+  let card : MarsUniversity; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new MarsUniversity();

--- a/tests/cards/base/MethaneFromTitan.spec.ts
+++ b/tests/cards/base/MethaneFromTitan.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {MethaneFromTitan} from '../../../src/cards/base/MethaneFromTitan';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('MethaneFromTitan', function() {
-  let card : MethaneFromTitan; let player : Player; let game : Game;
+  let card : MethaneFromTitan; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new MethaneFromTitan();

--- a/tests/cards/base/NaturalPreserve.spec.ts
+++ b/tests/cards/base/NaturalPreserve.spec.ts
@@ -2,13 +2,13 @@ import {expect} from 'chai';
 import {NaturalPreserve} from '../../../src/cards/base/NaturalPreserve';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('NaturalPreserve', () => {
-  let card : NaturalPreserve; let player : Player; let game : Game;
+  let card : NaturalPreserve; let player : TestPlayer; let game : Game;
 
   beforeEach(() => {
     card = new NaturalPreserve();

--- a/tests/cards/base/NoctisFarming.spec.ts
+++ b/tests/cards/base/NoctisFarming.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {NoctisFarming} from '../../../src/cards/base/NoctisFarming';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('NoctisFarming', function() {
-  let card : NoctisFarming; let player : Player; let game : Game;
+  let card : NoctisFarming; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new NoctisFarming();

--- a/tests/cards/base/OlympusConference.spec.ts
+++ b/tests/cards/base/OlympusConference.spec.ts
@@ -7,11 +7,11 @@ import {ScienceTagCard} from '../../../src/cards/community/ScienceTagCard';
 import {DeferredActionsQueue} from '../../../src/deferredActions/DeferredActionsQueue';
 import {Game} from '../../../src/Game';
 import {OrOptions} from '../../../src/inputs/OrOptions';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('OlympusConference', function() {
-  let card : OlympusConference; let player : Player; let game : Game;
+  let card : OlympusConference; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new OlympusConference();

--- a/tests/cards/base/OpenCity.spec.ts
+++ b/tests/cards/base/OpenCity.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {OpenCity} from '../../../src/cards/base/OpenCity';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('OpenCity', function() {
-  let card : OpenCity; let player : Player; let game : Game;
+  let card : OpenCity; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new OpenCity();

--- a/tests/cards/base/RadSuits.spec.ts
+++ b/tests/cards/base/RadSuits.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {RadSuits} from '../../../src/cards/base/RadSuits';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('RadSuits', function() {
-  let card : RadSuits; let player : Player; let game : Game;
+  let card : RadSuits; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new RadSuits();

--- a/tests/cards/base/Shuttles.spec.ts
+++ b/tests/cards/base/Shuttles.spec.ts
@@ -3,12 +3,12 @@ import {Bushes} from '../../../src/cards/base/Bushes';
 import {Shuttles} from '../../../src/cards/base/Shuttles';
 import {TollStation} from '../../../src/cards/base/TollStation';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Shuttles', function() {
-  let card : Shuttles; let player : Player; let game : Game;
+  let card : Shuttles; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Shuttles();

--- a/tests/cards/base/SoilFactory.spec.ts
+++ b/tests/cards/base/SoilFactory.spec.ts
@@ -1,11 +1,11 @@
 import {expect} from 'chai';
 import {SoilFactory} from '../../../src/cards/base/SoilFactory';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('SoilFactory', function() {
-  let card : SoilFactory; let player : Player;
+  let card : SoilFactory; let player : TestPlayer;
 
   beforeEach(function() {
     card = new SoilFactory();

--- a/tests/cards/base/SpaceElevator.spec.ts
+++ b/tests/cards/base/SpaceElevator.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {SpaceElevator} from '../../../src/cards/base/SpaceElevator';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('SpaceElevator', function() {
-  let card : SpaceElevator; let player : Player;
+  let card : SpaceElevator; let player : TestPlayer;
 
   beforeEach(function() {
     card = new SpaceElevator();

--- a/tests/cards/base/TectonicStressPower.spec.ts
+++ b/tests/cards/base/TectonicStressPower.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {TectonicStressPower} from '../../../src/cards/base/TectonicStressPower';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('TectonicStressPower', function() {
-  let card : TectonicStressPower; let player : Player;
+  let card : TectonicStressPower; let player : TestPlayer;
 
   beforeEach(function() {
     card = new TectonicStressPower();

--- a/tests/cards/base/Trees.spec.ts
+++ b/tests/cards/base/Trees.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {Trees} from '../../../src/cards/base/Trees';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Trees', function() {
-  let card : Trees; let player : Player; let game : Game;
+  let card : Trees; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Trees();

--- a/tests/cards/base/TundraFarming.spec.ts
+++ b/tests/cards/base/TundraFarming.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {TundraFarming} from '../../../src/cards/base/TundraFarming';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('TundraFarming', function() {
-  let card : TundraFarming; let player : Player; let game : Game;
+  let card : TundraFarming; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new TundraFarming();

--- a/tests/cards/base/WavePower.spec.ts
+++ b/tests/cards/base/WavePower.spec.ts
@@ -1,13 +1,13 @@
 import {expect} from 'chai';
 import {WavePower} from '../../../src/cards/base/WavePower';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('WavePower', function() {
-  let card : WavePower; let player : Player;
+  let card : WavePower; let player : TestPlayer;
 
   beforeEach(function() {
     card = new WavePower();

--- a/tests/cards/base/Windmills.spec.ts
+++ b/tests/cards/base/Windmills.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {Windmills} from '../../../src/cards/base/Windmills';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Windmills', function() {
-  let card : Windmills; let player : Player; let game : Game;
+  let card : Windmills; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Windmills();

--- a/tests/cards/base/Zeppelins.spec.ts
+++ b/tests/cards/base/Zeppelins.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
 import {Zeppelins} from '../../../src/cards/base/Zeppelins';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Zeppelins', function() {
-  let card : Zeppelins; let player : Player; let game : Game;
+  let card : Zeppelins; let player : TestPlayer; let game : Game;
 
   beforeEach(function() {
     card = new Zeppelins();

--- a/tests/cards/colonies/Conscription.spec.ts
+++ b/tests/cards/colonies/Conscription.spec.ts
@@ -2,12 +2,12 @@ import {expect} from 'chai';
 import {MicroMills} from '../../../src/cards/base/MicroMills';
 import {Conscription} from '../../../src/cards/colonies/Conscription';
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('Conscription', function() {
   let card: Conscription;
-  let player: Player;
+  let player: TestPlayer;
 
   beforeEach(() => {
     card = new Conscription();

--- a/tests/cards/moon/LunarMineUrbanization.spec.ts
+++ b/tests/cards/moon/LunarMineUrbanization.spec.ts
@@ -63,12 +63,12 @@ describe('LunarMineUrbanization', () => {
   });
 
   it('computeVictoryPoints', () => {
+    const vps = player.victoryPointsBreakdown;
     function computeVps() {
-      const vps = player.victoryPointsBreakdown;
       vps.moonColonies = 0;
       vps.moonMines = 0;
       vps.moonRoads = 0;
-      MoonExpansion.calculateVictoryPoints(player);
+      MoonExpansion.calculateVictoryPoints(player, vps);
       return {
         colonies: vps.moonColonies,
         mines: vps.moonMines,
@@ -78,7 +78,7 @@ describe('LunarMineUrbanization', () => {
 
     expect(computeVps()).eql({colonies: 0, mines: 0, roads: 0});
     MoonExpansion.addTile(player, 'm02', {tileType: TileType.MOON_ROAD});
-    MoonExpansion.calculateVictoryPoints(player);
+    MoonExpansion.calculateVictoryPoints(player, vps);
     expect(computeVps()).eql({colonies: 0, mines: 0, roads: 1});
     MoonExpansion.addTile(player, 'm03', {tileType: TileType.LUNAR_MINE_URBANIZATION});
 

--- a/tests/cards/moon/MoonTether.spec.ts
+++ b/tests/cards/moon/MoonTether.spec.ts
@@ -1,6 +1,6 @@
 import {Game} from '../../../src/Game';
-import {Player} from '../../../src/Player';
 import {TestingUtils} from '../../TestingUtils';
+import {TestPlayer} from '../../TestPlayer';
 import {TestPlayers} from '../../TestPlayers';
 import {MoonTether} from '../../../src/cards/moon/MoonTether';
 import {expect} from 'chai';
@@ -8,7 +8,7 @@ import {expect} from 'chai';
 const MOON_OPTIONS = TestingUtils.setCustomGameOptions({moonExpansion: true});
 
 describe('MoonTether', () => {
-  let player: Player;
+  let player: TestPlayer;
   let card: MoonTether;
 
   beforeEach(() => {

--- a/tests/moon/MoonExpansion.spec.ts
+++ b/tests/moon/MoonExpansion.spec.ts
@@ -76,12 +76,12 @@ describe('MoonExpansion', () => {
   });
 
   it('computeVictoryPoints', () => {
+    const vps = player.victoryPointsBreakdown;
     function computeVps() {
-      const vps = player.victoryPointsBreakdown;
       vps.moonColonies = 0;
       vps.moonMines = 0;
       vps.moonRoads = 0;
-      MoonExpansion.calculateVictoryPoints(player);
+      MoonExpansion.calculateVictoryPoints(player, vps);
       return {
         colonies: vps.moonColonies,
         mines: vps.moonMines,
@@ -91,7 +91,7 @@ describe('MoonExpansion', () => {
 
     expect(computeVps()).eql({colonies: 0, mines: 0, roads: 0});
     MoonExpansion.addTile(player, 'm02', {tileType: TileType.MOON_ROAD});
-    MoonExpansion.calculateVictoryPoints(player);
+    MoonExpansion.calculateVictoryPoints(player, vps);
     expect(computeVps()).eql({colonies: 0, mines: 0, roads: 1});
     MoonExpansion.addTile(player, 'm03', {tileType: TileType.MOON_COLONY});
 


### PR DESCRIPTION
This removes `victoryPointsBreakdown` as a property of `Player`. The property seemed to be used for tests. I moved the property to `TestPlayer` and updated tests to use `TestPlayer`. This should use less memory.