### PR TITLE
Reduce allowable heat when using Helion with Local Heat Trapping

### DIFF
--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -23,6 +23,7 @@ export interface StaticCardProperties {
   tags?: Array<Tags>;
   productionBox?: Units;
   cardDiscount?: CardDiscount;
+  reserveUnits?: Units,
 }
 
 export const staticCardProperties = new Map<CardName, StaticCardProperties>();
@@ -83,6 +84,9 @@ export abstract class Card {
   }
   public get cardDiscount() {
     return this.properties.cardDiscount;
+  }
+  public get reserveUnits(): Units {
+    return this.properties.reserveUnits || Units.EMPTY;
   }
   public canPlay(player: Player) {
     if (this.properties.requirements === undefined) {

--- a/src/cards/ProjectCard.ts
+++ b/src/cards/ProjectCard.ts
@@ -1,0 +1,12 @@
+import {MoonExpansion} from '../moon/MoonExpansion';
+import {Player} from '../Player';
+import {Card} from './Card';
+import {IProjectCard} from './IProjectCard';
+
+export class ProjectCard extends Card implements IProjectCard {
+  public play(player: Player) {
+    const adjustedReserveUnits = MoonExpansion.adjustedReserveCosts(player, this);
+    player.deductUnits(adjustedReserveUnits);
+    return undefined;
+  }
+}

--- a/src/cards/StandardProjectCard.ts
+++ b/src/cards/StandardProjectCard.ts
@@ -15,11 +15,13 @@ import {CardName} from '../CardName';
 import {SelectHowToPayDeferred} from '../deferredActions/SelectHowToPayDeferred';
 import {Card} from './Card';
 import {MoonExpansion} from '../moon/MoonExpansion';
+import {Units} from '../Units';
 
 interface StaticStandardProjectCardProperties {
   name: CardName,
   cost: number,
   metadata: CardMetadata,
+  reserveUnits?: Units,
 }
 
 export abstract class StandardProjectCard extends Card implements IActionCard, ICard {

--- a/src/cards/base/LocalHeatTrapping.ts
+++ b/src/cards/base/LocalHeatTrapping.ts
@@ -10,6 +10,7 @@ import {ICard} from '../ICard';
 import {CardName} from '../../CardName';
 import {Resources} from '../../Resources';
 import {CardRenderer} from '../render/CardRenderer';
+import {Units} from '../../Units';
 
 export class LocalHeatTrapping extends Card implements IProjectCard {
   constructor() {
@@ -17,6 +18,7 @@ export class LocalHeatTrapping extends Card implements IProjectCard {
       cardType: CardType.EVENT,
       name: CardName.LOCAL_HEAT_TRAPPING,
       cost: 1,
+      reserveUnits: Units.of({heat: 5}),
 
       metadata: {
         cardNumber: '190',
@@ -28,16 +30,6 @@ export class LocalHeatTrapping extends Card implements IProjectCard {
         description: 'Spend 5 heat to gain either 4 Plants, or to add 2 Animals to ANOTHER card.',
       },
     });
-  }
-  public canPlay(player: Player): boolean {
-    const requiredHeatAmt = 5;
-
-    // Helion must be able to pay for both the card and its effect
-    if (player.canUseHeatAsMegaCredits) {
-      return (player.heat >= requiredHeatAmt) && (player.heat + player.megaCredits >= requiredHeatAmt + player.getCardCost(this));
-    }
-
-    return player.availableHeat >= requiredHeatAmt;
   }
   public play(player: Player) {
     const animalCards: Array<ICard> = player.getResourceCards(ResourceType.ANIMAL);

--- a/src/cards/community/Playwrights.ts
+++ b/src/cards/community/Playwrights.ts
@@ -11,6 +11,7 @@ import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferr
 import {DeferredAction} from '../../deferredActions/DeferredAction';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../render/Size';
+import {MoonExpansion} from '../../moon/MoonExpansion';
 
 export class Playwrights extends Card implements CorporationCard {
   constructor() {
@@ -113,7 +114,9 @@ export class Playwrights extends Card implements CorporationCard {
       player.game.getPlayers().forEach((p) => {
         playedEvents.push(...p.playedCards.filter((card) => {
           return card.cardType === CardType.EVENT &&
-            player.canAfford(player.getCardCost(card)) &&
+            player.canAfford(player.getCardCost(card), {
+              reserveUnits: MoonExpansion.adjustedReserveCosts(player, card),
+            }) &&
             (card.canPlay === undefined || card.canPlay(player));
         }));
       });

--- a/src/cards/moon/AncientShipyards.ts
+++ b/src/cards/moon/AncientShipyards.ts
@@ -18,6 +18,7 @@ export class AncientShipyards extends MoonCard {
       tags: [Tags.MOON, Tags.SPACE],
       cost: 6,
       resourceType: ResourceType.RESOURCE_CUBE,
+      reserveUnits: Units.of({titanium: 3}),
 
       metadata: {
         description: 'Spend 3 titanium. -1 VP for every 2 resources here.',
@@ -30,8 +31,6 @@ export class AncientShipyards extends MoonCard {
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.resourceCube(-1, 2),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 3}),
     });
   };
   public resourceCount: number = 0;

--- a/src/cards/moon/AristarchusRoadNetwork.ts
+++ b/src/cards/moon/AristarchusRoadNetwork.ts
@@ -17,6 +17,7 @@ export class AristarchusRoadNetwork extends MoonCard {
       tags: [Tags.MOON],
       cost: 15,
       productionBox: Units.of({megacredits: 2}),
+      reserveUnits: Units.of({steel: 2}),
 
       metadata: {
         description: 'Spend 2 steel. Increase your M€ production 2 steps. ' +
@@ -28,7 +29,6 @@ export class AristarchusRoadNetwork extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({steel: 2}),
       tilesBuilt: [TileType.MOON_ROAD],
     });
   };

--- a/src/cards/moon/ColonistShuttles.ts
+++ b/src/cards/moon/ColonistShuttles.ts
@@ -17,6 +17,7 @@ export class ColonistShuttles extends MoonCard {
       cardType: CardType.AUTOMATED,
       tags: [Tags.SPACE],
       cost: 12,
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Raise the Colony Rate 1 step. Gain 2M€ for each colony tile on the Moon.',
@@ -27,7 +28,6 @@ export class ColonistShuttles extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   };

--- a/src/cards/moon/CopernicusSolarArrays.ts
+++ b/src/cards/moon/CopernicusSolarArrays.ts
@@ -14,9 +14,9 @@ export class CopernicusSolarArrays extends MoonCard {
       cardType: CardType.AUTOMATED,
       tags: [Tags.ENERGY, Tags.SPACE],
       cost: 8,
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
-
         description: 'Spend 1 titanium. Gain 2 heat. Incease your energy production 1 step.',
         cardNumber: 'M44',
         renderData: CardRenderer.builder((b) => {
@@ -27,8 +27,6 @@ export class CopernicusSolarArrays extends MoonCard {
           b.production((pb) => pb.energy(1));
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/DarksideIncubationPlant.ts
+++ b/src/cards/moon/DarksideIncubationPlant.ts
@@ -22,6 +22,7 @@ export class DarksideIncubationPlant extends MoonCard implements IActionCard, IP
       tags: [Tags.MICROBE, Tags.MOON],
       cost: 11,
       resourceType: ResourceType.MICROBE,
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: {
@@ -42,8 +43,6 @@ export class DarksideIncubationPlant extends MoonCard implements IActionCard, IP
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.microbes(1, 2),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
   public resourceCount = 0;

--- a/src/cards/moon/DeepLunarMining.ts
+++ b/src/cards/moon/DeepLunarMining.ts
@@ -15,6 +15,7 @@ export class DeepLunarMining extends MoonCard {
       tags: [Tags.MOON],
       cost: 18,
       productionBox: Units.of({titanium: 2}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your titanium production 2 steps. Raise the Mining Rate 1 step.',
@@ -26,8 +27,6 @@ export class DeepLunarMining extends MoonCard {
           b.moonMiningRate();
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/GeodesicTents.ts
+++ b/src/cards/moon/GeodesicTents.ts
@@ -17,6 +17,7 @@ export class GeodesicTents extends MoonCard {
       tags: [Tags.PLANT, Tags.CITY, Tags.MOON],
       cost: 13,
       productionBox: Units.of({energy: -1, plants: 1}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Decrease your energy production 1 step and increase your plant production 1 step. ' +
@@ -31,7 +32,6 @@ export class GeodesicTents extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   }

--- a/src/cards/moon/Habitat14.ts
+++ b/src/cards/moon/Habitat14.ts
@@ -17,6 +17,7 @@ export class Habitat14 extends MoonCard {
       tags: [Tags.CITY, Tags.MOON],
       cost: 5,
       productionBox: Units.of({energy: -1, megacredits: -1}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Decrease your energy production 1 step and your M€ production 1 step. Spend 1 titanium. Place a colony tile on the Moon and raise the Colony Rate 1 step.',
@@ -30,7 +31,6 @@ export class Habitat14 extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   }

--- a/src/cards/moon/HeliostatMirrorArray.ts
+++ b/src/cards/moon/HeliostatMirrorArray.ts
@@ -14,6 +14,7 @@ export class HeliostatMirrorArray extends MoonCard {
       cardType: CardType.AUTOMATED,
       name: CardName.HELIOSTAT_MIRROR_ARRAY,
       productionBox: Units.of({energy: 2}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Gain 1 heat. Increase your energy production 2 steps.',
@@ -24,8 +25,6 @@ export class HeliostatMirrorArray extends MoonCard {
           b.production((pb) => pb.energy(2));
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/HypersensitiveSiliconChipFactory.ts
+++ b/src/cards/moon/HypersensitiveSiliconChipFactory.ts
@@ -15,6 +15,7 @@ export class HypersensitiveSiliconChipFactory extends MoonCard {
       cost: 11,
       productionBox: Units.of({megacredits: 4}),
       requirements: CardRequirements.builder((b) => b.miningTiles(2).any()),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Requires 2 mining tiles on the Moon. Spend 2 titanium. Increase your M€ production 4 steps.',
@@ -24,8 +25,6 @@ export class HypersensitiveSiliconChipFactory extends MoonCard {
           b.production((pb) => pb.megacredits(4)).br;
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 2}),
     });
   };
 }

--- a/src/cards/moon/IMoonCard.ts
+++ b/src/cards/moon/IMoonCard.ts
@@ -1,7 +1,5 @@
 import {TileType} from '../../TileType';
-import {Units} from '../../Units';
 
 export interface IMoonCard {
   tilesBuilt: Array<TileType>;
-  reserveUnits: Units;
 }

--- a/src/cards/moon/ImprovedMoonConcrete.ts
+++ b/src/cards/moon/ImprovedMoonConcrete.ts
@@ -13,6 +13,7 @@ export class ImprovedMoonConcrete extends MoonCard implements IProjectCard {
       name: CardName.IMPROVED_MOON_CONCRETE,
       cardType: CardType.AUTOMATED,
       cost: 12,
+      reserveUnits: Units.of({steel: 2}),
 
       metadata: {
         description: 'Spend 2 steel. Raise the Mining Rate 1 step.',
@@ -24,8 +25,6 @@ export class ImprovedMoonConcrete extends MoonCard implements IProjectCard {
           b.minus().steel(2).moonMiningRate();
         }),
       },
-    }, {
-      reserveUnits: Units.of({steel: 2}),
     });
   }
 

--- a/src/cards/moon/IronExtractionCenter.ts
+++ b/src/cards/moon/IronExtractionCenter.ts
@@ -16,6 +16,7 @@ export class IronExtractionCenter extends MoonCard {
       tags: [Tags.BUILDING],
       cost: 10,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your steel production 1 step for every 2 raised steps of mining rate.',
@@ -25,8 +26,6 @@ export class IronExtractionCenter extends MoonCard {
           b.production((pb) => pb.steel(1)).slash().moonMiningRate({amount: 2});
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   }
 

--- a/src/cards/moon/LunaMiningHub.ts
+++ b/src/cards/moon/LunaMiningHub.ts
@@ -20,6 +20,7 @@ export class LunaMiningHub extends MoonCard {
       tags: [Tags.BUILDING],
       cost: 16,
       productionBox: Units.of({steel: 1, titanium: 1}),
+      reserveUnits: Units.of({steel: 1, titanium: 1}),
 
       requirements: CardRequirements.builder((b) => b.miningRate(5)),
       metadata: {
@@ -37,8 +38,6 @@ export class LunaMiningHub extends MoonCard {
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.moonMiningTile(2, true),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1, steel: 1}),
     });
   };
 

--- a/src/cards/moon/LunaResort.ts
+++ b/src/cards/moon/LunaResort.ts
@@ -16,6 +16,7 @@ export class LunaResort extends MoonCard {
       tags: [Tags.MOON],
       cost: 11,
       productionBox: Units.of({energy: -1, megacredits: 3}),
+      reserveUnits: Units.of({titanium: 2}),
 
       requirements: CardRequirements.builder((b) => b.colonyTiles(2).any()),
       metadata: {
@@ -29,8 +30,6 @@ export class LunaResort extends MoonCard {
           b.moonColonyRate();
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 2}),
     });
   };
 

--- a/src/cards/moon/LunaStagingStation.ts
+++ b/src/cards/moon/LunaStagingStation.ts
@@ -15,6 +15,7 @@ export class LunaStagingStation extends MoonCard {
       cardType: CardType.AUTOMATED,
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 12,
+      reserveUnits: Units.of({titanium: 1}),
 
       requirements: CardRequirements.builder((b) => b.logisticRate(2)),
       metadata: {
@@ -25,8 +26,6 @@ export class LunaStagingStation extends MoonCard {
           b.moonLogisticsRate({amount: 2});
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/LunaTradeStation.ts
+++ b/src/cards/moon/LunaTradeStation.ts
@@ -20,6 +20,7 @@ export class LunaTradeStation extends MoonCard implements IActionCard {
       tags: [Tags.MOON, Tags.MOON, Tags.SPACE],
       cost: 10,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Spend 2 titanium. Place this tile ON THE RESERVED AREA.',
@@ -30,8 +31,6 @@ export class LunaTradeStation extends MoonCard implements IActionCard {
           b.br.minus().titanium(2).tile(TileType.LUNA_TRADE_STATION, true).asterix();
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 2}),
     });
   };
 

--- a/src/cards/moon/LunaTrainStation.ts
+++ b/src/cards/moon/LunaTrainStation.ts
@@ -20,6 +20,7 @@ export class LunaTrainStation extends MoonCard {
       cost: 20,
       productionBox: Units.of({megacredits: 4}),
       requirements: CardRequirements.builder((b) => b.logisticRate(5)),
+      reserveUnits: Units.of({steel: 2}),
 
       metadata: {
         description: 'Requires a Logistic Rate of 5 or higher. Spend 2 steel. ' +
@@ -33,8 +34,6 @@ export class LunaTrainStation extends MoonCard {
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.moonRoadTile(2, true),
       },
-    }, {
-      reserveUnits: Units.of({steel: 2}),
     });
   }
 

--- a/src/cards/moon/LunarDustProcessingPlant.ts
+++ b/src/cards/moon/LunarDustProcessingPlant.ts
@@ -17,6 +17,7 @@ export class LunarDustProcessingPlant extends MoonCard implements IProjectCard {
       tags: [Tags.BUILDING],
       cost: 6,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Raise the Logistic Rate 1 step.',
@@ -28,8 +29,6 @@ export class LunarDustProcessingPlant extends MoonCard implements IProjectCard {
           b.minus().titanium(1).moonLogisticsRate();
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/LunarIndustryComplex.ts
+++ b/src/cards/moon/LunarIndustryComplex.ts
@@ -18,6 +18,7 @@ export class LunarIndustryComplex extends MoonCard implements IProjectCard {
       tags: [Tags.ENERGY, Tags.BUILDING],
       cost: 28,
       productionBox: Units.of({steel: 1, titanium: 1, energy: 2, heat: 1}),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Spend 2 Titanium. Place a mine tile on the Moon and raise the Mining Rate 1 step. ' +
@@ -29,7 +30,6 @@ export class LunarIndustryComplex extends MoonCard implements IProjectCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 2}),
       tilesBuilt: [TileType.MOON_MINE],
     });
   };

--- a/src/cards/moon/LunarObservationPost.ts
+++ b/src/cards/moon/LunarObservationPost.ts
@@ -19,6 +19,8 @@ export class LunarObservationPost extends MoonCard implements IActionCard {
       cost: 7,
       productionBox: Units.of({}),
       resourceType: ResourceType.DATA,
+      reserveUnits: Units.of({titanium: 1}),
+
       metadata: {
         description: 'Spend 1 titanium. 1 VP for every 3 data resources here.',
         cardNumber: 'M22',
@@ -31,8 +33,6 @@ export class LunarObservationPost extends MoonCard implements IActionCard {
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.data(1, 3),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   }
 

--- a/src/cards/moon/MareImbriumMine.ts
+++ b/src/cards/moon/MareImbriumMine.ts
@@ -20,6 +20,7 @@ export class MareImbriumMine extends MoonCard implements IProjectCard, IMoonCard
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 19,
       productionBox: Units.of({steel: 1, titanium: 1}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your steel production 1 step and your titanium production 1 step. Place a mine ON THE RESERVED AREA and raise the Mining Rate 1 step.',
@@ -31,7 +32,6 @@ export class MareImbriumMine extends MoonCard implements IProjectCard, IMoonCard
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_MINE],
     });
   }

--- a/src/cards/moon/MareNectarisMine.ts
+++ b/src/cards/moon/MareNectarisMine.ts
@@ -20,6 +20,7 @@ export class MareNectarisMine extends MoonCard implements IProjectCard, IMoonCar
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 14,
       productionBox: Units.of({steel: 1}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your steel production 1 step. Place a mine ON THE RESERVED AREA and raise the Mining Rate 1 step.',
@@ -31,7 +32,6 @@ export class MareNectarisMine extends MoonCard implements IProjectCard, IMoonCar
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_MINE],
     });
   }

--- a/src/cards/moon/MareNubiumMine.ts
+++ b/src/cards/moon/MareNubiumMine.ts
@@ -1,18 +1,16 @@
 import {CardName} from '../../CardName';
 import {Player} from '../../Player';
 import {CardType} from '../CardType';
-import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
 import {CardRenderer} from '../render/CardRenderer';
 import {MoonSpaces} from '../../moon/MoonSpaces';
 import {MoonExpansion} from '../../moon/MoonExpansion';
 import {Units} from '../../Units';
 import {TileType} from '../../TileType';
-import {IMoonCard} from './IMoonCard';
 import {MoonCard} from './MoonCard';
 import {AltSecondaryTag} from '../render/CardRenderItem';
 
-export class MareNubiumMine extends MoonCard implements IProjectCard, IMoonCard {
+export class MareNubiumMine extends MoonCard {
   constructor() {
     super({
       name: CardName.MARE_NUBIUM_MINE,
@@ -20,6 +18,7 @@ export class MareNubiumMine extends MoonCard implements IProjectCard, IMoonCard 
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 17,
       productionBox: Units.of({titanium: 1}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your titanium production 1 step. Place a mine ON THE RESERVED AREA and raise the Mining Rate 1 step.',
@@ -30,7 +29,6 @@ export class MareNubiumMine extends MoonCard implements IProjectCard, IMoonCard 
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_MINE],
     });
   }

--- a/src/cards/moon/MareSerenitatisMine.ts
+++ b/src/cards/moon/MareSerenitatisMine.ts
@@ -8,13 +8,11 @@ import {MoonExpansion} from '../../moon/MoonExpansion';
 import {PlaceMoonRoadTile} from '../../moon/PlaceMoonRoadTile';
 import {Units} from '../../Units';
 import {SpaceType} from '../../SpaceType';
-import {IProjectCard} from '../IProjectCard';
-import {IMoonCard} from './IMoonCard';
 import {TileType} from '../../TileType';
 import {MoonCard} from './MoonCard';
 import {AltSecondaryTag} from '../render/CardRenderItem';
 
-export class MareSerenitatisMine extends MoonCard implements IProjectCard, IMoonCard {
+export class MareSerenitatisMine extends MoonCard {
   constructor() {
     super({
       name: CardName.MARE_SERENITATIS_MINE,
@@ -22,6 +20,7 @@ export class MareSerenitatisMine extends MoonCard implements IProjectCard, IMoon
       tags: [Tags.MOON, Tags.BUILDING],
       cost: 21,
       productionBox: Units.of({steel: 1, titanium: 1}),
+      reserveUnits: Units.of({steel: 1, titanium: 2}),
 
       metadata: {
         description: 'Spend 2 titanium and 1 steel. Increase your steel and titanium production 1 step ' +
@@ -34,7 +33,6 @@ export class MareSerenitatisMine extends MoonCard implements IProjectCard, IMoon
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 2, steel: 1}),
       tilesBuilt: [TileType.MOON_MINE, TileType.MOON_ROAD],
     });
   }

--- a/src/cards/moon/MiningRobotsManufCenter.ts
+++ b/src/cards/moon/MiningRobotsManufCenter.ts
@@ -15,6 +15,7 @@ export class MiningRobotsManufCenter extends MoonCard {
       tags: [Tags.SCIENCE, Tags.BUILDING],
       cost: 12,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Raise the Mining Rate 2 steps.',
@@ -24,8 +25,6 @@ export class MiningRobotsManufCenter extends MoonCard {
           b.moonMiningRate({amount: 2});
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   }
 

--- a/src/cards/moon/MomentumViriumHabitat.ts
+++ b/src/cards/moon/MomentumViriumHabitat.ts
@@ -18,6 +18,7 @@ export class MomentumViriumHabitat extends MoonCard {
       tags: [Tags.CITY, Tags.SPACE],
       cost: 23,
       productionBox: Units.of({heat: 2, megacredits: 3}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Increase your heat production 2 steps and your M€ production 3 steps. ' +
@@ -32,7 +33,6 @@ export class MomentumViriumHabitat extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   };

--- a/src/cards/moon/MoonCard.ts
+++ b/src/cards/moon/MoonCard.ts
@@ -1,24 +1,18 @@
 import {MoonExpansion} from '../../moon/MoonExpansion';
 import {Player} from '../../Player';
 import {TileType} from '../../TileType';
-import {Units} from '../../Units';
 import {Card, StaticCardProperties} from '../Card';
 import {IProjectCard} from '../IProjectCard';
 import {IMoonCard} from './IMoonCard';
 
 export interface MoonCardProperties {
-  reserveUnits?: Units,
   tilesBuilt?: Array<TileType.MOON_COLONY | TileType.MOON_MINE | TileType.MOON_ROAD>
 }
 
 export abstract class MoonCard extends Card implements IProjectCard, IMoonCard {
   constructor(properties: StaticCardProperties,
-    private moonCardProperties: MoonCardProperties) {
+    private moonCardProperties: MoonCardProperties = {}) {
     super(properties);
-  }
-
-  public get reserveUnits(): Units {
-    return this.moonCardProperties.reserveUnits || Units.EMPTY;
   }
 
   public get tilesBuilt(): Array<TileType> {

--- a/src/cards/moon/MoonCard.ts
+++ b/src/cards/moon/MoonCard.ts
@@ -1,15 +1,14 @@
-import {MoonExpansion} from '../../moon/MoonExpansion';
 import {Player} from '../../Player';
 import {TileType} from '../../TileType';
-import {Card, StaticCardProperties} from '../Card';
-import {IProjectCard} from '../IProjectCard';
+import {StaticCardProperties} from '../Card';
+import {ProjectCard} from '../ProjectCard';
 import {IMoonCard} from './IMoonCard';
 
 export interface MoonCardProperties {
   tilesBuilt?: Array<TileType.MOON_COLONY | TileType.MOON_MINE | TileType.MOON_ROAD>
 }
 
-export abstract class MoonCard extends Card implements IProjectCard, IMoonCard {
+export abstract class MoonCard extends ProjectCard implements IMoonCard {
   constructor(properties: StaticCardProperties,
     private moonCardProperties: MoonCardProperties = {}) {
     super(properties);
@@ -24,8 +23,7 @@ export abstract class MoonCard extends Card implements IProjectCard, IMoonCard {
   }
 
   public play(player: Player) {
-    const adjustedReserveUnits = MoonExpansion.adjustedReserveCosts(player, this);
-    player.deductUnits(adjustedReserveUnits);
+    super.play(player);
     player.adjustProduction(this.productionBox, {log: true});
     return undefined;
   }

--- a/src/cards/moon/MoonColonyStandardProject.ts
+++ b/src/cards/moon/MoonColonyStandardProject.ts
@@ -15,6 +15,8 @@ export class MoonColonyStandardProject extends StandardProjectCard implements IM
     super({
       name: CardName.MOON_COLONY_STANDARD_PROJECT,
       cost: 22,
+      reserveUnits: Units.of({titanium: 1}),
+
       metadata: {
         cardNumber: '',
         renderData: CardRenderer.builder((b) =>
@@ -26,7 +28,6 @@ export class MoonColonyStandardProject extends StandardProjectCard implements IM
     });
   }
 
-  public reserveUnits = Units.of({titanium: 1});
   public tilesBuilt = [TileType.MOON_COLONY];
 
   protected discount(player: Player): number {

--- a/src/cards/moon/MoonMineStandardProject.ts
+++ b/src/cards/moon/MoonMineStandardProject.ts
@@ -15,6 +15,8 @@ export class MoonMineStandardProject extends StandardProjectCard implements IMoo
     super({
       name: CardName.MOON_MINE_STANDARD_PROJECT,
       cost: 20,
+      reserveUnits: Units.of({titanium: 1}),
+
       metadata: {
         cardNumber: '',
         renderData: CardRenderer.builder((b) =>
@@ -26,7 +28,6 @@ export class MoonMineStandardProject extends StandardProjectCard implements IMoo
     });
   }
 
-  public reserveUnits = Units.of({titanium: 1});
   public tilesBuilt = [TileType.MOON_MINE];
 
   protected discount(player: Player): number {

--- a/src/cards/moon/MoonRoadStandardProject.ts
+++ b/src/cards/moon/MoonRoadStandardProject.ts
@@ -14,6 +14,8 @@ export class MoonRoadStandardProject extends StandardProjectCard implements IMoo
     super({
       name: CardName.MOON_ROAD_STANDARD_PROJECT,
       cost: 18,
+      reserveUnits: Units.of({steel: 1}),
+
       metadata: {
         cardNumber: '',
         renderData: CardRenderer.builder((b) =>
@@ -25,7 +27,6 @@ export class MoonRoadStandardProject extends StandardProjectCard implements IMoo
     });
   }
 
-  public reserveUnits = Units.of({steel: 1});
   public tilesBuilt = [TileType.MOON_ROAD];
 
   protected discount(player: Player): number {

--- a/src/cards/moon/PrideoftheEarthArkship.ts
+++ b/src/cards/moon/PrideoftheEarthArkship.ts
@@ -19,6 +19,7 @@ export class PrideoftheEarthArkship extends MoonCard implements IActionCard {
       cost: 22,
       resourceType: ResourceType.SCIENCE,
       requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE).tag(Tags.SPACE, 2)),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Requires 1 science and 2 space tags. Spend 2 titanium. 1 VP per science resource here.',
@@ -31,8 +32,6 @@ export class PrideoftheEarthArkship extends MoonCard implements IActionCard {
         }),
         victoryPoints: CardRenderDynamicVictoryPoints.science(1, 1),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 2}),
     });
   };
   public resourceCount = 0;

--- a/src/cards/moon/SinusIridiumRoadNetwork.ts
+++ b/src/cards/moon/SinusIridiumRoadNetwork.ts
@@ -17,6 +17,7 @@ export class SinusIridiumRoadNetwork extends MoonCard {
       tags: [Tags.MOON],
       cost: 15,
       productionBox: Units.of({energy: -1, megacredits: 3}),
+      reserveUnits: Units.of({steel: 1}),
 
       metadata: {
         description: 'Decrease your energy production 1 step and increase your M€ production 3 steps. ' +
@@ -32,7 +33,6 @@ export class SinusIridiumRoadNetwork extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({steel: 1}),
       tilesBuilt: [TileType.MOON_ROAD],
     });
   }

--- a/src/cards/moon/SmallDutyRovers.ts
+++ b/src/cards/moon/SmallDutyRovers.ts
@@ -8,10 +8,10 @@ import {MoonExpansion} from '../../moon/MoonExpansion';
 import {SpaceType} from '../../SpaceType';
 import {Resources} from '../../Resources';
 import {Units} from '../../Units';
-import {MoonCard} from './MoonCard';
 import {Size} from '../render/Size';
+import {Card} from '../Card';
 
-export class SmallDutyRovers extends MoonCard implements IProjectCard {
+export class SmallDutyRovers extends Card implements IProjectCard {
   constructor() {
     super({
       name: CardName.SMALL_DUTY_ROVERS,
@@ -19,6 +19,7 @@ export class SmallDutyRovers extends MoonCard implements IProjectCard {
       tags: [Tags.MOON, Tags.SPACE],
       cost: 9,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Raise the Logistic Rate 1 step. Gain 1 M€ per colony tile, mine tile and road tile on the Moon.',
@@ -31,8 +32,6 @@ export class SmallDutyRovers extends MoonCard implements IProjectCard {
             .moonRoad({size: Size.SMALL}).any;
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/cards/moon/SphereHabitats.ts
+++ b/src/cards/moon/SphereHabitats.ts
@@ -16,6 +16,7 @@ export class SphereHabitats extends MoonCard {
       cardType: CardType.AUTOMATED,
       tags: [Tags.CITY, Tags.MOON],
       cost: 14,
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Spend 1 titanium. Place a colony tile on the Moon and raise the Colony Rate 1 step.',
@@ -26,7 +27,6 @@ export class SphereHabitats extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 1}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   };

--- a/src/cards/moon/SubterraneanHabitats.ts
+++ b/src/cards/moon/SubterraneanHabitats.ts
@@ -13,6 +13,7 @@ export class SubterraneanHabitats extends MoonCard implements IProjectCard {
       name: CardName.SUBTERRANEAN_HABITATS,
       cardType: CardType.ACTIVE,
       cost: 12,
+      reserveUnits: Units.of({steel: 2}),
 
       metadata: {
         description: 'Spend 2 steel. Raise the Colony Rate 1 step.',
@@ -25,8 +26,6 @@ export class SubterraneanHabitats extends MoonCard implements IProjectCard {
           b.minus().steel(2).moonColonyRate();
         }),
       },
-    }, {
-      reserveUnits: Units.of({steel: 2}),
     });
   };
 

--- a/src/cards/moon/TheWomb.ts
+++ b/src/cards/moon/TheWomb.ts
@@ -17,6 +17,7 @@ export class TheWomb extends MoonCard {
       tags: [Tags.CITY, Tags.MOON],
       cost: 16,
       productionBox: Units.of({energy: -2, megacredits: 4}),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Decrease your energy production 2 steps and increase your M€ production 4 steps. ' +
@@ -30,7 +31,6 @@ export class TheWomb extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({titanium: 2}),
       tilesBuilt: [TileType.MOON_COLONY],
     });
   };

--- a/src/cards/moon/TitaniumExtractionCenter.ts
+++ b/src/cards/moon/TitaniumExtractionCenter.ts
@@ -16,6 +16,7 @@ export class TitaniumExtractionCenter extends MoonCard {
       tags: [Tags.BUILDING],
       cost: 14,
       productionBox: Units.of({}),
+      reserveUnits: Units.of({titanium: 2}),
 
       metadata: {
         description: 'Spend 2 titanium. Increase your titanium production 1 step for every 2 raised steps of Mining Rate.',
@@ -25,8 +26,6 @@ export class TitaniumExtractionCenter extends MoonCard {
           b.production((pb) => pb.titanium(1)).slash().moonMiningRate({amount: 2});
         }),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 2}),
     });
   }
 

--- a/src/cards/moon/TychoRoadNetwork.ts
+++ b/src/cards/moon/TychoRoadNetwork.ts
@@ -17,6 +17,7 @@ export class TychoRoadNetwork extends MoonCard {
       tags: [Tags.MOON],
       cost: 15,
       productionBox: Units.of({megacredits: 1}),
+      reserveUnits: Units.of({steel: 1}),
 
       metadata: {
         description: 'Spend 1 steel. Increase your M€ production 1 step. ' +
@@ -29,7 +30,6 @@ export class TychoRoadNetwork extends MoonCard {
         }),
       },
     }, {
-      reserveUnits: Units.of({steel: 1}),
       tilesBuilt: [TileType.MOON_ROAD],
     });
   }

--- a/src/cards/moon/WaterTreatmentComplex.ts
+++ b/src/cards/moon/WaterTreatmentComplex.ts
@@ -15,6 +15,7 @@ export class WaterTreatmentComplex extends MoonCard {
       cardType: CardType.AUTOMATED,
       cost: 12,
       requirements: CardRequirements.builder((b) => b.colonyTiles(1).any()),
+      reserveUnits: Units.of({titanium: 1}),
 
       metadata: {
         description: 'Requires 1 colony tile on the Moon. Spend 1 titanium. Raise the Colony Rate 2 steps.',
@@ -22,8 +23,6 @@ export class WaterTreatmentComplex extends MoonCard {
         // requirements: CardRequirements.builder((b) => b.text('1 colony on Moon')),// TODO(kberg):
         renderData: CardRenderer.builder((b) => b.minus().titanium(1).br.moonColonyRate({amount: 2})),
       },
-    }, {
-      reserveUnits: Units.of({titanium: 1}),
     });
   };
 

--- a/src/components/SelectHowToPayForProjectCard.ts
+++ b/src/components/SelectHowToPayForProjectCard.ts
@@ -192,7 +192,7 @@ export const SelectHowToPayForProjectCard = Vue.component('select-how-to-pay-for
       }
     },
     canUseHeat: function(): boolean {
-      return (this.playerinput.canUseHeat ?? true) && this.player.heat > 0;
+      return this.playerinput.canUseHeat === true && this.player.heat > 0;
     },
     canUseSteel: function() {
       if (this.card !== undefined && this.available.steel > 0) {

--- a/src/moon/MoonExpansion.ts
+++ b/src/moon/MoonExpansion.ts
@@ -317,7 +317,7 @@ export class MoonExpansion {
 
     steel = Math.max(steel, 0);
     titanium = Math.max(titanium, 0);
-    return Units.of({steel, titanium});
+    return Units.of({steel: steel, titanium: titanium});
   }
 
   public static calculateVictoryPoints(player: Player, vpb: VictoryPointsBreakdown): void {

--- a/src/moon/MoonExpansion.ts
+++ b/src/moon/MoonExpansion.ts
@@ -292,12 +292,16 @@ export class MoonExpansion {
    * Reservation units adjusted for cards in a player's hand that might reduce or eliminate these costs.
    */
   public static adjustedReserveCosts(player: Player, card: IProjectCard) : Units {
+    // This is a bit hacky and uncoordinated only because this returns early when there's a moon card with LTF Privileges
+    // even though the heat component below could be considered (and is, for LocalHeatTrapping.)
+
     if (player.cardIsInEffect(CardName.LTF_PRIVILEGES) && card.tags.includes(Tags.MOON)) {
       return Units.EMPTY;
     }
 
     const reserveUnits: Units = card.reserveUnits || Units.EMPTY;
 
+    const heat = reserveUnits.heat || 0;
     let steel = reserveUnits.steel || 0;
     let titanium = reserveUnits.titanium || 0;
 
@@ -317,7 +321,7 @@ export class MoonExpansion {
 
     steel = Math.max(steel, 0);
     titanium = Math.max(titanium, 0);
-    return Units.of({steel: steel, titanium: titanium});
+    return Units.of({steel, titanium, heat});
   }
 
   public static calculateVictoryPoints(player: Player, vpb: VictoryPointsBreakdown): void {

--- a/tests/cards/base/LocalHeatTrapping.spec.ts
+++ b/tests/cards/base/LocalHeatTrapping.spec.ts
@@ -8,23 +8,26 @@ import {OrOptions} from '../../../src/inputs/OrOptions';
 import {Player} from '../../../src/Player';
 import {TestPlayers} from '../../TestPlayers';
 
-describe('LocalHeatTrapping', function() {
+describe('LocalHeatTrapping', () => {
   let card : LocalHeatTrapping; let player : Player;
 
-  beforeEach(function() {
+  beforeEach(() => {
     card = new LocalHeatTrapping();
     player = TestPlayers.BLUE.newPlayer();
     const redPlayer = TestPlayers.RED.newPlayer();
     Game.newInstance('foobar', [player, redPlayer], player);
   });
 
-  it('Can\'t play without 5 heat', function() {
-    expect(card.canPlay(player)).is.not.true;
+  it('Cannot play without 5 heat', () => {
+    player.cardsInHand = [card];
+    expect(player.getPlayableCards()).is.empty;
   });
 
-  it('Should play - no animal targets', function() {
+  it('Should play - no animal targets', () => {
     player.heat = 5;
-    expect(card.canPlay(player)).is.true;
+    player.megaCredits = 1;
+    player.cardsInHand = [card];
+    expect(player.getPlayableCards()).does.include(card);
 
     card.play(player);
     player.playedCards.push(card);
@@ -32,7 +35,7 @@ describe('LocalHeatTrapping', function() {
     expect(player.heat).to.eq(0);
   });
 
-  it('Should play - single animal target', function() {
+  it('Should play - single animal target', () => {
     player.heat = 5;
     const pets = new Pets();
     player.playedCards.push(card, pets);
@@ -49,7 +52,7 @@ describe('LocalHeatTrapping', function() {
     expect(player.getResourcesOnCard(pets)).to.eq(2);
   });
 
-  it('Should play - multiple animal targets', function() {
+  it('Should play - multiple animal targets', () => {
     player.heat = 5;
     const pets = new Pets();
     const fish = new Fish();
@@ -61,13 +64,16 @@ describe('LocalHeatTrapping', function() {
     expect(player.getResourcesOnCard(fish)).to.eq(2);
   });
 
-  it('Can\'t play as Helion if not enough heat left after paying for card', function() {
+  it('Cannot play as Helion if not enough heat left after paying for card', () => {
     const corp = new Helion();
     corp.play(player);
     player.corporationCard = corp;
 
     player.megaCredits = 0;
     player.heat = 5; // have to pay for card with 1 heat
-    expect(card.canPlay(player)).is.not.true;
+    player.cardsInHand = [card];
+    expect(player.getPlayableCards()).does.not.include(card);
+    player.megaCredits = 1;
+    expect(player.getPlayableCards()).does.include(card);
   });
 });

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -14,10 +14,10 @@ import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
-describe('Playwrights', function() {
+describe('Playwrights', () => {
   let card : Playwrights; let player : Player; let player2: Player; let game : Game;
 
-  beforeEach(function() {
+  beforeEach(() => {
     card = new Playwrights();
     player = TestPlayers.BLUE.newPlayer();
     player2 = TestPlayers.RED.newPlayer();
@@ -27,12 +27,12 @@ describe('Playwrights', function() {
     player.corporationCard = card;
   });
 
-  it('Cannot act without any played events', function() {
+  it('Cannot act without any played events', () => {
     expect(player.getProduction(Resources.ENERGY)).eq(1);
     expect(card.canAct(player)).is.not.true;
   });
 
-  it('Can replay own event', function() {
+  it('Can replay own event', () => {
     const event = new ReleaseOfInertGases();
     const tr = player.getTerraformRating();
     event.play(player);
@@ -56,7 +56,7 @@ describe('Playwrights', function() {
     expect(player.removedFromPlayCards).has.lengthOf(1);
   });
 
-  it('Can replay other player\'s event', function() {
+  it('Can replay other player\'s event', () => {
     const event = new ReleaseOfInertGases();
     const tr = player.getTerraformRating();
     event.play(player2);
@@ -76,7 +76,7 @@ describe('Playwrights', function() {
     expect(player.removedFromPlayCards).has.lengthOf(1);
   });
 
-  it('Cannot act without any playable events', function() {
+  it('Cannot act without any playable events', () => {
     player2.playedCards.push(new MartianSurvey(), new LocalHeatTrapping(), new DeimosDown());
 
     (game as any).oxygenLevel = 5;
@@ -85,23 +85,23 @@ describe('Playwrights', function() {
     expect(card.canAct(player)).is.not.true;
   });
 
-  it('Acts correctly for event cards that give one time discount', function() {
+  it('Acts correctly for event cards that give one time discount', () => {
     const indenturedWorkers = new IndenturedWorkers();
     player.playedCards.push(indenturedWorkers);
 
     const selectCard = card.action(player) as SelectCard<ICard>;
     selectCard.cb([indenturedWorkers]);
-        // SelectHowToPay
-        game.deferredActions.pop()!.execute();
+    // SelectHowToPay
+    game.deferredActions.pop()!.execute();
 
-        const deimosDown = new DeimosDown();
-        expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost - 8);
+    const deimosDown = new DeimosDown();
+    expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost - 8);
 
-        player.playCard(deimosDown);
-        expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost); // no more discount
+    player.playCard(deimosDown);
+    expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost); // no more discount
   });
 
-  it('Works with Law Suit', function() {
+  it('Works with Law Suit', () => {
     const event = new LawSuit();
     player2.playedCards.push(event);
 

--- a/tests/cards/moon/LTFPrivileges.spec.ts
+++ b/tests/cards/moon/LTFPrivileges.spec.ts
@@ -5,7 +5,7 @@ import {TestPlayers} from '../../TestPlayers';
 import {LTFPrivileges} from '../../../src/cards/moon/LTFPrivileges';
 import {expect} from 'chai';
 import {CardName} from '../../../src/CardName';
-import {MareSerenitatisMine} from '../../../src/cards/moon/MareSerenitatisMine';
+import {AristarchusRoadNetwork} from '../../../src/cards/moon/AristarchusRoadNetwork';
 
 const MOON_OPTIONS = TestingUtils.setCustomGameOptions({moonExpansion: true});
 
@@ -26,11 +26,9 @@ describe('LTFPrivileges', () => {
     player.steel = 2;
     player.megaCredits = 1000;
 
-    const msm = new MareSerenitatisMine();
-    // TODO(kberg): Find an example that needs 2 steel. For now, hack this card to need 2 steel.
-    msm.reserveUnits.steel = 2;
-    player.cardsInHand = [msm];
-    expect(player.getPlayableCards().map((card) => card.name)).deep.eq([CardName.MARE_SERENITATIS_MINE]);
+    const arn = new AristarchusRoadNetwork();
+    player.cardsInHand = [arn];
+    expect(player.getPlayableCards().map((card) => card.name)).deep.eq([CardName.ARISTARCHUS_ROAD_NETWORK]);
 
     player.titanium = 0;
     player.steel = 0;
@@ -38,7 +36,7 @@ describe('LTFPrivileges', () => {
 
     // And this one shows that with Improved Moon Concrete, doesn't need steel.
     player.playedCards = [card];
-    expect(player.getPlayableCards().map((card) => card.name)).deep.eq([CardName.MARE_SERENITATIS_MINE]);
+    expect(player.getPlayableCards().map((card) => card.name)).deep.eq([CardName.ARISTARCHUS_ROAD_NETWORK]);
   });
 });
 

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -82,6 +82,29 @@ describe('SelectHowToPayForProjectCard', () => {
     expect(heatTextBox.value).eq('3');
   });
 
+  it('select how to pay uses heat with reserve', async () => {
+    // Birds will cost 10. Player has 10 MC and 4 heat. It will select 10MC
+    //
+    // Then when clicking the 'max' button for heat, the algorithm will switch to 8 M€ and 2 heat.
+
+    const wrapper = setupCardForPurchase(
+      CardName.BIRDS, 10,
+      {heat: 4, megaCredits: 10, titaniumValue: 1, steelValue: 1},
+      {canUseHeat: true},
+      Units.of({heat: 2}));
+
+    const vm = wrapper.vm;
+    await vm.$nextTick();
+
+    expect(vm.megaCredits).eq(10);
+    expect(vm.heat).eq(0);
+    const maxButton = wrapper.find('[title~=Heat] ~ .btn-max');
+    await maxButton.trigger('click');
+
+    expect(vm.megaCredits).eq(8);
+    expect(vm.heat).eq(2);
+  });
+
   it('select how to pay uses microbes', async () => {
     // Moss will cost 10. Player has 7M€ and will 2 of the 4 available microbes units.
     const wrapper = setupCardForPurchase(


### PR DESCRIPTION
Fixes #3326.

This PR has 3 commits; the first moves `reserveUnits` to a thing called `ProjectCard` (there seems to be some difference between what an `IProjectCard` and a `Card` can do. A little pecuilar, but OK. To make that work I had to fix a brittle test in L.T.F. Privileges, OK.

The second one moves the `Local Heat Trapping` special reserve behavior to a `reserveUnits` and ties everything else up. To make the tests meaningful again, I replaced card.canPlay() with player.getPlayableCards(), which takes into account things like money + units in reserve. This PR also fixes an issue with Playwrights that is not compatible with the Moon Expansion.

The third commit updates the UI to respect reserved heat units.