### PR TITLE
Change Hydrogen To Venus name-based filter to tag-based

### DIFF
--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -41,9 +41,7 @@ export class HydrogenToVenus extends Card {
 
   public play(player: Player) {
     const jovianTags: number = player.getTagCount(Tags.JOVIAN);
-    const floatersCards = player.getResourceCards(ResourceType.FLOATER).filter((card) => {
-      return card.tags.filter((cardTag) => cardTag === Tags.VENUS).length > 0
-    });
+    const floatersCards = player.getResourceCards(ResourceType.FLOATER).filter((card) => card.tags.includes(Tags.VENUS));
     if (jovianTags > 0) {
       if (floatersCards.length === 1) {
         player.addResourceTo(floatersCards[0], {qty: jovianTags, log: true});

--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -30,19 +30,6 @@ export class HydrogenToVenus extends Card {
     });
   };
 
-  private static readonly venusCardsWithFloaters: Set<CardName> = new Set<CardName>([
-    CardName.AERIAL_MAPPERS,
-    CardName.CELESTIC,
-    CardName.DEUTERIUM_EXPORT,
-    CardName.DIRIGIBLES,
-    CardName.EXTRACTOR_BALLOONS,
-    CardName.FLOATING_HABS,
-    CardName.FORCED_PRECIPITATION,
-    CardName.JET_STREAM_MICROSCRAPPERS,
-    CardName.LOCAL_SHADING,
-    CardName.STRATOPOLIS,
-  ]);
-
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
@@ -55,7 +42,7 @@ export class HydrogenToVenus extends Card {
   public play(player: Player) {
     const jovianTags: number = player.getTagCount(Tags.JOVIAN);
     const floatersCards = player.getResourceCards(ResourceType.FLOATER).filter((card) => {
-      return HydrogenToVenus.venusCardsWithFloaters.has(card.name);
+      return card.tags.filter((cardTag) => cardTag === Tags.VENUS).length > 0
     });
     if (jovianTags > 0) {
       if (floatersCards.length === 1) {


### PR DESCRIPTION
Related to issue #3414

The name-based filter from `HydrogenToVenus.venusCardsWithFloaters` was unable to perform a text-compare on `CardName.CELESTIC` vs. `CardName.CELESTIC_REBALANCED`

Replaced with a check to see if the card contained any tags (copied from `Player.getTagCount()` https://github.com/bafolts/terraforming-mars/blob/26eecb167bed1595405193c555ea48fe6e04a01a/src/Player.ts#L770