### PR TITLE
Provide slightly better information during startup logging

### DIFF
--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -11,10 +11,13 @@ export class Database {
     public static getInstance() {
       if (!Database.instance) {
         if (process.env.POSTGRES_HOST !== undefined) {
+          console.log('Connecting to Postgres database.');
           Database.instance = new PostgreSQL();
         } else if (process.env.LOCAL_FS_DB !== undefined) {
+          console.log('Connecting to local filesystem database.');
           Database.instance = new Localfilesystem();
         } else {
+          console.log('Connecting to SQLite database.');
           Database.instance = new SQLite();
         }
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,10 +139,11 @@ console.log('version 0.X');
 
 server.listen(process.env.PORT || 8080);
 
+console.log();
 console.log(
-  '\nThe secret serverId for this server is \x1b[1m' +
+  'The secret serverId for this server is \x1b[1m' +
   serverId +
-  '\x1b[0m. Use it to access the following administrative routes:\n',
+  '\x1b[0m. Use it to access the following administrative routes:',
 );
 console.log(
   '* Overview of existing games: /games-overview?serverId=' + serverId,


### PR DESCRIPTION
Before
```
[2021-07-17 11:41:05 EDT] Starting server on port 8080
[2021-07-17 11:41:05 EDT] version 0.X
[2021-07-17 11:41:05 EDT] 
The secret serverId for this server is a20008759bcd. Use it to access the following administrative routes:

[2021-07-17 11:41:05 EDT] * Overview of existing games: /games-overview?serverId=a20008759bcd
[2021-07-17 11:41:05 EDT] * API for game IDs: /api/games?serverId=a20008759bcd
```

After
```
[2021-07-17 11:45:11 EDT] Starting server on port 8080
[2021-07-17 11:45:11 EDT] Connecting to SQLite database.
[2021-07-17 11:45:11 EDT] version 0.X
[2021-07-17 11:45:11 EDT] 
[2021-07-17 11:45:11 EDT] The secret serverId for this server is c60a5e4f3b63. Use it to access the following administrative routes:
[2021-07-17 11:45:11 EDT] * Overview of existing games: /games-overview?serverId=c60a5e4f3b63
[2021-07-17 11:45:11 EDT] * API for game IDs: /api/games?serverId=c60a5e4f3b63
```