### PR TITLE
Revert "try removing ended games again"

### DIFF
--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -116,10 +116,6 @@ export class GameLoader implements IGameLoader {
     this.getByParticipantId(spectatorId, cb);
   }
 
-  public remove(gameId: GameId): void {
-    this.games.set(gameId, undefined);
-  }
-
   public restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void {
     try {
       Database.getInstance().restoreGame(gameId, saveId, (err, game) => {

--- a/src/database/IGameLoader.ts
+++ b/src/database/IGameLoader.ts
@@ -19,6 +19,5 @@ export interface IGameLoader {
   getByGameId(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void;
   getByPlayerId(playerId: PlayerId, cb: LoadCallback): void;
   getBySpectatorId(spectatorId: SpectatorId, cb: LoadCallback): void;
-  remove(gameId: GameId): void;
   restoreGameAt(gameId: GameId, saveId: number, cb: LoadCallback): void;
 }

--- a/src/routes/PlayerInput.ts
+++ b/src/routes/PlayerInput.ts
@@ -1,23 +1,16 @@
 import * as http from 'http';
-import {Game, GameId} from '../Game';
-import {Phase} from '../Phase';
+import {Game} from '../Game';
 import {Player} from '../Player';
 import {Server} from '../models/ServerModel';
 import {Handler} from './Handler';
 import {IContext} from './IHandler';
-import {IGameLoader} from '../database/IGameLoader';
 import {OrOptions} from '../inputs/OrOptions';
 import {UndoActionOption} from '../inputs/UndoActionOption';
 
 export class PlayerInput extends Handler {
   public static readonly INSTANCE = new PlayerInput();
-  private removeTimeout = 60 * 60 * 1000;
   private constructor() {
     super();
-  }
-
-  public setRemoveTimeout(removeTimeout: number) {
-    this.removeTimeout = removeTimeout;
   }
 
   public post(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
@@ -72,13 +65,6 @@ export class PlayerInput extends Handler {
     });
   }
 
-  private scheduleRemoval(gameLoader: IGameLoader, gameId: GameId): void {
-    setTimeout(() => {
-      console.log(`remove ${gameId}`);
-      gameLoader.remove(gameId);
-    }, this.removeTimeout);
-  }
-
   private processInput(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -96,11 +82,7 @@ export class PlayerInput extends Handler {
           this.performUndo(res, ctx, player);
           return;
         }
-        const startPhase = player.game.phase;
         player.process(entity);
-        if (startPhase !== Phase.END && player.game.phase === Phase.END) {
-          this.scheduleRemoval(ctx.gameLoader, player.game.id);
-        }
         ctx.route.writeJson(res, Server.getPlayerModel(player));
       } catch (err) {
         res.writeHead(400, {

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -223,13 +223,4 @@ describe('GameLoader', function() {
       done();
     });
   });
-
-  it('removes', function(done) {
-    GameLoader.getInstance().add(game);
-    GameLoader.getInstance().remove(game.id);
-    GameLoader.getInstance().getByGameId(game.id, false, (game) => {
-      expect(game).is.undefined;
-      done();
-    });
-  });
 });

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -29,9 +29,6 @@ export class FakeGameLoader implements IGameLoader {
   getBySpectatorId(_spectatorId: string, _cb: (game: Game | undefined) => void): void {
     throw new Error('Method not implemented.');
   }
-  remove(_gameId: string): void {
-    throw new Error('Method not implemented.');
-  }
   restoreGameAt(_gameId: string, _saveId: number, _cb: (game: Game | undefined) => void): void {
     throw new Error('Method not implemented.');
   }

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -1,7 +1,6 @@
 import * as http from 'http';
 import * as EventEmitter from 'events';
 import {expect} from 'chai';
-import {Phase} from '../../src/Phase';
 import {PlayerInput} from '../../src/routes/PlayerInput';
 import {Route} from '../../src/routes/Route';
 import {MockResponse} from './HttpMocks';
@@ -91,24 +90,5 @@ describe('PlayerInput', function() {
     req.emit('data', '}{');
     req.emit('end');
     expect(res.content).eq('{"message":"Unexpected token } in JSON at position 0"}');
-  });
-
-  it('schedules game removal when game ends', (done) => {
-    const player = TestPlayers.BLUE.newPlayer();
-    req.url = '/player/input?id=' + player.id;
-    ctx.url = new URL('http://boo.com' + req.url);
-    const game = Game.newInstance('foo', [player], player);
-    ctx.gameLoader.add(game);
-    ctx.gameLoader.remove = function(gameId) {
-      expect(gameId).to.equal(game.id);
-      done();
-    };
-    player.process = function() {
-      player.game.phase = Phase.END;
-    };
-    PlayerInput.INSTANCE.setRemoveTimeout(0);
-    PlayerInput.INSTANCE.post(req, res.hide(), ctx);
-    req.emit('data', JSON.stringify([]));
-    req.emit('end');
   });
 });


### PR DESCRIPTION
Reverts bafolts/terraforming-mars#3327

Seeing strange memory spikes again after this change. The good news is I think something is being learned from each of these attempts at freeing memory. I am pretty sure users are attempting to access their game after we have removed it from javascript memory and those requests time out. When requests time out like in #3331 I am not sure what happens to the `req`, `res` or any memory we create along the way. I am guessing it piles up. Heroku cancels the request external of our node code.