### PR TITLE
Add Ecoexperts interaction with deco-eco

### DIFF
--- a/src/cards/base/Decomposers.ts
+++ b/src/cards/base/Decomposers.ts
@@ -9,6 +9,7 @@ import {IResourceCard} from '../ICard';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {Phase} from '../../Phase';
 
 export class Decomposers extends Card implements IProjectCard, IResourceCard {
   constructor() {
@@ -43,7 +44,11 @@ export class Decomposers extends Card implements IProjectCard, IResourceCard {
     public getVictoryPoints(): number {
       return Math.floor(this.resourceCount / 3);
     }
-    public play() {
+    public play(player: Player) {
+      // Get two extra microbes from EcoExperts if played during prelude while having just played EcoExperts
+      if (player.game.phase === Phase.PRELUDES && player.playedCards.length > 0 && player.playedCards[player.playedCards.length-1].name === CardName.ECOLOGY_EXPERTS) {
+        player.addResourceTo(this, 2);
+      }
       return undefined;
     }
 }

--- a/src/cards/base/EcologicalZone.ts
+++ b/src/cards/base/EcologicalZone.ts
@@ -14,6 +14,7 @@ import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
+import {Phase} from '../../Phase';
 
 export class EcologicalZone extends Card implements IProjectCard, IResourceCard {
   constructor(
@@ -69,6 +70,11 @@ export class EcologicalZone extends Card implements IProjectCard, IResourceCard 
     return Math.floor(this.resourceCount / 2);
   }
   public play(player: Player) {
+    // Get one extra animal from EcoExperts if played during prelude while having just played EcoExperts
+    if (player.game.phase === Phase.PRELUDES && player.playedCards.length > 0 && player.playedCards[player.playedCards.length-1].name === CardName.ECOLOGY_EXPERTS) {
+      player.addResourceTo(this, 1);
+    }
+
     return new SelectSpace(
       'Select space next to greenery for special tile',
       this.getAvailableSpaces(player),

--- a/tests/cards/base/Decomposers.spec.ts
+++ b/tests/cards/base/Decomposers.spec.ts
@@ -2,7 +2,9 @@ import {expect} from 'chai';
 import {Algae} from '../../../src/cards/base/Algae';
 import {Birds} from '../../../src/cards/base/Birds';
 import {Decomposers} from '../../../src/cards/base/Decomposers';
+import {EcologyExperts} from '../../../src/cards/prelude/EcologyExperts';
 import {Game} from '../../../src/Game';
+import {Phase} from '../../../src/Phase';
 import {Player} from '../../../src/Player';
 import {TestPlayers} from '../../TestPlayers';
 
@@ -23,7 +25,7 @@ describe('Decomposers', function() {
   it('Should play', function() {
     (game as any).oxygenLevel = 3;
     expect(card.canPlay(player)).is.true;
-    card.play();
+    card.play(player);
 
     card.onCardPlayed(player, new Birds());
     expect(card.resourceCount).to.eq(1);
@@ -33,5 +35,14 @@ describe('Decomposers', function() {
 
     expect(card.resourceCount).to.eq(3);
     expect(card.getVictoryPoints()).to.eq(1);
+  });
+
+  it('Should get triggered by EcoExperts if played together', function() {
+    const ecoExpertCard = new EcologyExperts();
+    game.phase = Phase.PRELUDES;
+    player.playCard(ecoExpertCard);
+    expect(card.canPlay(player)).is.true;
+    player.playCard(card);
+    expect(card.resourceCount).to.eq(3);
   });
 });

--- a/tests/cards/base/EcologicalZone.spec.ts
+++ b/tests/cards/base/EcologicalZone.spec.ts
@@ -1,7 +1,9 @@
 import {expect} from 'chai';
 import {EcologicalZone} from '../../../src/cards/base/EcologicalZone';
+import {EcologyExperts} from '../../../src/cards/prelude/EcologyExperts';
 import {Game} from '../../../src/Game';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
+import {Phase} from '../../../src/Phase';
 import {Player} from '../../../src/Player';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
@@ -36,6 +38,20 @@ describe('EcologicalZone', function() {
     expect(card.resourceCount).to.eq(2);
     expect(card.getVictoryPoints()).to.eq(1);
     expect(adjacentSpace.adjacency?.bonus).eq(undefined);
+  });
+
+  it('Should get triggered by EcoExperts if played together', function() {
+    game.phase = Phase.PRELUDES;
+
+    const landSpace = game.board.getAvailableSpacesOnLand(player)[0];
+    game.addGreenery(player, landSpace.id);
+
+    const ecoExpertCard = new EcologyExperts();
+    player.playCard(ecoExpertCard);
+    expect(card.canPlay(player)).is.true;
+
+    player.playCard(card);
+    expect(card.resourceCount).to.eq(3);
   });
 });
 


### PR DESCRIPTION
This PR can closes #3344 .

Note that EcoZone's requirement is not overridden by EcoExperts but it is possible to get a greenery tile from Experimental Forest and then play EcoExperts ignoring its benefit just so you can play EcoZone during the Preludes phase. If we are already talking about terrible plays (EcoExpert on Decomposers), we might as well fix this unimaginably bad play.

¯\\\_(ツ)\_/¯