### PR TITLE
Fix build on ARM + faster chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="bafolts" \
 RUN mkdir -p /usr/src/app/db \
    && addgroup -S tfm \
    && adduser -S -D -h /usr/src/app tfm tfm \
-   && apk add --no-cache git
+   && apk add --no-cache --virtual .gyp git python make g++
 
 WORKDIR /usr/src/app
 
@@ -17,12 +17,11 @@ COPY package*.json ./
 
 RUN npm install
 
-COPY . .
+COPY --chown=tfm:tfm . .
 
-RUN chown -R tfm:tfm /usr/src/app \
-   && npm run build \
+RUN npm run build  \
    && rm -rf .git \
-   && apk del git
+   && apk del git .gyp
 
 USER tfm
 


### PR DESCRIPTION
I'm not sure if it affects only ARM builds but I could not manager to build TMars without these changes.

- Justification for the change with chown : https://github.com/docker/for-linux/issues/388
- Justification for the virtual gyp to be able to build npm libs on ARM :  https://github.com/nodejs/docker-node/issues/282 