### PR TITLE
use brotli compression for styles

### DIFF
--- a/src/routes/ServeAsset.ts
+++ b/src/routes/ServeAsset.ts
@@ -40,6 +40,8 @@ export class ServeAsset extends Handler {
     this.cache.set('build/styles.css', styles);
     const compressed = fileApi.readFileSync('build/styles.css.gz');
     this.cache.set('build/styles.css.gz', compressed);
+    const brotli = fileApi.readFileSync('build/styles.css.br');
+    this.cache.set('build/styles.css.br', brotli);
   }
 
   public get(req: http.IncomingMessage, res: http.ServerResponse, ctx: IContext): void {
@@ -109,6 +111,9 @@ export class ServeAsset extends Handler {
       return {file: urlPath};
 
     case 'styles.css':
+      if (encodings.has('br')) {
+        return {file: 'build/styles.css.br', encoding: 'br'};
+      }
       if (encodings.has('gzip')) {
         return {file: 'build/styles.css.gz', encoding: 'gzip'};
       }

--- a/src/tools/gzip.js
+++ b/src/tools/gzip.js
@@ -4,7 +4,18 @@ const fs = require('fs');
 const zlib = require('zlib');
 
 const fileContents = fs.createReadStream('./build/styles.css');
-const writeStream = fs.createWriteStream('./build/styles.css.gz');
+const writeStreamGz = fs.createWriteStream('./build/styles.css.gz');
+const writeStreamBr = fs.createWriteStream('./build/styles.css.br');
 const zip = zlib.createGzip();
 
-fileContents.pipe(zip).pipe(writeStream);
+fileContents.pipe(zip).pipe(writeStreamGz);
+
+const br = zlib.createBrotliCompress({
+  chunkSize: 16 * 1024,
+  params: {
+    [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+    [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+  }
+});
+
+fileContents.pipe(br).pipe(writeStreamBr);

--- a/tests/routes/ServeAsset.spec.ts
+++ b/tests/routes/ServeAsset.spec.ts
@@ -88,7 +88,7 @@ describe('ServeAsset', () => {
   it('styles.css: uncached', () => {
     instance = new ServeAsset(undefined, false, fileApi);
     // Primes the cache.
-    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 2, existsSync: 0});
+    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 3, existsSync: 0});
 
     setRequest('/styles.css', [['accept-encoding', '']]);
     instance.get(req, res.hide(), ctx);
@@ -96,7 +96,7 @@ describe('ServeAsset', () => {
     expect(res.content).eq('data: build/styles.css');
     expect(fileApi.counts).deep.eq({
       readFile: 1, // Still read.
-      readFileSync: 2,
+      readFileSync: 3,
       existsSync: 0,
     });
   });
@@ -104,7 +104,7 @@ describe('ServeAsset', () => {
   it('styles.css.gz: cached', () => {
     instance = new ServeAsset(undefined, true, fileApi);
     // Primes the cache.
-    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 2, existsSync: 0});
+    expect(fileApi.counts).deep.eq({readFile: 0, readFileSync: 3, existsSync: 0});
 
     setRequest('/styles.css', [['accept-encoding', 'gzip']]);
     instance.get(req, res.hide(), ctx);
@@ -112,7 +112,7 @@ describe('ServeAsset', () => {
     expect(res.content).eq('data: build/styles.css.gz');
     expect(fileApi.counts).deep.eq({
       readFile: 0, // Does not change
-      readFileSync: 2,
+      readFileSync: 3,
       existsSync: 0,
     });
   });


### PR DESCRIPTION
This saves 10kb over `gzip` when loading CSS on browsers which support `br` compression.