### PR TITLE
fixed syntax error in the SQLite purge query

### DIFF
--- a/src/database/SQLite.ts
+++ b/src/database/SQLite.ts
@@ -134,7 +134,7 @@ export class SQLite implements IDatabase {
   purgeUnfinishedGames(): void {
     // Purge unfinished games older than MAX_GAME_DAYS days. If this .env variable is not present, unfinished games will not be purged.
     if (process.env.MAX_GAME_DAYS) {
-      this.db.run('DELETE FROM games WHERE created_time < strftime(\'%s\',date(\'now\', \'-? day\')) and status = \'running\'', [process.env.MAX_GAME_DAYS], function(err: Error | null) {
+      this.db.run(`DELETE FROM games WHERE created_time < strftime('%s',date('now', '-' || ? || ' day')) and status = 'running'`, [process.env.MAX_GAME_DAYS], function(err: Error | null) {
         if (err) {
           return console.warn(err.message);
         }


### PR DESCRIPTION
Since https://github.com/bafolts/terraforming-mars/pull/3470 was reverted, this is a lighter fix that does not change the timing. It just fixes the syntax error in the SQLite query.

Note: the timing issue might be present both before and after the fix and will need to be addressed separately.