### PR TITLE
Vastly simplify taking final greenery action, making it philares-compatible

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1068,7 +1068,8 @@ export class Game implements ISerializable<SerializedGame> {
   // Well, this isn't just "go to the final greenery placement". It finds the next player
   // who might be able to place a final greenery.
   // Rename to takeNextFinalGreeneryAction?
-  public gotoFinalGreeneryPlacement(): void {
+
+  public /* for testing */ gotoFinalGreeneryPlacement(): void {
     // this.getPlayers returns in turn order -- a necessary rule for final greenery placement.
     const players = this.getPlayers();
     for (let idx = 0; idx < players.length; idx++) {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1071,9 +1071,7 @@ export class Game implements ISerializable<SerializedGame> {
 
   public /* for testing */ gotoFinalGreeneryPlacement(): void {
     // this.getPlayers returns in turn order -- a necessary rule for final greenery placement.
-    const players = this.getPlayers();
-    for (let idx = 0; idx < players.length; idx++) {
-      const player = players[idx];
+    for (const player of this.getPlayers()) {
       if (this.donePlayers.has(player.id)) {
         continue;
       }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1691,6 +1691,14 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public takeActionForFinalGreenery(): void {
+    // Resolve any deferredAction before placing the next greenery
+    // Otherwise if two tiles are placed next to Philares, only the last benefit is triggered
+    // if Philares does not accept the first bonus before the second tile is down
+    if (this.game.deferredActions.length > 0) {
+      this.resolveFinalGreeneryDeferredActions();
+      return;
+    }
+
     if (this.game.canPlaceGreenery(this)) {
       const action: OrOptions = new OrOptions();
       action.title = 'Place any final greenery from plants';

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -219,6 +219,12 @@ describe('Game', function() {
     // Pass last turn
     game.playerHasPassed(player);
     game.playerHasPassed(player2);
+
+    // Must remove waitingFor or playerIsFinishedTakingActions
+    // will pre-emptively exit -- you can't end the game
+    // if the game is waiting for a player to do something!
+    (player as any).waitingFor = undefined;
+    (player2 as any).waitingFor = undefined;
     game.playerIsFinishedTakingActions();
     // Now game should be in end state
     expect(game.phase).to.eq(Phase.END);
@@ -278,15 +284,21 @@ describe('Game', function() {
 
   it('Should not give TR or raise oxygen for final greenery placements', function() {
     const player = TestPlayers.BLUE.newPlayer();
-    const redPlayer = TestPlayers.RED.newPlayer();
+    const otherPlayer = TestPlayers.RED.newPlayer();
 
-    const game = Game.newInstance('foobar', [player, redPlayer], player);
+    const game = Game.newInstance('foobar', [player, otherPlayer], player);
     game.generation = 14;
 
     // Terraform
     (game as any).temperature = constants.MAX_TEMPERATURE;
     (game as any).oxygenLevel = constants.MAX_OXYGEN_LEVEL - 2;
     TestingUtils.maxOutOceans(player);
+
+    // Must remove waitingFor or playerIsFinishedTakingActions
+    // will pre-emptively exit -- you can't end the game
+    // if the game is waiting for a player to do something!
+    (player as any).waitingFor = undefined;
+    (otherPlayer as any).waitingFor = undefined;
 
     // Trigger end game
     player.setTerraformRating(20);

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -27,8 +27,8 @@ import {RandomMAOptionType} from '../src/RandomMAOptionType';
 import {SpaceBonus} from '../src/SpaceBonus';
 import {TileType} from '../src/TileType';
 
-describe('Game', function() {
-  it('should initialize with right defaults', function() {
+describe('Game', () => {
+  it('should initialize with right defaults', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('foobar', [player, player2], player);
@@ -36,7 +36,7 @@ describe('Game', function() {
     expect(game.getGeneration()).to.eq(1);
   });
 
-  it('sets starting production if corporate era not selected', function() {
+  it('sets starting production if corporate era not selected', () => {
     const player = TestPlayers.BLUE.newPlayer();
 
     const gameOptions = TestingUtils.setCustomGameOptions({corporateEra: false});
@@ -50,7 +50,7 @@ describe('Game', function() {
     expect(player.getProduction(Resources.HEAT)).to.eq(1);
   });
 
-  it('correctly calculates victory points', function() {
+  it('correctly calculates victory points', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const player3 = TestPlayers.YELLOW.newPlayer();
@@ -112,7 +112,7 @@ describe('Game', function() {
     expect(player3.victoryPointsBreakdown.awards).to.eq(5); // one shared 1st place
   });
 
-  it('Disallows to set temperature more than allowed maximum', function() {
+  it('Disallows to set temperature more than allowed maximum', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('game-id', [player, player2], player);
@@ -133,7 +133,7 @@ describe('Game', function() {
     expect(player.getTerraformRating()).to.eq(initialTR + 1);
   });
 
-  it('Disallows to set oxygenLevel more than allowed maximum', function() {
+  it('Disallows to set oxygenLevel more than allowed maximum', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('game-id', [player, player2], player);
@@ -146,7 +146,7 @@ describe('Game', function() {
     expect(player.getTerraformRating()).to.eq(initialTR + 1);
   });
 
-  it('Draft round for 2 players', function() {
+  it('Draft round for 2 players', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('draft_game', [player, player2], player);
@@ -159,7 +159,7 @@ describe('Game', function() {
     expect(game.getGeneration()).to.eq(5);
   });
 
-  it('No draft round for 2 players', function() {
+  it('No draft round for 2 players', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('classic_game', [player, player2], player);
@@ -172,7 +172,7 @@ describe('Game', function() {
     expect(game.getGeneration()).to.eq(3);
   });
 
-  it('Solo play next generation', function() {
+  it('Solo play next generation', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('solo game', [player], player);
     game.gameOptions.venusNextExtension = false;
@@ -181,7 +181,7 @@ describe('Game', function() {
     expect(game.getGeneration()).to.eq(2);
   });
 
-  it('Should not finish game before Venus is terraformed, if chosen', function() {
+  it('Should not finish game before Venus is terraformed, if chosen', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('venusterraform', [player, player2], player);
@@ -203,7 +203,7 @@ describe('Game', function() {
     expect(game.phase).to.eq(Phase.RESEARCH);
   });
 
-  it('Should finish game if Mars and Venus is terraformed, if chosen', function() {
+  it('Should finish game if Mars and Venus is terraformed, if chosen', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('venusterraform', [player, player2], player);
@@ -230,7 +230,7 @@ describe('Game', function() {
     expect(game.phase).to.eq(Phase.END);
   });
 
-  it('Should not finish game if Mars is not terraformed but Venus is terraformed, if chosen', function() {
+  it('Should not finish game if Mars is not terraformed but Venus is terraformed, if chosen', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const game = Game.newInstance('venusterraform', [player, player2], player);
@@ -251,7 +251,7 @@ describe('Game', function() {
     expect(game.phase).to.eq(Phase.RESEARCH);
   });
 
-  it('Should finish solo game in the end of last generation', function() {
+  it('Should finish solo game in the end of last generation', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('solo1', [player], player);
     game.playerIsDoneWithGame(player);
@@ -262,7 +262,7 @@ describe('Game', function() {
     expect(game.isSoloModeWin()).is.not.true;
   });
 
-  it('Should not finish solo game before last generation if Mars is already terraformed', function() {
+  it('Should not finish solo game before last generation if Mars is already terraformed', () => {
     const player = TestPlayers.BLUE.newPlayer();
 
     const game = Game.newInstance('solo2', [player], player);
@@ -282,7 +282,7 @@ describe('Game', function() {
     expect(game.phase).to.eq(Phase.RESEARCH);
   });
 
-  it('Should not give TR or raise oxygen for final greenery placements', function() {
+  it('Should not give TR or raise oxygen for final greenery placements', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const otherPlayer = TestPlayers.RED.newPlayer();
 
@@ -327,7 +327,100 @@ describe('Game', function() {
     expect(game.getOxygenLevel()).to.eq(12);
   });
 
-  it('Should return players in turn order', function() {
+  it('Final greenery placement in order of the current generation', () => {
+    const player1 = new Player('p1', Color.BLUE, false, 0, 'p1-id');
+    const player2 = new Player('p2', Color.GREEN, false, 0, 'p2-id');
+    const player3 = new Player('p3', Color.YELLOW, false, 0, 'p3-id');
+    const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
+    const game = Game.newInstance('gto', [player1, player2, player3, player4], player3);
+
+    game.getPlayers().forEach((p) => {
+      (p as any).waitingFor = undefined;
+      p.plants = 8;
+    });
+
+    game.gotoFinalGreeneryPlacement();
+
+    expect(player1.getWaitingFor()).is.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.not.undefined;
+    expect(player4.getWaitingFor()).is.undefined;
+
+    // Skipping plants placement. Option 1 is "Don't place plants".
+    // This weird input is what would come from the server, and indicates "Don't place plants".
+    player3.process([['1'], []]);
+
+    expect(player1.getWaitingFor()).is.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.not.undefined;
+
+    player4.process([['1'], []]);
+
+    expect(player1.getWaitingFor()).is.not.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.undefined;
+
+    player1.process([['1'], []]);
+
+    expect(player1.getWaitingFor()).is.undefined;
+    expect(player2.getWaitingFor()).is.not.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.undefined;
+
+    player2.process([['1'], []]);
+
+    expect(player1.getWaitingFor()).is.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.undefined;
+
+    expect(game.phase).eq(Phase.END);
+  });
+
+  it('Final greenery placement skips players without enough plants', () => {
+    const player1 = new Player('p1', Color.BLUE, false, 0, 'p1-id');
+    const player2 = new Player('p2', Color.GREEN, false, 0, 'p2-id');
+    const player3 = new Player('p3', Color.YELLOW, false, 0, 'p3-id');
+    const player4 = new Player('p4', Color.RED, false, 0, 'p4-id');
+    const game = Game.newInstance('gto', [player1, player2, player3, player4], player2);
+    (game as any).incrementFirstPlayer();
+
+    game.getPlayers().forEach((p) => {
+      (p as any).waitingFor = undefined;
+    });
+
+    player1.plants = 8;
+    player4.plants = 8;
+
+    game.gotoFinalGreeneryPlacement();
+
+    // Even though player 3 is first player, they have no plants. So player 4 goes.
+
+    expect(player1.getWaitingFor()).is.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.not.undefined;
+
+    // Skipping plants placement. Option 1 is "Don't place plants".
+    // This weird input is what would come from the server, and indicates "Don't place plants".
+    player4.process([['1'], []]);
+
+    // After that, player 1 has plants.
+    expect(player1.getWaitingFor()).is.not.undefined;
+    expect(player2.getWaitingFor()).is.undefined;
+    expect(player3.getWaitingFor()).is.undefined;
+    expect(player4.getWaitingFor()).is.undefined;
+
+    player1.process([['1'], []]);
+
+    // But player 2 doesn't, and so the game is over.
+    expect(game.phase).eq(Phase.END);
+  });
+
+
+  it('Should return players in turn order', () => {
     const player1 = new Player('p1', Color.BLUE, false, 0, 'p1-id');
     const player2 = new Player('p2', Color.GREEN, false, 0, 'p2-id');
     const player3 = new Player('p3', Color.YELLOW, false, 0, 'p3-id');
@@ -356,7 +449,7 @@ describe('Game', function() {
     expect(players[3].name).to.eq('p4');
   });
 
-  it('Gets card player for corporation card', function() {
+  it('Gets card player for corporation card', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('gto', [player], player);
     const card = new SaturnSystems();
@@ -364,7 +457,7 @@ describe('Game', function() {
     expect(game.getCardPlayer(card.name)).to.eq(player);
   });
 
-  it('Does not assign player to ocean after placement', function() {
+  it('Does not assign player to ocean after placement', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('oceanz', [player], player);
     const spaceId: SpaceId = game.board.getAvailableSpacesForOcean(player)[0].id;
@@ -374,7 +467,7 @@ describe('Game', function() {
     expect(space.player).is.undefined;
   });
 
-  it('Check Ecologist Milestone', function() {
+  it('Check Ecologist Milestone', () => {
     const player = TestPlayers.BLUE.newPlayer();
 
     const card1 = new ResearchNetwork();
@@ -387,7 +480,7 @@ describe('Game', function() {
     expect(ecologist.canClaim(player)).is.true;
   });
 
-  it('Removes Hellas bonus ocean space if player cannot pay', function() {
+  it('Removes Hellas bonus ocean space if player cannot pay', () => {
     const player = TestPlayers.BLUE.newPlayer();
 
     // NOTE: By setting up the two-player game, instead of a solo game as we regularly do
@@ -415,7 +508,7 @@ describe('Game', function() {
     expect(availableSpacesOnLand.map((s) => s.id)).to.include(SpaceName.HELLAS_OCEAN_TILE);
   });
 
-  it('Removes Hellas bonus ocean space if Helion player cannot pay', function() {
+  it('Removes Hellas bonus ocean space if Helion player cannot pay', () => {
     const player = TestPlayers.BLUE.newPlayer();
     // NOTE: By setting up the two-player game, instead of a solo game as we regularly do
     // the neutral player can't claim the bonus ocean space before our player has a
@@ -445,7 +538,7 @@ describe('Game', function() {
     expect(availableSpacesOnLand.map((s) => s.id)).to.include(SpaceName.HELLAS_OCEAN_TILE);
   });
 
-  it('Generates random milestones and awards', function() {
+  it('Generates random milestones and awards', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const gameOptions = TestingUtils.setCustomGameOptions({boardName: BoardName.HELLAS, randomMA: RandomMAOptionType.UNLIMITED});
@@ -463,7 +556,7 @@ describe('Game', function() {
     expect(prevAwards).to.not.eq(awards);
   });
 
-  it('specifically-requested corps override expansion corps', function() {
+  it('specifically-requested corps override expansion corps', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const player2 = TestPlayers.RED.newPlayer();
     const corpsFromTurmoil = [
@@ -525,7 +618,7 @@ describe('Game', function() {
    * serialization. if this fails update SerializedGame
    * to match
    */
-  it('serializes properties', function() {
+  it('serializes properties', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
     const serialized = game.serialize();
@@ -535,7 +628,7 @@ describe('Game', function() {
     expect(serializedKeys).to.have.members(gameKeys.concat('moonData'));
   });
 
-  it('serializes every property', function() {
+  it('serializes every property', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player, TestingUtils.setCustomGameOptions({moonExpansion: true}));
     const serialized = game.serialize();

--- a/tests/cards/promo/Philares.spec.ts
+++ b/tests/cards/promo/Philares.spec.ts
@@ -10,11 +10,13 @@ import {Phase} from '../../../src/Phase';
 import {AndOptions} from '../../../src/inputs/AndOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {Units} from '../../../src/Units';
+import {MAX_OXYGEN_LEVEL, MAX_TEMPERATURE} from '../../../src/constants';
+import {OrOptions} from '../../../src/inputs/OrOptions';
 
 describe('Philares', () => {
   let card : Philares;
-  let player : TestPlayer;
-  let redPlayer: TestPlayer;
+  let philaresPlayer : TestPlayer;
+  let otherPlayer: TestPlayer;
   let game: Game;
   let space: ISpace;
   let adjacentSpace: ISpace;
@@ -22,129 +24,177 @@ describe('Philares', () => {
 
   beforeEach(() => {
     card = new Philares();
-    player = TestPlayers.BLUE.newPlayer();
-    redPlayer = TestPlayers.RED.newPlayer();
-    game = Game.newInstance('foobar', [player, redPlayer], player);
+    philaresPlayer = TestPlayers.BLUE.newPlayer();
+    otherPlayer = TestPlayers.RED.newPlayer();
+    // redPlayer is first for the final placement test.
+    game = Game.newInstance('foobar', [otherPlayer, philaresPlayer], otherPlayer);
     game.board = EmptyBoard.newInstance();
     space = game.board.spaces[4];
     adjacentSpace = game.board.getAdjacentSpaces(space)[0];
     adjacentSpace2 = game.board.getAdjacentSpaces(space)[2];
 
-    player.corporationCard = card;
+    philaresPlayer.corporationCard = card;
   });
 
   it('No bonus when placing next to self', () => {
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(player, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('bonus when placing next to opponent', () => {
-    game.addTile(redPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(player, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
   });
 
   it('bonus when opponent places next to you', () => {
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
   });
 
   it('placing ocean tile does not grant bonus', () => {
-    game.addTile(redPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
     adjacentSpace.spaceType = SpaceType.OCEAN; // Make this space an ocean space.
-    game.addTile(player, SpaceType.OCEAN, adjacentSpace, {tileType: TileType.OCEAN});
+    game.addTile(philaresPlayer, SpaceType.OCEAN, adjacentSpace, {tileType: TileType.OCEAN});
     expect(game.deferredActions).has.length(0);
   });
 
   it('ocean tile next to yours does not grant bonus', () => {
     space.spaceType = SpaceType.OCEAN; // Make this space an ocean space.
-    game.addTile(redPlayer, SpaceType.OCEAN, space, {tileType: TileType.OCEAN});
+    game.addTile(otherPlayer, SpaceType.OCEAN, space, {tileType: TileType.OCEAN});
     expect(game.deferredActions).has.length(0);
-    game.addTile(player, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('No adjacency bonus during WGT', () => {
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
     game.phase = Phase.SOLAR;
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
   });
 
   it('one tile one bonus', () => {
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = action?.execute() as AndOptions;
     // Options are ordered 0-5, MC to heat.
-    expect(player.purse()).deep.eq(Units.EMPTY);
+    expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
     options.cb();
-    expect(player.purse()).deep.eq(Units.of({megacredits: 1}));
+    expect(philaresPlayer.purse()).deep.eq(Units.of({megacredits: 1}));
   });
 
   it('one tile one bonus - player is greedy', () => {
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = action?.execute() as AndOptions;
     // Options are ordered 0-5, MC to heat.
-    expect(player.purse()).deep.eq(Units.EMPTY);
+    expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
     options.options[1].cb(1);
     expect(() => options.cb()).to.throw('Need to select 1 resource(s)');
   });
 
   it('Multiple bonuses when placing next to multiple tiles', () => {
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
     const options = action?.execute() as AndOptions;
     // Options are ordered 0-5, MC to heat.
-    expect(player.purse()).deep.eq(Units.EMPTY);
+    expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
     options.options[1].cb(1);
     options.cb();
-    expect(player.purse()).deep.eq(Units.of({megacredits: 1, steel: 1}));
+    expect(philaresPlayer.purse()).deep.eq(Units.of({megacredits: 1, steel: 1}));
   });
 
   it('Multiple bonuses when opponent places next to multiple of your tiles', () => {
-    game.addTile(player, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(player, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(0);
-    game.addTile(redPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     expect(game.deferredActions).has.length(1);
     const action = game.deferredActions.pop();
     const options = action?.execute() as AndOptions;
     // Options are ordered 0-5, MC to heat.
-    expect(player.purse()).deep.eq(Units.EMPTY);
+    expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
     options.options[1].cb(1);
     options.cb();
-    expect(player.purse()).deep.eq(Units.of({megacredits: 1, steel: 1}));
+    expect(philaresPlayer.purse()).deep.eq(Units.of({megacredits: 1, steel: 1}));
   });
 
   it('two tiles two bonuses - player is greedy', () => {
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
-    game.addTile(redPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
-    game.addTile(player, SpaceType.LAND, space, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace, {tileType: TileType.GREENERY});
+    game.addTile(otherPlayer, SpaceType.LAND, adjacentSpace2, {tileType: TileType.GREENERY});
+    game.addTile(philaresPlayer, SpaceType.LAND, space, {tileType: TileType.GREENERY});
     const action = game.deferredActions.pop();
     const options = action?.execute() as AndOptions;
     // Options are ordered 0-5, MC to heat.
-    expect(player.purse()).deep.eq(Units.EMPTY);
+    expect(philaresPlayer.purse()).deep.eq(Units.EMPTY);
     options.options[0].cb(1);
     options.options[1].cb(1);
     options.options[2].cb(1);
     expect(() => options.cb()).to.throw('Need to select 2 resource(s)');
+  });
+
+  it('Should take initial action', function() {
+    const action = card.initialAction(philaresPlayer);
+    expect(action).is.not.undefined;
+
+    action.cb(action.availableSpaces[0]);
+    expect(philaresPlayer.getTerraformRating()).to.eq(21);
+  });
+
+  it('Can place final greenery if gains enough plants from earlier players placing adjacent greeneries', function() {
+    game.addGreenery(philaresPlayer, space.id);
+
+    // Max out all global parameters
+    (game as any).temperature = MAX_TEMPERATURE;
+    (game as any).oxygenLevel = MAX_OXYGEN_LEVEL;
+    // TestingUtils.maxOutOceans(player);
+
+    // Setup plants for endgame
+    philaresPlayer.plants = 7;
+    otherPlayer.plants = 8;
+
+    // First player final greenery placement, done adjacent to one of Philares' tiles
+    game.gotoFinalGreeneryPlacement();
+    const firstPlayerGreeneryPlacement = otherPlayer.getWaitingFor() as OrOptions;
+
+    // Option 1 is 'Don't place a greenery'
+    // Don't place a greenery using the callback; add it directly via game.addGreenery() instead
+    // Workaround for test since the greenery placement option auto resolves deferred action
+    firstPlayerGreeneryPlacement.options[1].cb();
+    game.addGreenery(otherPlayer, adjacentSpace.id);
+    expect(game.deferredActions).has.lengthOf(1);
+
+    // Philares player gains plant and can subsequently place a greenery
+    philaresPlayer.takeActionForFinalGreenery();
+    const philaresPlayerResourceSelection = philaresPlayer.getWaitingFor() as AndOptions;
+    // Option 3 is plants.
+    philaresPlayerResourceSelection.options[3].cb(1);
+    philaresPlayerResourceSelection.cb();
+    expect(philaresPlayer.plants).to.eq(8);
+    (philaresPlayer as any).waitingFor = undefined;
+    (philaresPlayer as any).waitingForCb = undefined;
+    game.gotoFinalGreeneryPlacement();
+    const finalGreeneryPlacement = philaresPlayer.getWaitingFor() as OrOptions;
+    expect(game.phase).eq(Phase.RESEARCH);
+    finalGreeneryPlacement.options[1].cb();
+    expect(game.phase).eq(Phase.END);
   });
 });


### PR DESCRIPTION
Instead of relying on knowing that Philares is involved and shunting it into the existing code, this makes the assumption that if a player has a `waitingFor` they just aren't done. It also abandons precomputing whether a player may place greeneries during the phase start in favor of determining whether the player can place a greenery when it's that player's turn.

It's kind of unfortunate that this doesn't just use the existing code about active players and transitions, making it understandably difficult to parse and understand. I hope this code is easier to understand, made even easier by comments. Add more comments as need be. I will probably add more.