### PR TITLE
Patch: Player should be required arg for some Board methods

### DIFF
--- a/src/boards/Board.ts
+++ b/src/boards/Board.ts
@@ -120,7 +120,7 @@ export abstract class Board {
     }
   }
 
-  public getSpaces(spaceType: SpaceType, _player?: Player): Array<ISpace> {
+  public getSpaces(spaceType: SpaceType, _player : Player): Array<ISpace> {
     return this.spaces.filter((space) => space.spaceType === spaceType);
   }
 
@@ -166,7 +166,7 @@ export abstract class Board {
       );
   }
 
-  public getAvailableSpacesOnLand(player?: Player): Array<ISpace> {
+  public getAvailableSpacesOnLand(player: Player): Array<ISpace> {
     const landSpaces = this.getSpaces(SpaceType.LAND, player).filter((space) => {
       const hasPlayerMarker = space.player !== undefined;
       // A space is available if it doesn't have a player marker on it or it belongs to |player|

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -599,7 +599,7 @@ describe('Game', () => {
   it('grant space bonus sanity test', () => {
     const player = TestPlayers.BLUE.newPlayer();
     const game = Game.newInstance('foobar', [player], player);
-    const space = game.board.getAvailableSpacesOnLand()[0];
+    const space = game.board.getAvailableSpacesOnLand(player)[0];
 
     space.bonus = [SpaceBonus.DRAW_CARD, SpaceBonus.DRAW_CARD, SpaceBonus.DRAW_CARD, SpaceBonus.DRAW_CARD, SpaceBonus.PLANT, SpaceBonus.TITANIUM];
     expect(player.cardsInHand).has.length(0);

--- a/tests/ares/AresHandler.spec.ts
+++ b/tests/ares/AresHandler.spec.ts
@@ -216,12 +216,12 @@ describe('AresHandler', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(0);
 
     AresTestHelper.addOcean(game, player);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(2);
   });
 
@@ -233,14 +233,14 @@ describe('AresHandler', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(3);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
     const prior = player.getTerraformRating();
 
     AresTestHelper.addOcean(game, player);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
     expect(player.getTerraformRating()).eq(prior + 2); // One for the ocean, once for the dust storm event.
@@ -254,7 +254,7 @@ describe('AresHandler', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(3);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
 
@@ -266,7 +266,7 @@ describe('AresHandler', function() {
 
     AresTestHelper.addOcean(game, player);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(1);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
     expect(player.getTerraformRating()).eq(priorTr + 2); // One for the ocean, once for the dust storm event.
@@ -278,13 +278,13 @@ describe('AresHandler', function() {
       game.increaseOxygenLevel(player, 1);
     }
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(3);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
 
     game.increaseOxygenLevel(player, 1);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(3);
   });
@@ -295,7 +295,7 @@ describe('AresHandler', function() {
       game.increaseOxygenLevel(player, 1);
     }
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(3);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(0);
     const protectedTile = tiles.get(TileType.DUST_STORM_MILD)![0];
@@ -303,7 +303,7 @@ describe('AresHandler', function() {
 
     game.increaseOxygenLevel(player, 1);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).has.lengthOf(3);
     expect(protectedTile.tile!.protectedHazard).is.true;
@@ -318,13 +318,13 @@ describe('AresHandler', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(2);
     expect(tiles.get(TileType.EROSION_SEVERE)).has.lengthOf(0);
 
     game.increaseTemperature(player, 1);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.EROSION_SEVERE)).has.lengthOf(2);
   });
@@ -337,7 +337,7 @@ describe('AresHandler', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.EROSION_SEVERE)).has.lengthOf(0);
 
@@ -348,14 +348,14 @@ describe('AresHandler', function() {
 
     AresTestHelper.addOcean(game, player);
 
-    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     expect(tiles.get(TileType.EROSION_MILD)).has.lengthOf(0);
     expect(tiles.get(TileType.EROSION_SEVERE)).has.lengthOf(2);
   });
 
   it('Placing on top of an ocean doesn\'t regrant bonuses', function() {
     game.board = OriginalBoard.newInstance(false, new Random(0), false);
-    const space = game.board.getSpaces(SpaceType.OCEAN).find((space) => {
+    const space = game.board.getSpaces(SpaceType.OCEAN, player).find((space) => {
       return space.bonus.length > 0 && space.bonus[0] === SpaceBonus.PLANT;
     })!;
     const spaceId = space.id;

--- a/tests/ares/AresTestHelper.ts
+++ b/tests/ares/AresTestHelper.ts
@@ -57,8 +57,8 @@ export class AresTestHelper {
     return space;
   }
 
-  public static getHazards(game: Game): Array<ISpace> {
-    return game.board.getSpaces(SpaceType.LAND).filter((space) => AresHandler.hasHazardTile(space));
+  public static getHazards(player: Player, game: Game): Array<ISpace> {
+    return game.board.getSpaces(SpaceType.LAND, player).filter((space) => AresHandler.hasHazardTile(space));
   }
 
   public static byTileType(spaces: Array<ISpace>): Map<number, Array<ISpace>> {

--- a/tests/cards/ares/DesperateMeasures.spec.ts
+++ b/tests/cards/ares/DesperateMeasures.spec.ts
@@ -17,7 +17,7 @@ describe('DesperateMeasures', function() {
   });
 
   it('play on top of dust storm', function() {
-    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
 
     const priorTr = player.getTerraformRating();
@@ -34,7 +34,7 @@ describe('DesperateMeasures', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     const protectedErosion = tiles.get(TileType.EROSION_MILD)![0];
 
     const priorTr = player.getTerraformRating();
@@ -47,7 +47,7 @@ describe('DesperateMeasures', function() {
   });
 
   it('hazard tile with player marker cannot be played on', function() {
-    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
     expect(game.board.getAvailableSpacesOnLand(player).map((s) => s.id)).contains(protectedDustStorm.id);
 
@@ -57,7 +57,7 @@ describe('DesperateMeasures', function() {
   });
 
   it('hazard tile with player marker is not removed after placing the sixth ocean', function() {
-    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(game));
+    const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game));
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
     card.play(player).cb(protectedDustStorm);
 
@@ -68,10 +68,10 @@ describe('DesperateMeasures', function() {
     AresTestHelper.addOcean(game, player);
     AresTestHelper.addOcean(game, player);
 
-    let mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(game)).get(TileType.DUST_STORM_MILD);
+    let mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game)).get(TileType.DUST_STORM_MILD);
     expect(mildDustStorms).has.length(3);
     AresTestHelper.addOcean(game, player);
-    mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(game)).get(TileType.DUST_STORM_MILD);
+    mildDustStorms = AresTestHelper.byTileType(AresTestHelper.getHazards(player, game)).get(TileType.DUST_STORM_MILD);
     expect(mildDustStorms).has.length(1);
     expect(mildDustStorms![0].id).eq(protectedDustStorm.id);
   });

--- a/tests/cards/moon/CosmicRadiation.spec.ts
+++ b/tests/cards/moon/CosmicRadiation.spec.ts
@@ -38,7 +38,7 @@ describe('CosmicRadiation', () => {
   });
 
   it('play', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player1);
 
     const assignTile = function(idx: number, player: Player) {
       spaces[idx].tile = {tileType: TileType.MOON_MINE};

--- a/tests/cards/moon/HE3ProductionQuotas.spec.ts
+++ b/tests/cards/moon/HE3ProductionQuotas.spec.ts
@@ -30,7 +30,7 @@ describe('HE3ProductionQuotas', () => {
     player.megaCredits = card.cost;
     game.turmoil!.rulingParty = new Kelvinists();
 
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     spaces[0].tile = {tileType: TileType.MOON_MINE};
     spaces[1].tile = {tileType: TileType.MOON_MINE};
     spaces[2].tile = {tileType: TileType.MOON_MINE};
@@ -52,7 +52,7 @@ describe('HE3ProductionQuotas', () => {
   });
 
   it('play', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     spaces[0].tile = {tileType: TileType.MOON_MINE};
     spaces[1].tile = {tileType: TileType.MOON_MINE};
     spaces[2].tile = {tileType: TileType.MOON_MINE};

--- a/tests/cards/moon/HypersensitiveSiliconChipFactory.spec.ts
+++ b/tests/cards/moon/HypersensitiveSiliconChipFactory.spec.ts
@@ -27,8 +27,8 @@ describe('HypersensitiveSiliconChipFactory', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
 
-    const space1 = moonData.moon.getAvailableSpacesOnLand()[0];
-    const space2 = moonData.moon.getAvailableSpacesOnLand()[1];
+    const space1 = moonData.moon.getAvailableSpacesOnLand(player)[0];
+    const space2 = moonData.moon.getAvailableSpacesOnLand(player)[1];
 
     space1.tile = {tileType: TileType.MOON_MINE};
     space2.tile = {tileType: TileType.MOON_MINE};

--- a/tests/cards/moon/LunaConference.spec.ts
+++ b/tests/cards/moon/LunaConference.spec.ts
@@ -37,7 +37,7 @@ describe('LunaConference', () => {
   });
 
   it('play', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     spaces[0].tile = {tileType: TileType.MOON_ROAD};
     spaces[1].tile = {tileType: TileType.MOON_ROAD};
 

--- a/tests/cards/moon/LunaHyperloopCorporation.spec.ts
+++ b/tests/cards/moon/LunaHyperloopCorporation.spec.ts
@@ -22,7 +22,7 @@ describe('LunaHyperloopCorporation', () => {
   });
 
   it('action', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     player.megaCredits = 0;
     MoonExpansion.addRoadTile(player, spaces[0].id);
     card.action(player);
@@ -45,7 +45,7 @@ describe('LunaHyperloopCorporation', () => {
   });
 
   it('victory points', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     player.megaCredits = 0;
     MoonExpansion.addRoadTile(player, spaces[0].id);
     card.action(player);

--- a/tests/cards/moon/LunaResort.spec.ts
+++ b/tests/cards/moon/LunaResort.spec.ts
@@ -28,7 +28,7 @@ describe('LunaResort', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
 
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
 
     spaces[0].tile = {tileType: TileType.MOON_COLONY};
     spaces[1].tile = {tileType: TileType.MOON_COLONY};

--- a/tests/cards/moon/LunarMineUrbanization.spec.ts
+++ b/tests/cards/moon/LunarMineUrbanization.spec.ts
@@ -27,7 +27,7 @@ describe('LunarMineUrbanization', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
 
-    const space = moonData.moon.getAvailableSpacesOnLand()[0];
+    const space = moonData.moon.getAvailableSpacesOnLand(player)[0];
 
     space.tile = {tileType: TileType.MOON_MINE};
     space.player = player;
@@ -38,7 +38,7 @@ describe('LunarMineUrbanization', () => {
   });
 
   it('play', () => {
-    const space = moonData.moon.getAvailableSpacesOnLand()[0];
+    const space = moonData.moon.getAvailableSpacesOnLand(player)[0];
     space.tile = {tileType: TileType.MOON_MINE};
     space.player = player;
 

--- a/tests/cards/moon/LunarSecurityStations.spec.ts
+++ b/tests/cards/moon/LunarSecurityStations.spec.ts
@@ -34,7 +34,7 @@ describe('LunarSecurityStations', () => {
     player.cardsInHand = [lunaSecurityStations];
     player.megaCredits = lunaSecurityStations.cost;
 
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player);
     spaces[0].tile = {tileType: TileType.MOON_ROAD};
     spaces[1].tile = {tileType: TileType.MOON_ROAD};
     spaces[2].tile = {tileType: TileType.MOON_ROAD};

--- a/tests/cards/moon/MicrosingularityPlant.spec.ts
+++ b/tests/cards/moon/MicrosingularityPlant.spec.ts
@@ -27,8 +27,8 @@ describe('MicrosingularityPlant', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
 
-    const space1 = moonData.moon.getAvailableSpacesOnLand()[0];
-    const space2 = moonData.moon.getAvailableSpacesOnLand()[1];
+    const space1 = moonData.moon.getAvailableSpacesOnLand(player)[0];
+    const space2 = moonData.moon.getAvailableSpacesOnLand(player)[1];
 
     space1.tile = {tileType: TileType.MOON_COLONY};
     space2.tile = {tileType: TileType.MOON_COLONY};

--- a/tests/cards/moon/OffWorldCityLiving.spec.ts
+++ b/tests/cards/moon/OffWorldCityLiving.spec.ts
@@ -41,7 +41,7 @@ describe('OffWorldCityLiving', () => {
     colonySpaces[0].tile = {tileType: TileType.CITY};
     colonySpaces[1].tile = {tileType: TileType.CITY};
 
-    const landSpaces = player.game.board.getAvailableSpacesOnLand();
+    const landSpaces = player.game.board.getAvailableSpacesOnLand(player);
     landSpaces[0].tile = {tileType: TileType.CITY};
     landSpaces[1].tile = {tileType: TileType.CITY};
     landSpaces[2].tile = {tileType: TileType.CITY};
@@ -61,7 +61,7 @@ describe('OffWorldCityLiving', () => {
     colonySpaces[1].tile = {tileType: TileType.CITY};
     expect(card.getVictoryPoints(player)).eq(0);
 
-    const landSpaces = player.game.board.getAvailableSpacesOnLand();
+    const landSpaces = player.game.board.getAvailableSpacesOnLand(player);
     landSpaces[0].tile = {tileType: TileType.CITY};
     expect(card.getVictoryPoints(player)).eq(1);
     landSpaces[1].tile = {tileType: TileType.CITY};

--- a/tests/cards/moon/OrbitalPowerGrid.spec.ts
+++ b/tests/cards/moon/OrbitalPowerGrid.spec.ts
@@ -46,7 +46,7 @@ describe('OrbitalPowerGrid', () => {
     colonySpaces[0].tile = {tileType: TileType.CITY};
     colonySpaces[1].tile = {tileType: TileType.CITY};
 
-    const landSpaces = player.game.board.getAvailableSpacesOnLand();
+    const landSpaces = player.game.board.getAvailableSpacesOnLand(player);
     landSpaces[0].tile = {tileType: TileType.CITY};
     landSpaces[1].tile = {tileType: TileType.CITY};
     landSpaces[2].tile = {tileType: TileType.CITY};

--- a/tests/cards/moon/RevoltingColonists.spec.ts
+++ b/tests/cards/moon/RevoltingColonists.spec.ts
@@ -38,7 +38,7 @@ describe('RevoltingColonists', () => {
   });
 
   it('play', () => {
-    const spaces = moonData.moon.getAvailableSpacesOnLand();
+    const spaces = moonData.moon.getAvailableSpacesOnLand(player1);
 
     const assignTile = function(idx: number, player: Player) {
       spaces[idx].tile = {tileType: TileType.MOON_COLONY};

--- a/tests/cards/moon/WaterTreatmentComplex.spec.ts
+++ b/tests/cards/moon/WaterTreatmentComplex.spec.ts
@@ -26,7 +26,7 @@ describe('WaterTreatmentComplex', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
 
-    const space = moonData.moon.getAvailableSpacesOnLand()[0];
+    const space = moonData.moon.getAvailableSpacesOnLand(player)[0];
 
     player.titanium = 1;
     space.tile = {tileType: TileType.MOON_COLONY};


### PR DESCRIPTION
This does not prevent a current bug in main, but it caused one in Pathfinders. Nothing pathfinders-specific, but Pathfinders has code that calls `player.game.board.getSpaces(/* no parameter */)`. No cards on the main server skip that parameter. And that's all fine until you play with Hellas, whicch overrides `getSpaces` with a mandatory player parameter.

This led to my second-ever stackoverflow question: https://stackoverflow.com/questions/69340304/is-there-a-typescript-compiler-option-to-prevent-a-subclass-method-from-removing