### PR TITLE
Add Turmoil.ifTurmoil, Turmoil.ifTurmoilElse, Turmoil.getTurmoil.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -794,9 +794,9 @@ export class Game implements ISerializable<SerializedGame> {
       this.syndicatePirateRaider = undefined;
     }
 
-    if (this.gameOptions.turmoilExtension) {
-      this.turmoil?.endGeneration(this);
-    }
+    Turmoil.ifTurmoil(this, (turmoil) => {
+      turmoil.endGeneration(this);
+    });
 
     // Resolve Turmoil deferred actions
     if (this.deferredActions.length > 0) {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -74,6 +74,7 @@ import {LogHelper} from './LogHelper';
 import {UndoActionOption} from './inputs/UndoActionOption';
 import {LawSuit} from './cards/promo/LawSuit';
 import {CrashSiteCleanup} from './cards/promo/CrashSiteCleanup';
+import {Turmoil} from './turmoil/Turmoil';
 
 export type PlayerId = string;
 
@@ -548,9 +549,11 @@ export class Player implements ISerializable<SerializedPlayer> {
     // Turmoil Victory Points
     const includeTurmoilVP : boolean = this.game.gameIsOver() || this.game.phase === Phase.END;
 
-    if (includeTurmoilVP && this.game.gameOptions.turmoilExtension && this.game.turmoil) {
-      victoryPointsBreakdown.setVictoryPoints('victoryPoints', this.game.turmoil.getPlayerVictoryPoints(this), 'Turmoil Points');
-    }
+    Turmoil.ifTurmoil(this.game, (turmoil) => {
+      if (includeTurmoilVP) {
+        victoryPointsBreakdown.setVictoryPoints('victoryPoints', turmoil.getPlayerVictoryPoints(this), 'Turmoil Points');
+      }
+    });
 
     // Titania Colony VP
     if (this.colonyVictoryPoints > 0) {
@@ -1991,13 +1994,13 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
 
     // If you can pay to add a delegate to a party.
-    if (this.game.gameOptions.turmoilExtension && this.game.turmoil !== undefined) {
+    Turmoil.ifTurmoil(this.game, (turmoil) => {
       let sendDelegate;
-      if (this.game.turmoil?.lobby.has(this.id)) {
+      if (turmoil.lobby.has(this.id)) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (from lobby)');
-      } else if (this.isCorporation(CardName.INCITE) && this.canAfford(3) && this.game.turmoil.getDelegatesInReserve(this.id) > 0) {
+      } else if (this.isCorporation(CardName.INCITE) && this.canAfford(3) && turmoil.getDelegatesInReserve(this.id) > 0) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (3 M€)', {cost: 3});
-      } else if (this.canAfford(5) && this.game.turmoil.getDelegatesInReserve(this.id) > 0) {
+      } else if (this.canAfford(5) && turmoil.getDelegatesInReserve(this.id) > 0) {
         sendDelegate = new SendDelegateToArea(this, 'Send a delegate in an area (5 M€)', {cost: 5});
       }
       if (sendDelegate) {
@@ -2006,7 +2009,7 @@ export class Player implements ISerializable<SerializedPlayer> {
           action.options.push(input);
         }
       }
-    }
+    });
 
     if (this.game.getPlayers().length > 1 &&
       this.actionsTakenThisRound > 0 &&

--- a/src/cards/CardRequirement.ts
+++ b/src/cards/CardRequirement.ts
@@ -7,6 +7,7 @@ import {ResourceType} from '../ResourceType';
 import {TileType} from '../TileType';
 import {GlobalParameter} from '../GlobalParameter';
 import {MoonExpansion} from '../moon/MoonExpansion';
+import {Turmoil} from '../turmoil/Turmoil';
 
 const firstLetterUpperCase = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
 
@@ -91,7 +92,7 @@ export class CardRequirement {
   public satisfies(player: Player): boolean {
     switch (this.type) {
     case RequirementType.CHAIRMAN:
-      return player.game.turmoil?.chairman === player.id;
+      return Turmoil.getTurmoil(player.game).chairman === player.id;
 
     case RequirementType.CITIES:
       if (this._isAny) {
@@ -117,11 +118,9 @@ export class CardRequirement {
       return this.satisfiesInequality(greeneries);
 
     case RequirementType.PARTY_LEADERS:
-      if (player.game.turmoil !== undefined) {
-        const parties = player.game.turmoil.parties.filter((party) => party.partyLeader === player.id).length;
-        return this.satisfiesInequality(parties);
-      }
-      return false;
+      const turmoil = Turmoil.getTurmoil(player.game);
+      const parties = turmoil.parties.filter((party) => party.partyLeader === player.id).length;
+      return this.satisfiesInequality(parties);
 
     case RequirementType.OCEANS:
       return this.checkGlobalRequirement(player, GlobalParameter.OCEANS, this.amount, this.isMax);
@@ -257,9 +256,6 @@ export class PartyCardRequirement extends CardRequirement {
     return this.party.toLowerCase();
   }
   public satisfies(player: Player): boolean {
-    if (player.game.turmoil !== undefined) {
-      return player.game.turmoil.canPlay(player, this.party);
-    }
-    return false;
+    return Turmoil.getTurmoil(player.game).canPlay(player, this.party);
   }
 }

--- a/src/cards/community/ByElection.ts
+++ b/src/cards/community/ByElection.ts
@@ -3,7 +3,7 @@ import {Player} from '../../Player';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {IProjectCard} from '../IProjectCard';
 import {CardName} from '../../CardName';
-import {ALL_PARTIES} from '../../turmoil/Turmoil';
+import {ALL_PARTIES, Turmoil} from '../../turmoil/Turmoil';
 import {SelectOption} from '../../inputs/SelectOption';
 import {OrOptions} from '../../inputs/OrOptions';
 import {DeferredAction} from '../../deferredActions/DeferredAction';
@@ -27,14 +27,13 @@ export class ByElection extends PreludeCard implements IProjectCard {
       },
     });
   }
-  public canPlay(player: Player) {
-    return player.game.turmoil !== undefined;
+  public canPlay() {
+    return true;
   }
+
   public play(player: Player) {
-    const turmoil = player.game.turmoil;
-    if (turmoil === undefined) {
-      return;
-    }
+    const turmoil = Turmoil.getTurmoil(player.game);
+
     turmoil.addInfluenceBonus(player);
     const setRulingParty = new OrOptions();
 

--- a/src/cards/community/Incite.ts
+++ b/src/cards/community/Incite.ts
@@ -7,6 +7,7 @@ import {CardType} from '../CardType';
 import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../render/Size';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class Incite extends Card implements CorporationCard {
   constructor() {
@@ -38,17 +39,13 @@ export class Incite extends Card implements CorporationCard {
     });
   }
   public play(player: Player) {
-    if (player.game.turmoil) {
-      player.game.turmoil.addInfluenceBonus(player);
-    }
+    Turmoil.getTurmoil(player.game).addInfluenceBonus(player);
     return undefined;
   }
 
   public initialAction(player: Player) {
-    if (player.game.turmoil) {
-      const title = 'Incite first action - Select where to send two delegates';
-      player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
-    }
+    const title = 'Incite first action - Select where to send two delegates';
+    player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
 
     return undefined;
   }

--- a/src/cards/moon/LunaPoliticalInstitute.ts
+++ b/src/cards/moon/LunaPoliticalInstitute.ts
@@ -8,6 +8,7 @@ import {CardRequirements} from '../CardRequirements';
 import {IActionCard} from '../ICard';
 import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {Card} from '../Card';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class LunaPoliticalInstitute extends Card implements IActionCard, IProjectCard {
   constructor() {
@@ -35,7 +36,7 @@ export class LunaPoliticalInstitute extends Card implements IActionCard, IProjec
   }
 
   public canAct(player: Player) {
-    return player.game.turmoil?.hasAvailableDelegates(player.id) || false;
+    return Turmoil.getTurmoil(player.game).hasAvailableDelegates(player.id);
   }
 
   public action(player: Player) {

--- a/src/cards/moon/TempestConsultancy.ts
+++ b/src/cards/moon/TempestConsultancy.ts
@@ -38,10 +38,8 @@ export class TempestConsultancy extends Card implements CorporationCard {
   }
 
   public initialAction(player: Player) {
-    if (player.game.turmoil) {
-      const title = 'Tempest Consultancy first action - Select where to send two delegates';
-      player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
-    }
+    const title = 'Tempest Consultancy first action - Select where to send two delegates';
+    player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
 
     return undefined;
   }

--- a/src/cards/turmoil/BannedDelegate.ts
+++ b/src/cards/turmoil/BannedDelegate.ts
@@ -8,7 +8,7 @@ import {SelectDelegate} from '../../inputs/SelectDelegate';
 import {IParty} from '../../turmoil/parties/IParty';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
-import {NeutralPlayer} from '../../turmoil/Turmoil';
+import {NeutralPlayer, Turmoil} from '../../turmoil/Turmoil';
 
 export class BannedDelegate extends Card implements IProjectCard {
   constructor() {
@@ -29,48 +29,49 @@ export class BannedDelegate extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
+    const turmoil = Turmoil.getTurmoil(player.game);
     const orOptions: Array<SelectDelegate> = [];
-        // Take each party having more than just the party leader in the area
-        player.game.turmoil!.parties.forEach((party) => {
-          if (party.delegates.length > 1) {
-            // Remove the party leader from available choices
-            const delegates = party.delegates.slice();
-            delegates.splice(party.delegates.indexOf(party.partyLeader!), 1);
-            const playersId = Array.from(new Set<PlayerId | NeutralPlayer>(delegates));
-            const players: Array<Player | NeutralPlayer> = [];
-            playersId.forEach((playerId) => {
-              if (playerId === 'NEUTRAL') {
-                players.push('NEUTRAL');
-              } else {
-                players.push(player.game.getPlayerById(playerId));
-              }
-            });
-
-            if (players.length > 0) {
-              const selectDelegate = new SelectDelegate(players, 'Select player delegate to remove from ' + party.name + ' party', (selectedPlayer: Player | NeutralPlayer) => {
-                let playerToRemove = '';
-                if (selectedPlayer === 'NEUTRAL') {
-                  playerToRemove = 'NEUTRAL';
-                } else {
-                  playerToRemove = selectedPlayer.id;
-                }
-                player.game.turmoil!.removeDelegateFromParty(playerToRemove, party.name, player.game);
-                this.log(player, party, selectedPlayer);
-                return undefined;
-              });
-              selectDelegate.buttonLabel = 'Remove delegate';
-              orOptions.push(selectDelegate);
-            }
+    // Take each party having more than just the party leader in the area
+    turmoil.parties.forEach((party) => {
+      if (party.delegates.length > 1) {
+        // Remove the party leader from available choices
+        const delegates = party.delegates.slice();
+        delegates.splice(party.delegates.indexOf(party.partyLeader!), 1);
+        const playersId = Array.from(new Set<PlayerId | NeutralPlayer>(delegates));
+        const players: Array<Player | NeutralPlayer> = [];
+        playersId.forEach((playerId) => {
+          if (playerId === 'NEUTRAL') {
+            players.push('NEUTRAL');
+          } else {
+            players.push(player.game.getPlayerById(playerId));
           }
         });
-        if (orOptions.length === 0) {
-          return undefined;
-        } else if (orOptions.length === 1) {
-          return orOptions[0];
-        } else {
-          const options = new OrOptions(...orOptions);
-          return options;
+
+        if (players.length > 0) {
+          const selectDelegate = new SelectDelegate(players, 'Select player delegate to remove from ' + party.name + ' party', (selectedPlayer: Player | NeutralPlayer) => {
+            let playerToRemove = '';
+            if (selectedPlayer === 'NEUTRAL') {
+              playerToRemove = 'NEUTRAL';
+            } else {
+              playerToRemove = selectedPlayer.id;
+            }
+            turmoil.removeDelegateFromParty(playerToRemove, party.name, player.game);
+            this.log(player, party, selectedPlayer);
+            return undefined;
+          });
+          selectDelegate.buttonLabel = 'Remove delegate';
+          orOptions.push(selectDelegate);
         }
+      }
+    });
+    if (orOptions.length === 0) {
+      return undefined;
+    } else if (orOptions.length === 1) {
+      return orOptions[0];
+    } else {
+      const options = new OrOptions(...orOptions);
+      return options;
+    }
   }
 
   private log(player: Player, party: IParty, selectedPlayer: Player | NeutralPlayer) {

--- a/src/cards/turmoil/CulturalMetropolis.ts
+++ b/src/cards/turmoil/CulturalMetropolis.ts
@@ -11,6 +11,7 @@ import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class CulturalMetropolis extends Card implements IProjectCard {
   constructor() {
@@ -36,7 +37,7 @@ export class CulturalMetropolis extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    if ( ! super.canPlay(player)) {
+    if (!super.canPlay(player)) {
       return false;
     }
 
@@ -45,14 +46,10 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     }
 
     // This card requires player has 2 delegates available
-    const turmoil = player.game.turmoil;
-    if (turmoil !== undefined) {
-      const hasEnoughDelegates = turmoil.getDelegatesInReserve(player.id) > 1 ||
-        (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id));
-      return hasEnoughDelegates;
-    }
-
-    return false;
+    const turmoil = Turmoil.getTurmoil(player.game);
+    const hasEnoughDelegates = turmoil.getDelegatesInReserve(player.id) > 1 ||
+      (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id));
+    return hasEnoughDelegates;
   }
 
   public play(player: Player) {
@@ -61,9 +58,10 @@ export class CulturalMetropolis extends Card implements IProjectCard {
     player.game.defer(new PlaceCityTile(player));
     const title = 'Select where to send two delegates';
 
-    if (player.game.turmoil!.getDelegatesInReserve(player.id) > 1) {
+    const turmoil = Turmoil.getTurmoil(player.game);
+    if (turmoil.getDelegatesInReserve(player.id) > 1) {
       player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'reserve'}));
-    } else if (player.game.turmoil!.getDelegatesInReserve(player.id) === 1 && player.game.turmoil!.lobby.has(player.id)) {
+    } else if (turmoil.getDelegatesInReserve(player.id) === 1 && turmoil.lobby.has(player.id)) {
       player.game.defer(new SendDelegateToArea(player, title, {count: 2, source: 'lobby'}));
     }
     return undefined;

--- a/src/cards/turmoil/EventAnalysts.ts
+++ b/src/cards/turmoil/EventAnalysts.ts
@@ -7,6 +7,7 @@ import {Player} from '../../Player';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRequirements} from '../CardRequirements';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class EventAnalysts extends Card implements IProjectCard {
   constructor() {
@@ -28,9 +29,7 @@ export class EventAnalysts extends Card implements IProjectCard {
   }
 
   public play(player: Player) {
-    if (player.game.turmoil) {
-      player.game.turmoil.addInfluenceBonus(player);
-    }
+    Turmoil.getTurmoil(player.game).addInfluenceBonus(player);
     return undefined;
   }
 }

--- a/src/cards/turmoil/MartianMediaCenter.ts
+++ b/src/cards/turmoil/MartianMediaCenter.ts
@@ -11,6 +11,7 @@ import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class MartianMediaCenter extends Card implements IProjectCard {
   constructor() {
@@ -43,7 +44,7 @@ export class MartianMediaCenter extends Card implements IProjectCard {
   }
 
   public canAct(player: Player): boolean {
-    return player.canAfford(3) && player.game.turmoil!.hasAvailableDelegates(player.id);
+    return player.canAfford(3) && Turmoil.getTurmoil(player.game).hasAvailableDelegates(player.id);
   }
 
   public action(player: Player) {

--- a/src/cards/turmoil/Recruitment.ts
+++ b/src/cards/turmoil/Recruitment.ts
@@ -5,6 +5,7 @@ import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {SendDelegateToArea} from '../../deferredActions/SendDelegateToArea';
 import {CardRenderer} from '../render/CardRenderer';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class Recruitment extends Card implements IProjectCard {
   constructor() {
@@ -24,11 +25,12 @@ export class Recruitment extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    if (player.game.turmoil === undefined || player.game.turmoil.hasAvailableDelegates(player.id) === false) {
+    const turmoil = Turmoil.getTurmoil(player.game);
+    if (turmoil.hasAvailableDelegates(player.id) === false) {
       return false;
     }
 
-    return player.game.turmoil.parties.some((party) => {
+    return turmoil.parties.some((party) => {
       const neutralDelegates = party.getDelegates('NEUTRAL');
       return neutralDelegates > 1 || (neutralDelegates === 1 && party.partyLeader !== 'NEUTRAL');
     });

--- a/src/cards/turmoil/SeptumTribus.ts
+++ b/src/cards/turmoil/SeptumTribus.ts
@@ -7,6 +7,7 @@ import {CardName} from '../../CardName';
 import {CardType} from '../CardType';
 import {CardRenderer} from '../render/CardRenderer';
 import {Resources} from '../../Resources';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class SeptumTribus extends Card implements IActionCard, CorporationCard {
   constructor() {
@@ -36,15 +37,14 @@ export class SeptumTribus extends Card implements IActionCard, CorporationCard {
     return undefined;
   }
 
-  public canAct(player: Player): boolean {
-    return player.game.gameOptions.turmoilExtension;
+  public canAct(): boolean {
+    return true;
   }
 
   public action(player: Player) {
-    if (player.game.turmoil !== undefined) {
-      const partiesWithPresence = player.game.turmoil.parties.filter((party) => party.delegates.includes(player.id));
-      player.addResource(Resources.MEGACREDITS, partiesWithPresence.length * 2, {log: true});
-    }
+    const turmoil = Turmoil.getTurmoil(player.game);
+    const partiesWithPresence = turmoil.parties.filter((party) => party.delegates.includes(player.id));
+    player.addResource(Resources.MEGACREDITS, partiesWithPresence.length * 2, {log: true});
 
     return undefined;
   }

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -8,6 +8,7 @@ import {REDS_RULING_POLICY_COST} from '../../constants';
 import {Card} from '../Card';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
+import {Turmoil} from '../../turmoil/Turmoil';
 
 export class VoteOfNoConfidence extends Card implements IProjectCard {
   constructor() {
@@ -34,31 +35,28 @@ export class VoteOfNoConfidence extends Card implements IProjectCard {
     if (!super.canPlay(player)) {
       return false;
     }
-    if (player.game.turmoil !== undefined) {
-      if (!player.game.turmoil.hasAvailableDelegates(player.id)) return false;
+    const turmoil = Turmoil.getTurmoil(player.game);
+    if (!turmoil.hasAvailableDelegates(player.id)) return false;
 
-      const chairmanIsNeutral = player.game.turmoil.chairman === 'NEUTRAL';
-      if (chairmanIsNeutral === false) {
-        return false;
-      }
-
-      if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
-        return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
-      }
-      return true;
+    const chairmanIsNeutral = turmoil.chairman === 'NEUTRAL';
+    if (chairmanIsNeutral === false) {
+      return false;
     }
-    return false;
+
+    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
+    }
+    return true;
   }
 
   public play(player: Player) {
-    if (player.game.turmoil !== undefined) {
-            player.game.turmoil.chairman! = player.id;
-            const index = player.game.turmoil.delegateReserve.indexOf(player.id);
-            if (index > -1) {
-              player.game.turmoil.delegateReserve.splice(index, 1);
-            }
-            player.increaseTerraformRating();
+    const turmoil = Turmoil.getTurmoil(player.game);
+    turmoil.chairman = player.id;
+    const index = turmoil.delegateReserve.indexOf(player.id);
+    if (index > -1) {
+      turmoil.delegateReserve.splice(index, 1);
     }
+    player.increaseTerraformRating();
     return undefined;
   }
 }

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -35,17 +35,14 @@ export class WildlifeDome extends Card implements IProjectCard {
     if (!super.canPlay(player)) {
       return false;
     }
-    if (player.game.turmoil !== undefined) {
-      const canPlaceTile = player.game.board.getAvailableSpacesForGreenery(player).length > 0;
-      const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
+    const canPlaceTile = player.game.board.getAvailableSpacesForGreenery(player).length > 0;
+    const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-      if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
-        return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true, microbes: true}) && canPlaceTile;
-      }
-
-      return canPlaceTile;
+    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+      return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true, microbes: true}) && canPlaceTile;
     }
-    return false;
+
+    return canPlaceTile;
   }
 
   public play(player: Player) {

--- a/src/colonies/Colony.ts
+++ b/src/colonies/Colony.ts
@@ -23,6 +23,7 @@ import {StealResources} from '../deferredActions/StealResources';
 import {Tags} from '../cards/Tags';
 import {SendDelegateToArea} from '../deferredActions/SendDelegateToArea';
 import {Game} from '../Game';
+import {Turmoil} from '../turmoil/Turmoil';
 
 export enum ShouldIncreaseTrack { YES, NO, ASK }
 
@@ -219,16 +220,16 @@ export abstract class Colony implements SerializedColony {
         break;
 
       case ColonyBenefit.GAIN_INFLUENCE:
-        if (game.turmoil !== undefined) {
-          game.turmoil.addInfluenceBonus(player);
+        Turmoil.ifTurmoil(game, (turmoil) => {
+          turmoil.addInfluenceBonus(player);
           game.log('${0} gained 1 influence', (b) => b.player(player));
-        }
+        });
         break;
 
       case ColonyBenefit.PLACE_DELEGATES:
-        if (game.turmoil !== undefined) {
-          const playerHasLobbyDelegate = game.turmoil.lobby.has(player.id);
-          let availablePlayerDelegates = game.turmoil.getDelegatesInReserve(player.id);
+        Turmoil.ifTurmoil(game, (turmoil) => {
+          const playerHasLobbyDelegate = turmoil.lobby.has(player.id);
+          let availablePlayerDelegates = turmoil.getDelegatesInReserve(player.id);
           if (playerHasLobbyDelegate) availablePlayerDelegates += 1;
 
           const qty = Math.min(quantity, availablePlayerDelegates);
@@ -237,17 +238,17 @@ export abstract class Colony implements SerializedColony {
             const fromLobby = (i === qty - 1 && qty === availablePlayerDelegates && playerHasLobbyDelegate);
             game.defer(new SendDelegateToArea(player, 'Select where to send delegate', {source: fromLobby ? 'lobby' : 'reserve'}));
           }
-        }
+        });
         break;
 
       case ColonyBenefit.GIVE_MC_PER_DELEGATE:
-        if (game.turmoil !== undefined) {
-          let partyDelegateCount = PLAYER_DELEGATES_COUNT - game.turmoil.getDelegatesInReserve(player.id);
-          if (game.turmoil.lobby.has(player.id)) partyDelegateCount--;
-          if (game.turmoil.chairman === player.id) partyDelegateCount--;
+        Turmoil.ifTurmoil(game, (turmoil) => {
+          let partyDelegateCount = PLAYER_DELEGATES_COUNT - turmoil.getDelegatesInReserve(player.id);
+          if (turmoil.lobby.has(player.id)) partyDelegateCount--;
+          if (turmoil.chairman === player.id) partyDelegateCount--;
 
           player.addResource(Resources.MEGACREDITS, partyDelegateCount, {log: true});
-        }
+        });
         break;
 
       case ColonyBenefit.GAIN_TR:

--- a/src/deferredActions/SendDelegateToArea.ts
+++ b/src/deferredActions/SendDelegateToArea.ts
@@ -2,7 +2,7 @@ import {Player, PlayerId} from '../Player';
 import {SelectPartyToSendDelegate} from '../inputs/SelectPartyToSendDelegate';
 import {DeferredAction, Priority} from './DeferredAction';
 import {SelectHowToPayDeferred} from './SelectHowToPayDeferred';
-import {NeutralPlayer} from '../turmoil/Turmoil';
+import {NeutralPlayer, Turmoil} from '../turmoil/Turmoil';
 import {PartyName} from '../turmoil/parties/PartyName';
 
 export class SendDelegateToArea implements DeferredAction {
@@ -14,10 +14,7 @@ export class SendDelegateToArea implements DeferredAction {
   ) {}
 
   public execute() {
-    const turmoil = this.player.game.turmoil;
-    if (turmoil === undefined) {
-      throw new Error(`Turmoil not defined in game ${this.player.game.id}`);
-    }
+    const turmoil = Turmoil.getTurmoil(this.player.game);
 
     // All parties are eligible, unless this action is used to replace a delegate.
     let parties = turmoil.parties;

--- a/src/milestones/Terraformer.ts
+++ b/src/milestones/Terraformer.ts
@@ -1,5 +1,6 @@
 import {IMilestone} from './IMilestone';
 import {Player} from '../Player';
+import {Turmoil} from '../turmoil/Turmoil';
 
 export class Terraformer implements IMilestone {
     public name: string = 'Terraformer';
@@ -15,9 +16,8 @@ export class Terraformer implements IMilestone {
       return player.getTerraformRating();
     }
     public canClaim(player: Player): boolean {
-      if (player.game.gameOptions.turmoilExtension) {
-        return this.getScore(player) >= this.terraformRatingTurmoil;
-      }
-      return this.getScore(player) >= this.terraformRating;
+      const target = Turmoil.ifTurmoilElse(player.game, () => this.terraformRatingTurmoil, () => this.terraformRating);
+      const score = this.getScore(player);
+      return score >= target;
     }
 }

--- a/src/models/ServerModel.ts
+++ b/src/models/ServerModel.ts
@@ -30,7 +30,7 @@ import {
 } from './ClaimedMilestoneModel';
 import {FundedAwardModel, IAwardScore} from './FundedAwardModel';
 import {
-  getTurmoil,
+  getTurmoilModel,
 } from './TurmoilModel';
 import {SelectDelegate} from '../inputs/SelectDelegate';
 import {SelectColony} from '../inputs/SelectColony';
@@ -41,6 +41,7 @@ import {MoonModel} from './MoonModel';
 import {Units} from '../Units';
 import {SelectPartyToSendDelegate} from '../inputs/SelectPartyToSendDelegate';
 import {GameModel} from './GameModel';
+import {Turmoil} from '../turmoil/Turmoil';
 
 export class Server {
   public static getGameModel(game: Game): SimpleGameModel {
@@ -59,7 +60,7 @@ export class Server {
   }
 
   public static getCommonGameModel(game: Game): GameModel {
-    const turmoil = getTurmoil(game);
+    const turmoil = getTurmoilModel(game);
 
     return {
       aresData: game.aresData,
@@ -89,7 +90,6 @@ export class Server {
 
   public static getPlayerModel(player: Player): PlayerModel {
     const game = player.game;
-    const turmoil = getTurmoil(game);
 
     return {
       actionsTakenThisRound: player.actionsTakenThisRound,
@@ -113,7 +113,7 @@ export class Server {
       heat: player.heat,
       heatProduction: player.getProduction(Resources.HEAT),
       id: player.id,
-      influence: turmoil ? game.turmoil!.getPlayerInfluence(player) : 0,
+      influence: Turmoil.ifTurmoilElse(game, (turmoil) => turmoil.getPlayerInfluence(player), () => 0),
       isActive: player.id === game.activePlayer,
       megaCredits: player.megaCredits,
       megaCreditProduction: player.getProduction(Resources.MEGACREDITS),
@@ -343,7 +343,7 @@ export class Server {
     case PlayerInputTypes.SELECT_PARTY_TO_SEND_DELEGATE:
       playerInputModel.availableParties = (waitingFor as SelectPartyToSendDelegate).availableParties;
       if (player.game !== undefined) {
-        playerInputModel.turmoil = getTurmoil(player.game);
+        playerInputModel.turmoil = getTurmoilModel(player.game);
       }
       break;
     case PlayerInputTypes.SELECT_PRODUCTION_TO_LOSE:
@@ -391,8 +391,6 @@ export class Server {
     }));
   }
   public static getPlayers(players: Array<Player>, game: Game): Array<PlayerModel> {
-    const turmoil = getTurmoil(game);
-
     const gameModel = this.getCommonGameModel(game);
 
     return players.map((player) => {
@@ -412,7 +410,7 @@ export class Server {
         heat: player.heat,
         heatProduction: player.getProduction(Resources.HEAT),
         id: game.phase === Phase.END ? player.id : player.color,
-        influence: turmoil ? game.turmoil!.getPlayerInfluence(player) : 0,
+        influence: Turmoil.ifTurmoilElse(game, (turmoil) => turmoil.getPlayerInfluence(player), () => 0),
         isActive: player.id === game.activePlayer,
         megaCredits: player.megaCredits,
         megaCreditProduction: player.getProduction(Resources.MEGACREDITS),

--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -97,6 +97,34 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
       return turmoil;
     }
 
+    public static getTurmoil(game: Game): Turmoil {
+      if (game.turmoil === undefined) {
+        throw new Error(`Assertion error: Turmoil not defined for ${game.id}`);
+      }
+      return game.turmoil;
+    }
+
+    public static ifTurmoil(game: Game, cb: (turmoil: Turmoil) => void) {
+      if (game.gameOptions.turmoilExtension !== false) {
+        if (game.turmoil === undefined) {
+          console.log(`Assertion failure: game.turmoil is undefined for ${game.id}`);
+        } else {
+          return cb(game.turmoil);
+        }
+      }
+    }
+
+    public static ifTurmoilElse<T>(game: Game, cb: (turmoil: Turmoil) => T, elseCb: () => T): T {
+      if (game.gameOptions.turmoilExtension !== false) {
+        if (game.turmoil === undefined) {
+          console.log(`Assertion failure: game.turmoil is undefined for ${game.id}`);
+        } else {
+          return cb(game.turmoil);
+        }
+      }
+      return elseCb();
+    }
+
     public initGlobalEvent(game: Game) {
       // Draw the first global event to setup the game
       this.comingGlobalEvent = this.globalEventDealer.draw();

--- a/src/turmoil/parties/PartyHooks.ts
+++ b/src/turmoil/parties/PartyHooks.ts
@@ -9,6 +9,7 @@ import {ISpace} from '../../boards/ISpace';
 import {GREENS_POLICY_1} from './Greens';
 import {TurmoilPolicy} from '../TurmoilPolicy';
 import {PoliticalAgendas} from '../PoliticalAgendas';
+import {Turmoil} from '../Turmoil';
 
 export class PartyHooks {
   static applyMarsFirstRulingPolicy(player: Player, spaceType: SpaceType) {
@@ -28,25 +29,22 @@ export class PartyHooks {
   // Return true when the supplied policy is active. When `policyId` is inactive, it selects
   // the default policy for `partyName`.
   static shouldApplyPolicy(game: Game, partyName: PartyName, policyId?: PolicyId): boolean {
-    if (!game.gameOptions.turmoilExtension) return false;
+    return Turmoil.ifTurmoilElse(game, (turmoil) => {
+      if (game.phase !== Phase.ACTION) return false;
 
-    if (game.phase !== Phase.ACTION) return false;
+      const rulingParty = turmoil.rulingParty;
+      if (rulingParty === undefined) return false;
 
-    const turmoil = game.turmoil!;
-    if (!turmoil) return false;
+      // Set the default policy if not given
+      if (policyId === undefined) {
+        policyId = rulingParty.policies[0].id;
+      }
 
-    const rulingParty = turmoil.rulingParty;
-    if (rulingParty === undefined) return false;
+      const currentPolicyId: PolicyId = (turmoil.politicalAgendasData === undefined) ?
+        rulingParty.policies[0].id :
+        PoliticalAgendas.currentAgenda(turmoil).policyId;
 
-    // Set the default policy if not given
-    if (policyId === undefined) {
-      policyId = rulingParty.policies[0].id;
-    }
-
-    const currentPolicyId: PolicyId = (turmoil.politicalAgendasData === undefined) ?
-      rulingParty.policies[0].id :
-      PoliticalAgendas.currentAgenda(turmoil).policyId;
-
-    return rulingParty.name === partyName && currentPolicyId === policyId;
+      return rulingParty.name === partyName && currentPolicyId === policyId;
+    }, () => false);
   }
 }

--- a/tests/cards/turmoil/SeptumTribus.spec.ts
+++ b/tests/cards/turmoil/SeptumTribus.spec.ts
@@ -34,16 +34,4 @@ describe('SeptumTribus', function() {
       expect(player.megaCredits).to.eq(6);
     }
   });
-
-  it('Cannot act without Turmoil expansion', function() {
-    const card = new SeptumTribus();
-    const player = TestPlayers.BLUE.newPlayer();
-
-    const gameOptions = TestingUtils.setCustomGameOptions({turmoilExtension: false});
-    Game.newInstance('foobar', [player], player, gameOptions);
-    card.play();
-
-    player.corporationCard = card;
-    expect(card.canAct(player)).is.not.true;
-  });
 });


### PR DESCRIPTION
While there are places where this change is slightly more complicated, it eliminates the need for if(there's a turmoil object) guards, and more important the (I know there's turmoil, so `game.turmoil!`) cases. Those will still fail with an error, but the error will report which game was the problem.

In a couple of places, it looks like a huge change, and it's just whitespace. I tried to avoid those but the linter insisted. Use the github code review feature that ignores whitespace - I'm sure you know how to do that.

There are some places where it seems I removed guards. For example `Septum Tribus`, which had a `canPlay` test. But Septum Tribus is a Turmoil card. `game.turmoil` WILL be there. In fact, the card won't even be in the deck without it. That kind of made the test useless, which is why you'll see I deleted it.

Speaking of cards in the deck, that means I also removed cards from other manifests that had the Turmoil compatibility attribute. So, I think all-in-all this is a safe change.

But if you think this requires some extra tests, let me know.