### PR TITLE
store all bonuses for mining cards

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -2338,7 +2338,7 @@ export class Player implements ISerializable<SerializedPlayer> {
         });
       }
       if (card instanceof MiningCard && element.bonusResource !== undefined) {
-        card.bonusResource = element.bonusResource;
+        card.bonusResource = Array.isArray(element.bonusResource) ? element.bonusResource : [element.bonusResource];
       }
       return card;
     });

--- a/src/SerializedCard.ts
+++ b/src/SerializedCard.ts
@@ -4,7 +4,7 @@ import {Tags} from './cards/Tags';
 
 export interface SerializedCard {
   allTags?: Array<Tags>;
-  bonusResource?: Resources;
+  bonusResource?: (Resources.STEEL | Resources.TITANIUM) | Array<Resources.STEEL | Resources.TITANIUM>;
   isDisabled?: boolean;
   name: CardName;
   resourceCount?: number;

--- a/src/cards/IProjectCard.ts
+++ b/src/cards/IProjectCard.ts
@@ -11,7 +11,7 @@ export interface IProjectCard extends ICard {
     // bonus besides the obvious ones printed on the card. Mining Rights and Mining Area are the only
     // two that use this field at the time (though don't expect this comment to be kept up to date if
     // that changes.)
-    bonusResource?: Resources | undefined;
+    bonusResource?: Array<Resources.STEEL | Resources.TITANIUM>;
 
     // Represents resources held in reserve when paying for a card.
     // Cards that require a unit of steel while playing, for instance.

--- a/src/cards/base/MiningCard.ts
+++ b/src/cards/base/MiningCard.ts
@@ -11,6 +11,9 @@ import {SelectSpace} from '../../inputs/SelectSpace';
 import {SpaceBonus} from '../../SpaceBonus';
 import {Tags} from '../../cards/Tags';
 import {TileType} from '../../TileType';
+import {DeferredAction} from '../../deferredActions/DeferredAction';
+import {SelectOption} from '../../inputs/SelectOption';
+import {OrOptions} from '../../inputs/OrOptions';
 
 export abstract class MiningCard extends Card implements IProjectCard {
   constructor(
@@ -25,7 +28,7 @@ export abstract class MiningCard extends Card implements IProjectCard {
       metadata,
     });
   }
-    public bonusResource: Resources | undefined = undefined;
+    public bonusResource?: Array<Resources.STEEL | Resources.TITANIUM>;
     public canPlay(player: Player): boolean {
       return this.getAvailableSpaces(player).length > 0;
     }
@@ -63,22 +66,54 @@ export abstract class MiningCard extends Card implements IProjectCard {
       return TileType.MINING_AREA;
     }
 
-    public produce(player: Player) {
+    public produce(player: Player, cb: (resource: Resources.STEEL | Resources.TITANIUM) => void = () => {}) {
       if (this.bonusResource === undefined) {
         return;
       }
-      player.addProduction(this.bonusResource, 1, {log: true});
+
+      const selectResource = (resource: Resources.STEEL | Resources.TITANIUM) => {
+        player.addProduction(resource, 1, {log: true});
+        cb(resource);
+      };
+
+      if (this.bonusResource.length === 1) {
+        selectResource(this.bonusResource[0]);
+      } else {
+        player.game.defer(new DeferredAction(
+          player,
+          () => {
+            return new OrOptions(
+              new SelectOption('Gain steel production', 'Steel', () => {
+                selectResource(Resources.STEEL);
+                return undefined;
+              }),
+              new SelectOption('Gain titanium production', 'Titanium', () => {
+                selectResource(Resources.TITANIUM);
+                return undefined;
+              }),
+            );
+          }));
+      }
     }
 
     public play(player: Player): SelectSpace {
       return new SelectSpace(this.getSelectTitle(), this.getAvailableSpaces(player), (space: ISpace) => {
+        const grantSteel = space.bonus.includes(SpaceBonus.STEEL);
         const grantTitanium = space.bonus.includes(SpaceBonus.TITANIUM);
-        this.bonusResource = grantTitanium ? Resources.TITANIUM : Resources.STEEL;
-        this.produce(player);
 
-        const spaceBonus = grantTitanium ? SpaceBonus.TITANIUM : SpaceBonus.STEEL;
-        player.game.addTile(player, space.spaceType, space, {tileType: this.getTileType(spaceBonus)});
-        space.adjacency = this.getAdjacencyBonus(spaceBonus);
+        if (grantSteel && grantTitanium) {
+          this.bonusResource = [Resources.TITANIUM, Resources.STEEL];
+        } else if (grantSteel) {
+          this.bonusResource = [Resources.STEEL];
+        } else {
+          this.bonusResource = [Resources.TITANIUM];
+        }
+
+        this.produce(player, (resource) => {
+          const spaceBonus = resource === Resources.TITANIUM ? SpaceBonus.TITANIUM : SpaceBonus.STEEL;
+          player.game.addTile(player, space.spaceType, space, {tileType: this.getTileType(spaceBonus)});
+          space.adjacency = this.getAdjacencyBonus(spaceBonus);
+        });
         return undefined;
       });
     }

--- a/src/client/components/card/CardExtraContent.vue
+++ b/src/client/components/card/CardExtraContent.vue
@@ -29,9 +29,9 @@ export default Vue.extend({
       const miningCard = [CardName.MINING_RIGHTS, CardName.MINING_AREA, CardName.MINING_RIGHTS_ARES, CardName.MINING_AREA_ARES];
       if (miningCard.includes(card.name)) {
         if (metal === Resources.TITANIUM) {
-          return card.bonusResource === Resources.TITANIUM;
+          return card.bonusResource?.includes(Resources.TITANIUM) === true;
         } else if (metal === Resources.STEEL) {
-          return card.bonusResource === Resources.STEEL;
+          return card.bonusResource?.includes(Resources.STEEL) === true;
         }
       }
       return false;

--- a/src/models/CardModel.ts
+++ b/src/models/CardModel.ts
@@ -16,5 +16,5 @@ export interface CardModel {
     isDisabled: boolean;
     warning?: string | Message;
     reserveUnits: Readonly<Units>;
-    bonusResource?: Resources | undefined;
+    bonusResource?: Array<Resources.STEEL | Resources.TITANIUM>;
 }

--- a/tests/cards/base/MiningRights.spec.ts
+++ b/tests/cards/base/MiningRights.spec.ts
@@ -1,12 +1,14 @@
 import {expect} from 'chai';
 import {MiningRights} from '../../../src/cards/base/MiningRights';
 import {Game} from '../../../src/Game';
+import {OrOptions} from '../../../src/inputs/OrOptions';
 import {SelectSpace} from '../../../src/inputs/SelectSpace';
 import {Player} from '../../../src/Player';
 import {Resources} from '../../../src/Resources';
 import {SpaceBonus} from '../../../src/SpaceBonus';
 import {TileType} from '../../../src/TileType';
 import {TestPlayers} from '../../TestPlayers';
+import {ISpace} from '../../../src/boards/ISpace';
 
 describe('MiningRights', () => {
   let card : MiningRights; let player : Player; let game : Game;
@@ -50,5 +52,26 @@ describe('MiningRights', () => {
     expect(steelSpace!.tile && steelSpace!.tile!.tileType).to.eq(TileType.MINING_RIGHTS);
     expect(player.getProduction(Resources.TITANIUM)).to.eq(1);
     expect(steelSpace!.adjacency?.bonus).eq(undefined);
+  });
+
+  it('Should play when steel and titanium', () => {
+    const action = card.play(player);
+    expect(action instanceof SelectSpace).is.true;
+    const space = action.availableSpaces.find((space) => space.tile === undefined && space.bonus.includes(SpaceBonus.TITANIUM) && space.bonus.includes(SpaceBonus.STEEL) === false) as ISpace;
+    space.bonus = [SpaceBonus.STEEL, SpaceBonus.TITANIUM];
+
+    action.cb(space);
+
+    expect(card.bonusResource?.length).eq(2);
+
+    expect(game.deferredActions.length).eq(1);
+
+    const deferredAction = game.deferredActions.pop();
+
+    const orOptions = deferredAction?.execute() as OrOptions;
+
+    expect(orOptions instanceof OrOptions).is.true;
+    orOptions.options[0].cb();
+    expect(player.getProduction(Resources.STEEL)).to.eq(1);
   });
 });


### PR DESCRIPTION
This fixes #3669 . Stores resources which were available under the placed tile for a Mining Rights card. When two resources are available allows player to select which resource to gain. Upon playing robotic workforce player can again select the resource.

I tested this with robotic workforce and the following logs demonstrates first selecting steel and then titanium with robotic workforce.

🕑You played MINING RIGHTS
🕑You's steel production increased by 1
🕑You placed Mining Rights tile on row 3 position 7
🕑You's steel amount increased by 1
🕑You's titanium amount increased by 1
🕑You played ROBOTIC WORKFORCE
🕑You copied MINING RIGHTS production with ROBOTIC WORKFORCE
🕑You's titanium production increased by 1