### PR TITLE
pull in encodings as string and not array

### DIFF
--- a/src/routes/ServeAsset.ts
+++ b/src/routes/ServeAsset.ts
@@ -135,6 +135,12 @@ export class ServeAsset extends Handler {
   }
 
   private supportedEncodings(req: http.IncomingMessage): Set<Encoding> {
-    return new Set(req.headers['accept-encoding'] as (Array<Encoding> | undefined));
+    const result = new Set<Encoding>();
+    for (const header of String(req.headers['accept-encoding']).split(', ')) {
+      if (header === 'br' || header === 'gzip') {
+        result.add(header);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
At some point I remember suggesting using `Set(req.headers['accept-encoding'])` to be clever. This has caused a bug. Since `req.headers['accept-encoding']` returns a `string` we end up with a `Set` that has each character in the string as an element in the set. This changes the code to pull the values from the array. The logic is now written out to enforce the typing as well as avoiding a type cast.

Tested this locally.

![image](https://user-images.githubusercontent.com/2707843/121279558-fb7cb800-c891-11eb-994b-df361df1a6d9.png)

This closes #3348 