### PR TITLE
Make Luna Ecumenopolis not playable unless player can place 2 colonies.

### DIFF
--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -24,9 +24,20 @@ describe('LunaEcumenopolis', () => {
     card = new LunaEcumenopolis();
   });
 
+  // The part of the moon map being used for this test
+  // x   12  13  x   x  ...
+  //   17  18  19  x   x ...
+  // 22  x   x   25
+  //
+  // x is not a valid space (it's reserved for mines.)
+
   it('can play', () => {
     player.cardsInHand = [card];
     player.megaCredits = card.cost;
+
+    const moon = moonData.moon;
+    moon.getSpace('m12').tile = {tileType: TileType.MOON_COLONY};
+    moon.getSpace('m19').tile = {tileType: TileType.MOON_COLONY};
 
     player.titanium = 2;
     expect(player.getPlayableCards()).does.include(card);
@@ -35,31 +46,11 @@ describe('LunaEcumenopolis', () => {
     expect(player.getPlayableCards()).does.not.include(card);
   });
 
-  it('raise TR even when no tile placement is possible', () => {
-    moonData.colonyRate = 2;
-    expect(player.getTerraformRating()).eq(14);
-
-    card.play(player);
-    expect(game.deferredActions.pop()!.execute()).is.undefined;
-    expect(player.getTerraformRating()).eq(14);
-    expect(game.deferredActions.pop()!.execute()).is.undefined;
-    expect(player.getTerraformRating()).eq(14);
-    game.deferredActions.runAll(() => {});
-    expect(player.getTerraformRating()).eq(15);
-  });
-
-  // The part of the moon map being used for this test
-  // x   12  13  x   x  ...
-  //   17  18  19  x   x ...
-  // 22  x   x   25
-  //
-  // x is not a valid space (it's reserved for mines.)
-
-  it('Cannot place a colony when colony tiles are not adjacent', () => {
+  it('Cannot play: not enough adjacent colony tiles', () => {
+    player.titanium = 2;
     moonData.moon.getSpace('m09').tile = {tileType: TileType.MOON_COLONY};
     moonData.moon.getSpace('m18').tile = {tileType: TileType.MOON_COLONY};
-    card.play(player);
-    expect(game.deferredActions.pop()!.execute()).is.undefined;
+    expect(player.getPlayableCards()).does.not.include(card);
   });
 
   it('Place 2 colony tiles', () => {
@@ -85,4 +76,3 @@ describe('LunaEcumenopolis', () => {
     expect(player.getTerraformRating()).eq(18);
   });
 });
-


### PR DESCRIPTION
This was surprisingly easier than I expected. What am I missing?

The algorithm takes into account the possibility that the first
colony placed is necessary to place to second colony.