### PR TITLE
Prototype: report when log message placeholders don't match data parameters.

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -66,6 +66,7 @@ import {Random} from './Random';
 import {MilestoneAwardSelector} from './MilestoneAwardSelector';
 import {BoardType} from './boards/BoardType';
 import {Multiset} from './utils/Multiset';
+import {Log} from './Log';
 
 export type GameId = string;
 export type SpectatorId = string;
@@ -1477,7 +1478,19 @@ export class Game implements ISerializable<SerializedGame> {
     if (f) {
       f(builder);
     }
+
+    const intest = typeof (global as any).it === 'function';
     const logMessage = builder.build();
+    if (intest) {
+      const idxs = new Set<number>();
+      Log.applyData(logMessage, (_, idx) => {
+        idxs.add(idx);
+        return '';
+      });
+      if (idxs.size !== logMessage.data.length) {
+        throw new Error('Log parameter mismatch: ' + logMessage.message);
+      }
+    }
     logMessage.playerId = options?.reservedFor?.id;
     this.gameLog.push(logMessage);
     this.gameAge++;

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -1,0 +1,10 @@
+import {LogMessageData} from './LogMessageData';
+import {Message} from './Message';
+
+export class Log {
+  public static applyData(message: Message, cb: (datum: LogMessageData, idx: number) => string): string {
+    return message.message.replace(/\$\{(\d{1,2})\}/gi, (_match, idx) => {
+      return cb(message.data[idx], idx);
+    });
+  }
+}

--- a/src/LogHelper.ts
+++ b/src/LogHelper.ts
@@ -62,15 +62,17 @@ export class LogHelper {
 
   static logDiscardedCards(game: Game, cards: Array<ICard> | Array<CardName>) {
     game.log('${0} card(s) were discarded', (b) => {
-      b.rawString(cards.length.toString());
-      for (const card of cards) {
-        if (typeof card === 'string') {
-          b.cardName(card);
-        } else {
-          b.card(card);
-        }
-      }
+      b.number(cards.length);
     });
+    //   b.rawString(cards.length.toString());
+    //   for (const card of cards) {
+    //     if (typeof card === 'string') {
+    //       b.cardName(card);
+    //     } else {
+    //       b.card(card);
+    //     }
+    //   }
+    // });
   }
 
   static logDrawnCards(player: Player, cards: Array<ICard> | Array<CardName>, privateMessage: boolean = false) {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,4 +1,3 @@
-
 import {LogMessageData} from './LogMessageData';
 
 export interface Message {

--- a/src/components/LogPanel.vue
+++ b/src/components/LogPanel.vue
@@ -56,6 +56,7 @@ import {getGlobalEventByName} from '../turmoil/globalEvents/GlobalEventDealer';
 import {GlobalEventModel} from '../models/TurmoilModel';
 import {PartyName} from '../turmoil/parties/PartyName';
 import Button from './common/Button.vue';
+import {Log} from '../Log';
 
 let logRequest: XMLHttpRequest | undefined;
 
@@ -216,9 +217,7 @@ export default Vue.extend({
         }
         if (message.type !== undefined && message.message !== undefined) {
           message.message = $t(message.message);
-          return logEntryBullet + message.message.replace(/\$\{(\d{1,2})\}/gi, (_match, idx) => {
-            return this.messageDataToHTML(message.data[idx]);
-          });
+          return logEntryBullet + Log.applyData(message, this.messageDataToHTML);
         }
       } catch (err) {
         return this.safeMessage(message);

--- a/src/directives/i18n.ts
+++ b/src/directives/i18n.ts
@@ -1,16 +1,17 @@
-
 import {LogMessageDataType} from '../LogMessageDataType';
 import {Message} from '../Message';
 import {PreferencesManager} from '../components/PreferencesManager';
 import * as raw_translations from '../genfiles/translations.json';
 import {LogMessageData} from '../LogMessageData';
+import {Log} from '../Log';
 
 const TM_translations: {[x: string]: {[x: string]: string}} = raw_translations;
 
 export function translateMessage(message: Message): string {
-  return translateText(message.message).replace(/\$\{(\d{1,2})\}/gi, (_match, idx) => {
-    if (message.data[idx] !== undefined && message.data[idx].type === LogMessageDataType.RAW_STRING) {
-      return message.data[idx].value;
+  message.message = translateText(message.message);
+  return Log.applyData(message, (datum) => {
+    if (datum !== undefined && datum.type === LogMessageDataType.RAW_STRING) {
+      return datum.value;
     }
     return '';
   });

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -11,6 +11,7 @@ import {IParty} from '../src/turmoil/parties/IParty';
 import {Turmoil} from '../src/turmoil/Turmoil';
 import {TurmoilPolicy} from '../src/turmoil/TurmoilPolicy';
 import {LogMessage} from '../src/LogMessage';
+import {Log} from '../src/Log';
 
 export class TestingUtils {
   // Returns the oceans created during this operation which may not reflect all oceans.
@@ -109,8 +110,6 @@ export class TestingUtils {
 
   // Provides a readable version of a log message for easier testing.
   public static formatLogMessage(message: LogMessage): string {
-    return message.message.replace(/\$\{(\d{1,2})\}/gi, (_match, idx) => {
-      return message.data[idx].value;
-    });
+    return Log.applyData(message, (datum) => datum.value);
   }
 }


### PR DESCRIPTION
I found a case where log message parameters don't match their data, and thought: surely I can write a test for this. And so you see what I've done so far. A prototype that's right in the path for logging messages. I don't mind it _terribly_ but I'd rather do something that allows us to replace Game.log in tests, or something. Thoughts?

(PS that bit of extra logging should be removed; it leaks data players shouldn't see.)