### PR TITLE
Luna Archives pre-cost calculation

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1295,6 +1295,10 @@ export class Player implements ISerializable<SerializedPlayer> {
     return card.tags.includes(Tags.VENUS);
   }
 
+  private canUseScience(card: ICard): boolean {
+    return card.tags.includes(Tags.MOON);
+  }
+
   private getMcTradeCost(): number {
     return MC_TRADE_COST - this.colonyTradeDiscount;
   }
@@ -1793,15 +1797,14 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public canPlay(card: IProjectCard): boolean {
-    const cost = this.getCardCost(card) - MoonExpansion.spendableLunaArchiveResources(this, card);
-
     const canAfford = this.canAfford(
-      cost,
+      this.getCardCost(card),
       {
         steel: this.canUseSteel(card),
         titanium: this.canUseTitanium(card),
         floaters: this.canUseFloaters(card),
         microbes: this.canUseMicrobes(card),
+        science: this.canUseScience(card),
         reserveUnits: MoonExpansion.adjustedReserveCosts(this, card),
       });
 
@@ -1815,6 +1818,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     titanium?: boolean,
     floaters?: boolean,
     microbes?: boolean,
+    science?: boolean,
     reserveUnits?: Units
   }) {
     const reserveUnits = options?.reserveUnits ?? Units.EMPTY;
@@ -1826,6 +1830,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     const canUseTitanium: boolean = options?.titanium ?? false;
     const canUseFloaters: boolean = options?.floaters ?? false;
     const canUseMicrobes: boolean = options?.microbes ?? false;
+    const canUseScience: boolean = options?.science ?? false;
 
     return cost <=
       this.megaCredits - reserveUnits.megacredits +
@@ -1833,7 +1838,8 @@ export class Player implements ISerializable<SerializedPlayer> {
       (canUseSteel ? (this.steel - reserveUnits.steel) * this.getSteelValue() : 0) +
       (canUseTitanium ? (this.titanium - reserveUnits.titanium) * this.getTitaniumValue() : 0) +
       (canUseFloaters ? this.getFloatersCanSpend() * 3 : 0) +
-      (canUseMicrobes ? this.getMicrobesCanSpend() * 2 : 0);
+      (canUseMicrobes ? this.getMicrobesCanSpend() * 2 : 0) +
+      (canUseScience ? this.getSpendableScienceResources() : 0);
   }
 
   private getStandardProjects(): Array<StandardProjectCard> {

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1793,8 +1793,10 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public canPlay(card: IProjectCard): boolean {
+    const cost = this.getCardCost(card) - MoonExpansion.spendableLunaArchiveResources(this, card);
+
     const canAfford = this.canAfford(
-      this.getCardCost(card),
+      cost,
       {
         steel: this.canUseSteel(card),
         titanium: this.canUseTitanium(card),

--- a/src/moon/MoonExpansion.ts
+++ b/src/moon/MoonExpansion.ts
@@ -353,15 +353,4 @@ export class MoonExpansion {
       });
     });
   }
-
-  static spendableLunaArchiveResources(player: Player, card: IProjectCard): number {
-    if (card.tags.includes(Tags.MOON) === true) {
-      for (const playedCard of player.playedCards) {
-        if (playedCard.name === CardName.LUNA_ARCHIVES) {
-          return playedCard.resourceCount ?? 0;
-        }
-      }
-    }
-    return 0;
-  }
 }

--- a/src/moon/MoonExpansion.ts
+++ b/src/moon/MoonExpansion.ts
@@ -353,4 +353,15 @@ export class MoonExpansion {
       });
     });
   }
+
+  static spendableLunaArchiveResources(player: Player, card: IProjectCard): number {
+    if (card.tags.includes(Tags.MOON) === true) {
+      for (const playedCard of player.playedCards) {
+        if (playedCard.name === CardName.LUNA_ARCHIVES) {
+          return playedCard.resourceCount ?? 0;
+        }
+      }
+    }
+    return 0;
+  }
 }

--- a/tests/cards/moon/LunaArchives.spec.ts
+++ b/tests/cards/moon/LunaArchives.spec.ts
@@ -2,6 +2,7 @@ import {Game} from '../../../src/Game';
 import {TestingUtils} from '../../TestingUtils';
 import {TestPlayers} from '../../TestPlayers';
 import {LunaArchives} from '../../../src/cards/moon/LunaArchives';
+import {EarthEmbassy} from '../../../src/cards/moon/EarthEmbassy';
 import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 
@@ -28,6 +29,22 @@ describe('LunaArchives', () => {
     card.action(player);
     expect(card.resourceCount).eq(5);
     expect(player.getSpendableScienceResources()).eq(5);
+  });
+
+  it('pay for moon card', () => {
+    const ee = new EarthEmbassy();
+    player.megaCredits = ee.cost;
+    expect(player.canPlay(ee)).is.true;
+    player.megaCredits-=2;
+    expect(player.canPlay(ee)).is.false;
+    card.resourceCount = 1;
+    expect(player.canPlay(ee)).is.false;
+    card.resourceCount = 2;
+    expect(player.canPlay(ee)).is.true;
+ });
+
+  it('pay for non-moon card', () => {
+    card.resourceCount = 2;
   });
 });
 

--- a/tests/cards/moon/LunaArchives.spec.ts
+++ b/tests/cards/moon/LunaArchives.spec.ts
@@ -41,10 +41,6 @@ describe('LunaArchives', () => {
     expect(player.canPlay(ee)).is.false;
     card.resourceCount = 2;
     expect(player.canPlay(ee)).is.true;
- });
-
-  it('pay for non-moon card', () => {
-    card.resourceCount = 2;
   });
 });
 


### PR DESCRIPTION
Science resources on Luna Archives reduces the cost of Moon cards by 1MC per resource. SelectHowToPayForProjectCard already takes this into account, but it wasn't taken into account when choosing valid cards to play.

Fixes #3626