### PR TITLE
Show card resource icons instead of 'RES' in the corner.

### DIFF
--- a/src/client/components/card/Card.vue
+++ b/src/client/components/card/Card.vue
@@ -10,7 +10,7 @@
                 <CardNumber v-if="getCardMetadata() !== undefined" :number="getCardNumber()"/>
             </div>
             <CardExpansion :expansion="getCardExpansion()" :isCorporation="isCorporationCard()"/>
-            <CardResourceCounter v-if="card.resources !== undefined" :amount="getResourceAmount(card)" />
+            <CardResourceCounter v-if="card.resources !== undefined" :amount="getResourceAmount(card)" :type="card.resourceType" />
             <CardExtraContent :card="card" />
             <slot/>
         </div>

--- a/src/client/components/card/CardResourceCounter.vue
+++ b/src/client/components/card/CardResourceCounter.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="card-resources-counter">
-      <span class="card-resource" :class="getClass"></span>
-      <span class="card-resources-counter-label">:</span>
       <span class="card-resources-counter-number"> {{ amount }}</span>
+      <span class="card-resource" :class="getClass"></span>
   </div>
 </template>
 

--- a/src/client/components/card/CardResourceCounter.vue
+++ b/src/client/components/card/CardResourceCounter.vue
@@ -1,18 +1,57 @@
 <template>
-        <div class="card-resources-counter">
-            <span class="card-resources-counter-label">res:</span><span class="card-resources-counter-number"> {{ amount }}</span>
-        </div>
+  <div class="card-resources-counter">
+      <span class="card-resource" :class="getClass"></span>
+      <span class="card-resources-counter-label">:</span>
+      <span class="card-resources-counter-number"> {{ amount }}</span>
+  </div>
 </template>
 
 <script lang="ts">
 
 import Vue from 'vue';
+import {ResourceType} from '@/ResourceType';
 export default Vue.extend({
   name: 'CardResourceCounter',
   props: {
     amount: {
       type: Number,
       required: true,
+    },
+    type: {
+      type: String as () => ResourceType,
+      required: true,
+    },
+  },
+  computed: {
+    getClass(): string {
+      switch (this.type) {
+      case ResourceType.ANIMAL:
+        return 'card-resource-animal';
+      case ResourceType.MICROBE:
+        return 'card-resource-microbe';
+      case ResourceType.FIGHTER:
+        return 'card-resource-fighter';
+      case ResourceType.SCIENCE:
+        return 'card-resource-science';
+      case ResourceType.FLOATER:
+        return 'card-resource-floater';
+      case ResourceType.ASTEROID:
+        return 'card-resource-asteroid';
+      case ResourceType.PRESERVATION:
+        return 'card-resource-preservation';
+      case ResourceType.CAMP:
+        return 'card-resource-camp';
+      case ResourceType.DISEASE:
+        return 'card-resource-disease';
+      case ResourceType.RESOURCE_CUBE:
+        return 'card-resource-resource-cube';
+      case ResourceType.DATA:
+        return 'card-resource-data';
+      case ResourceType.SYNDICATE_FLEET:
+        return 'card-resource-syndicate-fleet';
+      default:
+        return '';
+      }
     },
   },
 });

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1817,3 +1817,57 @@
         top: -16px;
     }
 }
+
+.card-resources-counter {
+
+    .card-resource {
+        position: relative;
+        display: inline-block;
+        margin-bottom: 4px;
+        width: 22px;
+        height: 22px;
+        background-size: 22px;
+        vertical-align: middle;
+    }
+    .card-resource-microbe {
+        background-image: url(./assets/resources/microbe.png);
+    }
+    .card-resource-animal {
+        background-image: url(./assets/resources/animal.png);
+    }
+    .card-resource-science {
+        background-image: url(./assets/resources/science.png);
+    }
+    .card-resource-floater {
+        background-image: url(./assets/resources/floater.png);
+    }
+    .card-resource-fighter {
+        background-image: url(./assets/resources/fighter.png);
+    }
+    .card-resource-camp {
+        background-image: url(./assets/resources/camp.png);
+    }
+    .card-resource-asteroid {
+        color: #0000 !important;
+        background-image: url(./assets/resources/asteroid.png);
+    }
+    .card-resource-disease {
+        color: #0000 !important;
+        background-image: url(./assets/resources/disease.png);
+    }
+    .card-resource-preservation {
+        background-image: url(./assets/resources/pristar.png);
+    }
+    .card-resource-data {
+        color: #0000 !important;
+        background-image: url(./assets/resources/data.png);
+    }
+    .card-resource-syndicate-fleet {
+        color: #0000 !important;
+        background-image: url(./assets/resources/syndicate-fleet.png);
+    }
+    .card-resource-cube {
+        color: #0000 !important;
+        background-image: url(./assets/cube.png);
+    }
+}

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -915,6 +915,9 @@
                 font-size: 24px;
                 line-height: 46px;
             }
+
+            // TODO(kberg): this is a duplicate of .card-resources-counter / .card-resource@{value})
+            // Not only can this be reduced using the same construct, but let's get rid of the CSS duplication.
             .card-resource-steel {
                 background-image: url(./assets/resources/steel.png);
             }
@@ -1819,7 +1822,6 @@
 }
 
 .card-resources-counter {
-
     .card-resource {
         position: relative;
         display: inline-block;
@@ -1829,45 +1831,11 @@
         background-size: 22px;
         vertical-align: middle;
     }
-    .card-resource-microbe {
-        background-image: url(./assets/resources/microbe.png);
-    }
-    .card-resource-animal {
-        background-image: url(./assets/resources/animal.png);
-    }
-    .card-resource-science {
-        background-image: url(./assets/resources/science.png);
-    }
-    .card-resource-floater {
-        background-image: url(./assets/resources/floater.png);
-    }
-    .card-resource-fighter {
-        background-image: url(./assets/resources/fighter.png);
-    }
-    .card-resource-camp {
-        background-image: url(./assets/resources/camp.png);
-    }
-    .card-resource-asteroid {
-        color: #0000 !important;
-        background-image: url(./assets/resources/asteroid.png);
-    }
-    .card-resource-disease {
-        color: #0000 !important;
-        background-image: url(./assets/resources/disease.png);
-    }
-    .card-resource-preservation {
-        background-image: url(./assets/resources/pristar.png);
-    }
-    .card-resource-data {
-        color: #0000 !important;
-        background-image: url(./assets/resources/data.png);
-    }
-    .card-resource-syndicate-fleet {
-        color: #0000 !important;
-        background-image: url(./assets/resources/syndicate-fleet.png);
-    }
-    .card-resource-cube {
-        color: #0000 !important;
-        background-image: url(./assets/cube.png);
-    }
+
+    @resource_types: microbe, animal, science, floater, fighter, camp, asteroid, disease, preservation, data, syndicate-fleet, cube;
+    each(@resource_types, {
+      .card-resource-@{value} {
+        background-image: url("./assets/resources/@{value}.png");
+      }
+    })
 }


### PR DESCRIPTION
I don't like copying the CSS. I wonder if `less` can help here.

![image](https://user-images.githubusercontent.com/413481/134455145-34572913-6d70-4b76-ad90-84a971b3a643.png)
