### PR TITLE
fix interplanetary trade

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -831,7 +831,10 @@ export class Player implements ISerializable<SerializedPlayer> {
       }
     }
     if (countWild) {
-      return uniqueTags.size + wildcardCount;
+      let maxTagCount = constants.DEFAULT_TAG_COUNT;
+      if (this.game.gameOptions.venusNextExtension) maxTagCount++;
+      if (this.game.gameOptions.moonExpansion) maxTagCount++;
+      return Math.min(uniqueTags.size + wildcardCount, maxTagCount);
     } else {
       return uniqueTags.size;
     }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -831,7 +831,7 @@ export class Player implements ISerializable<SerializedPlayer> {
       }
     }
     if (countWild) {
-      let maxTagCount = constants.DEFAULT_TAG_COUNT;
+      let maxTagCount = 10;
       if (this.game.gameOptions.venusNextExtension) maxTagCount++;
       if (this.game.gameOptions.moonExpansion) maxTagCount++;
       return Math.min(uniqueTags.size + wildcardCount, maxTagCount);

--- a/src/cards/promo/InterplanetaryTrade.ts
+++ b/src/cards/promo/InterplanetaryTrade.ts
@@ -6,7 +6,6 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {CardRenderer} from '../../cards/render/CardRenderer';
-import {DEFAULT_TAG_COUNT} from '../../constants';
 
 export class InterplanetaryTrade extends Card implements IProjectCard {
   constructor() {
@@ -31,11 +30,7 @@ export class InterplanetaryTrade extends Card implements IProjectCard {
   public play(player: Player) {
     // This card tag is counting as well
     const availableTags = player.getDistinctTagCount(true, Tags.SPACE);
-    // There is only 10 tags in the base game. One more for Venus and one more for Moon.
-    let existingTags = DEFAULT_TAG_COUNT;
-    if (player.game.gameOptions.venusNextExtension) existingTags++;
-    if (player.game.gameOptions.moonExpansion) existingTags++;
-    player.addProduction(Resources.MEGACREDITS, Math.min(availableTags, existingTags), {log: true});
+    player.addProduction(Resources.MEGACREDITS, availableTags, {log: true});
     return undefined;
   }
 

--- a/src/cards/promo/InterplanetaryTrade.ts
+++ b/src/cards/promo/InterplanetaryTrade.ts
@@ -6,6 +6,7 @@ import {Tags} from '../Tags';
 import {Player} from '../../Player';
 import {Resources} from '../../Resources';
 import {CardRenderer} from '../../cards/render/CardRenderer';
+import {DEFAULT_TAG_COUNT} from '../../constants';
 
 export class InterplanetaryTrade extends Card implements IProjectCard {
   constructor() {
@@ -30,8 +31,10 @@ export class InterplanetaryTrade extends Card implements IProjectCard {
   public play(player: Player) {
     // This card tag is counting as well
     const availableTags = player.getDistinctTagCount(true, Tags.SPACE);
-    // Only count wildcards up to the max amount of tag types existing (minus events and wildcards)
-    const existingTags = Object.keys(Tags).length - 2;
+    // There is only 10 tags in the base game. One more for Venus and one more for Moon.
+    let existingTags = DEFAULT_TAG_COUNT;
+    if (player.game.gameOptions.venusNextExtension) existingTags++;
+    if (player.game.gameOptions.moonExpansion) existingTags++;
     player.addProduction(Resources.MEGACREDITS, Math.min(availableTags, existingTags), {log: true});
     return undefined;
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,6 @@ export const MILESTONE_COST: number = 8;
 export const MAX_MILESTONES = 3;
 export const AWARD_COSTS: Array<number> = [8, 14, 20];
 export const MAX_AWARDS = 3;
-export const DEFAULT_TAG_COUNT = 10;
 
 export const DEFAULT_STEEL_VALUE: number = 2;
 export const DEFAULT_TITANIUM_VALUE: number = 3;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const MILESTONE_COST: number = 8;
 export const MAX_MILESTONES = 3;
 export const AWARD_COSTS: Array<number> = [8, 14, 20];
 export const MAX_AWARDS = 3;
+export const DEFAULT_TAG_COUNT = 10;
 
 export const DEFAULT_STEEL_VALUE: number = 2;
 export const DEFAULT_TITANIUM_VALUE: number = 3;

--- a/tests/cards/promo/InterplanetaryTrade.spec.ts
+++ b/tests/cards/promo/InterplanetaryTrade.spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {AdvancedAlloys} from '../../../src/cards/base/AdvancedAlloys';
 import {AdvancedEcosystems} from '../../../src/cards/base/AdvancedEcosystems';
 import {ColonizerTrainingCamp} from '../../../src/cards/base/ColonizerTrainingCamp';
+import {CupolaCity} from '../../../src/cards/base/CupolaCity';
 import {LunarBeam} from '../../../src/cards/base/LunarBeam';
 import {MarsUniversity} from '../../../src/cards/base/MarsUniversity';
 import {SpaceElevator} from '../../../src/cards/base/SpaceElevator';
@@ -14,12 +15,12 @@ import {Resources} from '../../../src/Resources';
 import {TestPlayers} from '../../TestPlayers';
 
 describe('InterplanetaryTrade', function() {
-  let card : InterplanetaryTrade; let player : Player;
+  let card : InterplanetaryTrade; let player : Player; let game: Game;
 
   beforeEach(function() {
     card = new InterplanetaryTrade();
     player = TestPlayers.BLUE.newPlayer();
-    Game.newInstance('foo', [player], player);
+    game = Game.newInstance('foo', [player], player);
   });
 
   it('Should play', function() {
@@ -32,7 +33,21 @@ describe('InterplanetaryTrade', function() {
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(4);
   });
 
-  it('Should only count wildcards up to the max amount of tag types existing', function() {
+  it('Should only count wildcards up to the max amount of tag types existing (10 at base)', function() {
+    player.playedCards.push(new AdvancedAlloys());
+    player.playedCards.push(new SpaceElevator());
+    player.playedCards.push(new MarsUniversity());
+    player.playedCards.push(new ResearchCoordination());
+    player.playedCards.push(new AdvancedEcosystems());
+    player.playedCards.push(new CupolaCity());
+    player.playedCards.push(new LunarBeam());
+    player.playedCards.push(new ColonizerTrainingCamp());
+    card.play(player);
+    expect(player.getProduction(Resources.MEGACREDITS)).to.eq(10);
+  });
+
+  it('Should only count wildcards up to the max amount of tag types existing (11 with venus)', function() {
+    game.gameOptions.venusNextExtension = true;
     player.playedCards.push(new AdvancedAlloys());
     player.playedCards.push(new SpaceElevator());
     player.playedCards.push(new MarsUniversity());
@@ -41,7 +56,21 @@ describe('InterplanetaryTrade', function() {
     player.playedCards.push(new MaxwellBase());
     player.playedCards.push(new LunarBeam());
     player.playedCards.push(new ColonizerTrainingCamp());
+    card.play(player);
+    expect(player.getProduction(Resources.MEGACREDITS)).to.eq(11);
+  });
 
+  it('Should only count wildcards up to the max amount of tag types existing (12 with venus and moon)', function() {
+    game.gameOptions.venusNextExtension = true;
+    game.gameOptions.moonExpansion = true;
+    player.playedCards.push(new AdvancedAlloys());
+    player.playedCards.push(new SpaceElevator());
+    player.playedCards.push(new MarsUniversity());
+    player.playedCards.push(new ResearchCoordination());
+    player.playedCards.push(new AdvancedEcosystems());
+    player.playedCards.push(new MaxwellBase());
+    player.playedCards.push(new LunarBeam());
+    player.playedCards.push(new ColonizerTrainingCamp());
     card.play(player);
     expect(player.getProduction(Resources.MEGACREDITS)).to.eq(12);
   });

--- a/tests/milestones/Diversifier.spec.ts
+++ b/tests/milestones/Diversifier.spec.ts
@@ -3,11 +3,13 @@ import {expect} from 'chai';
 import {Diversifier} from '../../src/milestones/Diversifier';
 import {ResearchNetwork} from '../../src/cards/prelude/ResearchNetwork';
 import {TestPlayers} from '../TestPlayers';
+import {Game} from '../../src/Game';
 
 describe('Diversifier', function() {
   it('Counts wildcard tags as unique tags', function() {
     const milestone = new Diversifier();
     const player = TestPlayers.BLUE.newPlayer();
+    Game.newInstance('foo', [player], player);
     expect(milestone.canClaim(player)).is.not.true;
     for (let i = 0; i < 8; i++) {
       player.playedCards.push(new ResearchNetwork());


### PR DESCRIPTION
Planetary Trade (card) should not count Venus tag or Moon tag by default.