### PR TITLE
Revert "Fixed issues with purging old running games in sqlite database"

### DIFF
--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -132,14 +132,14 @@ export class SQLite implements IDatabase {
   }
 
   purgeUnfinishedGames(): void {
-    // Purge unfinished games older than MAX_GAME_DAYS days. If this environment variable is absent, it uses the default of 10 days.
-    const envDays = parseInt(process.env.MAX_GAME_DAYS || '');
-    const days = Number.isInteger(envDays) ? envDays : 10;
-    this.db.run('DELETE FROM games WHERE created_time < strftime(\'%s\',date(\'now\', \'-\' || ? || \' day\')) and status = \'running\'', [days.toString()], function(err: Error | null) {
-      if (err) {
-        return console.warn(err.message);
-      }
-    });
+    // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
+    if (process.env.MAX_GAME_DAYS) {
+      this.db.run('DELETE FROM games WHERE created_time < strftime(\'%s\',date(\'now\', \'-? day\')) and status = \'running\'', [process.env.MAX_GAME_DAYS], function(err: Error | null) {
+        if (err) {
+          return console.warn(err.message);
+        }
+      });
+    }
   }
 
   restoreGame(game_id: GameId, save_id: number, cb: DbLoadCallback<Game>): void {


### PR DESCRIPTION
Reverts bafolts/terraforming-mars#3470

We have an issue where we don't wait for queries to finish running. The tables haven't necessarily been created by the time we call to `purgeUnfinishedGames`. We will need to fix this problem as it is preventing a fresh clone from starting without error.

This will close #3500 for the time being until we can improve our `IDatabase` implementations.