### PR TITLE
Fix: Agendas Scientists P4 for multi-tag requirements

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -846,6 +846,8 @@ export class Player implements ISerializable<SerializedPlayer> {
     tags.forEach((tag) => {
       if (this.getTagCount(tag, false, false) > 0) {
         distinctCount++;
+      } else if (tag === Tags.SCIENCE && this.hasTurmoilScienceTagBonus) {
+        distinctCount++;
       }
     });
     if (distinctCount + this.getTagCount(Tags.WILDCARD) >= tags.length) {

--- a/tests/turmoil/parties/Scientists.spec.ts
+++ b/tests/turmoil/parties/Scientists.spec.ts
@@ -8,6 +8,9 @@ import {Scientists, SCIENTISTS_BONUS_1, SCIENTISTS_BONUS_2, SCIENTISTS_POLICY_1,
 import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {Research} from '../../../src/cards/base/Research';
 import {GeneRepair} from '../../../src/cards/base/GeneRepair';
+import {PrideoftheEarthArkship} from '../../../src/cards/moon/PrideoftheEarthArkship';
+import {SpaceStation} from '../../../src/cards/base/SpaceStation';
+import {Satellites} from '../../../src/cards/base/Satellites';
 
 describe('Scientists', function() {
   let player : Player; let game : Game; let turmoil: Turmoil; let scientists: Scientists;
@@ -81,6 +84,20 @@ describe('Scientists', function() {
     const scientistsPolicy = SCIENTISTS_POLICY_4;
     scientistsPolicy.apply(game);
     player.playedCards.push(new Research());
+    expect(card.canPlay(player)).to.be.true;
+  });
+
+  it('Ruling policy 4: Cards with multiple tag requirements may be played with 1 less Science tag', function() {
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[3].id);
+
+    // Meet all card requirements except the Science tag
+    player.playedCards.push(new SpaceStation(), new Satellites());
+    player.titanium = 2;
+    const card = new PrideoftheEarthArkship();
+    expect(card.canPlay(player)).to.be.false;
+
+    const scientistsPolicy = SCIENTISTS_POLICY_4;
+    scientistsPolicy.apply(game);
     expect(card.canPlay(player)).to.be.true;
   });
 });

--- a/tests/turmoil/parties/Scientists.spec.ts
+++ b/tests/turmoil/parties/Scientists.spec.ts
@@ -4,7 +4,7 @@ import {Game} from '../../../src/Game';
 import {Turmoil} from '../../../src/turmoil/Turmoil';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
-import {Scientists, SCIENTISTS_BONUS_1, SCIENTISTS_BONUS_2, SCIENTISTS_POLICY_1, SCIENTISTS_POLICY_4} from '../../../src/turmoil/parties/Scientists';
+import {Scientists, SCIENTISTS_BONUS_1, SCIENTISTS_BONUS_2, SCIENTISTS_POLICY_1, SCIENTISTS_POLICY_2, SCIENTISTS_POLICY_3, SCIENTISTS_POLICY_4} from '../../../src/turmoil/parties/Scientists';
 import {SearchForLife} from '../../../src/cards/base/SearchForLife';
 import {Research} from '../../../src/cards/base/Research';
 import {GeneRepair} from '../../../src/cards/base/GeneRepair';
@@ -42,7 +42,7 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 1: Pay 10 M€ to draw 3 cards', function() {
-    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[0].id);
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, SCIENTISTS_POLICY_1.id);
 
     const scientistsPolicy = SCIENTISTS_POLICY_1;
     player.megaCredits = 10;
@@ -56,7 +56,7 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 2: Your global requirements are +/- 2 steps', function() {
-    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[1].id);
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, SCIENTISTS_POLICY_2.id);
 
     const card = new SearchForLife();
     (game as any).oxygenLevel = 8;
@@ -64,7 +64,7 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 3: When you raise a global parameter, draw a card per step raised', function() {
-    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[2].id);
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, SCIENTISTS_POLICY_3.id);
 
     game.increaseOxygenLevel(player, 1);
     game.deferredActions.runNext();
@@ -76,7 +76,7 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 4: Cards with Science tag requirements may be played with 1 less Science tag', function() {
-    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[3].id);
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, SCIENTISTS_POLICY_4.id);
 
     const card = new GeneRepair();
     expect(card.canPlay(player)).to.be.false;
@@ -88,7 +88,7 @@ describe('Scientists', function() {
   });
 
   it('Ruling policy 4: Cards with multiple tag requirements may be played with 1 less Science tag', function() {
-    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, scientists.policies[3].id);
+    TestingUtils.setRulingPartyAndRulingPolicy(game, turmoil, scientists, SCIENTISTS_POLICY_4.id);
 
     // Meet all card requirements except the Science tag
     player.playedCards.push(new SpaceStation(), new Satellites());


### PR DESCRIPTION
Bug reported on https://discord.com/channels/737945098695999559/742721510376210583/873835903758499851. Agendas Scientists P4 should consider a bonus Science tag for cards with multiple tag requirements.