### PR TITLE
ignore HEAD requests

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,10 @@ const handlers: Map<string, IHandler> = new Map(
 );
 
 function processRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+  if (req.method === 'HEAD') {
+    res.end();
+    return;
+  }
   if (req.url === undefined) {
     route.notFound(req, res);
     return;


### PR DESCRIPTION
Something has started to request HEAD requests every few minutes to terraforming-mars.herokuapp.com. This change ignores the request. Without ignoring these requests they time out as we don't support HEAD requests. Test this with curl locally.