### PR TITLE
Remove incorrect line in Water Treatment Complex

### DIFF
--- a/src/cards/moon/WaterTreatmentComplex.ts
+++ b/src/cards/moon/WaterTreatmentComplex.ts
@@ -2,7 +2,6 @@ import {CardName} from '../../CardName';
 import {Player} from '../../Player';
 import {CardType} from '../CardType';
 import {MoonExpansion} from '../../moon/MoonExpansion';
-import {Resources} from '../../Resources';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
 import {MoonCard} from './MoonCard';
@@ -28,7 +27,6 @@ export class WaterTreatmentComplex extends MoonCard {
 
   public play(player: Player) {
     super.play(player);
-    player.addProduction(Resources.PLANTS, -1, {log: true});
     MoonExpansion.raiseColonyRate(player, 2);
     return undefined;
   }


### PR DESCRIPTION
Bug report from Discord. The card does not seem like it should decrease plant production. The reserved unit cost of 1 Ti is already covered by `player.deductUnits(adjustedReserveUnits)` in `ProjectCard`