### PR TITLE
Disable css caching more effectively.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint": "eslint --cache src tests --ext ts --ext vue",
     "lint:fix": "eslint --fix src tests --ext ts --ext vue",
     "lint:sfc": "vti diagnostics",
-    "make:css": "lessc src/styles/common.less build/styles.css",
+    "make:css": "lessc src/styles/common.less build/styles.css && gzip -9 --force --keep build/styles.css",
     "make:json": "node make_static_json.js",
     "make:static": "npm run make:css && npm run make:json",
     "test": "npm run test:server && npm run test:client",

--- a/src/routes/ServeAsset.ts
+++ b/src/routes/ServeAsset.ts
@@ -1,7 +1,6 @@
 import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as zlib from 'zlib';
 
 import {IContext} from './IHandler';
 import {BufferCache} from './BufferCache';
@@ -11,6 +10,21 @@ import {isProduction} from '../utils/server';
 
 type Encoding = 'gzip' | 'br';
 
+export class FileAPI {
+  public static readonly INSTANCE: FileAPI = new FileAPI();
+
+  protected constructor() {}
+
+  public readFileSync(path: string): Buffer {
+    return fs.readFileSync(path);
+  }
+  public readFile(path: string, cb: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void {
+    fs.readFile(path, cb);
+  }
+  public existsSync(path: string): boolean {
+    return fs.existsSync(path);
+  }
+}
 export class ServeAsset extends Handler {
   public static readonly INSTANCE: ServeAsset = new ServeAsset();
   private readonly cache = new BufferCache();
@@ -18,18 +32,14 @@ export class ServeAsset extends Handler {
   // Public for tests
   public constructor(private cacheAgeSeconds: string | number = process.env.ASSET_CACHE_MAX_AGE || 0,
     // only production caches resources
-    private cacheAssets: boolean = isProduction()) {
+    private cacheAssets: boolean = isProduction(),
+    private fileApi: FileAPI = FileAPI.INSTANCE) {
     super();
     // prime the cache with styles.css and a compressed copy of it styles.css
-    const styles = fs.readFileSync('build/styles.css');
-    this.cache.set('styles.css', styles);
-    zlib.gzip(styles, (err, compressed) => {
-      if (err !== null) {
-        console.warn('error compressing styles', err);
-        return;
-      }
-      this.cache.set('styles.css.gz', compressed);
-    });
+    const styles = fileApi.readFileSync('build/styles.css');
+    this.cache.set('build/styles.css', styles);
+    const compressed = fileApi.readFileSync('build/styles.css.gz');
+    this.cache.set('build/styles.css.gz', compressed);
   }
 
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
@@ -51,7 +61,7 @@ export class ServeAsset extends Handler {
     const file = toFile.file;
 
     // asset caching
-    const buffer = this.cache.get(file);
+    const buffer = this.cacheAssets ? this.cache.get(file) : undefined;
     if (buffer !== undefined) {
       if (req.headers['if-none-match'] === buffer.hash) {
         ctx.route.notModified(res);
@@ -78,9 +88,10 @@ export class ServeAsset extends Handler {
       return;
     }
 
-    fs.readFile(file, (err, data) => {
+    this.fileApi.readFile(file, (err, data) => {
       if (err) {
-        return ctx.route.internalServerError(req, res, err);
+        console.log(err);
+        return ctx.route.internalServerError(req, res, 'Cannot serve ' + path);
       }
       res.setHeader('Content-Length', data.length);
       res.end(data);
@@ -98,11 +109,10 @@ export class ServeAsset extends Handler {
       return {file: urlPath};
 
     case 'styles.css':
-      const compressed = this.cache.get('styles.css.gz');
-      if (compressed !== undefined && encodings.has('gzip')) {
-        return {file: urlPath + '.gz', encoding: 'gzip'};
+      if (encodings.has('gzip')) {
+        return {file: 'build/styles.css.gz', encoding: 'gzip'};
       }
-      return {file: urlPath};
+      return {file: 'build/styles.css'};
 
     case 'main.js':
     case 'main.js.map':
@@ -117,7 +127,7 @@ export class ServeAsset extends Handler {
       }
 
       // Return not-compressed .js files for development mode
-      if (!fs.existsSync(file)) {
+      if (!this.fileApi.existsSync(file)) {
         encoding = undefined;
         file = `build/${urlPath}`;
       }

--- a/tests/routes/ServeAsset.spec.ts
+++ b/tests/routes/ServeAsset.spec.ts
@@ -1,16 +1,40 @@
 import * as http from 'http';
 import {expect} from 'chai';
-import {ServeAsset} from '../../src/routes/ServeAsset';
+import {FileAPI, ServeAsset} from '../../src/routes/ServeAsset';
 import {Route} from '../../src/routes/Route';
 import {FakeGameLoader} from './FakeGameLoader';
 import {MockResponse} from './HttpMocks';
 import {IContext} from '../../src/routes/IHandler';
+
+class FileApiMock extends FileAPI {
+  public counts = {
+    readFile: 0,
+    readFileSync: 0,
+    existsSync: 0,
+  }
+  public constructor() {
+    super();
+  }
+  public readFileSync(path: string): Buffer {
+    this.counts.readFileSync++;
+    return Buffer.from('data: ' + path);
+  }
+  public readFile(path: string, cb: (err: NodeJS.ErrnoException | null, data: Buffer) => void): void {
+    this.counts.readFile++;
+    cb(null, Buffer.from('data: ' + path));
+  }
+  public existsSync(_path: string): boolean {
+    this.counts.existsSync++;
+    return true;
+  }
+}
 
 describe('ServeAsset', () => {
   let instance: ServeAsset;
   let req: http.IncomingMessage;
   let res: MockResponse;
   let ctx: IContext;
+  let fileApi: FileApiMock;
 
   // Strictly speaking |parameters| can also accept a fragment.
   const setRequest = function(parameters: string, headers: Array<Array<string>> = []) {
@@ -25,6 +49,7 @@ describe('ServeAsset', () => {
     instance = new ServeAsset(undefined, false);
     req = {headers: {}} as http.IncomingMessage;
     res = new MockResponse();
+    fileApi = new FileApiMock();
     ctx = {
       route: new Route(),
       serverId: '1',
@@ -45,4 +70,54 @@ describe('ServeAsset', () => {
     instance.get(req, res.hide(), ctx);
     expect(res.content.startsWith('<!DOCTYPE html>'));
   });
+
+  it('styles.css', () => {
+    instance = new ServeAsset(undefined, false, fileApi);
+    setRequest('/styles.css', [['accept-encoding', '']]);
+    instance.get(req, res.hide(), ctx);
+    expect(res.content).eq('data: build/styles.css');
+  });
+
+  it('styles.css.gz', () => {
+    instance = new ServeAsset(undefined, false, fileApi);
+    setRequest('/styles.css', [['accept-encoding', 'gzip']]);
+    instance.get(req, res.hide(), ctx);
+    expect(res.content).eq('data: build/styles.css.gz');
+  });
+
+  it('styles.css: uncached', () => {
+    instance = new ServeAsset(undefined, false, fileApi);
+    // Primes the cache.
+    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 2, existsSync: 0});
+
+    setRequest('/styles.css', [['accept-encoding', '']]);
+    instance.get(req, res.hide(), ctx);
+
+    expect(res.content).eq('data: build/styles.css');
+    expect(fileApi.counts).deep.eq({
+      readFile: 1, // Still read.
+      readFileSync: 2,
+      existsSync: 0,
+    });
+  });
+
+  it('styles.css.gz: cached', () => {
+    instance = new ServeAsset(undefined, true, fileApi);
+    // Primes the cache.
+    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 2, existsSync: 0});
+
+    setRequest('/styles.css', [['accept-encoding', 'gzip']]);
+    instance.get(req, res.hide(), ctx);
+
+    expect(res.content).eq('data: build/styles.css.gz');
+    expect(fileApi.counts).deep.eq({
+      readFile: 0, // Does not change
+      readFileSync: 2,
+      existsSync: 0,
+    });
+  });
+
+
+  // Cached CSS
+  // Uncached CSS
 });


### PR DESCRIPTION
This makes it possible to locally change CSS without having to restart the server.

Dev still works:

![image](https://user-images.githubusercontent.com/413481/133682690-5ac51c5b-e12e-4655-8988-2ed9bf1f665e.png)

And production reads from the cache (set `NODE_ENV=production` and verified with a debugger)

![Uploading image.png…]()
