### PR TITLE
An attempt to fix #2802

### DIFF
--- a/src/database/GameIds.ts
+++ b/src/database/GameIds.ts
@@ -33,9 +33,10 @@ export class GameIds extends EventEmitter {
   }
 
   private async getAllInstances(allGameIds: Array<GameId>) : Promise<void> {
-    for (const gameId of allGameIds) {
-      await this.getInstance(gameId);
-    }
+    const promises = allGameIds.map((x) => {
+      this.getInstance(x);
+    });
+    await Promise.all(promises);
   }
 
   public load() : void {

--- a/src/database/GameIds.ts
+++ b/src/database/GameIds.ts
@@ -32,11 +32,10 @@ export class GameIds extends EventEmitter {
     });
   }
 
-  private async getAllInstances(allGameIds: Array<GameId>) : Promise<void> {
-    const promises = allGameIds.map((x) => {
-      this.getInstance(x);
-    });
-    await Promise.all(promises);
+  private async getAllInstances(allGameIds: Array<GameId>) : Promise<void[]> {
+    return Promise.all(allGameIds.map((x) => {
+      return this.getInstance(x);
+    }));
   }
 
   public load() : void {

--- a/src/database/GameIds.ts
+++ b/src/database/GameIds.ts
@@ -1,0 +1,62 @@
+import {Database} from './Database';
+import {Game, GameId, SpectatorId} from '../Game';
+import {PlayerId} from '../Player';
+import {once} from 'events';
+import {EventEmitter} from 'events';
+
+export class GameIds extends EventEmitter {
+  private loaded = false;
+  private readonly games = new Map<GameId, Game | undefined>();
+  private readonly participantIds = new Map<SpectatorId | PlayerId, GameId>();
+  private getInstance(gameId: GameId) : Promise<void> {
+    return new Promise<void>((resolve) => {
+      Database.getInstance().getGame(
+        gameId,
+        (err, game) => {
+          if (err || (game === undefined)) {
+            console.error(`unable to load game ${gameId}`, err);
+          } else {
+            console.log(`load game ${gameId} with ${game.spectatorId}`);
+            if (this.games.get(gameId) === undefined) {
+              this.games.set(gameId, undefined);
+              if (game.spectatorId !== undefined) {
+                this.participantIds.set(game.spectatorId, gameId);
+              }
+              for (const player of game.players) {
+                this.participantIds.set(player.id, gameId);
+              }
+            }
+          }
+          resolve();
+        });
+    });
+  }
+
+  private async getAllInstances(allGameIds: Array<GameId>) : Promise<void> {
+    for (const gameId of allGameIds) {
+      await this.getInstance(gameId);
+    }
+  }
+
+  public load() : void {
+    Database.getInstance().getGames((err, allGameIds) => {
+      if (err) {
+        console.error('error loading all games', err);
+        this.loaded = true;
+        this.emit('loaded');
+        return;
+      }
+      this.getAllInstances(allGameIds).then(() =>{
+        this.loaded = true;
+        this.emit('loaded');
+      });
+    });
+  }
+
+  public async getGames(): Promise<{games:Map<GameId, Game | undefined>, participantIds:Map<SpectatorId | PlayerId, GameId>}> {
+    if (!this.loaded) {
+      await once(this, 'loaded');
+    }
+    return {games: this.games, participantIds: this.participantIds};
+  }
+}

--- a/src/database/GameLoader.ts
+++ b/src/database/GameLoader.ts
@@ -2,59 +2,28 @@ import {Database} from './Database';
 import {Game, GameId, SpectatorId} from '../Game';
 import {PlayerId} from '../Player';
 import {IGameLoader} from './IGameLoader';
+import {GameIds} from './GameIds';
 import {MultiMap} from 'mnemonist';
 
 type LoadCallback = (game: Game | undefined) => void;
-
-enum State {
-  /**
-   * No id has been requested
-   */
-  WAITING,
-  /**
-   * Running query and populating ids
-   */
-  LOADING,
-  /**
-   * ids populated from database
-   */
-  READY
-}
-
-type GameIdCallback = () => void;
+type ListLoadCallback = (list: Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}> | undefined) => void;
 
 /**
  * Loads games from javascript memory or database
  * Loads games from database sequentially as needed
  */
 export class GameLoader implements IGameLoader {
-  private state = State.WAITING;
-
-  // indicates if game is being loaded from database
-  private loadingGame = false;
-
-  // games available in javascript memory, undefined represents game
-  // in database not yet loaded
-  private readonly games = new Map<GameId, Game | undefined>();
-
-  // player ids which we know exist mapped to game id
-  private readonly onGameIdsLoaded: Array<GameIdCallback> = [];
-
-  // participant ids which we know exist mapped to game id
-  private readonly participantIds = new Map<SpectatorId | PlayerId, GameId>();
-
   private static readonly instance = new GameLoader();
 
-  private constructor() {}
+  private idsContainer = new GameIds();
+
+  private constructor() {
+    this.idsContainer.load();
+  }
 
   public reset(): void {
-    this.games.clear();
-    this.participantIds.clear();
-    this.state = State.WAITING;
-    this.loadingGame = false;
-    if (this.onGameIdsLoaded.length > 0) {
-      throw new Error('can not reset with pending callbacks');
-    }
+    this.idsContainer = new GameIds();
+    this.idsContainer.load();
   }
 
   public static getInstance(): IGameLoader {
@@ -62,50 +31,49 @@ export class GameLoader implements IGameLoader {
   }
 
   public add(game: Game): void {
-    this.games.set(game.id, game);
-    if (game.spectatorId !== undefined) {
-      this.participantIds.set(game.spectatorId, game.id);
-    }
-    for (const player of game.getPlayers()) {
-      this.participantIds.set(player.id, game.id);
-    }
+    this.idsContainer.getGames().then( (d) => {
+      d.games.set(game.id, game);
+      if (game.spectatorId !== undefined) {
+        d.participantIds.set(game.spectatorId, game.id);
+      }
+      for (const player of game.getPlayers()) {
+        d.participantIds.set(player.id, game.id);
+      }
+    });
   }
 
-  public getLoadedGameIds(): Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}> {
-    const map = new MultiMap<GameId, SpectatorId | PlayerId>();
-
-    this.participantIds.forEach((gameId, participantId) => map.set(gameId, participantId));
-    const arry: Array<[string, Array<string>]> = Array.from(map.associations());
-    return arry.map(([id, participants]) => ({id: id, participants: participants}));
+  public getLoadedGameIds(cb: ListLoadCallback): void {
+    this.idsContainer.getGames().then( (d) => {
+      const map = new MultiMap<GameId, SpectatorId | PlayerId>();
+      d.participantIds.forEach((gameId, participantId) => map.set(gameId, participantId));
+      const arry: Array<[string, Array<string>]> = Array.from(map.associations());
+      cb(arry.map(([id, participants]) => ({id: id, participants: participants})));
+    });
   }
 
   public getByGameId(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void {
-    this.loadAllGameIds();
-    if (bypassCache === false && this.games.get(gameId) !== undefined) {
-      cb(this.games.get(gameId));
-    } else if (this.games.has(gameId) || this.state !== State.READY) {
-      this.onGameIdsLoaded.unshift(() => {
-        this.loadGame(gameId, bypassCache, this.onGameLoaded(cb));
-      });
-      this.runGameIdLoadedCallback();
-    } else {
-      cb(undefined);
-    }
+    this.idsContainer.getGames().then( (d) => {
+      if (bypassCache === false && d.games.get(gameId) !== undefined) {
+        cb(d.games.get(gameId));
+      } else if (d.games.has(gameId)) {
+        this.loadGame(gameId, bypassCache, cb);
+      } else {
+        cb(undefined);
+      }
+    });
   }
 
   private getByParticipantId(id: PlayerId | SpectatorId, cb: LoadCallback): void {
-    this.loadAllGameIds();
-    const gameId = this.participantIds.get(id);
-    if (gameId !== undefined && this.games.get(gameId) !== undefined) {
-      cb(this.games.get(gameId));
-    } else if (gameId !== undefined || this.state !== State.READY) {
-      this.onGameIdsLoaded.push(() => {
-        this.loadParticipant(id, this.onGameLoaded(cb));
-      });
-      this.runGameIdLoadedCallback();
-    } else {
-      cb(undefined);
-    }
+    this.idsContainer.getGames().then( (d) => {
+      const gameId = d.participantIds.get(id);
+      if (gameId !== undefined && d.games.get(gameId) !== undefined) {
+        cb(d.games.get(gameId));
+      } else if (gameId !== undefined) {
+        this.loadParticipant(id, cb);
+      } else {
+        cb(undefined);
+      }
+    });
   }
 
   public getByPlayerId(playerId: PlayerId, cb: LoadCallback): void {
@@ -139,112 +107,47 @@ export class GameLoader implements IGameLoader {
   }
 
   private loadGame(gameId: GameId, bypassCache: boolean, cb: LoadCallback): void {
-    this.loadingGame = true;
-    if (bypassCache === false && this.games.get(gameId) !== undefined) {
-      cb(this.games.get(gameId));
-    } else if (this.games.has(gameId) === false) {
-      console.warn(`GameLoader:game id not found ${gameId}`);
-      cb(undefined);
-    } else {
-      Database.getInstance().getGame(gameId, (err: any, serializedGame?) => {
-        if (err || (serializedGame === undefined)) {
-          console.error('GameLoader:loadGame', err);
-          cb(undefined);
-          return;
-        }
-        try {
-          const game = Game.deserialize(serializedGame);
-          this.add(game);
-          console.log(`GameLoader loaded game ${gameId} into memory from database`);
-          cb(game);
-        } catch (e) {
-          console.error('GameLoader:loadGame', e);
-          cb(undefined);
-          return;
-        }
-      });
-    }
+    this.idsContainer.getGames().then( (d) => {
+      if (bypassCache === false && d.games.get(gameId) !== undefined) {
+        cb(d.games.get(gameId));
+      } else if (d.games.has(gameId) === false) {
+        console.warn(`GameLoader:game id not found ${gameId}`);
+        cb(undefined);
+      } else {
+        Database.getInstance().getGame(gameId, (err: any, serializedGame?) => {
+          if (err || (serializedGame === undefined)) {
+            console.error('GameLoader:loadGame', err);
+            cb(undefined);
+            return;
+          }
+          try {
+            const game = Game.deserialize(serializedGame);
+            this.add(game);
+            console.log(`GameLoader loaded game ${gameId} into memory from database`);
+            cb(game);
+          } catch (e) {
+            console.error('GameLoader:loadGame', e);
+            cb(undefined);
+            return;
+          }
+        });
+      }
+    });
   }
 
   private loadParticipant(id: PlayerId | SpectatorId, cb: LoadCallback): void {
-    const gameId = this.participantIds.get(id);
-    this.loadingGame = true;
-    if (gameId === undefined) {
-      console.warn(`GameLoader:id not found ${id}`);
-      cb(undefined);
-      return;
-    }
-    if (this.games.get(gameId) !== undefined) {
-      cb(this.games.get(gameId));
-      return;
-    }
-    this.loadGame(gameId, false, cb);
-  }
-
-  private onGameLoaded(cb: LoadCallback) {
-    return (game: Game | undefined) => {
-      cb(game);
-      this.loadingGame = false;
-      this.runGameIdLoadedCallback();
-    };
-  }
-
-  private runGameIdLoadedCallback(): void {
-    if (this.state === State.READY && this.loadingGame === false) {
-      const callback = this.onGameIdsLoaded.shift();
-      if (callback !== undefined) {
-        callback();
-      }
-    }
-  }
-
-  private allGameIdsLoaded(): void {
-    this.state = State.READY;
-    this.runGameIdLoadedCallback();
-  }
-
-  private loadAllGameIds(): void {
-    if (this.state !== State.WAITING) {
-      return;
-    }
-    this.state = State.LOADING;
-    Database.getInstance().getGames((err, allGameIds) => {
-      if (err) {
-        console.error('error loading all games', err);
-        this.allGameIdsLoaded();
+    this.idsContainer.getGames().then( (d) => {
+      const gameId = d.participantIds.get(id);
+      if (gameId === undefined) {
+        console.warn(`GameLoader:id not found ${id}`);
+        cb(undefined);
         return;
       }
-
-      if (allGameIds.length === 0) {
-        this.allGameIdsLoaded();
+      if (d.games.get(gameId) !== undefined) {
+        cb(d.games.get(gameId));
         return;
       }
-
-      let loaded = 0;
-      allGameIds.forEach((gameId) => {
-        Database.getInstance().getGame(
-          gameId,
-          (err, game) => {
-            loaded++;
-            if (err || (game === undefined)) {
-              console.error(`unable to load game ${gameId}`, err);
-            } else {
-              console.log(`load game ${gameId} with ${game.spectatorId}`);
-              if (this.games.get(gameId) === undefined) {
-                this.games.set(gameId, undefined);
-                if (game.spectatorId !== undefined) {
-                  this.participantIds.set(game.spectatorId, gameId);
-                }
-                for (const player of game.players) {
-                  this.participantIds.set(player.id, gameId);
-                }
-              }
-            }
-            if (loaded === allGameIds.length) {
-              this.allGameIdsLoaded();
-            }
-          });
-      });
+      this.loadGame(gameId, false, cb);
     });
   }
 }

--- a/src/database/IGameLoader.ts
+++ b/src/database/IGameLoader.ts
@@ -2,6 +2,7 @@ import {Game, GameId, SpectatorId} from '../Game';
 import {PlayerId} from '../Player';
 
 type LoadCallback = (game: Game | undefined) => void;
+type ListLoadCallback = (list: Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}> | undefined) => void;
 
 /**
  * Loads games from javascript memory or database
@@ -9,7 +10,7 @@ type LoadCallback = (game: Game | undefined) => void;
  */
 export interface IGameLoader {
   add(game: Game): void;
-  getLoadedGameIds(): Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}>;
+  getLoadedGameIds(cb: ListLoadCallback): void;
   /**
    * Gets a game from javascript memory or pulls from database if needed.
    * @param {GameId} gameId the id of the game to retrieve

--- a/src/routes/ApiGames.ts
+++ b/src/routes/ApiGames.ts
@@ -1,6 +1,9 @@
 import * as http from 'http';
 import {Handler} from './Handler';
 import {IContext} from './IHandler';
+import {GameId, SpectatorId} from '../Game';
+import {PlayerId} from '../Player';
+
 
 export class ApiGames extends Handler {
   public static readonly INSTANCE = new ApiGames();
@@ -8,8 +11,13 @@ export class ApiGames extends Handler {
     super({validateServerId: true});
   }
 
-  public get(_req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
-    const ids = ctx.gameLoader.getLoadedGameIds();
-    ctx.route.writeJson(res, ids);
+  public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
+    ctx.gameLoader.getLoadedGameIds((list: Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}> | undefined) => {
+      if (list === undefined) {
+        ctx.route.notFound(req, res, 'could not load game list');
+        return;
+      }
+      ctx.route.writeJson(res, list);
+    });
   }
 }

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -21,7 +21,6 @@ describe('GameLoader', function() {
     };
     const database = {
       getGame: function(gameId: string, theCb: (err: unknown, serializedGame?: SerializedGame) => void) {
-        console.log('getGame original');
         if (gameId === 'foobar') {
           theCb(undefined, game.serialize());
         } else {
@@ -115,7 +114,6 @@ describe('GameLoader', function() {
     GameLoader.getInstance().getByGameId('never', false, (game1) => {
       expect(game1).is.undefined;
       Database.getInstance().getGame = function(_gameId: string, cb: (err: any, serializedGame?: SerializedGame) => void) {
-        console.log('getGame test');
         cb(undefined, undefined);
       };
     });
@@ -131,7 +129,6 @@ describe('GameLoader', function() {
     GameLoader.getInstance().getByGameId('never', false, (game1) => {
       expect(game1).is.undefined;
       Database.getInstance().getGame = function(_gameId: string, cb: (err: any, serializedGame?: SerializedGame) => void) {
-        console.log('getGame test');
         cb(undefined, undefined);
       };
     });

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -1,16 +1,18 @@
 import {IGameLoader} from '../../src/database/IGameLoader';
-import {Game} from '../../src/Game';
+import {Game, GameId, SpectatorId} from '../../src/Game';
+import {PlayerId} from '../../src/Player';
+
 
 export class FakeGameLoader implements IGameLoader {
   private games: Map<string, Game> = new Map();
   add(game: Game): void {
     this.games.set(game.id, game);
   }
-  getLoadedGameIds() {
-    return Array.from(this.games.keys())
+  getLoadedGameIds(cb: (list: Array<{id: GameId, participants: Array<SpectatorId | PlayerId>}> | undefined) => void) {
+    cb(Array.from(this.games.keys())
       .map((id) => {
         return {id: id, participants: []};
-      });
+      }));
   }
   getByGameId(gameId: string, _bypassCache: boolean, cb: (game: Game | undefined) => void): void {
     cb(this.games.get(gameId));


### PR DESCRIPTION
Hello, everyone,

this is an attempt to fix #2802, unfortunately it comes with rather major refactoring of the `GameLoader` class.  Please be gentle with me, because I have not written for nodejs before, and I have not used typescript before, so I have certain gaps in the knowledge. I do understand how nodejs works in principle, though.

I tried to keep the spirit of the functionality of the class intact, and only change what is required for better flow, and for adding the [necessary callback](https://github.com/bafolts/terraforming-mars/pull/2807#discussion_r579861467) for fixing the issue.

The need to refactor the `GameLoader` class came from the desire to streamline and simplify state tracking and callbacks that were used there before the refactoring.

The main idea behind the refactoring is that we moved the following entities in their own class, `GameIds`:

- `loadAllGameIds` function
- `games` field
- `participantIds` field

This new `GameIds` class is an [EventEmitter](https://nodejs.org/api/events.html#events_class_eventemitter), and its main goal is to make sure that loading game ids from the database happens before they are used in the `GameLoader` class.  Thie `GameIds` class has the `load` function, which is called from the constructor of the `GameLoader` class. It also has the `getGames` function which returns a promise which is only resolved when the database load has finished. The promise contains `games` and  `participantIds` fields, I mentioned above.

With this promise based flow, we now can get rid of the following entities of the old class:

- `State` enum
- `state` field
- `loadingGame` field
- `onGameIdsLoaded` field
- `onGameLoaded` function
- `runGameIdLoadedCallback` function
- `allGameIdsLoaded` function

This significantly simplifies the flow and improves the class readability.

#2802 also warrants a single interface change for the Game Loader, and this is the callback for the `getLoadedGameIds` function as was discussed in the earlier PR linked above. This interface change feels self-explanatory, but please do not hesitate to ask if you need this or anything else in the PR clarified.

Naturally, `FakeGameLoader` from tests needed a corresponding change to conform the interface change. Same can be said about the `ApiGames` class.

Finally, there is a question of tests. My belief (which I'm happy to be corrected in if I'm wrong), is that the tests that I have changed always had a race. That is, it's because of luck/timing they have not failed before. There were two major problems with the tests in `GameLoader.spec.ts`.

Firstly, consider this code from the current file (before the PR):

```
  it('gets undefined when game will never exist', function() {
    let actualGame1: Game | undefined = game;
    let actualGame2: Game | undefined = game;
    GameLoader.getInstance().getByPlayerId('foobar', (game1) => {
      actualGame1 = game1;
    });
    GameLoader.getInstance().getByPlayerId('never', (game2) => {
      actualGame2 = game2;
    });
    GameLoader.getInstance().getByGameId('foobar', false, (game1) => {
      expect(game1).not.is.undefined;
    });
    expect(actualGame1).is.undefined;
    expect(actualGame2).is.undefined;
  });
```

In here the last two `expect` lines are not guaranteed to run after the call backs above. They can run before, which was the case in my testing. Because of this I had to move all similar `expect` occurrences in this the file inside the callbacks.

Secondly, the following excerpt may also problematic:

```
  it('gets no game when game goes missing from database', function() {
    const originalGetGame = Database.getInstance().getGame;
    GameLoader.getInstance().getByGameId('never', false, (game1) => {
      expect(game1).is.undefined;
      Database.getInstance().getGame = function(_gameId: string, cb: (err: any, serializedGame?: SerializedGame) => void) {
        cb(undefined, undefined);
      };
    });
    GameLoader.getInstance().getByGameId('foobar', false, (game1) => {
      expect(game1).is.undefined;
    });
    Database.getInstance().getGame = originalGetGame;
  });
```
What happens here, is that we try to substitute `Database.getInstance().getGame` with a temporary function, and then restore it. Again, in my tests, _subsequent tests_ (not this one) manage to run _before_ the restoration has taken place, and were running "bad" substituted function causing failed tests.

I had do use the `done` parameter in those test to make sure this does not happen.

Apologies, that this is too lengthy, the intention is to help, and share work. Please let me know your thoughts.