### PR TITLE
Fix: Colony placement cards should only consider active colonies

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2344,12 +2344,13 @@ export class Player implements ISerializable<SerializedPlayer> {
   public hasAvailableColonyTileToBuildOn(): boolean {
     if (this.game.gameOptions.coloniesExtension === false) return false;
 
+    const availableColonyTiles = this.game.colonies.filter((colony) => colony.isActive);
     let colonyTilesAlreadyBuiltOn: number = 0;
 
-    this.game.colonies.forEach((colony) => {
+    availableColonyTiles.forEach((colony) => {
       if (colony.colonies.includes(this.id)) colonyTilesAlreadyBuiltOn++;
     });
 
-    return colonyTilesAlreadyBuiltOn < this.game.colonies.length;
+    return colonyTilesAlreadyBuiltOn < availableColonyTiles.length;
   }
 }

--- a/tests/cards/colonies/TradingColony.spec.ts
+++ b/tests/cards/colonies/TradingColony.spec.ts
@@ -1,0 +1,47 @@
+import {expect} from 'chai';
+import {TradingColony} from '../../../src/cards/colonies/TradingColony';
+import {Callisto} from '../../../src/colonies/Callisto';
+import {Ceres} from '../../../src/colonies/Ceres';
+import {ColonyName} from '../../../src/colonies/ColonyName';
+import {Miranda} from '../../../src/colonies/Miranda';
+import {Game} from '../../../src/Game';
+import {SelectColony} from '../../../src/inputs/SelectColony';
+import {Player} from '../../../src/Player';
+import {Resources} from '../../../src/Resources';
+import {TestingUtils} from '../../TestingUtils';
+import {TestPlayers} from '../../TestPlayers';
+
+describe('TradingColony', function() {
+  let card : TradingColony; let player : Player; let player2: Player; let game: Game;
+
+  beforeEach(function() {
+    card = new TradingColony();
+    player = TestPlayers.BLUE.newPlayer();
+    player2 = TestPlayers.RED.newPlayer();
+
+    const gameOptions = TestingUtils.setCustomGameOptions({coloniesExtension: true});
+    game = Game.newInstance('foobar', [player, player2], player, gameOptions);
+    game.colonies = [new Callisto(), new Ceres(), new Miranda()];
+  });
+
+  it('Should play', function() {
+    card.play(player);
+    expect(game.deferredActions).has.length(1);
+
+    const selectColony = game.deferredActions.pop()!.execute() as SelectColony;
+    selectColony.cb((<any>ColonyName)[selectColony.coloniesModel[0].name.toUpperCase()]);
+    expect(player.getProduction(Resources.ENERGY)).to.eq(1);
+    expect(player.colonyTradeOffset).to.eq(1);
+  });
+
+  it('Can play if there are available colony tiles to build on', function() {
+    game.colonies[0].colonies.push(player.id);
+    expect(card.canPlay(player)).is.true;
+  });
+
+  it('Cannot play if there are no available colony tiles to build on', function() {
+    game.colonies[0].colonies.push(player.id);
+    game.colonies[1].colonies.push(player.id);
+    expect(card.canPlay(player)).is.false;
+  });
+});


### PR DESCRIPTION
Fix for bug raised in https://discord.com/channels/737945098695999559/742721510376210583/874003713889562624. Also adds missing tests for TradingColony to verify existing and new behaviour.