### PR TITLE
use playerView instead of player for PlayerStatus component

### DIFF
--- a/src/components/overview/PlayerInfo.vue
+++ b/src/components/overview/PlayerInfo.vue
@@ -112,7 +112,7 @@ export default Vue.extend({
             <div class="icon-first-player" v-if="firstForGen && playerView.players.length > 1">1st</div>
             <div class="player-info-corp" v-if="player.corporationCard !== undefined" :title="player.corporationCard.name">{{ player.corporationCard.name }}</div>
           </div>
-          <player-status :player="player" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" :playerIndex="playerIndex"/>
+          <player-status :playerView="playerView" :firstForGen="firstForGen" v-trim-whitespace :actionLabel="actionLabel" :playerIndex="playerIndex"/>
         </div>
           <PlayerResources :player="player" v-trim-whitespace />
           <div class="player-played-cards">

--- a/src/components/overview/PlayerStatus.vue
+++ b/src/components/overview/PlayerStatus.vue
@@ -3,7 +3,7 @@
         <div class="player-status-bottom">
           <div :class="getLabelAndTimerClasses()">
             <div :class="getActionStatusClasses()">{{ actionLabel }}</div>
-            <div class="player-status-timer" v-if="player.game.gameOptions.showTimers"><player-timer :timer="player.thisPlayer.timer"/></div>
+            <div class="player-status-timer" v-if="playerView.game.gameOptions.showTimers"><player-timer :timer="playerView.thisPlayer.timer"/></div>
           </div>
         </div>
       </div>
@@ -24,7 +24,7 @@ export const hidePlayerData = (root: typeof mainAppSettings.methods, playerIndex
 export default Vue.extend({
   name: 'player-status',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     firstForGen: {
@@ -45,7 +45,7 @@ export default Vue.extend({
       const classes: Array<string> = [];
       const baseClass = 'player-action-status-container';
       classes.push(baseClass);
-      if (!this.player.game.gameOptions.showTimers) {
+      if (!this.playerView.game.gameOptions.showTimers) {
         classes.push('no-timer');
       }
       if (this.actionLabel === ActionLabel.PASSED) {


### PR DESCRIPTION
Fixes minor issue with recent refactor. This warning was seen prior to this change.

```
vue.esm.js:628 [Vue warn]: Error in render: "TypeError: Cannot read property 'timer' of undefined"

found in

---> <PlayerStatus> at src/components/overview/PlayerStatus.vue
       <PlayerInfo> at src/components/overview/PlayerInfo.vue
         <PlayersOverview> at src/components/overview/PlayersOverview.vue
           <PlayerHome> at src/components/PlayerHome.vue
```

Would have expected vetur to catch this but it may not be as robust as we expect. Could consider failing component tests on any warning from vue. 