### PR TITLE
PartyHooks.shouldApplyPolicy(game -> player)

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -197,7 +197,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public getTitaniumValue(): number {
-    if (PartyHooks.shouldApplyPolicy(this.game, PartyName.UNITY)) return this.titaniumValue + 1;
+    if (PartyHooks.shouldApplyPolicy(this, PartyName.UNITY)) return this.titaniumValue + 1;
     return this.titaniumValue;
   }
 
@@ -216,7 +216,7 @@ export class Player implements ISerializable<SerializedPlayer> {
   }
 
   public getSteelValue(): number {
-    if (PartyHooks.shouldApplyPolicy(this.game, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_3)) return this.steelValue + 1;
+    if (PartyHooks.shouldApplyPolicy(this, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_3)) return this.steelValue + 1;
     return this.steelValue;
   }
 
@@ -246,7 +246,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
 
     // Turmoil Reds capacity
-    if (PartyHooks.shouldApplyPolicy(this.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(this, PartyName.REDS)) {
       if (this.canAfford(REDS_RULING_POLICY_COST)) {
         this.game.defer(new SelectHowToPayDeferred(this, REDS_RULING_POLICY_COST, {title: 'Select how to pay for TR increase'}));
       } else {
@@ -662,7 +662,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     }
 
     // PoliticalAgendas Scientists P2 hook
-    if (PartyHooks.shouldApplyPolicy(this.game, PartyName.SCIENTISTS, TurmoilPolicy.SCIENTISTS_POLICY_2)) {
+    if (PartyHooks.shouldApplyPolicy(this, PartyName.SCIENTISTS, TurmoilPolicy.SCIENTISTS_POLICY_2)) {
       requirementsBonus += 2;
     }
 
@@ -1272,7 +1272,7 @@ export class Player implements ISerializable<SerializedPlayer> {
     });
 
     // PoliticalAgendas Unity P4 hook
-    if (card.tags.includes(Tags.SPACE) && PartyHooks.shouldApplyPolicy(this.game, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_4)) {
+    if (card.tags.includes(Tags.SPACE) && PartyHooks.shouldApplyPolicy(this, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_4)) {
       cost -= 2;
     }
 

--- a/src/cards/ares/SurveyCard.ts
+++ b/src/cards/ares/SurveyCard.ts
@@ -49,7 +49,7 @@ export abstract class SurveyCard extends Card implements IProjectCard {
       switch (resource) {
       case Resources.STEEL:
         grant = space.spaceType !== SpaceType.COLONY &&
-            PartyHooks.shouldApplyPolicy(cardOwner.game, PartyName.MARS, TurmoilPolicy.MARS_FIRST_DEFAULT_POLICY);
+            PartyHooks.shouldApplyPolicy(cardOwner, PartyName.MARS, TurmoilPolicy.MARS_FIRST_DEFAULT_POLICY);
         break;
       case Resources.PLANTS:
         grant = space.tile?.tileType === TileType.OCEAN &&

--- a/src/cards/base/AquiferPumping.ts
+++ b/src/cards/base/AquiferPumping.ts
@@ -38,7 +38,7 @@ export class AquiferPumping extends Card implements IActionCard, IProjectCard {
 
     if (oceansMaxed) return player.canAfford(oceanCost, {steel: true});
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, {steel: true});
     }
 

--- a/src/cards/base/ArtificialLake.ts
+++ b/src/cards/base/ArtificialLake.ts
@@ -36,7 +36,7 @@ export class ArtificialLake extends Card implements IProjectCard {
     }
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true});
     }
 

--- a/src/cards/base/Asteroid.ts
+++ b/src/cards/base/Asteroid.ts
@@ -32,7 +32,7 @@ export class Asteroid extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const temperatureMaxed = player.game.getTemperature() === MAX_TEMPERATURE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !temperatureMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !temperatureMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/BigAsteroid.ts
+++ b/src/cards/base/BigAsteroid.ts
@@ -34,7 +34,7 @@ export class BigAsteroid extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true});
     }
 

--- a/src/cards/base/BlackPolarDust.ts
+++ b/src/cards/base/BlackPolarDust.ts
@@ -33,7 +33,7 @@ export class BlackPolarDust extends Card implements IProjectCard {
     const meetsMcProdRequirement = player.getProduction(Resources.MEGACREDITS) >= -3;
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST) && meetsMcProdRequirement;
     }
 

--- a/src/cards/base/BribedCommittee.ts
+++ b/src/cards/base/BribedCommittee.ts
@@ -26,7 +26,7 @@ export class BribedCommittee extends Card implements IProjectCard {
     });
   }
   public canPlay(player: Player): boolean {
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2);
     }
 

--- a/src/cards/base/CaretakerContract.ts
+++ b/src/cards/base/CaretakerContract.ts
@@ -34,7 +34,7 @@ export class CaretakerContract extends Card implements IActionCard, IProjectCard
   public canAct(player: Player): boolean {
     const hasEnoughHeat = player.availableHeat >= 8;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughHeat;
     }
 

--- a/src/cards/base/Comet.ts
+++ b/src/cards/base/Comet.ts
@@ -35,7 +35,7 @@ export class Comet extends Card implements IProjectCard {
     const oceanStep = player.game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
     const totalSteps = temperatureStep + oceanStep;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * totalSteps, {titanium: true});
     }
 

--- a/src/cards/base/ConvoyFromEuropa.ts
+++ b/src/cards/base/ConvoyFromEuropa.ts
@@ -29,7 +29,7 @@ export class ConvoyFromEuropa extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/DeepWellHeating.ts
+++ b/src/cards/base/DeepWellHeating.ts
@@ -32,7 +32,7 @@ export class DeepWellHeating extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const temperatureMaxed = player.game.getVenusScaleLevel() === MAX_TEMPERATURE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !temperatureMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !temperatureMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true});
     }
 

--- a/src/cards/base/DeimosDown.ts
+++ b/src/cards/base/DeimosDown.ts
@@ -34,7 +34,7 @@ export class DeimosDown extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 3);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true});
     }
 

--- a/src/cards/base/EquatorialMagnetizer.ts
+++ b/src/cards/base/EquatorialMagnetizer.ts
@@ -35,7 +35,7 @@ export class EquatorialMagnetizer extends Card implements IActionCard, IProjectC
   public canAct(player: Player): boolean {
     const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction;
     }
 

--- a/src/cards/base/Flooding.ts
+++ b/src/cards/base/Flooding.ts
@@ -36,7 +36,7 @@ export class Flooding extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 

--- a/src/cards/base/GHGProducingBacteria.ts
+++ b/src/cards/base/GHGProducingBacteria.ts
@@ -56,7 +56,7 @@ export class GHGProducingBacteria extends Card implements IActionCard, IProjectC
       }
 
       const orOptions = new OrOptions();
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
 
       if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
         orOptions.options.push(new SelectOption('Remove 2 microbes to raise temperature 1 step', 'Remove microbes', () => {

--- a/src/cards/base/GiantIceAsteroid.ts
+++ b/src/cards/base/GiantIceAsteroid.ts
@@ -36,7 +36,7 @@ export class GiantIceAsteroid extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 2) + Math.min(remainingOceans, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true});
     }
 

--- a/src/cards/base/IceAsteroid.ts
+++ b/src/cards/base/IceAsteroid.ts
@@ -30,7 +30,7 @@ export class IceAsteroid extends Card implements IProjectCard {
     const remainingOceans = MAX_OCEAN_TILES - player.game.board.getOceansOnBoard();
     const oceansPlaced = Math.min(remainingOceans, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * oceansPlaced, {titanium: true});
     }
 

--- a/src/cards/base/IceCapMelting.ts
+++ b/src/cards/base/IceCapMelting.ts
@@ -31,7 +31,7 @@ export class IceCapMelting extends Card implements IProjectCard {
     }
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 

--- a/src/cards/base/ImportedHydrogen.ts
+++ b/src/cards/base/ImportedHydrogen.ts
@@ -42,7 +42,7 @@ export class ImportedHydrogen extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/ImportedNitrogen.ts
+++ b/src/cards/base/ImportedNitrogen.ts
@@ -33,7 +33,7 @@ export class ImportedNitrogen extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/Ironworks.ts
+++ b/src/cards/base/Ironworks.ts
@@ -36,7 +36,7 @@ export class Ironworks extends Card implements IActionCard, IProjectCard {
     const hasEnoughEnergy = player.energy >= 4;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
     }
 

--- a/src/cards/base/LakeMarineris.ts
+++ b/src/cards/base/LakeMarineris.ts
@@ -33,7 +33,7 @@ export class LakeMarineris extends Card implements IProjectCard {
     const remainingOceans = MAX_OCEAN_TILES - player.game.board.getOceansOnBoard();
     const oceansPlaced = Math.min(remainingOceans, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * oceansPlaced);
     }
 

--- a/src/cards/base/LargeConvoy.ts
+++ b/src/cards/base/LargeConvoy.ts
@@ -41,7 +41,7 @@ export class LargeConvoy extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/LavaFlows.ts
+++ b/src/cards/base/LavaFlows.ts
@@ -61,7 +61,7 @@ export class LavaFlows extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
     }
 

--- a/src/cards/base/MagneticFieldDome.ts
+++ b/src/cards/base/MagneticFieldDome.ts
@@ -36,7 +36,7 @@ export class MagneticFieldDome extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 2;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true}) && hasEnergyProduction;
     }
 

--- a/src/cards/base/MagneticFieldGenerators.ts
+++ b/src/cards/base/MagneticFieldGenerators.ts
@@ -37,7 +37,7 @@ export class MagneticFieldGenerators extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const meetsEnergyRequirements = player.getProduction(Resources.ENERGY) >= 4;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 3, {steel: true}) && meetsEnergyRequirements;
     }
 

--- a/src/cards/base/Mangrove.ts
+++ b/src/cards/base/Mangrove.ts
@@ -36,7 +36,7 @@ export class Mangrove extends Card implements IProjectCard {
     const meetsCardRequirements = super.canPlay(player);
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {microbes: true}) && meetsCardRequirements;
     }
 

--- a/src/cards/base/MiningExpedition.ts
+++ b/src/cards/base/MiningExpedition.ts
@@ -31,7 +31,7 @@ export class MiningExpedition extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 

--- a/src/cards/base/NitriteReducingBacteria.ts
+++ b/src/cards/base/NitriteReducingBacteria.ts
@@ -63,7 +63,7 @@ export class NitriteReducingBacteria extends Card implements IActionCard, IProje
       }
 
       const orOptions = new OrOptions();
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
 
       if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
         orOptions.options.push(new SelectOption('Remove 3 microbes to increase your terraform rating 1 step', 'Remove microbes', () => {

--- a/src/cards/base/NitrogenRichAsteroid.ts
+++ b/src/cards/base/NitrogenRichAsteroid.ts
@@ -36,7 +36,7 @@ export class NitrogenRichAsteroid extends Card implements IProjectCard {
     let steps = 2;
     if (player.game.getTemperature() < MAX_TEMPERATURE) steps++;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * steps, {titanium: true});
     }
 

--- a/src/cards/base/NuclearZone.ts
+++ b/src/cards/base/NuclearZone.ts
@@ -41,7 +41,7 @@ export class NuclearZone extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised) && canPlaceTile;
     }
 

--- a/src/cards/base/OreProcessor.ts
+++ b/src/cards/base/OreProcessor.ts
@@ -36,7 +36,7 @@ export class OreProcessor extends Card implements IActionCard, IProjectCard {
     const hasEnoughEnergy = player.energy >= 4;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
     }
 

--- a/src/cards/base/PermafrostExtraction.ts
+++ b/src/cards/base/PermafrostExtraction.ts
@@ -33,7 +33,7 @@ export class PermafrostExtraction extends Card implements IProjectCard {
     const meetsTemperatureRequirements = super.canPlay(player);
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST) && meetsTemperatureRequirements;
     }
 

--- a/src/cards/base/Plantation.ts
+++ b/src/cards/base/Plantation.ts
@@ -41,7 +41,7 @@ export class Plantation extends Card implements IProjectCard {
 
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {microbes: true});
     }
 

--- a/src/cards/base/ProtectedValley.ts
+++ b/src/cards/base/ProtectedValley.ts
@@ -37,7 +37,7 @@ export class ProtectedValley extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true, microbes: true});
     }
 

--- a/src/cards/base/RadChemFactory.ts
+++ b/src/cards/base/RadChemFactory.ts
@@ -32,7 +32,7 @@ export class RadChemFactory extends Card implements IProjectCard {
   }
   public canPlay(player: Player): boolean {
     const hasEnergyProduction = player.getProduction(Resources.ENERGY) >= 1;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, {steel: true}) && hasEnergyProduction;
     }
 

--- a/src/cards/base/RegolithEaters.ts
+++ b/src/cards/base/RegolithEaters.ts
@@ -53,7 +53,7 @@ export class RegolithEaters extends Card implements IActionCard, IProjectCard, I
       }
 
       const orOptions = new OrOptions();
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
 
       if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
         orOptions.options.push(new SelectOption('Remove 2 microbes to raise oxygen level 1 step', 'Remove microbes', () => {

--- a/src/cards/base/ReleaseOfInertGases.ts
+++ b/src/cards/base/ReleaseOfInertGases.ts
@@ -26,7 +26,7 @@ export class ReleaseOfInertGases extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2);
     }
 

--- a/src/cards/base/Steelworks.ts
+++ b/src/cards/base/Steelworks.ts
@@ -32,7 +32,7 @@ export class Steelworks extends Card implements IProjectCard, IActionCard {
     const hasEnoughEnergy = player.energy >= 4;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
     }
 

--- a/src/cards/base/StripMine.ts
+++ b/src/cards/base/StripMine.ts
@@ -39,7 +39,7 @@ export class StripMine extends Card implements IProjectCard {
     const stepsRaised = Math.min(remainingOxygenSteps, 2);
     const requiredMC = REDS_RULING_POLICY_COST * stepsRaised;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + requiredMC, {steel: true}) && player.canAfford(requiredMC) && hasEnergyProduction;
     }
 

--- a/src/cards/base/SubterraneanReservoir.ts
+++ b/src/cards/base/SubterraneanReservoir.ts
@@ -29,7 +29,7 @@ export class SubterraneanReservoir extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const oceansMaxed = player.game.board.getOceansOnBoard() === MAX_OCEAN_TILES;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 

--- a/src/cards/base/TerraformingGanymede.ts
+++ b/src/cards/base/TerraformingGanymede.ts
@@ -31,7 +31,7 @@ export class TerraformingGanymede extends Card implements IProjectCard {
   public canPlay(player: Player): boolean {
     const steps = 1 + player.getTagCount(Tags.JOVIAN);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * steps, {titanium: true});
     }
 

--- a/src/cards/base/TowingAComet.ts
+++ b/src/cards/base/TowingAComet.ts
@@ -33,7 +33,7 @@ export class TowingAComet extends Card implements IProjectCard {
     const oceanStep = player.game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
     const totalSteps = oxygenStep + oceanStep;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * totalSteps, {titanium: true});
     }
 

--- a/src/cards/base/WaterImportFromEuropa.ts
+++ b/src/cards/base/WaterImportFromEuropa.ts
@@ -45,7 +45,7 @@ export class WaterImportFromEuropa extends Card implements IActionCard, IProject
 
     if (oceansMaxed) return player.canAfford(oceanCost, {titanium: true});
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(oceanCost + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/base/WaterSplittingPlant.ts
+++ b/src/cards/base/WaterSplittingPlant.ts
@@ -37,7 +37,7 @@ export class WaterSplittingPlant extends Card implements IProjectCard {
     const hasEnoughEnergy = player.energy >= 3;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnoughEnergy;
     }
 

--- a/src/cards/base/standardActions/ConvertHeat.ts
+++ b/src/cards/base/standardActions/ConvertHeat.ts
@@ -30,7 +30,7 @@ export class ConvertHeat extends StandardActionCard {
       return false;
     }
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return (!player.isCorporation(CardName.HELION) && player.canAfford(REDS_RULING_POLICY_COST)) ||
         player.canAfford(REDS_RULING_POLICY_COST + 8);
     }

--- a/src/cards/base/standardActions/ConvertPlants.ts
+++ b/src/cards/base/standardActions/ConvertPlants.ts
@@ -34,7 +34,7 @@ export class ConvertPlants extends StandardActionCard {
     if (player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL) {
       return true;
     }
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(REDS_RULING_POLICY_COST);
     }
     return true;

--- a/src/cards/base/standardProjects/AquiferStandardProject.ts
+++ b/src/cards/base/standardProjects/AquiferStandardProject.ts
@@ -28,7 +28,7 @@ export class AquiferStandardProject extends StandardProjectCard {
     }
 
     let additionalCost = 0;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       additionalCost += REDS_RULING_POLICY_COST;
     }
 

--- a/src/cards/base/standardProjects/AsteroidStandardProject.ts
+++ b/src/cards/base/standardProjects/AsteroidStandardProject.ts
@@ -25,7 +25,7 @@ export class AsteroidStandardProject extends StandardProjectCard {
 
   public canAct(player: Player): boolean {
     let asteroidCost = this.cost;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) asteroidCost += REDS_RULING_POLICY_COST;
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) asteroidCost += REDS_RULING_POLICY_COST;
 
     return player.canAfford(asteroidCost) && player.game.getTemperature() < constants.MAX_TEMPERATURE;
   }

--- a/src/cards/base/standardProjects/GreeneryStandardProject.ts
+++ b/src/cards/base/standardProjects/GreeneryStandardProject.ts
@@ -27,7 +27,7 @@ export class GreeneryStandardProject extends StandardProjectCard {
   public canAct(player: Player): boolean {
     let greeneryCost = this.cost;
     const oxygenNotMaxed = player.game.getOxygenLevel() < constants.MAX_OXYGEN_LEVEL;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && oxygenNotMaxed) greeneryCost += REDS_RULING_POLICY_COST;
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && oxygenNotMaxed) greeneryCost += REDS_RULING_POLICY_COST;
 
     return player.canAfford(greeneryCost) && player.game.board.getAvailableSpacesForGreenery(player).length > 0;
   }

--- a/src/cards/colonies/BuildColonyStandardProject.ts
+++ b/src/cards/colonies/BuildColonyStandardProject.ts
@@ -30,7 +30,7 @@ export class BuildColonyStandardProject extends StandardProjectCard {
       colony.isActive);
 
     // TODO: Europa sometimes costs additional 3.
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST)) {
       openColonies = openColonies.filter((colony) => colony.name !== ColonyName.VENUS);
     }
 

--- a/src/cards/colonies/IceMoonColony.ts
+++ b/src/cards/colonies/IceMoonColony.ts
@@ -32,7 +32,7 @@ export class IceMoonColony extends Card implements IProjectCard {
     const hasAvailableColonyTile = player.hasAvailableColonyTileToBuildOn();
     const canPayForReds = player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oceansMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oceansMaxed) {
       return hasAvailableColonyTile && canPayForReds;
     }
 

--- a/src/cards/colonies/JovianLanterns.ts
+++ b/src/cards/colonies/JovianLanterns.ts
@@ -49,7 +49,7 @@ export class JovianLanterns extends Card implements IProjectCard, IResourceCard 
       return false;
     }
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
 

--- a/src/cards/colonies/NitrogenFromTitan.ts
+++ b/src/cards/colonies/NitrogenFromTitan.ts
@@ -31,7 +31,7 @@ export class NitrogenFromTitan extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player) : boolean {
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, {titanium: true});
     }
 

--- a/src/cards/colonies/TitanAirScrapping.ts
+++ b/src/cards/colonies/TitanAirScrapping.ts
@@ -44,7 +44,7 @@ export class TitanAirScrapping extends Card implements IProjectCard, IResourceCa
     const hasTitanium = player.titanium > 0;
     const hasResources = this.resourceCount >= 2;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return hasTitanium || (player.canAfford(REDS_RULING_POLICY_COST) && hasResources);
     }
 
@@ -58,7 +58,7 @@ export class TitanAirScrapping extends Card implements IProjectCard, IResourceCa
     const spendResource = new SelectOption('Remove 2 floaters on this card to increase your TR 1 step', 'Remove floaters', () => this.spendResource(player));
 
     if (this.resourceCount >= 2 && player.titanium > 0) {
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
       if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {
         opts.push(spendResource);
       }

--- a/src/cards/corporation/UnitedNationsMarsInitiative.ts
+++ b/src/cards/corporation/UnitedNationsMarsInitiative.ts
@@ -42,7 +42,7 @@ export class UnitedNationsMarsInitiative extends Card implements IActionCard, Co
     const hasIncreasedTR = player.hasIncreasedTerraformRatingThisGeneration;
     const actionCost = 3;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return hasIncreasedTR && player.canAfford(REDS_RULING_POLICY_COST + actionCost);
     }
 

--- a/src/cards/prelude/BufferGasStandardProject.ts
+++ b/src/cards/prelude/BufferGasStandardProject.ts
@@ -24,7 +24,7 @@ export class BufferGasStandardProject extends StandardProjectCard {
 
   public canAct(player: Player): boolean {
     let cost = this.cost;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) cost += REDS_RULING_POLICY_COST;
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) cost += REDS_RULING_POLICY_COST;
 
     return player.canAfford(cost);
   }

--- a/src/cards/promo/CometAiming.ts
+++ b/src/cards/promo/CometAiming.ts
@@ -49,7 +49,7 @@ export class CometAiming extends Card implements IActionCard, IProjectCard, IRes
       const hasTitanium = player.titanium > 0;
       const canPlaceOcean = this.resourceCount > 0 && player.game.board.getOceansOnBoard() < MAX_OCEAN_TILES;
 
-      if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+      if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
         return hasTitanium || (player.canAfford(REDS_RULING_POLICY_COST) && canPlaceOcean);
       }
 
@@ -91,7 +91,7 @@ export class CometAiming extends Card implements IActionCard, IProjectCard, IRes
       if (player.titanium === 0) return spendAsteroidResource();
 
       const availableActions: Array<SelectOption | SelectCard<ICard>> = [];
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
       const canPlaceOcean = player.game.board.getOceansOnBoard() < MAX_OCEAN_TILES;
 
       if (canPlaceOcean && !redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {

--- a/src/cards/promo/DeimosDownPromo.ts
+++ b/src/cards/promo/DeimosDownPromo.ts
@@ -38,7 +38,7 @@ export class DeimosDownPromo extends Card implements IProjectCard {
     const remainingTemperatureSteps = (MAX_TEMPERATURE - player.game.getTemperature()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, 3);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true}) && canPlaceTile;
     }
 

--- a/src/cards/promo/DirectedImpactors.ts
+++ b/src/cards/promo/DirectedImpactors.ts
@@ -52,7 +52,7 @@ export class DirectedImpactors extends Card implements IActionCard, IProjectCard
       if (player.game.getTemperature() === MAX_TEMPERATURE && cardHasResources) return true;
       if (canPayForAsteroid) return true;
 
-      if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+      if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
         return player.canAfford(REDS_RULING_POLICY_COST) && cardHasResources;
       }
 
@@ -65,7 +65,7 @@ export class DirectedImpactors extends Card implements IActionCard, IProjectCard
 
       const addResource = new SelectOption('Pay 6 to add 1 asteroid to a card', 'Pay', () => this.addResource(player, asteroidCards));
       const spendResource = new SelectOption('Remove 1 asteroid to raise temperature 1 step', 'Remove asteroid', () => this.spendResource(player));
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
       const temperatureIsMaxed = player.game.getTemperature() === MAX_TEMPERATURE;
 
       if (this.resourceCount > 0) {

--- a/src/cards/promo/JovianEmbassy.ts
+++ b/src/cards/promo/JovianEmbassy.ts
@@ -29,7 +29,7 @@ export class JovianEmbassy extends Card implements IProjectCard {
   }
 
   public canPlay(player: Player): boolean {
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true});
     }
 

--- a/src/cards/promo/MagneticFieldGeneratorsPromo.ts
+++ b/src/cards/promo/MagneticFieldGeneratorsPromo.ts
@@ -40,7 +40,7 @@ export class MagneticFieldGeneratorsPromo extends Card implements IProjectCard {
     const meetsEnergyRequirements = player.getProduction(Resources.ENERGY) >= 4;
     const canPlaceTile = player.game.board.getAvailableSpacesOnLand(player).length > 0;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 3, {steel: true}) && meetsEnergyRequirements && canPlaceTile;
     }
 

--- a/src/cards/promo/MagneticShield.ts
+++ b/src/cards/promo/MagneticShield.ts
@@ -31,7 +31,7 @@ export class MagneticShield extends Card implements IProjectCard {
     if (!super.canPlay(player)) {
       return false;
     }
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 4, {titanium: true});
     }
     return true;

--- a/src/cards/promo/MoholeLake.ts
+++ b/src/cards/promo/MoholeLake.ts
@@ -40,7 +40,7 @@ export class MoholeLake extends Card implements IActionCard, IProjectCard {
     const oceanStep = player.game.board.getOceansOnBoard() < MAX_OCEAN_TILES ? 1 : 0;
     const totalSteps = temperatureStep + oceanStep;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(REDS_RULING_POLICY_COST * totalSteps, {steel: true});
     }
 

--- a/src/cards/promo/PharmacyUnion.ts
+++ b/src/cards/promo/PharmacyUnion.ts
@@ -78,7 +78,7 @@ export class PharmacyUnion extends Card implements CorporationCard {
       const hasScienceTag = card.tags.includes(Tags.SCIENCE);
       const hasMicrobesTag = card.tags.includes(Tags.MICROBE);
       const isPharmacyUnion = player.isCorporation(CardName.PHARMACY_UNION);
-      const redsAreRuling = PartyHooks.shouldApplyPolicy(game, PartyName.REDS);
+      const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
 
       // Edge case, let player pick order of resolution (see https://github.com/bafolts/terraforming-mars/issues/1286)
       if (isPharmacyUnion && hasScienceTag && hasMicrobesTag && this.resourceCount === 0) {

--- a/src/cards/promo/SmallAsteroid.ts
+++ b/src/cards/promo/SmallAsteroid.ts
@@ -31,7 +31,7 @@ export class SmallAsteroid extends Card implements IProjectCard {
 
   public canPlay(player: Player): boolean {
     const canRaiseTemperature = player.game.getTemperature() < MAX_TEMPERATURE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && canRaiseTemperature) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && canRaiseTemperature) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/turmoil/PROffice.ts
+++ b/src/cards/turmoil/PROffice.ts
@@ -35,7 +35,7 @@ export class PROffice extends Card implements IProjectCard {
     if (!super.canPlay(player)) {
       return false;
     }
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
     return true;

--- a/src/cards/turmoil/PoliticalAlliance.ts
+++ b/src/cards/turmoil/PoliticalAlliance.ts
@@ -31,7 +31,7 @@ export class PoliticalAlliance extends Card implements IProjectCard {
     if (!super.canPlay(player)) {
       return false;
     }
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
     return true;

--- a/src/cards/turmoil/VoteOfNoConfidence.ts
+++ b/src/cards/turmoil/VoteOfNoConfidence.ts
@@ -43,7 +43,7 @@ export class VoteOfNoConfidence extends Card implements IProjectCard {
       return false;
     }
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST);
     }
     return true;

--- a/src/cards/turmoil/WildlifeDome.ts
+++ b/src/cards/turmoil/WildlifeDome.ts
@@ -38,7 +38,7 @@ export class WildlifeDome extends Card implements IProjectCard {
     const canPlaceTile = player.game.board.getAvailableSpacesForGreenery(player).length > 0;
     const oxygenMaxed = player.game.getOxygenLevel() === MAX_OXYGEN_LEVEL;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !oxygenMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !oxygenMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {steel: true, microbes: true}) && canPlaceTile;
     }
 

--- a/src/cards/venusNext/AirScrappingExpedition.ts
+++ b/src/cards/venusNext/AirScrappingExpedition.ts
@@ -31,7 +31,7 @@ export class AirScrappingExpedition extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {floaters: true});
     }
 

--- a/src/cards/venusNext/AirScrappingStandardProject.ts
+++ b/src/cards/venusNext/AirScrappingStandardProject.ts
@@ -27,7 +27,7 @@ export class AirScrappingStandardProject extends StandardProjectCard {
     if (player.game.getVenusScaleLevel() >= constants.MAX_VENUS_SCALE) return false;
     let cost = this.cost;
     cost -= this.discount(player);
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) cost += REDS_RULING_POLICY_COST;
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) cost += REDS_RULING_POLICY_COST;
     return player.canAfford(cost);
   }
 

--- a/src/cards/venusNext/Atmoscoop.ts
+++ b/src/cards/venusNext/Atmoscoop.ts
@@ -46,7 +46,7 @@ export class Atmoscoop extends Card implements IProjectCard {
     const remainingVenusSteps = (constants.MAX_VENUS_SCALE - player.game.getVenusScaleLevel()) / 2;
     const stepsRaised = Math.min(remainingTemperatureSteps, remainingVenusSteps, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(this.cost + constants.REDS_RULING_POLICY_COST * stepsRaised, {titanium: true});
     }
 

--- a/src/cards/venusNext/CometForVenus.ts
+++ b/src/cards/venusNext/CometForVenus.ts
@@ -32,7 +32,7 @@ export class CometForVenus extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/venusNext/ExtractorBalloons.ts
+++ b/src/cards/venusNext/ExtractorBalloons.ts
@@ -49,7 +49,7 @@ export class ExtractorBalloons extends Card implements IActionCard, IResourceCar
   }
   public action(player: Player) {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    const cannotAffordRed = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !player.canAfford(REDS_RULING_POLICY_COST);
+    const cannotAffordRed = PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !player.canAfford(REDS_RULING_POLICY_COST);
     if (this.resourceCount < 2 || venusMaxed || cannotAffordRed) {
       player.addResourceTo(this, {log: true});
       return undefined;

--- a/src/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/cards/venusNext/ForcedPrecipitation.ts
@@ -47,7 +47,7 @@ export class ForcedPrecipitation extends Card implements IActionCard, IResourceC
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 1 && !venusMaxed;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(2) || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
     }
 
@@ -59,7 +59,7 @@ export class ForcedPrecipitation extends Card implements IActionCard, IResourceC
 
     const addResource = new SelectOption('Pay 2 to add 1 floater to this card', 'Pay', () => this.addResource(player));
     const spendResource = new SelectOption('Remove 2 floaters to raise Venus 1 step', 'Remove floaters', () => this.spendResource(player));
-    const canAffordRed = !PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) || player.canAfford(REDS_RULING_POLICY_COST);
+    const canAffordRed = !PartyHooks.shouldApplyPolicy(player, PartyName.REDS) || player.canAfford(REDS_RULING_POLICY_COST);
     if (this.resourceCount > 1 && player.game.getVenusScaleLevel() < MAX_VENUS_SCALE && canAffordRed) {
       opts.push(spendResource);
     } else {

--- a/src/cards/venusNext/GHGImportFromVenus.ts
+++ b/src/cards/venusNext/GHGImportFromVenus.ts
@@ -31,7 +31,7 @@ export class GHGImportFromVenus extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true, floaters: true});
     }
 

--- a/src/cards/venusNext/GiantSolarShade.ts
+++ b/src/cards/venusNext/GiantSolarShade.ts
@@ -28,7 +28,7 @@ export class GiantSolarShade extends Card {
     const remainingVenusSteps = (MAX_VENUS_SCALE - player.game.getVenusScaleLevel()) / 2;
     const stepsRaised = Math.min(remainingVenusSteps, 3);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true, floaters: true});
     }
 

--- a/src/cards/venusNext/HydrogenToVenus.ts
+++ b/src/cards/venusNext/HydrogenToVenus.ts
@@ -32,7 +32,7 @@ export class HydrogenToVenus extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/cards/venusNext/JetStreamMicroscrappers.ts
+++ b/src/cards/venusNext/JetStreamMicroscrappers.ts
@@ -46,7 +46,7 @@ export class JetStreamMicroscrappers extends Card implements IActionCard, IResou
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 1 && !venusMaxed;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.titanium > 0 || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
     }
 

--- a/src/cards/venusNext/NeutralizerFactory.ts
+++ b/src/cards/venusNext/NeutralizerFactory.ts
@@ -30,7 +30,7 @@ export class NeutralizerFactory extends Card {
 
   public canPlay(player: Player): boolean {
     const globalRequirementsMet = super.canPlay(player);
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {floaters: true}) && globalRequirementsMet;
     }
 

--- a/src/cards/venusNext/Omnicourt.ts
+++ b/src/cards/venusNext/Omnicourt.ts
@@ -30,7 +30,7 @@ export class Omnicourt extends Card {
 
   public canPlay(player: Player): boolean {
     const hasRequiredTags = super.canPlay(player);
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, {steel: true}) && hasRequiredTags;
     }
 

--- a/src/cards/venusNext/OrbitalReflectors.ts
+++ b/src/cards/venusNext/OrbitalReflectors.ts
@@ -34,7 +34,7 @@ export class OrbitalReflectors extends Card {
     const remainingVenusSteps = (MAX_VENUS_SCALE - player.game.getVenusScaleLevel()) / 2;
     const stepsRaised = Math.min(remainingVenusSteps, 2);
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * stepsRaised, {titanium: true, floaters: true});
     }
 

--- a/src/cards/venusNext/RotatorImpacts.ts
+++ b/src/cards/venusNext/RotatorImpacts.ts
@@ -48,7 +48,7 @@ export class RotatorImpacts extends Card implements IActionCard, IResourceCard {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const canSpendResource = this.resourceCount > 0 && !venusMaxed;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(6, {titanium: true}) || (canSpendResource && player.canAfford(REDS_RULING_POLICY_COST));
     }
 

--- a/src/cards/venusNext/SpinInducingAsteroid.ts
+++ b/src/cards/venusNext/SpinInducingAsteroid.ts
@@ -34,7 +34,7 @@ export class SpinInducingAsteroid extends Card implements IProjectCard {
       return false;
     }
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST * 2, {titanium: true});
     }
 

--- a/src/cards/venusNext/SulphurExports.ts
+++ b/src/cards/venusNext/SulphurExports.ts
@@ -30,7 +30,7 @@ export class SulphurExports extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true, floaters: true});
     }
 

--- a/src/cards/venusNext/Thermophiles.ts
+++ b/src/cards/venusNext/Thermophiles.ts
@@ -80,7 +80,7 @@ export class Thermophiles extends Card implements IActionCard, IResourceCard {
       return undefined;
     });
 
-    const redsAreRuling = PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS);
+    const redsAreRuling = PartyHooks.shouldApplyPolicy(player, PartyName.REDS);
 
     if (canRaiseVenus) {
       if (!redsAreRuling || (redsAreRuling && player.canAfford(REDS_RULING_POLICY_COST))) {

--- a/src/cards/venusNext/VenusMagnetizer.ts
+++ b/src/cards/venusNext/VenusMagnetizer.ts
@@ -39,7 +39,7 @@ export class VenusMagnetizer extends Card implements IActionCard {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
     const hasEnergyProduction = player.getProduction(Resources.ENERGY) > 0;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS)) {
       return player.canAfford(REDS_RULING_POLICY_COST) && hasEnergyProduction && !venusMaxed;
     }
 

--- a/src/cards/venusNext/VenusSoils.ts
+++ b/src/cards/venusNext/VenusSoils.ts
@@ -33,7 +33,7 @@ export class VenusSoils extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {floaters: true, microbes: true});
     }
 

--- a/src/cards/venusNext/VenusianPlants.ts
+++ b/src/cards/venusNext/VenusianPlants.ts
@@ -44,7 +44,7 @@ export class VenusianPlants extends Card implements IProjectCard {
     }
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
 
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {floaters: true, microbes: true});
     }
 

--- a/src/cards/venusNext/WaterToVenus.ts
+++ b/src/cards/venusNext/WaterToVenus.ts
@@ -26,7 +26,7 @@ export class WaterToVenus extends Card {
 
   public canPlay(player: Player): boolean {
     const venusMaxed = player.game.getVenusScaleLevel() === MAX_VENUS_SCALE;
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS) && !venusMaxed) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS) && !venusMaxed) {
       return player.canAfford(player.getCardCost(this) + REDS_RULING_POLICY_COST, {titanium: true});
     }
 

--- a/src/turmoil/TurmoilHandler.ts
+++ b/src/turmoil/TurmoilHandler.ts
@@ -20,7 +20,7 @@ export class TurmoilHandler {
 
   public static addPlayerAction(player: Player, options: PlayerInput[]): void {
     // Turmoil Scientists action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.SCIENTISTS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.SCIENTISTS)) {
       const scientistsPolicy = SCIENTISTS_POLICY_1;
 
       if (scientistsPolicy.canAct(player)) {
@@ -35,7 +35,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Kelvinists action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.KELVINISTS)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.KELVINISTS)) {
       const kelvinistsPolicy = KELVINISTS_POLICY_1;
 
       if (kelvinistsPolicy.canAct(player)) {
@@ -50,7 +50,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Kelvinists action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.KELVINISTS, 'kp03')) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.KELVINISTS, 'kp03')) {
       const kelvinistsPolicy = KELVINISTS_POLICY_3;
 
       if (kelvinistsPolicy.canAct(player)) {
@@ -65,7 +65,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Greens action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_4)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_4)) {
       const greensPolicy = GREENS_POLICY_4;
 
       if (greensPolicy.canAct(player)) {
@@ -80,7 +80,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Mars First action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_4)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_4)) {
       const marsFirstPolicy = MARS_FIRST_POLICY_4;
 
       if (marsFirstPolicy.canAct(player)) {
@@ -95,7 +95,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Unity action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_2)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_2)) {
       const unityPolicy = UNITY_POLICY_2;
 
       if (unityPolicy.canAct(player)) {
@@ -110,7 +110,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Unity action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_3)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.UNITY, TurmoilPolicy.UNITY_POLICY_3)) {
       const unityPolicy = UNITY_POLICY_3;
 
       if (unityPolicy.canAct(player)) {
@@ -125,7 +125,7 @@ export class TurmoilHandler {
     }
 
     // Turmoil Reds action
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS, TurmoilPolicy.REDS_POLICY_3)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS, TurmoilPolicy.REDS_POLICY_3)) {
       const redsPolicy = REDS_POLICY_3;
 
       if (redsPolicy.canAct(player)) {
@@ -142,13 +142,13 @@ export class TurmoilHandler {
 
   public static applyOnCardPlayedEffect(player: Player, selectedCard: IProjectCard): void {
     // PoliticalAgendas Greens P3 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_3)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_3)) {
       const policy = GREENS_POLICY_3;
       policy.onCardPlayed(player, selectedCard);
     }
 
     // PoliticalAgendas MarsFirst P2 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_2)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.MARS, TurmoilPolicy.MARS_FIRST_POLICY_2)) {
       const policy = MARS_FIRST_POLICY_2;
       policy.onCardPlayed(player, selectedCard);
     }
@@ -156,7 +156,7 @@ export class TurmoilHandler {
 
   public static resolveTilePlacementCosts(player: Player): void {
     // PoliticalAgendas Reds P2 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS, TurmoilPolicy.REDS_POLICY_2)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS, TurmoilPolicy.REDS_POLICY_2)) {
       const redsPolicy = REDS_POLICY_2;
       redsPolicy.onTilePlaced(player);
     }
@@ -166,13 +166,13 @@ export class TurmoilHandler {
     PartyHooks.applyMarsFirstRulingPolicy(player, spaceType);
 
     // PoliticalAgendas Greens P2 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_2)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.GREENS, TurmoilPolicy.GREENS_POLICY_2)) {
       const greensPolicy = GREENS_POLICY_2;
       greensPolicy.onTilePlaced(player);
     }
 
     // PoliticalAgendas Kelvinists P4 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.KELVINISTS, TurmoilPolicy.KELVINISTS_POLICY_4)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.KELVINISTS, TurmoilPolicy.KELVINISTS_POLICY_4)) {
       const kelvinistsPolicy = KELVINISTS_POLICY_4;
       kelvinistsPolicy.onTilePlaced(player);
     }
@@ -181,18 +181,18 @@ export class TurmoilHandler {
   public static onGlobalParameterIncrease(player: Player, parameter: GlobalParameter, steps: number = 1): void {
     if (parameter === GlobalParameter.TEMPERATURE) {
       // PoliticalAgendas Kelvinists P2 hook
-      if (PartyHooks.shouldApplyPolicy(player.game, PartyName.KELVINISTS, TurmoilPolicy.KELVINISTS_POLICY_2)) {
+      if (PartyHooks.shouldApplyPolicy(player, PartyName.KELVINISTS, TurmoilPolicy.KELVINISTS_POLICY_2)) {
         player.addResource(Resources.MEGACREDITS, steps * 3);
       }
     }
 
     // PoliticalAgendas Reds P4 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.REDS, TurmoilPolicy.REDS_POLICY_4)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.REDS, TurmoilPolicy.REDS_POLICY_4)) {
       player.addProduction(Resources.MEGACREDITS, -1 * steps, {log: true});
     }
 
     // PoliticalAgendas Scientists P3 hook
-    if (PartyHooks.shouldApplyPolicy(player.game, PartyName.SCIENTISTS, TurmoilPolicy.SCIENTISTS_POLICY_3)) {
+    if (PartyHooks.shouldApplyPolicy(player, PartyName.SCIENTISTS, TurmoilPolicy.SCIENTISTS_POLICY_3)) {
       player.drawCard(steps);
     }
   }

--- a/src/turmoil/parties/PartyHooks.ts
+++ b/src/turmoil/parties/PartyHooks.ts
@@ -1,5 +1,4 @@
 import {Player} from '../../Player';
-import {Game} from '../../Game';
 import {PartyName} from './PartyName';
 import {SpaceType} from '../../SpaceType';
 import {Phase} from '../../Phase';
@@ -13,14 +12,14 @@ import {Turmoil} from '../Turmoil';
 
 export class PartyHooks {
   static applyMarsFirstRulingPolicy(player: Player, spaceType: SpaceType) {
-    if (this.shouldApplyPolicy(player.game, PartyName.MARS, TurmoilPolicy.MARS_FIRST_DEFAULT_POLICY) &&
+    if (this.shouldApplyPolicy(player, PartyName.MARS, TurmoilPolicy.MARS_FIRST_DEFAULT_POLICY) &&
         spaceType !== SpaceType.COLONY) {
       player.addResource(Resources.STEEL, 1);
     }
   }
 
   static applyGreensRulingPolicy(player: Player, space: ISpace) {
-    if (this.shouldApplyPolicy(player.game, PartyName.GREENS, TurmoilPolicy.GREENS_DEFAULT_POLICY)) {
+    if (this.shouldApplyPolicy(player, PartyName.GREENS, TurmoilPolicy.GREENS_DEFAULT_POLICY)) {
       const greensPolicy = GREENS_POLICY_1;
       greensPolicy.onTilePlaced(player, space);
     }
@@ -28,7 +27,8 @@ export class PartyHooks {
 
   // Return true when the supplied policy is active. When `policyId` is inactive, it selects
   // the default policy for `partyName`.
-  static shouldApplyPolicy(game: Game, partyName: PartyName, policyId?: PolicyId): boolean {
+  static shouldApplyPolicy(player: Player, partyName: PartyName, policyId?: PolicyId): boolean {
+    const game = player.game;
     return Turmoil.ifTurmoilElse(game, (turmoil) => {
       if (game.phase !== Phase.ACTION) return false;
 


### PR DESCRIPTION
This changes the method signature for `PartyHooks.shouldApplyPolicy` from accepting game to accepting player.

For one thing, it slightly reduces code a little bit, but it's also a small part of a humble attempt to bring the code between community and base more closely aligned. (Most changes should be pulls from base to community, but moving a couple in the opposite direction isn't a bit deal.)