### PR TITLE
use v-show to run preferences javascript

### DIFF
--- a/src/components/Sidebar.ts
+++ b/src/components/Sidebar.ts
@@ -181,7 +181,7 @@ export const Sidebar = Vue.component('sidebar', {
 
   <div class="sidebar_item sidebar_item--settings">
     <i class="sidebar_icon sidebar_icon--settings" :class="{'sidebar_item--is-active': ui.preferences_panel_open}" v-on:click="ui.preferences_panel_open = !ui.preferences_panel_open"></i>
-    <preferences-dialog v-if="ui.preferences_panel_open" @okButtonClicked="ui.preferences_panel_open = false"/>
+    <preferences-dialog v-show="ui.preferences_panel_open" @okButtonClicked="ui.preferences_panel_open = false"/>
   </div>
 </div>
     `,


### PR DESCRIPTION
There is javascript we rely on running as the `PreferencesDialog` component is mounted. Using `v-show` ensures that it is mounted and runs javascript to apply css to the DOM. This can close #3321 

Where we call to `syncPreferences()`.

https://github.com/bafolts/terraforming-mars/blob/main/src/components/PreferencesDialog.ts#L103