### PR TITLE
Improve components testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:server": "mocha --require build/tests/utils/setup.js --recursive build/tests --exclude 'build/tests/components/**'",
     "pretest:server": "tsc --build tests/tsconfig.json",
     "test:components": "vti diagnostics && mochapack --require tests/components/setup.ts tests/components/*.spec.ts",
+    "test:components:watch": "mochapack --watch --require tests/components/setup.ts tests/components/*.spec.ts",
     "watch": "webpack --watch --mode=development",
     "webpack": "webpack"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test": "npm run test:server && npm run test:components",
     "test:server": "mocha --require build/tests/utils/setup.js --recursive build/tests --exclude 'build/tests/components/**'",
     "pretest:server": "tsc --build tests/tsconfig.json",
-    "test:components": "vti diagnostics && npm run compile && mochapack --mode development --webpack-config webpack.config.js --require tests/components/setup.ts tests/components/*.spec.ts",
+    "test:components": "vti diagnostics && mochapack --require tests/components/setup.ts tests/components/*.spec.ts",
     "watch": "webpack --watch --mode=development",
     "webpack": "webpack"
   },


### PR DESCRIPTION
Removed: `--mode development`
There is no [option](https://sysgears.github.io/mochapack/docs/installation/cli-usage.html) `mode` in mochapack cli

Removed: `--webpack-config webpack.config.js`
webpack.config.js is set by default

Removed: `npm run compile`
Seems like this command is unnecessary here 🤔

Added watch mode to component testing. No more waiting 15s+ to check a test