### PR TITLE
Loads compression plugin only in production mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,31 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const zlib = require('zlib');
 
+const plugins = [
+  new ForkTsCheckerWebpackPlugin({
+    typescript: {
+      configOverwrite: {
+        exclude: [
+          'tests/**/*.ts',
+        ],
+      },
+      extensions: {
+        vue: true,
+      },
+    },
+  }),
+  new VueLoaderPlugin(),
+];
+
+if (process.env.NODE_ENV === 'production') {
+  plugins.push(new CompressionPlugin());
+  plugins.push(new CompressionPlugin({
+    algorithm: 'brotliCompress',
+    filename: '[path][base].br',
+    compressionOptions: {params: {[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY}},
+  }));
+}
+
 module.exports = {
   devtool: 'source-map',
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -37,27 +62,7 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new ForkTsCheckerWebpackPlugin({
-      typescript: {
-        configOverwrite: {
-          exclude: [
-            "tests/**/*.ts"
-          ],
-        },
-        extensions: {
-          vue: true
-        }
-      }
-    }),
-    new VueLoaderPlugin(),
-    new CompressionPlugin(),
-    new CompressionPlugin({
-      algorithm: 'brotliCompress',
-      filename: '[path][base].br',
-      compressionOptions: {params: {[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY}},
-    }),
-  ],
+  plugins,
   output: {
     path: __dirname + '/build',
   },


### PR DESCRIPTION
This change speeds up `npm run watch` and `npm run test:components:watch` by 20x