### PR TITLE
Only register with Polyfill when window does not contain HTMLDialogElement.

### DIFF
--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -151,7 +151,7 @@ export const mainAppSettings = {
   },
   'mounted': function() {
     document.title = constants.APP_NAME;
-    dialogPolyfill.default.registerDialog(document.getElementById('alert-dialog'));
+    if (!window.HTMLDialogElement) dialogPolyfill.default.registerDialog(document.getElementById('alert-dialog'));
     const currentPathname: string = window.location.pathname;
     const app = this as unknown as (typeof mainAppSettings.data) & (typeof mainAppSettings.methods);
     if (currentPathname === '/player' || currentPathname === '/the-end') {

--- a/src/components/common/ConfirmDialog.ts
+++ b/src/components/common/ConfirmDialog.ts
@@ -36,7 +36,7 @@ export const ConfirmDialog = Vue.component('confirm-dialog', {
     },
   },
   mounted: function() {
-    (dialogPolyfill.default || dialogPolyfill).registerDialog(this.$refs['dialog']);
+    if (!window.HTMLDialogElement) dialogPolyfill.default.registerDialog(this.$refs['dialog']);
   },
   template: `<dialog ref="dialog">
       <form method="dialog">


### PR DESCRIPTION
I verified this manually on Chrome, looks reasonable.

For the most part this removes clutter warnings from tests such as what is below. I got the conditional by reading the code for dialogPolyfill:

```
  dialogPolyfill.forceRegisterDialog = function(element) {
    if (window.HTMLDialogElement || element.showModal) {
      console.warn('This browser already supports <dialog>, the polyfill ' +
          'may not work correctly', element);
    }
   ...
  };
```