### PR TITLE
Have input selection use playerView

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -34,14 +34,14 @@
                 ></game-home>
                 <player-home
                     v-else-if="screen === 'player-home'"
-                    :player="player"
+                    :player-view="playerView"
                     :key="playerkey"
                     :settings="settings"
                 ></player-home>
                 <spectator-home v-else-if="screen === 'spectator-home'"></spectator-home>
                 <game-end
                     v-else-if="screen === 'the-end'"
-                    :player="player"
+                    :player-view="playerView"
                 ></game-end>
                 <games-overview
                     v-else-if="screen === 'games-overview'"

--- a/src/components/AndOptions.vue
+++ b/src/components/AndOptions.vue
@@ -4,7 +4,7 @@
     <player-input-factory v-for="(option, idx) in (playerinput.options || [])"
       :key="idx"
       :players="players"
-      :player="player"
+      :playerView="playerView"
       :playerinput="option"
       :onsave="playerFactorySaved(idx)"
       :showsave="false"
@@ -26,7 +26,7 @@ import {TranslateMixin} from '../components/TranslateMixin';
 export default Vue.extend({
   name: 'and-options',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     players: {

--- a/src/components/App.ts
+++ b/src/components/App.ts
@@ -37,7 +37,7 @@ interface MainAppData {
      * use this property we can't trigger vue state without
      * a refactor.
      */
-    player?: PlayerViewModel;
+    playerView?: PlayerViewModel;
     playerkey: number;
     settings: typeof raw_settings;
     isServerSideRequestInProgress: boolean;
@@ -120,10 +120,10 @@ export const mainAppSettings = {
       };
       xhr.onload = () => {
         if (xhr.status === 200) {
-          app.player = xhr.response as PlayerViewModel;
+          app.playerView = xhr.response as PlayerViewModel;
           app.playerkey++;
           if (
-            app.player.game.phase === 'end' &&
+            app.playerView.game.phase === 'end' &&
                         window.location.search.includes('&noredirect') === false
           ) {
             app.screen = 'the-end';
@@ -131,7 +131,7 @@ export const mainAppSettings = {
               window.history.replaceState(
                 xhr.response,
                 `${constants.APP_NAME} - Player`,
-                '/the-end?id=' + app.player.id,
+                '/the-end?id=' + app.playerView.id,
               );
             }
           } else {
@@ -140,7 +140,7 @@ export const mainAppSettings = {
               window.history.replaceState(
                 xhr.response,
                 `${constants.APP_NAME} - Game`,
-                '/player?id=' + app.player.id,
+                '/player?id=' + app.playerView.id,
               );
             }
           }

--- a/src/components/GameEnd.vue
+++ b/src/components/GameEnd.vue
@@ -3,7 +3,7 @@
             <h1>{{ constants.APP_NAME }} - Game finished!</h1>
             <div class="game_end">
                 <div v-if="isSoloGame()">
-                    <div v-if="player.game.isSoloModeWin">
+                    <div v-if="playerView.game.isSoloModeWin">
                         <div class="game_end_success">
                             <h2 v-i18n>You win!</h2>
                             <div class="game_end_solo_img">
@@ -15,7 +15,7 @@
                             <ul class="game_end_list">
                                 <li v-i18n>Try to win with expansions enabled</li>
                                 <li v-i18n>Try to win before the last generation comes</li>
-                                <li><span v-i18n>Can you get</span> {{ player.thisPlayer.victoryPointsBreakdown.total + 10 }}<span v-i18n>+ Victory Points?</span></li>
+                                <li><span v-i18n>Can you get</span> {{ playerView.thisPlayer.victoryPointsBreakdown.total + 10 }}<span v-i18n>+ Victory Points?</span></li>
                             </ul>
                         </div>
                     </div>
@@ -41,11 +41,11 @@
                         Go to main page
                     </a>
                 </div>
-                <div v-if="!isSoloGame() || player.game.isSoloModeWin" class="game-end-winer-announcement">
+                <div v-if="!isSoloGame() || game.isSoloModeWin" class="game-end-winer-announcement">
                     <span v-for="p in getWinners()" :key="p.color"><span :class="'log-player ' + getEndGamePlayerRowColorClass(p.color)">{{ p.name }}</span></span> won!
                 </div>
                 <div class="game_end_victory_points">
-                    <h2 v-i18n>Victory points breakdown after<span> {{player.game.generation}} </span>generations</h2>
+                    <h2 v-i18n>Victory points breakdown after<span> {{game.generation}} </span>generations</h2>
                     <table class="table game_end_table">
                         <thead>
                             <tr v-i18n>
@@ -55,13 +55,13 @@
                                 <th><div class="m-and-a" title="Awards points">A</div></th>
                                 <th><div class="table-forest-tile"></div></th>
                                 <th><div class="table-city-tile"></div></th>
-                                <th v-if="player.game.moon !== undefined"><div class="table-moon-road-tile"></div></th>
-                                <th v-if="player.game.moon !== undefined"><div class="table-moon-colony-tile"></div></th>
-                                <th v-if="player.game.moon !== undefined"><div class="table-moon-mine-tile"></div></th>
+                                <th v-if="game.moon !== undefined"><div class="table-moon-road-tile"></div></th>
+                                <th v-if="game.moon !== undefined"><div class="table-moon-colony-tile"></div></th>
+                                <th v-if="game.moon !== undefined"><div class="table-moon-mine-tile"></div></th>
                                 <th><div class="vp">VP</div></th>
                                 <th class="game-end-total"><div class="game-end-total-column">Total</div></th>
                                 <th><div class="mc-icon"></div></th>
-                                <th v-if="player.game.gameOptions.showTimers" class="clock-icon">&#x1F551;</th>
+                                <th v-if="game.gameOptions.showTimers" class="clock-icon">&#x1F551;</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -75,16 +75,16 @@
                                 <td>{{ p.victoryPointsBreakdown.awards }}</td>
                                 <td>{{ p.victoryPointsBreakdown.greenery }}</td>
                                 <td>{{ p.victoryPointsBreakdown.city }}</td>
-                                <td v-if="player.game.moon !== undefined">{{ p.victoryPointsBreakdown.moonRoads }}</td>
-                                <td v-if="player.game.moon !== undefined">{{ p.victoryPointsBreakdown.moonColonies }}</td>
-                                <td v-if="player.game.moon !== undefined">{{ p.victoryPointsBreakdown.moonMines }}</td>
+                                <td v-if="game.moon !== undefined">{{ p.victoryPointsBreakdown.moonRoads }}</td>
+                                <td v-if="game.moon !== undefined">{{ p.victoryPointsBreakdown.moonColonies }}</td>
+                                <td v-if="game.moon !== undefined">{{ p.victoryPointsBreakdown.moonMines }}</td>
                                 <td>{{ p.victoryPointsBreakdown.victoryPoints }}</td>
                                 <td class="game-end-total">{{ p.victoryPointsBreakdown.total }}</td>
                                 <td class="game-end-mc">
                                   <div>{{ p.megaCredits }}</div>
                                 </td>
                                 <td>
-                                  <div v-if="player.game.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
+                                  <div v-if="game.gameOptions.showTimers" class="game-end-timer">{{ getTimer(p) }}</div>
                                 </td>
                             </tr>
                         </tbody>
@@ -125,18 +125,18 @@
                 <div class="game_end_block--board game-end-column">
                     <h2 v-i18n>Final situation on the board</h2>
                     <board
-                        :spaces="player.game.spaces"
-                        :venusNextExtension="player.game.gameOptions.venusNextExtension"
-                        :venusScaleLevel="player.game.venusScaleLevel"
-                        :aresExtension="player.game.gameOptions.aresExtension"
-                        :boardName ="player.game.gameOptions.boardName"
-                        :oceans_count="player.game.oceans"
-                        :oxygen_level="player.game.oxygenLevel"
-                        :temperature="player.game.temperature"></board>
-                  <MoonBoard v-if="player.game.gameOptions.moonExpansion" :model="player.game.moon"></MoonBoard>
+                        :spaces="game.spaces"
+                        :venusNextExtension="game.gameOptions.venusNextExtension"
+                        :venusScaleLevel="game.venusScaleLevel"
+                        :aresExtension="game.gameOptions.aresExtension"
+                        :boardName ="game.gameOptions.boardName"
+                        :oceans_count="game.oceans"
+                        :oxygen_level="game.oxygenLevel"
+                        :temperature="game.temperature"></board>
+                  <MoonBoard v-if="game.gameOptions.moonExpansion" :model="game.moon"></MoonBoard>
                 </div>
                 <div class="game_end_block--log game-end-column">
-                  <log-panel :color="player.thisPlayer.color" :generation="player.game.generation" :id="player.id" :lastSoloGeneration="player.game.lastSoloGeneration" :players="player.players"></log-panel>
+                  <log-panel :color="playerView.thisPlayer.color" :generation="game.generation" :id="playerView.id" :lastSoloGeneration="game.lastSoloGeneration" :players="playerView.players"></log-panel>
                 </div>
               </div>
             </div>
@@ -146,6 +146,7 @@
 <script lang="ts">
 
 import Vue from 'vue';
+import {GameModel} from '../models/GameModel';
 import {PlayerViewModel, PublicPlayerModel} from '../models/PlayerModel';
 import Board from './Board.vue';
 import MoonBoard from './moon/MoonBoard.vue';
@@ -159,8 +160,13 @@ import * as constants from '../constants';
 export default Vue.extend({
   name: 'game-end',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
+    },
+  },
+  computed: {
+    game(): GameModel {
+      return this.playerView.game;
     },
   },
   data() {
@@ -182,14 +188,14 @@ export default Vue.extend({
       return Timer.toString(p.timer);
     },
     getSortedPlayers() {
-      this.player.players.sort(function(a:PublicPlayerModel, b:PublicPlayerModel) {
+      this.playerView.players.sort(function(a:PublicPlayerModel, b:PublicPlayerModel) {
         if (a.victoryPointsBreakdown.total < b.victoryPointsBreakdown.total) return -1;
         if (a.victoryPointsBreakdown.total > b.victoryPointsBreakdown.total) return 1;
         if (a.megaCredits < b.megaCredits) return -1;
         if (a.megaCredits > b.megaCredits) return 1;
         return 0;
       });
-      return this.player.players.reverse();
+      return this.playerView.players.reverse();
     },
     getWinners() {
       const sortedPlayers = this.getSortedPlayers();
@@ -204,7 +210,7 @@ export default Vue.extend({
       return winners;
     },
     isSoloGame(): boolean {
-      return this.player.players.length === 1;
+      return this.playerView.players.length === 1;
     },
   },
 });

--- a/src/components/OrOptions.vue
+++ b/src/components/OrOptions.vue
@@ -10,7 +10,7 @@
       <div v-if="selectedOption === option" style="margin-left: 30px">
         <player-input-factory ref="inputfactory"
                               :players="players"
-                              :player="player"
+                              :playerView="playerView"
                               :playerinput="option"
                               :onsave="playerFactorySaved()"
                               :showsave="false"
@@ -39,7 +39,7 @@ let unique = 0;
 export default Vue.extend({
   name: 'or-options',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     players: {

--- a/src/components/PaymentWidgetMixin.ts
+++ b/src/components/PaymentWidgetMixin.ts
@@ -36,7 +36,7 @@ export interface PaymentWidgetModel extends SelectHowToPayModel {
   tags?: Array<Tags>;
   available?: Units;
   $data: SelectHowToPayModel | SelectHowToPayForProjectCardModel;
-  player: PlayerViewModel;
+  playerView: PlayerViewModel;
   playerinput: PlayerInputModel;
 }
 
@@ -53,14 +53,14 @@ export const PaymentWidgetMixin = {
     },
     getMegaCreditsMax(): number {
       const model = this.asModel();
-      return Math.min(model.player.thisPlayer.megaCredits, model.$data.cost);
+      return Math.min(model.playerView.thisPlayer.megaCredits, model.$data.cost);
     },
     getResourceRate(resourceName: ResourcesWithRates): number {
       let rate = 1; // one resource == one money
       if (resourceName === 'titanium') {
-        rate = this.asModel().player.thisPlayer.titaniumValue;
+        rate = this.asModel().playerView.thisPlayer.titaniumValue;
       } else if (resourceName === 'steel') {
-        rate = this.asModel().player.thisPlayer.steelValue;
+        rate = this.asModel().playerView.thisPlayer.steelValue;
       } else if (resourceName === 'microbes') {
         rate = 2;
       } else if (resourceName === 'floaters') {
@@ -94,7 +94,7 @@ export const PaymentWidgetMixin = {
       let maxValue: number | undefined = max;
 
       if (maxValue === undefined && target !== 'microbes' && target !== 'floaters' && target !== 'science') {
-        maxValue = this.asModel().player.thisPlayer[target];
+        maxValue = this.asModel().playerView.thisPlayer[target];
       }
 
       switch (target) {
@@ -148,7 +148,7 @@ export const PaymentWidgetMixin = {
       const cardCost: number = this.asModel().$data.cost;
       let amountHave: number | undefined = max;
       if (max === undefined && target !== 'microbes' && target !== 'floaters' && target !== 'science') {
-        amountHave = this.asModel().player.thisPlayer[target];
+        amountHave = this.asModel().playerView.thisPlayer[target];
       }
 
       let amountNeed = cardCost;
@@ -174,7 +174,7 @@ export const PaymentWidgetMixin = {
     },
     isStratosphericBirdsEdgeCase(): boolean {
       if (this.asModel().$data.card?.name === CardName.STRATOSPHERIC_BIRDS) {
-        const playedCards = this.asModel().player.thisPlayer.playedCards as Array<CardModel>;
+        const playedCards = this.asModel().playerView.thisPlayer.playedCards as Array<CardModel>;
         const cardsWithFloaters = playedCards.filter((card) => card.resourceType === ResourceType.FLOATER && card.resources);
         return cardsWithFloaters.length === 1;
       }

--- a/src/components/PlayerHome.vue
+++ b/src/components/PlayerHome.vue
@@ -165,7 +165,7 @@
                 </template>
 
                 <dynamic-title v-if="playerView.pickedCorporationCard.length === 0" title="Select initial cards:" :color="thisPlayer.color"/>
-                <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :player="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
+                <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :playerView="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
 
                 <dynamic-title title="Game details" :color="thisPlayer.color"/>
 

--- a/src/components/PlayerHome.vue
+++ b/src/components/PlayerHome.vue
@@ -1,16 +1,16 @@
 <template>
         <div id="player-home" :class="(game.turmoil ? 'with-turmoil': '')">
-            <top-bar :player="player" />
+            <top-bar :playerView="playerView" />
 
             <div v-if="game.phase === 'end'">
                 <div class="player_home_block">
                     <DynamicTitle title="This game is over!" :color="thisPlayer.color"/>
-                    <a :href="'/the-end?id='+ player.id" v-i18n>Go to game results</a>
+                    <a :href="'/the-end?id='+ playerView.id" v-i18n>Go to game results</a>
                 </div>
             </div>
 
             <sidebar v-trim-whitespace
-              :acting_player="isPlayerActing(player)"
+              :acting_player="isPlayerActing(playerView)"
               :player_color="thisPlayer.color"
               :generation="game.generation"
               :coloniesCount="game.colonies.length"
@@ -21,7 +21,7 @@
               :turmoil = "game.turmoil"
               :moonData="game.moon"
               :gameOptions = "game.gameOptions"
-              :playerNumber = "player.players.length"
+              :playerNumber = "playerView.players.length"
               :lastSoloGeneration = "game.lastSoloGeneration">
                 <div class="deck-size">{{ game.deckSize }}</div>
             </sidebar>
@@ -49,35 +49,35 @@
 
                     <MoonBoard v-if="game.gameOptions.moonExpansion" :model="game.moon" :hideTiles="hideTiles"/>
 
-                    <div v-if="player.players.length > 1" class="player_home_block--milestones-and-awards">
+                    <div v-if="playerView.players.length > 1" class="player_home_block--milestones-and-awards">
                         <Milestone :milestones_list="game.milestones" />
                         <Award :awards_list="game.awards" />
                     </div>
                 </div>
 
-                <players-overview class="player_home_block player_home_block--players nofloat:" :playerView="player" v-trim-whitespace id="shortkey-playersoverview"/>
+                <players-overview class="player_home_block player_home_block--players nofloat:" :playerView="playerView" v-trim-whitespace id="shortkey-playersoverview"/>
 
                 <div class="player_home_block nofloat">
-                    <log-panel :id="player.id" :players="player.players" :generation="game.generation" :lastSoloGeneration="game.lastSoloGeneration" :color="thisPlayer.color"></log-panel>
+                    <log-panel :id="playerView.id" :players="playerView.players" :generation="game.generation" :lastSoloGeneration="game.lastSoloGeneration" :color="thisPlayer.color"></log-panel>
                 </div>
 
                 <div class="player_home_block player_home_block--actions nofloat">
                     <a name="actions" class="player_home_anchor"></a>
                     <dynamic-title title="Actions" :color="thisPlayer.color"/>
-                    <waiting-for v-if="game.phase !== 'end'" :players="player.players" :player="player" :settings="settings" :waitingfor="player.waitingFor"></waiting-for>
+                    <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :player="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
                 </div>
 
-                <div class="player_home_block player_home_block--hand" v-if="player.draftedCards.length > 0">
+                <div class="player_home_block player_home_block--hand" v-if="playerView.draftedCards.length > 0">
                     <dynamic-title title="Drafted cards" :color="thisPlayer.color" />
-                    <div v-for="card in player.draftedCards" :key="card.name" class="cardbox">
+                    <div v-for="card in playerView.draftedCards" :key="card.name" class="cardbox">
                         <Card :card="card"/>
                     </div>
                 </div>
 
                 <a name="cards" class="player_home_anchor"></a>
-                <div class="player_home_block player_home_block--hand" v-if="player.cardsInHand.length + player.preludeCardsInHand.length > 0" id="shortkey-hand">
-                    <dynamic-title title="Cards In Hand" :color="thisPlayer.color" :withAdditional="true" :additional="(thisPlayer.cardsInHandNbr + player.preludeCardsInHand.length).toString()" />
-                    <sortable-cards :playerId="player.id" :cards="player.preludeCardsInHand.concat(player.cardsInHand)" />
+                <div class="player_home_block player_home_block--hand" v-if="playerView.cardsInHand.length + playerView.preludeCardsInHand.length > 0" id="shortkey-hand">
+                    <dynamic-title title="Cards In Hand" :color="thisPlayer.color" :withAdditional="true" :additional="(thisPlayer.cardsInHandNbr + playerView.preludeCardsInHand.length).toString()" />
+                    <sortable-cards :playerId="playerView.id" :cards="playerView.preludeCardsInHand.concat(playerView.cardsInHand)" />
                 </div>
 
                 <div class="player_home_block player_home_block--cards">
@@ -126,61 +126,61 @@
             <div class="player_home_block player_home_block--setup nofloat"  v-if="!thisPlayer.corporationCard">
 
                 <template v-if="isInitialDraftingPhase()">
-                  <div v-for="card in player.dealtCorporationCards" :key="card.name" class="cardbox">
+                  <div v-for="card in playerView.dealtCorporationCards" :key="card.name" class="cardbox">
                     <Card :card="card"/>
                   </div>
 
-                  <div v-for="card in player.dealtPreludeCards" :key="card.name" class="cardbox">
+                  <div v-for="card in playerView.dealtPreludeCards" :key="card.name" class="cardbox">
                     <Card :card="card"/>
                   </div>
 
-                  <div v-for="card in player.dealtProjectCards" :key="card.name" class="cardbox">
+                  <div v-for="card in playerView.dealtProjectCards" :key="card.name" class="cardbox">
                     <Card :card="card"/>
                   </div>
                 </template>
-                <div class="player_home_block player_home_block--hand" v-if="player.draftedCards.length > 0">
+                <div class="player_home_block player_home_block--hand" v-if="playerView.draftedCards.length > 0">
                     <dynamic-title title="Drafted Cards" :color="thisPlayer.color"/>
-                    <div v-for="card in player.draftedCards" :key="card.name" class="cardbox">
+                    <div v-for="card in playerView.draftedCards" :key="card.name" class="cardbox">
                         <Card :card="card"/>
                     </div>
                 </div>
 
-                <template v-if="player.pickedCorporationCard.length === 1">
+                <template v-if="playerView.pickedCorporationCard.length === 1">
                   <dynamic-title title="Your selected cards:" :color="thisPlayer.color"/>
                   <div>
                     <div class="cardbox">
-                      <Card :card="player.pickedCorporationCard[0]"/>
+                      <Card :card="playerView.pickedCorporationCard[0]"/>
                     </div>
                     <template v-if="game.gameOptions.preludeExtension">
-                      <div v-for="card in player.preludeCardsInHand" :key="card.name" class="cardbox">
+                      <div v-for="card in playerView.preludeCardsInHand" :key="card.name" class="cardbox">
                         <Card :card="card"/>
                       </div>
                     </template>
                   </div>
                   <div>
-                    <div v-for="card in player.cardsInHand" :key="card.name" class="cardbox">
+                    <div v-for="card in playerView.cardsInHand" :key="card.name" class="cardbox">
                       <Card :card="card"/>
                     </div>
                   </div>
                 </template>
 
-                <dynamic-title v-if="player.pickedCorporationCard.length === 0" title="Select initial cards:" :color="thisPlayer.color"/>
-                <waiting-for v-if="game.phase !== 'end'" :players="player.players" :player="player" :settings="settings" :waitingfor="player.waitingFor"></waiting-for>
+                <dynamic-title v-if="playerView.pickedCorporationCard.length === 0" title="Select initial cards:" :color="thisPlayer.color"/>
+                <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :player="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
 
                 <dynamic-title title="Game details" :color="thisPlayer.color"/>
 
-                <div class="player_home_block" v-if="player.players.length > 1">
+                <div class="player_home_block" v-if="playerView.players.length > 1">
                     <Milestone :show_scores="false" :milestones_list="game.milestones" />
                     <Award :show_scores="false" :awards_list="game.awards" />
                 </div>
 
-                <div class="player_home_block player_home_block--turnorder nofloat" v-if="player.players.length>1">
+                <div class="player_home_block player_home_block--turnorder nofloat" v-if="playerView.players.length>1">
                     <dynamic-title title="Turn order" :color="thisPlayer.color"/>
-                    <div class="player_item" v-for="(p, idx) in player.players" :key="idx" v-trim-whitespace>
+                    <div class="player_item" v-for="(p, idx) in playerView.players" :key="idx" v-trim-whitespace>
                         <div class="player_name_cont" :class="getPlayerCssForTurnOrder(p, true)">
                             <span class="player_number">{{ idx+1 }}.</span><span class="player_name" :class="getPlayerCssForTurnOrder(p, false)" href="#">{{ p.name }}</span>
                         </div>
-                        <div class="player_separator" v-if="idx !== player.players.length - 1">⟶</div>
+                        <div class="player_separator" v-if="idx !== playerView.players.length - 1">⟶</div>
                     </div>
                 </div>
 
@@ -213,7 +213,7 @@
                 <a name="colonies" class="player_home_anchor"></a>
                 <dynamic-title title="Colonies" :color="thisPlayer.color"/>
                 <div class="colonies-fleets-cont" v-if="thisPlayer.corporationCard">
-                    <div class="colonies-player-fleets" v-for="colonyPlayer in player.players" :key="colonyPlayer.color">
+                    <div class="colonies-player-fleets" v-for="colonyPlayer in playerView.players" :key="colonyPlayer.color">
                         <div :class="'colonies-fleet colonies-fleet-'+ colonyPlayer.color" v-for="idx in getFleetsCountRange(colonyPlayer)" :key="idx"></div>
                     </div>
                 </div>
@@ -287,7 +287,7 @@ export default Vue.extend({
     },
   },
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     settings: {
@@ -296,10 +296,10 @@ export default Vue.extend({
   },
   computed: {
     thisPlayer(): PublicPlayerModel {
-      return this.player.thisPlayer;
+      return this.playerView.thisPlayer;
     },
     game(): GameModel {
-      return this.player.game;
+      return this.playerView.game;
     },
   },
   components: {
@@ -349,8 +349,8 @@ export default Vue.extend({
         }
       }
     },
-    isPlayerActing(player: PlayerViewModel) : boolean {
-      return player.players.length > 1 && player.waitingFor !== undefined;
+    isPlayerActing(playerView: PlayerViewModel) : boolean {
+      return playerView.players.length > 1 && playerView.waitingFor !== undefined;
     },
     getPlayerCssForTurnOrder: (
       player: PublicPlayerModel,

--- a/src/components/PlayerHome.vue
+++ b/src/components/PlayerHome.vue
@@ -64,7 +64,7 @@
                 <div class="player_home_block player_home_block--actions nofloat">
                     <a name="actions" class="player_home_anchor"></a>
                     <dynamic-title title="Actions" :color="thisPlayer.color"/>
-                    <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :player="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
+                    <waiting-for v-if="game.phase !== 'end'" :players="playerView.players" :playerView="playerView" :settings="settings" :waitingfor="playerView.waitingFor"></waiting-for>
                 </div>
 
                 <div class="player_home_block player_home_block--hand" v-if="playerView.draftedCards.length > 0">

--- a/src/components/PlayerInputFactory.vue
+++ b/src/components/PlayerInputFactory.vue
@@ -1,7 +1,7 @@
 <template>
   <component :is="getComponentName(playerinput.inputType)"
     :players="players"
-    :player="player"
+    :playerView="playerView"
     :playerinput="playerinput"
     :onsave="onsave"
     :showsave="showsave"
@@ -35,7 +35,7 @@ export default Vue.component('player-input-factory', {
     players: {
       type: Array as () => Array<PublicPlayerModel>,
     },
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     playerinput: {

--- a/src/components/SelectCard.vue
+++ b/src/components/SelectCard.vue
@@ -40,7 +40,7 @@ interface SelectCardModel {
 export default Vue.extend({
   name: 'SelectCard',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     playerinput: {
@@ -63,6 +63,12 @@ export default Vue.extend({
       cards: [],
       warning: undefined,
     } as SelectCardModel;
+  },
+  computed: {
+    // TODO(kberg): Remove after everything becomes playerView.
+    player(): PlayerViewModel {
+      return this.playerView;
+    },
   },
   components: {
     Card,

--- a/src/components/SelectHowToPay.vue
+++ b/src/components/SelectHowToPay.vue
@@ -11,7 +11,7 @@ import {TranslateMixin} from './TranslateMixin';
 export default Vue.extend({
   name: 'SelectHowToPay',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     playerinput: {
@@ -28,6 +28,10 @@ export default Vue.extend({
     },
   },
   computed: {
+    // TODO(kberg): Remove after everything becomes playerView.
+    player(): PlayerViewModel {
+      return this.playerView;
+    },
     thisPlayer: function(): PublicPlayerModel {
       return this.player.thisPlayer;
     },

--- a/src/components/SelectHowToPayForProjectCard.vue
+++ b/src/components/SelectHowToPayForProjectCard.vue
@@ -18,7 +18,7 @@ import {Units} from '../Units';
 export default Vue.extend({
   name: 'SelectHowToPayForProjectCard',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     playerinput: {
@@ -35,6 +35,10 @@ export default Vue.extend({
     },
   },
   computed: {
+    // TODO(kberg): Remove after everything becomes playerView.
+    player(): PlayerViewModel {
+      return this.playerView;
+    },
     thisPlayer: function(): PublicPlayerModel {
       return this.player.thisPlayer;
     },
@@ -46,7 +50,7 @@ export default Vue.extend({
             this.playerinput.cards !== undefined &&
             this.playerinput.cards.length > 0) {
       cards = CardOrderStorage.getOrdered(
-        CardOrderStorage.getCardOrder(this.player.id),
+        CardOrderStorage.getCardOrder(this.playerView.id),
         this.playerinput.cards,
       );
       card = cards[0];

--- a/src/components/SelectInitialCards.vue
+++ b/src/components/SelectInitialCards.vue
@@ -4,9 +4,9 @@
       message="Continue without buying initial cards?"
       ref="confirmation"
       v-on:accept="confirmSelection" />
-    <SelectCard :player="player" :playerinput="getOption(0)" :showtitle="true" :onsave="noop" v-on:cardschanged="corporationChanged" />
-    <SelectCard v-if="hasPrelude()" :player="player" :playerinput="getOption(1)" :onsave="noop" :showtitle="true" v-on:cardschanged="preludesChanged" />
-    <SelectCard :player="player" :playerinput="getOption(hasPrelude() ? 2 : 1)" :onsave="noop" :showtitle="true" v-on:cardschanged="cardsChanged" />
+    <SelectCard :playerView="player" :playerinput="getOption(0)" :showtitle="true" :onsave="noop" v-on:cardschanged="corporationChanged" />
+    <SelectCard v-if="hasPrelude()" :playerView="player" :playerinput="getOption(1)" :onsave="noop" :showtitle="true" v-on:cardschanged="preludesChanged" />
+    <SelectCard :playerView="player" :playerinput="getOption(hasPrelude() ? 2 : 1)" :onsave="noop" :showtitle="true" v-on:cardschanged="cardsChanged" />
     <div v-if="selectedCorporation" v-i18n>Starting Megacredits: <div class="megacredits">{{getStartingMegacredits()}}</div></div>
     <div v-if="selectedCorporation && hasPrelude()" v-i18n>After Preludes: <div class="megacredits">{{getStartingMegacredits() + getAfterPreludes()}}</div></div>
     <Button v-if="showsave" @click="saveIfConfirmed" type="submit" :title="playerinput.buttonLabel" />
@@ -31,7 +31,7 @@ import {PreferencesManager} from './PreferencesManager';
 export default Vue.extend({
   name: 'SelectInitialCards',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     playerinput: {
@@ -45,6 +45,12 @@ export default Vue.extend({
     },
     showtitle: {
       type: Boolean,
+    },
+  },
+  computed: {
+    // TODO(kberg): Remove after everything becomes playerView.
+    player(): PlayerViewModel {
+      return this.playerView;
     },
   },
   components: {

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="formatCssClass()" :key="componentKey">
-      <PlayerInfo v-show="isExpanded()" :player="player.thisPlayer" :playerView="player" actionLabel="" :playerIndex="0" :hideZeroTags="true"/>
+      <PlayerInfo v-show="isExpanded()" :player="playerView.thisPlayer" :playerView="playerView" actionLabel="" :playerIndex="0" :hideZeroTags="true"/>
       <div class="top-bar-collapser" v-on:click="toggleBar()">
         <img src="/assets/arrows_left.png">
       </div>
@@ -17,7 +17,7 @@ import {PreferencesManager} from './PreferencesManager';
 export default Vue.extend({
   name: 'top-bar',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
   },

--- a/src/components/WaitingFor.vue
+++ b/src/components/WaitingFor.vue
@@ -2,7 +2,7 @@
   <div v-if="waitingfor === undefined">{{ $t('Not your turn to take any actions') }}</div>
   <div v-else class="wf-root">
     <player-input-factory :players="players"
-                          :player="player"
+                          :playerView="playerView"
                           :playerinput="waitingfor"
                           :onsave="onsave"
                           :showsave="true"
@@ -32,7 +32,7 @@ let documentTitleTimer: number | undefined;
 export default Vue.extend({
   name: 'waiting-for',
   props: {
-    player: {
+    playerView: {
       type: Object as () => PlayerViewModel,
     },
     players: {
@@ -72,7 +72,7 @@ export default Vue.extend({
       }
 
       root.isServerSideRequestInProgress = true;
-      xhr.open('POST', '/player/input?id=' + this.player.id);
+      xhr.open('POST', '/player/input?id=' + this.playerView.id);
       xhr.responseType = 'json';
       xhr.onload = () => {
         if (xhr.status === 200) {
@@ -80,7 +80,7 @@ export default Vue.extend({
           root.playerView = xhr.response;
           root.playerkey++;
           root.screen = 'player-home';
-          if (this.player.game.phase === 'end' && window.location.pathname !== '/the-end') {
+          if (this.playerView.game.phase === 'end' && window.location.pathname !== '/the-end') {
             (window).location = (window).location;
           }
         } else if (xhr.status === 400 && xhr.responseType === 'json') {
@@ -101,7 +101,7 @@ export default Vue.extend({
       clearTimeout(ui_update_timeout_id);
       const askForUpdate = () => {
         const xhr = new XMLHttpRequest();
-        xhr.open('GET', '/api/waitingfor' + window.location.search + '&gameAge=' + this.player.game.gameAge + '&undoCount=' + this.player.game.undoCount);
+        xhr.open('GET', '/api/waitingfor' + window.location.search + '&gameAge=' + this.playerView.game.gameAge + '&undoCount=' + this.playerView.game.undoCount);
         xhr.onerror = function() {
           root.showAlert('Unable to reach the server. The server may be restarting or down for maintenance.', () => vueApp.waitForUpdate());
         };
@@ -148,7 +148,7 @@ export default Vue.extend({
     if (this.waitingfor === undefined) {
       this.waitForUpdate();
     }
-    if (this.player.players.length > 1 && this.player.waitingFor !== undefined) {
+    if (this.playerView.players.length > 1 && this.playerView.waitingFor !== undefined) {
       documentTitleTimer = window.setInterval(() => this.animateTitle(), 1000);
     }
   },

--- a/src/components/WaitingFor.vue
+++ b/src/components/WaitingFor.vue
@@ -77,7 +77,7 @@ export default Vue.extend({
       xhr.onload = () => {
         if (xhr.status === 200) {
           root.screen = 'empty';
-          root.player = xhr.response;
+          root.playerView = xhr.response;
           root.playerkey++;
           root.screen = 'player-home';
           if (this.player.game.phase === 'end' && window.location.pathname !== '/the-end') {

--- a/tests/components/PlayerInputFactory.spec.ts
+++ b/tests/components/PlayerInputFactory.spec.ts
@@ -138,7 +138,7 @@ describe('PlayerInputFactory', function() {
         localVue: getLocalVue(),
         propsData: {
           players: [],
-          player: {
+          playerView: {
             id: 'foo',
           },
           playerinput,

--- a/tests/components/SelectHowToPay.spec.ts
+++ b/tests/components/SelectHowToPay.spec.ts
@@ -82,7 +82,7 @@ describe('SelectHowToPay', () => {
       steelValue: 2,
       titaniumValue: 3,
     }, playerFields);
-    const player: Partial<PlayerViewModel> = {
+    const playerView: Partial<PlayerViewModel> = {
       thisPlayer: thisPlayer as PublicPlayerModel,
       id: 'foo',
     };
@@ -98,7 +98,7 @@ describe('SelectHowToPay', () => {
     return mount(SelectHowToPay, {
       localVue: getLocalVue(),
       propsData: {
-        player: player,
+        playerView: playerView,
         playerinput: playerInput,
         onsave: () => {},
         showsave: true,

--- a/tests/components/SelectHowToPayForProjectCard.spec.ts
+++ b/tests/components/SelectHowToPayForProjectCard.spec.ts
@@ -36,7 +36,7 @@ describe('SelectHowToPayForProjectCard', () => {
     const sortable = mount(SelectHowToPayForProjectCard, {
       localVue: getLocalVue(),
       propsData: {
-        player: {
+        playerView: {
           cardsInHand: [{
             calculatedCost: 4,
             name: CardName.ANTS,
@@ -329,7 +329,7 @@ describe('SelectHowToPayForProjectCard', () => {
       titanium: 0,
     }, playerFields);
 
-    const player: Partial<PlayerViewModel>= {
+    const playerView: Partial<PlayerViewModel>= {
       id: 'foo',
       thisPlayer: thisPlayer as PublicPlayerModel,
     };
@@ -350,7 +350,7 @@ describe('SelectHowToPayForProjectCard', () => {
     return mount(SelectHowToPayForProjectCard, {
       localVue: getLocalVue(),
       propsData: {
-        player: player,
+        playerView: playerView,
         playerinput: playerInput,
         onsave: () => {},
         showsave: true,

--- a/tests/components/SelectInitialCards.spec.ts
+++ b/tests/components/SelectInitialCards.spec.ts
@@ -16,7 +16,7 @@ describe('SelectInitialCards', function() {
     const component = mount(SelectInitialCards, {
       localVue: getLocalVue(),
       propsData: {
-        player: {
+        playerView: {
           id: 'foo',
         },
         playerinput: {
@@ -51,7 +51,7 @@ describe('SelectInitialCards', function() {
     const component = mount(SelectInitialCards, {
       localVue: getLocalVue(),
       propsData: {
-        player: {
+        playerView: {
           id: 'foo',
         },
         playerinput: {


### PR DESCRIPTION
Depends on #3563 and #3564

Rather than rename all the fields in all the components at once, this commit uses computed to ease the transition. Then I can do the change for each one individually. But these have to be in a bunch because there's a cross-reference between them thanks to the relationship between PlayerInputFactory, AndOptions and OrOptions.