### PR TITLE
Default collapsed milestones display once they have been funded

### DIFF
--- a/src/client/components/Milestone.vue
+++ b/src/client/components/Milestone.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
       showDescription[milestone.milestone.name] = false;
     }
     return {
-      showList: true,
+      showList: this.milestones_list.filter((milestone) => milestone.player_name).length === MAX_MILESTONES ? false : true,
       showDescription,
     };
   },

--- a/src/client/components/Milestone.vue
+++ b/src/client/components/Milestone.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
       showDescription[milestone.milestone.name] = false;
     }
     return {
-      showList: this.milestones_list.filter((milestone) => milestone.player_name).length === MAX_MILESTONES ? false : true,
+      showList: this.milestones_list.filter((milestone) => milestone.player_name !== undefined).length === MAX_MILESTONES ? false : true,
       showDescription,
     };
   },


### PR DESCRIPTION
Set milestones display to collapsed by default once all milestones have been funded.