### PR TITLE
PF18: Add pathfinders card Flat Mars Theory.

### DIFF
--- a/src/cards/CardRequirement.ts
+++ b/src/cards/CardRequirement.ts
@@ -223,7 +223,8 @@ export class TagCardRequirement extends CardRequirement {
     return firstLetterUpperCase(this.tag);
   }
   public satisfies(player: Player): boolean {
-    let tagCount = player.getTagCount(this.tag);
+    const includeWildTags = this.isMax !== true;
+    let tagCount = player.getTagCount(this.tag, false, includeWildTags);
     // PoliticalAgendas Scientists P4 hook
     if (this.tag === Tags.SCIENCE && player.hasTurmoilScienceTagBonus) tagCount += 1;
 

--- a/src/cards/CardRequirements.ts
+++ b/src/cards/CardRequirements.ts
@@ -41,7 +41,11 @@ export class CardRequirements {
     return this.requirements.some((req) => req.type === RequirementType.REMOVED_PLANTS);
   }
   public satisfies(player: Player): boolean {
-    const tags = this.requirements.filter((requirement) => requirement.type === RequirementType.TAG)
+    // Process tags separately, though max tag criteria will be processed later.
+    // This pre-computation takes the wild tag into account.
+    const tags = this.requirements
+      .filter((requirement) => requirement.type === RequirementType.TAG)
+      .filter((requirement) => requirement.isMax !== true)
       .map((requirement) => (requirement as TagCardRequirement).tag);
     if (!player.checkMultipleTagPresence(tags)) {
       return false;

--- a/src/cards/pathfinders/FlatMarsTheory.ts
+++ b/src/cards/pathfinders/FlatMarsTheory.ts
@@ -1,0 +1,36 @@
+import {IProjectCard} from '../IProjectCard';
+import {Player} from '../../Player';
+import {Card} from '../Card';
+import {CardType} from '../CardType';
+import {CardName} from '../../CardName';
+import {CardRenderer} from '../render/CardRenderer';
+import {Tags} from '../Tags';
+import {CardRequirements} from '../CardRequirements';
+import {Resources} from '../../Resources';
+import {max} from '../Options';
+
+export class FlatMarsTheory extends Card implements IProjectCard {
+  constructor() {
+    super({
+      cardType: CardType.AUTOMATED,
+      name: CardName.FLAT_MARS_THEORY,
+      cost: 8,
+      tags: [Tags.EARTH],
+      requirements: CardRequirements.builder((b) => b.tag(Tags.SCIENCE, 1, {max})),
+
+      metadata: {
+        cardNumber: 'Pf39',
+        renderData: CardRenderer.builder((b) => {
+          b.production((pb) => pb.megacredits(1)).slash().text('GENERATION');
+        }),
+        description: 'Requires maximum 1 science tag. Increase your MC production 1 step for every generation played so far.',
+      },
+    });
+  }
+
+  public play(player: Player) {
+    const generation = player.game.generation;
+    player.addProduction(Resources.MEGACREDITS, generation, {log: true});
+    return undefined;
+  }
+}

--- a/src/cards/pathfinders/PathfindersCardManifest.ts
+++ b/src/cards/pathfinders/PathfindersCardManifest.ts
@@ -28,7 +28,7 @@ import {EarlyExpedition} from './EarlyExpedition';
 // import {EconomicEspionage} from './EconomicEspionage';
 // import {EconomicHelp} from './EconomicHelp';
 // import {ExpeditiontotheSurfaceVenus} from './ExpeditiontotheSurfaceVenus';
-// import {FlatMarsTheory} from './FlatMarsTheory';
+import {FlatMarsTheory} from './FlatMarsTheory';
 // import {FloaterUrbanism} from './FloaterUrbanism';
 // import {HighTempSuperconductors} from './HighTempSuperconductors';
 // import {HydrogenBombardment} from './HydrogenBombardment';
@@ -115,7 +115,7 @@ export const PATHFINDERS_CARD_MANIFEST = new CardManifest({
     // {cardName: CardName.OZONE_GENERATORS, Factory: OzoneGenerators},
     // {cardName: CardName.SMALL_COMET, Factory: SmallComet},
     // {cardName: CardName.ECONOMIC_ESPIONAGE, Factory: EconomicEspionage},
-    // {cardName: CardName.FLAT_MARS_THEORY, Factory: FlatMarsTheory},
+    {cardName: CardName.FLAT_MARS_THEORY, Factory: FlatMarsTheory},
     // {cardName: CardName.ASTEROID_RESOURCES, Factory: AsteroidResources},
     // {cardName: CardName.KICKSTARTER, Factory: Kickstarter},
     // {cardName: CardName.ECONOMIC_HELP, Factory: EconomicHelp},

--- a/tests/TestPlayer.ts
+++ b/tests/TestPlayer.ts
@@ -56,7 +56,11 @@ export class TestPlayer extends Player {
 
   public getTagCount(tag: Tags, includeEventsTags:boolean = false, includeWildcardTags:boolean = true): number {
     if (this.tagsForTest !== undefined) {
-      return this.tagsForTest[tag] || 0;
+      let count = this.tagsForTest[tag] ?? 0;
+      if (tag !== Tags.WILDCARD && includeWildcardTags === true) {
+        count += this.tagsForTest[Tags.WILDCARD] ?? 0;
+      }
+      return count;
     }
     return super.getTagCount(tag, includeEventsTags, includeWildcardTags);
   }

--- a/tests/cards/CardRequirements.spec.ts
+++ b/tests/cards/CardRequirements.spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {CardRequirements} from '../../src/cards/CardRequirements';
-import {Player} from '../../src/Player';
 import {TestingUtils} from '../TestingUtils';
 import {TestPlayers} from '../TestPlayers';
 import {Game} from '../../src/Game';
@@ -15,9 +14,10 @@ import {ResearchCoordination} from '../../src/cards/prelude/ResearchCoordination
 import {Resources} from '../../src/Resources';
 import {SmallAsteroid} from '../../src/cards/promo/SmallAsteroid';
 import {OrOptions} from '../../src/inputs/OrOptions';
+import {TestPlayer} from '../TestPlayer';
 
 describe('CardRequirements', function() {
-  let player: Player; let player2: Player;
+  let player: TestPlayer; let player2: TestPlayer;
   const adaptationTechnology = new AdaptationTechnology();
 
   beforeEach(function() {
@@ -172,14 +172,26 @@ describe('CardRequirements', function() {
   it('satisfies properly for different tags', function() {
     const requirements = CardRequirements.builder((b) => b.tag(Tags.MICROBE).tag(Tags.ANIMAL));
 
-    const researchCoordination = new ResearchCoordination();
-    player.playedCards.push(researchCoordination);
+    player.tagsForTest = {wild: 1};
     expect(requirements.satisfies(player)).eq(false);
 
-    const ants = new Ants();
-    player.playedCards.push(ants);
+    player.tagsForTest = {wild: 1, microbe: 1};
     expect(requirements.satisfies(player)).eq(true);
   });
+
+  it('satisfies properly for max tag requirement', function() {
+    const requirements = CardRequirements.builder((b) => b.tag(Tags.MICROBE, 1, {max: true}));
+
+    player.tagsForTest = {microbe: 1};
+    expect(requirements.satisfies(player)).eq(true);
+
+    player.tagsForTest = {microbe: 2};
+    expect(requirements.satisfies(player)).eq(false);
+
+    player.tagsForTest = {microbe: 1, wild: 1};
+    expect(requirements.satisfies(player)).eq(true);
+  });
+
 
   it('satisfies properly for production', function() {
     const requirements = CardRequirements.builder((b) => b.production(Resources.PLANTS));

--- a/tests/cards/pathfinders/FlatMarsTheory.spec.ts
+++ b/tests/cards/pathfinders/FlatMarsTheory.spec.ts
@@ -1,0 +1,46 @@
+import {expect} from 'chai';
+import {FlatMarsTheory} from '../../../src/cards/pathfinders/FlatMarsTheory';
+import {Game} from '../../../src/Game';
+import {TestPlayer} from '../../TestPlayer';
+import {TestPlayers} from '../../TestPlayers';
+import {Units} from '../../../src/Units';
+
+describe('FlatMarsTheory', function() {
+  let card: FlatMarsTheory;
+  let player: TestPlayer;
+  let game: Game;
+
+  beforeEach(function() {
+    card = new FlatMarsTheory();
+    player = TestPlayers.BLUE.newPlayer();
+    game = Game.newInstance('foobar', [player], player);
+  });
+
+  it('canPlay', function() {
+    player.tagsForTest = {};
+    expect(player.canPlayIgnoringCost(card)).is.true;
+
+    player.tagsForTest = {science: 1};
+    expect(player.canPlayIgnoringCost(card)).is.true;
+
+    player.tagsForTest = {science: 2};
+    expect(player.canPlayIgnoringCost(card)).is.false;
+
+    player.tagsForTest = {science: 1, wild: 1};
+    expect(player.canPlayIgnoringCost(card)).is.true;
+
+    player.tagsForTest = {wild: 2};
+    expect(player.canPlayIgnoringCost(card)).is.true;
+  });
+
+  it('play', function() {
+    (game as any).generation = 4;
+    card.play(player);
+    expect(player.getProductionForTest()).deep.eq(Units.of({megacredits: 4}));
+
+    player.setProductionForTest(Units.EMPTY);
+    (game as any).generation = 7;
+    card.play(player);
+    expect(player.getProductionForTest()).deep.eq(Units.of({megacredits: 7}));
+  });
+});


### PR DESCRIPTION
This required tweaking a few changes to how tag requirements are calculated. Also, TestPlayer's `tagsForTest` didn't take wild tags into account.