### PR TITLE
Using dev:client and dev:server after build doesn't allow for refresh…

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,10 @@
     "test:client": "cross-env NODE_ENV=development mochapack --require tests/components/setup.ts \"tests/components/**/*.spec.ts\"",
     "test:client:watch": "cross-env NODE_ENV=development mochapack --watch --require tests/components/setup.ts \"tests/components/**/*.spec.ts\"",
     "cover": "nyc ts-mocha -p tests/tsconfig.json -r tests/utils/setup.ts \"tests/*.spec.ts\" \"tests/!(components)/**/*.spec.ts\"",
-    "dev:client": "cross-env NODE_ENV=development webpack --watch",
-    "dev:server": "npm run make:static && cross-env NODE_ENV=development tsnd src/server.ts"
+    "//": "When the zipped versions of JS are available dev:client and dev:server do not refresh automatically",
+    "dev:prepare": "rm build/main.js.gz build/main.js.br || true",
+    "dev:client": "npm run dev:prepare && cross-env NODE_ENV=development webpack --watch",
+    "dev:server": "npm run dev:prepare && npm run make:static && cross-env NODE_ENV=development tsnd src/server.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
…es, because something something the zipped versions of the codebase takes precendence.