### PR TITLE
Minor warnings in vscode that seem to make sense.

### DIFF
--- a/src/client/directives/i18n.ts
+++ b/src/client/directives/i18n.ts
@@ -16,7 +16,8 @@ export function translateMessage(message: Message): string {
 
 export function translateText(englishText: string): string {
   const lang = PreferencesManager.load('lang') || 'en';
-  if (lang === 'en' || window._translations === undefined) {
+  const translations = window._translations;
+  if (lang === 'en' || translations === undefined) {
     return englishText;
   }
 
@@ -27,14 +28,14 @@ export function translateText(englishText: string): string {
     return englishText;
   }
 
-  let translatedText = window._translations[englishText];
+  let translatedText = translations[englishText];
 
   // Check if translated word is in brackets
   if (translatedText === undefined) {
     const isTextInBrackets = englishText.startsWith('(') && englishText.endsWith(')');
 
     if (isTextInBrackets) {
-      const translationAttempt = window._translations[englishText.slice(1, -1)];
+      const translationAttempt = translations[englishText.slice(1, -1)];
       if (translationAttempt) {
         translatedText = `(${translationAttempt})`;
       }

--- a/tests/cards/base/standardProjects/PowerPlantStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/PowerPlantStandardProject.spec.ts
@@ -5,6 +5,7 @@ import {TestingUtils} from '../../../TestingUtils';
 import {TestPlayers} from '../../../TestPlayers';
 import {Game} from '../../../../src/Game';
 import {StandardTechnology} from '../../../../src/cards/base/StandardTechnology';
+import {Resources} from '@/Resources';
 
 describe('PowerPlantStandardProjects', function() {
   let card: PowerPlantStandardProject; let player: Player;
@@ -25,7 +26,7 @@ describe('PowerPlantStandardProjects', function() {
     expect(game.deferredActions.length).eq(1);
     expect(player.megaCredits).eq(11);
     game.deferredActions.runNext();
-    expect(player.energyProduction).eq(1);
+    expect(player.getProduction(Resources.ENERGY)).eq(1);
     expect(player.megaCredits).eq(3);
   });
 });

--- a/tests/venusNext/GrantVenusAltTrackBonusDeferred.spec.ts
+++ b/tests/venusNext/GrantVenusAltTrackBonusDeferred.spec.ts
@@ -7,11 +7,10 @@ import {AndOptions} from '@/inputs/AndOptions';
 
 describe('GrantVenusAltTrackBonusDeferred', function() {
   let player: Player;
-  let game: Game;
 
   beforeEach(() => {
     player = TestPlayers.BLUE.newPlayer();
-    game = Game.newInstance('x', [player], player);
+    Game.newInstance('x', [player], player);
   });
 
   it('grant single bonus', () => {


### PR DESCRIPTION
Though why consolidating window._translations into one space got rid of
3 vscode errors I don't know.