### PR TITLE
Improve DX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2168,6 +2168,16 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -2375,6 +2385,17 @@
         "inherits": "~2.0.0",
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "function-bind": {
@@ -2984,6 +3005,17 @@
         "make-dir": "^2.1.0",
         "rimraf": "^2.6.3",
         "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "istanbul-reports": {
@@ -4019,6 +4051,15 @@
         "which": "1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -4051,6 +4092,14 @@
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "semver": {
@@ -4295,6 +4344,15 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         },
         "string-width": {
           "version": "3.1.0",
@@ -5023,9 +5081,10 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -5234,6 +5293,17 @@
         "rimraf": "^2.6.2",
         "signal-exit": "^3.0.2",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "spdx-correct": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,6 +1309,52 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "console-stamp": "3.0.0-rc4.2",
+    "cross-env": "^7.0.3",
     "dialog-polyfill": "^0.5.1",
     "dotenv": "^8.2.0",
     "eslint": "^6.6.0",
@@ -72,10 +73,10 @@
     "test": "npm run test:server && npm run test:components",
     "test:server": "mocha --require build/tests/utils/setup.js --recursive build/tests --exclude 'build/tests/components/**'",
     "pretest:server": "tsc --build tests/tsconfig.json",
-    "test:components": "vti diagnostics && mochapack --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
-    "test:components:watch": "mochapack --watch --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
-    "watch": "webpack --watch --mode=development",
-    "webpack": "webpack"
+    "test:components": "cross-env NODE_ENV=development vti diagnostics && mochapack --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
+    "test:components:watch": "cross-env NODE_ENV=development mochapack --watch --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
+    "watch": "cross-env NODE_ENV=development webpack --watch",
+    "webpack": "cross-env NODE_ENV=production webpack"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mochapack": "^2.1.2",
     "mutation-observer": "^1.0.3",
     "nyc": "^14.1.1",
+    "rimraf": "^3.0.2",
     "sinon": "^11.1.1",
     "ts-loader": "^9.2.2",
     "vue-loader": "^15.9.7",
@@ -75,6 +76,7 @@
     "pretest:server": "tsc --build tests/tsconfig.json",
     "test:components": "cross-env NODE_ENV=development vti diagnostics && mochapack --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
     "test:components:watch": "cross-env NODE_ENV=development mochapack --watch --require tests/components/setup.ts 'tests/components/**/*.spec.ts'",
+    "prewatch": "rimraf build/main.js*.{br,gz}",
     "watch": "cross-env NODE_ENV=development webpack --watch",
     "webpack": "cross-env NODE_ENV=production webpack"
   },

--- a/src/routes/ServeAsset.ts
+++ b/src/routes/ServeAsset.ts
@@ -115,6 +115,13 @@ export class ServeAsset extends Handler {
         encoding = 'gzip';
         file += '.gz';
       }
+
+      // Return not-compressed .js files for development mode
+      if (!fs.existsSync(file)) {
+        encoding = undefined;
+        file = `build/${urlPath}`;
+      }
+
       return {file, encoding};
 
     case 'favicon.ico':

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,31 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const zlib = require('zlib');
 
+const plugins = [
+  new ForkTsCheckerWebpackPlugin({
+    typescript: {
+      configOverwrite: {
+        exclude: [
+          'tests/**/*.ts',
+        ],
+      },
+      extensions: {
+        vue: true,
+      },
+    },
+  }),
+  new VueLoaderPlugin(),
+];
+
+if (process.env.NODE_ENV === 'production') {
+  plugins.push(new CompressionPlugin());
+  plugins.push(new CompressionPlugin({
+    algorithm: 'brotliCompress',
+    filename: '[path][base].br',
+    compressionOptions: {params: {[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY}},
+  }));
+}
+
 module.exports = {
   devtool: 'source-map',
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -37,27 +62,7 @@ module.exports = {
       },
     ],
   },
-  plugins: [
-    new ForkTsCheckerWebpackPlugin({
-      typescript: {
-        configOverwrite: {
-          exclude: [
-            "tests/**/*.ts"
-          ],
-        },
-        extensions: {
-          vue: true
-        }
-      }
-    }),
-    new VueLoaderPlugin(),
-    new CompressionPlugin(),
-    new CompressionPlugin({
-      algorithm: 'brotliCompress',
-      filename: '[path][base].br',
-      compressionOptions: {params: {[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY}},
-    }),
-  ],
+  plugins,
   output: {
     path: __dirname + '/build',
   },


### PR DESCRIPTION
It's a little workaround because backend doesn't have separation of prod/dev mode.

# What's changed
1. If there is no `main.js.br` - the server sends original js file. This uncompressed file is necessary in front dev mode
2. The `npm run watch` command now deletes `.js*.br` and `.js*.gz` files before it runs
3. Webpack compression plugin is only available in production mode
4. `NODE_ENV` is now explicitly set for each of build/dev command

# Why?
1. Users will no longer build their instances in webpack development mode. (to build in production mode you must have NODE_ENV set to the `production` and nobody except heroku has)
2. Recompiling components in `npm run watch` now takes 20x faster
3. Rerun test in `npm run test:componets:watch` now is instant