### PR TITLE
Don't grant bonuses to Ecological Survey and Geological Survey when overplacing tiles.

### DIFF
--- a/src/cards/ares/EcologicalSurvey.ts
+++ b/src/cards/ares/EcologicalSurvey.ts
@@ -42,6 +42,10 @@ export class EcologicalSurvey extends Card implements IProjectCard {
     return player.game.board.getAdjacentSpaces(space).some((adj) => adj.adjacency?.bonus.includes(bonus));
   }
 
+  private grantsBonusNow(space: ISpace, bonus: SpaceBonus) {
+    return space.tile?.covers !== undefined && space.bonus.includes(bonus);
+  }
+
   public onTilePlaced(cardOwner: Player, activePlayer: Player, space: ISpace, boardType: BoardType) {
     // Adjacency bonuses are only available on Mars.
     if (boardType !== BoardType.MARS) {
@@ -52,7 +56,7 @@ export class EcologicalSurvey extends Card implements IProjectCard {
     }
 
     // Plants
-    if (space.bonus.includes(SpaceBonus.PLANT) ||
+    if (this.grantsBonusNow(space, SpaceBonus.PLANT) ||
         this.anyAdjacentSpaceGivesBonus(cardOwner, space, SpaceBonus.PLANT) ||
         (space.tile?.tileType === TileType.OCEAN && cardOwner.playedCards.some((card) => card.name === CardName.ARCTIC_ALGAE))) {
       cardOwner.game.defer(new GainResources(
@@ -68,7 +72,7 @@ export class EcologicalSurvey extends Card implements IProjectCard {
     // Microbes and Animals
     ([[ResourceType.MICROBE, SpaceBonus.MICROBE], [ResourceType.ANIMAL, SpaceBonus.ANIMAL]] as [ResourceType, SpaceBonus][]).forEach(([resource, bonus]) => {
       if (cardOwner.playedCards.some((card) => card.resourceType === resource) &&
-          (space.bonus.includes(bonus) || this.anyAdjacentSpaceGivesBonus(cardOwner, space, bonus))) {
+          (this.grantsBonusNow(space, bonus) || this.anyAdjacentSpaceGivesBonus(cardOwner, space, bonus))) {
         cardOwner.game.defer(new AddResourcesToCard(
           cardOwner,
           resource,

--- a/src/cards/ares/GeologicalSurvey.ts
+++ b/src/cards/ares/GeologicalSurvey.ts
@@ -43,6 +43,10 @@ export class GeologicalSurvey extends Card implements IProjectCard {
     return player.game.board.getAdjacentSpaces(space).some((adj) => adj.adjacency?.bonus.includes(bonus));
   }
 
+  private grantsBonusNow(space: ISpace, bonus: SpaceBonus) {
+    return space.tile?.covers !== undefined && space.bonus.includes(bonus);
+  }
+
   public onTilePlaced(cardOwner: Player, activePlayer: Player, space: ISpace, boardType: BoardType) {
     // Adjacency bonuses are only available on Mars.
     if (boardType !== BoardType.MARS) {
@@ -55,7 +59,7 @@ export class GeologicalSurvey extends Card implements IProjectCard {
     // Steel, Titanium and Heat
     ([[Resources.STEEL, SpaceBonus.STEEL], [Resources.TITANIUM, SpaceBonus.TITANIUM], [Resources.HEAT, SpaceBonus.HEAT]] as [Resources, SpaceBonus][]).forEach(([resource, bonus]) => {
       if ((resource === Resources.STEEL && space.spaceType !== SpaceType.COLONY && PartyHooks.shouldApplyPolicy(cardOwner.game, PartyName.MARS, TurmoilPolicy. MARS_FIRST_DEFAULT_POLICY)) ||
-          space.bonus.includes(bonus) ||
+          this.grantsBonusNow(space, bonus) ||
           this.anyAdjacentSpaceGivesBonus(cardOwner, space, bonus)) {
         cardOwner.game.defer(new GainResources(
           cardOwner,

--- a/tests/cards/ares/EcologicalSurvey.spec.ts
+++ b/tests/cards/ares/EcologicalSurvey.spec.ts
@@ -14,13 +14,13 @@ import {Phase} from '../../../src/Phase';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
-describe('EcologicalSurvey', function() {
+describe('EcologicalSurvey', () => {
   let card : EcologicalSurvey;
   let player : Player;
   let redPlayer : Player;
   let game : Game;
 
-  beforeEach(function() {
+  beforeEach(() => {
     card = new EcologicalSurvey();
     player = TestPlayers.BLUE.newPlayer();
     redPlayer = TestPlayers.RED.newPlayer();
@@ -28,7 +28,7 @@ describe('EcologicalSurvey', function() {
     game.board = EmptyBoard.newInstance();
   });
 
-  it('Can play', function() {
+  it('Can play', () => {
     AresTestHelper.addGreenery(player);
     expect(card.canPlay(player)).is.false;
 
@@ -41,7 +41,7 @@ describe('EcologicalSurvey', function() {
 
   // This doesn't test anything about this card, but about the behavior this card provides, from
   // AresHandler.
-  it('Bonus in the field', function() {
+  it('Bonus in the field', () => {
     // tile types in this test are irrelevant.
     // What's key is that this space has a weird behavior - it grants all the bonuses.
     // Only three of them will grant additional bonuses: plants, animals, and microbes.
@@ -91,10 +91,24 @@ describe('EcologicalSurvey', function() {
     expect(animalCard.resourceCount).eq(2);
   });
 
-  it('Bonus granted with Arctic Algae', function() {
+  it('Bonus not granted when overplacing', () => {
+    player.playedCards.push(card);
+
+    // Hand-placing an ocean to make things easy, since this test suite relies on an otherwise empty board.
+    game.board.spaces[5].spaceType = SpaceType.OCEAN;
+    game.board.spaces[5].bonus = [SpaceBonus.PLANT];
+    game.simpleAddTile(redPlayer, game.board.spaces[5], {tileType: TileType.OCEAN});
+
+    player.plants = 0;
+    game.addTile(player, SpaceType.OCEAN, game.board.spaces[5], {tileType: TileType.OCEAN_CITY});
+    TestingUtils.runAllActions(game);
+    expect(player.plants).eq(0);
+  });
+
+  it('Bonus granted with Arctic Algae', () => {
     // Player has Arctic Algae, will grants two plants when anyone plays an ocean.
     player.playedCards.push(new ArcticAlgae());
-    player.playedCards.push(new EcologicalSurvey());
+    player.playedCards.push(card);
 
     // Hand-placing an ocean to make things easy, since this test suite relies on an otherwise empty board.
     game.board.spaces[5].spaceType = SpaceType.OCEAN;
@@ -106,10 +120,10 @@ describe('EcologicalSurvey', function() {
     expect(player.plants).eq(3);
   });
 
-  it('Bonus granted with Arctic Algae not granted during WGT', function() {
+  it('Bonus granted with Arctic Algae not granted during WGT', () => {
     // Player has Arctic Algae, will grants two plants when anyone plays an ocean.
     player.playedCards.push(new ArcticAlgae());
-    player.playedCards.push(new EcologicalSurvey());
+    player.playedCards.push(card);
 
     // Hand-placing an ocean to make things easy, since this test suite relies on an otherwise empty board.
     game.board.spaces[5].spaceType = SpaceType.OCEAN;

--- a/tests/cards/ares/GeologicalSurvey.spec.ts
+++ b/tests/cards/ares/GeologicalSurvey.spec.ts
@@ -14,18 +14,21 @@ import {MarsFirst} from '../../../src/turmoil/parties/MarsFirst';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 
-describe('GeologicalSurvey', function() {
-  let card : GeologicalSurvey; let player : Player; let game : Game;
+describe('GeologicalSurvey', () => {
+  let card : GeologicalSurvey;
+  let player : Player;
+  let redPlayer : Player;
+  let game : Game;
 
-  beforeEach(function() {
+  beforeEach(() => {
     card = new GeologicalSurvey();
     player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    redPlayer = TestPlayers.RED.newPlayer();
     game = Game.newInstance('foobar', [player, redPlayer], player, ARES_OPTIONS_NO_HAZARDS);
     game.board = EmptyBoard.newInstance();
   });
 
-  it('Can play', function() {
+  it('Can play', () => {
     AresTestHelper.addGreenery(player);
     expect(card.canPlay(player)).is.true;
 
@@ -46,7 +49,7 @@ describe('GeologicalSurvey', function() {
   });
 
 
-  it('Bonus in the field', function() {
+  it('Bonus in the field', () => {
     // tile types in this test are irrelevant.
     // What's key is that this space has a weird behavior - it grants all the bonuses.
     // Only three of them will grant additional bonuses: steel, titanium, and heat.
@@ -98,7 +101,7 @@ describe('GeologicalSurvey', function() {
     expect(animalCard.resourceCount).eq(1);
   });
 
-  it('Works with Mars First policy', function() {
+  it('Works with Mars First policy', () => {
     player = TestPlayers.BLUE.newPlayer();
     const gameOptions = TestingUtils.setCustomGameOptions();
     game = Game.newInstance('foobar', [player], player, gameOptions);
@@ -120,5 +123,19 @@ describe('GeologicalSurvey', function() {
     game.addGreenery(player, '11');
     TestingUtils.runAllActions(game);
     expect(player.steel).eq(2);
+  });
+
+  it('Bonus not granted when overplacing', () => {
+    player.playedCards.push(card);
+
+    // Hand-placing an ocean to make things easy, since this test suite relies on an otherwise empty board.
+    game.board.spaces[5].spaceType = SpaceType.OCEAN;
+    game.board.spaces[5].bonus = [SpaceBonus.HEAT];
+    game.simpleAddTile(redPlayer, game.board.spaces[5], {tileType: TileType.OCEAN});
+
+    player.heat = 0;
+    game.addTile(player, SpaceType.OCEAN, game.board.spaces[5], {tileType: TileType.OCEAN_CITY});
+    TestingUtils.runAllActions(game);
+    expect(player.heat).eq(0);
   });
 });


### PR DESCRIPTION
Fixes #3358.

I'll follow this up with code that removes the duplication between these cards.