### PR TITLE
Rename CardMetadata -> ICardMetadata. 

### DIFF
--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -1,4 +1,4 @@
-import {ICardMetadata} from './CardMetadata';
+import {ICardMetadata} from './ICardMetadata';
 import {CardName} from '../CardName';
 import {CardType} from './CardType';
 import {IAdjacencyBonus} from '../ares/IAdjacencyBonus';

--- a/src/cards/Card.ts
+++ b/src/cards/Card.ts
@@ -1,4 +1,4 @@
-import {CardMetadata} from './CardMetadata';
+import {ICardMetadata} from './CardMetadata';
 import {CardName} from '../CardName';
 import {CardType} from './CardType';
 import {IAdjacencyBonus} from '../ares/IAdjacencyBonus';
@@ -15,7 +15,7 @@ export interface StaticCardProperties {
   cardType: CardType;
   cost?: number;
   initialActionText?: string;
-  metadata: CardMetadata;
+  metadata: ICardMetadata;
   requirements?: CardRequirements;
   name: CardName;
   resourceType?: ResourceType;

--- a/src/cards/CardMetadata.ts
+++ b/src/cards/CardMetadata.ts
@@ -2,7 +2,7 @@ import {CardRenderer} from '../cards/render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from './render/CardRenderDynamicVictoryPoints';
 import {ICardRenderDescription} from './render/ICardRenderDescription';
 
-export interface CardMetadata {
+export interface ICardMetadata {
   cardNumber: string;
   description?: string | ICardRenderDescription;
   renderData?: CardRenderer;

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -15,7 +15,7 @@ import {OrOptions} from '../inputs/OrOptions';
 import {SelectOption} from '../inputs/SelectOption';
 import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
-import {ICardMetadata} from './CardMetadata';
+import {ICardMetadata} from './ICardMetadata';
 import {StandardProjectCard} from './StandardProjectCard';
 import {CardRequirements} from './CardRequirements';
 import {GlobalParameter} from '../GlobalParameter';

--- a/src/cards/ICard.ts
+++ b/src/cards/ICard.ts
@@ -15,7 +15,7 @@ import {OrOptions} from '../inputs/OrOptions';
 import {SelectOption} from '../inputs/SelectOption';
 import {ResourceType} from '../ResourceType';
 import {CardName} from '../CardName';
-import {CardMetadata} from './CardMetadata';
+import {ICardMetadata} from './CardMetadata';
 import {StandardProjectCard} from './StandardProjectCard';
 import {CardRequirements} from './CardRequirements';
 import {GlobalParameter} from '../GlobalParameter';
@@ -57,7 +57,7 @@ export interface ICard {
     cost?: number;
     cardType: CardType;
     requirements?: CardRequirements;
-    metadata: CardMetadata;
+    metadata: ICardMetadata;
     warning?: string | Message;
     productionBox?: Units;
     produce?: (player: Player) => void;

--- a/src/cards/ICardMetadata.ts
+++ b/src/cards/ICardMetadata.ts
@@ -1,4 +1,4 @@
-import {CardRenderer} from '../cards/render/CardRenderer';
+import {CardRenderer} from './render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from './render/CardRenderDynamicVictoryPoints';
 import {ICardRenderDescription} from './render/ICardRenderDescription';
 

--- a/src/cards/StandardActionCard.ts
+++ b/src/cards/StandardActionCard.ts
@@ -1,6 +1,6 @@
 import {CardType} from './CardType';
 import {Player} from '../Player';
-import {ICardMetadata} from './CardMetadata';
+import {ICardMetadata} from './ICardMetadata';
 import {CardName} from '../CardName';
 import {Card} from './Card';
 import {IActionCard, ICard} from './ICard';

--- a/src/cards/StandardActionCard.ts
+++ b/src/cards/StandardActionCard.ts
@@ -1,6 +1,6 @@
 import {CardType} from './CardType';
 import {Player} from '../Player';
-import {CardMetadata} from './CardMetadata';
+import {ICardMetadata} from './CardMetadata';
 import {CardName} from '../CardName';
 import {Card} from './Card';
 import {IActionCard, ICard} from './ICard';
@@ -8,7 +8,7 @@ import {PlayerInput} from '../PlayerInput';
 
 interface StaticStandardActionCardProperties {
   name: CardName,
-  metadata: CardMetadata,
+  metadata: ICardMetadata,
 }
 
 export abstract class StandardActionCard extends Card implements IActionCard, ICard {

--- a/src/cards/StandardProjectCard.ts
+++ b/src/cards/StandardProjectCard.ts
@@ -10,7 +10,7 @@ import {SelectPlayer} from '../inputs/SelectPlayer';
 import {AndOptions} from '../inputs/AndOptions';
 import {SelectCard} from '../inputs/SelectCard';
 import {SelectSpace} from '../inputs/SelectSpace';
-import {ICardMetadata} from './CardMetadata';
+import {ICardMetadata} from './ICardMetadata';
 import {CardName} from '../CardName';
 import {SelectHowToPayDeferred} from '../deferredActions/SelectHowToPayDeferred';
 import {Card} from './Card';

--- a/src/cards/StandardProjectCard.ts
+++ b/src/cards/StandardProjectCard.ts
@@ -10,7 +10,7 @@ import {SelectPlayer} from '../inputs/SelectPlayer';
 import {AndOptions} from '../inputs/AndOptions';
 import {SelectCard} from '../inputs/SelectCard';
 import {SelectSpace} from '../inputs/SelectSpace';
-import {CardMetadata} from './CardMetadata';
+import {ICardMetadata} from './CardMetadata';
 import {CardName} from '../CardName';
 import {SelectHowToPayDeferred} from '../deferredActions/SelectHowToPayDeferred';
 import {Card} from './Card';
@@ -20,7 +20,7 @@ import {Units} from '../Units';
 interface StaticStandardProjectCardProperties {
   name: CardName,
   cost: number,
-  metadata: CardMetadata,
+  metadata: ICardMetadata,
   reserveUnits?: Units,
 }
 

--- a/src/cards/base/Capital.ts
+++ b/src/cards/base/Capital.ts
@@ -11,7 +11,7 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
 import {Board} from '../../boards/Board';
-import {CardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
@@ -21,7 +21,7 @@ export class Capital extends Card implements IProjectCard {
   constructor(
     name: CardName = CardName.CAPITAL,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata: ICardMetadata = {
       cardNumber: '008',
       description: {
         text: 'Requires 4 ocean tiles. Place this tile. Decrease your Energy production 2 steps and increase your M€ production 5 steps.',

--- a/src/cards/base/Capital.ts
+++ b/src/cards/base/Capital.ts
@@ -11,7 +11,7 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
 import {Board} from '../../boards/Board';
-import {ICardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../ICardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';

--- a/src/cards/base/CommercialDistrict.ts
+++ b/src/cards/base/CommercialDistrict.ts
@@ -10,7 +10,6 @@ import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {Board} from '../../boards/Board';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
 import {Units} from '../../Units';
@@ -19,7 +18,7 @@ export class CommercialDistrict extends Card implements IProjectCard {
   constructor(
     name: CardName = CardName.COMMERCIAL_DISTRICT,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '085',
       description: 'Place this tile. Decrease your energy production 1 step and increase your M€ production 4 steps.',
       renderData: CardRenderer.builder((b) => {

--- a/src/cards/base/EcologicalZone.ts
+++ b/src/cards/base/EcologicalZone.ts
@@ -10,7 +10,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../CardName';
 import {IResourceCard} from '../ICard';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';
@@ -21,7 +21,7 @@ export class EcologicalZone extends Card implements IProjectCard, IResourceCard 
     name: CardName = CardName.ECOLOGICAL_ZONE,
     cost: number = 12,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata: ICardMetadata = {
       description: {
         text: 'Requires that YOU have a greenery tile. Place this tile adjacent to ANY greenery.',
         align: 'left',

--- a/src/cards/base/EcologicalZone.ts
+++ b/src/cards/base/EcologicalZone.ts
@@ -10,7 +10,7 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../CardName';
 import {IResourceCard} from '../ICard';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {ICardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../ICardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardRenderDynamicVictoryPoints} from '../render/CardRenderDynamicVictoryPoints';

--- a/src/cards/base/IndustrialCenter.ts
+++ b/src/cards/base/IndustrialCenter.ts
@@ -12,14 +12,13 @@ import {CardName} from '../../CardName';
 import {Board} from '../../boards/Board';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class IndustrialCenter extends Card implements IActionCard, IProjectCard {
   constructor(
     name: CardName = CardName.INDUSTRIAL_CENTER,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '123',
       renderData: CardRenderer.builder((b) => {
         b.action('Spend 7 M€ to increase your steel production 1 step.', (eb) => {

--- a/src/cards/base/LavaFlows.ts
+++ b/src/cards/base/LavaFlows.ts
@@ -13,14 +13,13 @@ import {MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class LavaFlows extends Card implements IProjectCard {
   constructor(
     name: CardName = CardName.LAVA_FLOWS,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '140',
       renderData: CardRenderer.builder((b) => {
         b.temperature(2).br;

--- a/src/cards/base/MiningArea.ts
+++ b/src/cards/base/MiningArea.ts
@@ -2,13 +2,12 @@ import {Player} from '../../Player';
 import {TileType} from '../../TileType';
 import {CardName} from '../../CardName';
 import {MiningCard} from './MiningCard';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MiningArea extends MiningCard {
   constructor(
     name: CardName = CardName.MINING_AREA,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '064',
       renderData: CardRenderer.builder((b) => {
         b.tile(TileType.MINING_AREA, true).asterix().br;

--- a/src/cards/base/MiningCard.ts
+++ b/src/cards/base/MiningCard.ts
@@ -1,5 +1,5 @@
 import {Card} from '../Card';
-import {CardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../CardMetadata';
 import {CardName} from '../../CardName';
 import {CardType} from '../../cards/CardType';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
@@ -16,7 +16,7 @@ export abstract class MiningCard extends Card implements IProjectCard {
   constructor(
     name: CardName,
     cost: number,
-    metadata: CardMetadata) {
+    metadata: ICardMetadata) {
     super({
       cardType: CardType.AUTOMATED,
       name,

--- a/src/cards/base/MiningCard.ts
+++ b/src/cards/base/MiningCard.ts
@@ -1,5 +1,5 @@
 import {Card} from '../Card';
-import {ICardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../ICardMetadata';
 import {CardName} from '../../CardName';
 import {CardType} from '../../cards/CardType';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';

--- a/src/cards/base/MiningRights.ts
+++ b/src/cards/base/MiningRights.ts
@@ -2,13 +2,12 @@
 import {CardName} from '../../CardName';
 import {MiningCard} from './MiningCard';
 import {TileType} from '../../TileType';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class MiningRights extends MiningCard {
   constructor(
     name: CardName = CardName.MINING_RIGHTS,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '067',
       renderData: CardRenderer.builder((b) => {
         b.tile(TileType.MINING_RIGHTS, true).asterix().br;

--- a/src/cards/base/MoholeArea.ts
+++ b/src/cards/base/MoholeArea.ts
@@ -10,7 +10,6 @@ import {ISpace} from '../../boards/ISpace';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
 
@@ -18,7 +17,7 @@ export class MoholeArea extends Card implements IProjectCard {
   constructor(
     name: CardName = CardName.MOHOLE_AREA,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '142',
       renderData: CardRenderer.builder((b) => {
         b.production((pb) => pb.heat(4).digit).br;

--- a/src/cards/base/NaturalPreserve.ts
+++ b/src/cards/base/NaturalPreserve.ts
@@ -9,7 +9,6 @@ import {SelectSpace} from '../../inputs/SelectSpace';
 import {Resources} from '../../Resources';
 import {CardName} from '../../CardName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRequirements} from '../CardRequirements';
 import {CardRenderer} from '../render/CardRenderer';
 import {Units} from '../../Units';
@@ -18,7 +17,7 @@ export class NaturalPreserve extends Card implements IProjectCard {
   constructor(
     name: CardName = CardName.NATURAL_PRESERVE,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '044',
       renderData: CardRenderer.builder((b) => {
         b.production((pb) => pb.megacredits(1)).nbsp.tile(TileType.NATURAL_PRESERVE, true).asterix();

--- a/src/cards/base/NuclearZone.ts
+++ b/src/cards/base/NuclearZone.ts
@@ -11,7 +11,6 @@ import {MAX_TEMPERATURE, REDS_RULING_POLICY_COST} from '../../constants';
 import {PartyHooks} from '../../turmoil/parties/PartyHooks';
 import {PartyName} from '../../turmoil/parties/PartyName';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class NuclearZone extends Card implements IProjectCard {
@@ -19,7 +18,7 @@ export class NuclearZone extends Card implements IProjectCard {
     name: CardName = CardName.NUCLEAR_ZONE,
     cost: number = 10,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '097',
       renderData: CardRenderer.builder((b) => {
         b.tile(TileType.NUCLEAR_ZONE, true).br;

--- a/src/cards/base/RestrictedArea.ts
+++ b/src/cards/base/RestrictedArea.ts
@@ -10,14 +10,13 @@ import {ISpace} from '../../boards/ISpace';
 import {CardName} from '../../CardName';
 import {SelectHowToPayDeferred} from '../../deferredActions/SelectHowToPayDeferred';
 import {IAdjacencyBonus} from '../../ares/IAdjacencyBonus';
-import {CardMetadata} from '../CardMetadata';
 import {CardRenderer} from '../render/CardRenderer';
 
 export class RestrictedArea extends Card implements IActionCard, IProjectCard {
   constructor(
     name: CardName = CardName.RESTRICTED_AREA,
     adjacencyBonus: IAdjacencyBonus | undefined = undefined,
-    metadata: CardMetadata = {
+    metadata = {
       cardNumber: '199',
       renderData: CardRenderer.builder((b) => {
         b.action('Spend 2 M€ to draw a card.', (eb) => {

--- a/src/cards/community/ScienceTagCard.ts
+++ b/src/cards/community/ScienceTagCard.ts
@@ -2,7 +2,7 @@ import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {CardName} from '../../CardName';
-import {ICardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../ICardMetadata';
 
 export class ScienceTagCard implements IProjectCard {
   public get cost() {

--- a/src/cards/community/ScienceTagCard.ts
+++ b/src/cards/community/ScienceTagCard.ts
@@ -2,7 +2,7 @@ import {IProjectCard} from '../IProjectCard';
 import {Tags} from '../Tags';
 import {CardType} from '../CardType';
 import {CardName} from '../../CardName';
-import {CardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../CardMetadata';
 
 export class ScienceTagCard implements IProjectCard {
   public get cost() {
@@ -17,7 +17,7 @@ export class ScienceTagCard implements IProjectCard {
   public get cardType() {
     return CardType.PROXY;
   }
-  public get metadata(): CardMetadata {
+  public get metadata(): ICardMetadata {
     throw new Error('ScienceTagCard is a proxy card, not a real card. Should not render');
   }
   public play() {

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -2,7 +2,7 @@ import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
-import {ICardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../ICardMetadata';
 import {CardName} from '../../CardName';
 import {Tags} from '../Tags';
 import {IProjectCard} from '../IProjectCard';

--- a/src/cards/prelude/PreludeCard.ts
+++ b/src/cards/prelude/PreludeCard.ts
@@ -2,14 +2,14 @@ import {Card} from '../Card';
 import {CardType} from '../CardType';
 import {Player} from '../../Player';
 import {PlayerInput} from '../../PlayerInput';
-import {CardMetadata} from '../CardMetadata';
+import {ICardMetadata} from '../CardMetadata';
 import {CardName} from '../../CardName';
 import {Tags} from '../Tags';
 import {IProjectCard} from '../IProjectCard';
 import {Units} from '../../Units';
 
 interface StaticPreludeProperties {
-    metadata: CardMetadata;
+    metadata: ICardMetadata;
     name: CardName;
     tags?: Array<Tags>;
     productionBox?: Units;

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -35,7 +35,7 @@ import CardExpansion from './CardExpansion.vue';
 import CardTags from './CardTags.vue';
 import {CardType} from '../../cards/CardType';
 import CardContent from './CardContent.vue';
-import {ICardMetadata} from '../../cards/CardMetadata';
+import {ICardMetadata} from '../../cards/ICardMetadata';
 import {Tags} from '../../cards/Tags';
 import {ALL_CARD_MANIFESTS} from '../../cards/AllCards';
 import {GameModule} from '../../GameModule';

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -35,7 +35,7 @@ import CardExpansion from './CardExpansion.vue';
 import CardTags from './CardTags.vue';
 import {CardType} from '../../cards/CardType';
 import CardContent from './CardContent.vue';
-import {CardMetadata} from '../../cards/CardMetadata';
+import {ICardMetadata} from '../../cards/CardMetadata';
 import {Tags} from '../../cards/Tags';
 import {ALL_CARD_MANIFESTS} from '../../cards/AllCards';
 import {GameModule} from '../../GameModule';
@@ -157,7 +157,7 @@ export default Vue.extend({
       }
       return classes.join(' ');
     },
-    getCardMetadata(): CardMetadata | undefined {
+    getCardMetadata(): ICardMetadata | undefined {
       return this.getCard()?.metadata;
     },
     getCardRequirements(): CardRequirements | undefined {

--- a/src/components/card/CardContent.vue
+++ b/src/components/card/CardContent.vue
@@ -10,7 +10,7 @@
 <script lang="ts">
 
 import Vue from 'vue';
-import {ICardMetadata} from '../../cards/CardMetadata';
+import {ICardMetadata} from '../../cards/ICardMetadata';
 import CardRequirementsComponent from './CardRequirementsComponent.vue';
 import CardVictoryPoints from './CardVictoryPoints.vue';
 import CardDescription from './CardDescription.vue';

--- a/src/components/card/CardContent.vue
+++ b/src/components/card/CardContent.vue
@@ -10,7 +10,7 @@
 <script lang="ts">
 
 import Vue from 'vue';
-import {CardMetadata} from '../../cards/CardMetadata';
+import {ICardMetadata} from '../../cards/CardMetadata';
 import CardRequirementsComponent from './CardRequirementsComponent.vue';
 import CardVictoryPoints from './CardVictoryPoints.vue';
 import CardDescription from './CardDescription.vue';
@@ -21,7 +21,7 @@ export default Vue.extend({
   name: 'CardContent',
   props: {
     metadata: {
-      type: Object as () => CardMetadata,
+      type: Object as () => ICardMetadata,
       required: true,
     },
     requirements: {

--- a/tests/cards/moon/EarthEmbassy.spec.ts
+++ b/tests/cards/moon/EarthEmbassy.spec.ts
@@ -8,7 +8,7 @@ import {Tags} from '../../../src/cards/Tags';
 import {CardType} from '../../../src/cards/CardType';
 import {CardName} from '../../../src/CardName';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {CardMetadata} from '../../../src/cards/CardMetadata';
+import {ICardMetadata} from '../../../src/cards/CardMetadata';
 
 const MOON_OPTIONS = TestingUtils.setCustomGameOptions({moonExpansion: true});
 
@@ -29,7 +29,7 @@ describe('EarthEmbassy', () => {
       cardType: CardType.AUTOMATED,
       name: CardName.ZEPPELINS,
       tags: tags,
-      metadata: {} as CardMetadata,
+      metadata: {} as ICardMetadata,
       play: () => undefined,
     };
 

--- a/tests/cards/moon/EarthEmbassy.spec.ts
+++ b/tests/cards/moon/EarthEmbassy.spec.ts
@@ -8,7 +8,7 @@ import {Tags} from '../../../src/cards/Tags';
 import {CardType} from '../../../src/cards/CardType';
 import {CardName} from '../../../src/CardName';
 import {IProjectCard} from '../../../src/cards/IProjectCard';
-import {ICardMetadata} from '../../../src/cards/CardMetadata';
+import {ICardMetadata} from '../../../src/cards/ICardMetadata';
 
 const MOON_OPTIONS = TestingUtils.setCustomGameOptions({moonExpansion: true});
 


### PR DESCRIPTION
As I start to detach the card metadata interface, I'm going to take advantage of the (inconsistently applied) standard in this project to start interfaces with I. As I've been prototyping a solution, not knowing what's a class and what's an interface has been a significant point of confusion.

Note that some of the changes include removing CardMetadata for some cards and renaming the interface in others. For some reason I don't yet understand, some of those parameters need the declaration. So I'm not sure if I'm causing a breakable issue by doing this.
