### PR TITLE
Nerf Luna Ecumenopolis.

### DIFF
--- a/src/cards/moon/LunaEcumenopolis.ts
+++ b/src/cards/moon/LunaEcumenopolis.ts
@@ -23,12 +23,12 @@ export class LunaEcumenopolis extends MoonCard {
       metadata: {
         description: 'Spend 2 Titanium. ' +
         'Place 2 colony tiles adjacent to at least 2 other colony tiles and raise Colony rate 2 steps. ' +
-        'Increase your TR 1 step for each step of the colony rate.',
+        'Increase your TR 1 step for each 2 steps of the colony rate.',
         cardNumber: 'M84',
         renderData: CardRenderer.builder((b) => {
           b.minus().titanium(2).nbsp;
           b.text('2').moonColony().secondaryTag(AltSecondaryTag.MOON_COLONY_RATE).asterix().br;
-          b.tr(1).slash().moonColonyRate();
+          b.tr(1).slash().moonColonyRate().moonColonyRate();
         }),
       },
     }, {
@@ -42,7 +42,7 @@ export class LunaEcumenopolis extends MoonCard {
     player.game.defer(new CustomPlaceMoonTile(player));
     player.game.defer(new DeferredAction(player, () => {
       const colonyRate = MoonExpansion.moonData(player.game).colonyRate;
-      player.increaseTerraformRatingSteps(colonyRate);
+      player.increaseTerraformRatingSteps(Math.floor(colonyRate / 2));
       return undefined;
     }));
     return undefined;

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -45,7 +45,7 @@ describe('LunaEcumenopolis', () => {
     expect(game.deferredActions.pop()!.execute()).is.undefined;
     expect(player.getTerraformRating()).eq(14);
     game.deferredActions.runAll(() => {});
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.getTerraformRating()).eq(15);
   });
 
   // The part of the moon map being used for this test
@@ -82,7 +82,7 @@ describe('LunaEcumenopolis', () => {
     input1.cb(moon.getSpace('m13'));
     expect(moonData.colonyRate).eq(4);
     game.deferredActions.runAll(() => {});
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.getTerraformRating()).eq(18);
   });
 });
 


### PR DESCRIPTION
According to the designer:

> That card is based on "Terraforming Ganymede" card of the original game. Ganymede card grants 1 TR per Jovian tag plus 2VPs at the end of the game.  Yes both cards have a high potential but they can be played at the very end of the game. Plus Luna Ecu has a requirement to place your colonies to adjacent colonies, and due to placements and/or cards played just to increase colony rate without placing colonies on Moon, you may not find the chance to play it at all.

However,
> For Terraforming Ganymade you has to put effort in building up your jovian tag yourself, but with Luna Ecu you don't need to invest in the colony rating at all and you will get this great award anyway. The only difference is the requirement that you have to place the colony tiles, which is not a problem at all on the bigger moon map. So this is not a restrictions.