### PR TITLE
remove double setting of property

### DIFF
--- a/src/turmoil/Turmoil.ts
+++ b/src/turmoil/Turmoil.ts
@@ -488,8 +488,6 @@ export class Turmoil implements ISerializable<SerializedTurmoil> {
 
       turmoil.playersInfluenceBonus = new Map<string, number>(d.playersInfluenceBonus);
 
-      turmoil.playersInfluenceBonus = new Map<string, number>(d.playersInfluenceBonus);
-
       if (d.distantGlobalEvent) {
         turmoil.distantGlobalEvent = getGlobalEventByName(d.distantGlobalEvent);
       }


### PR DESCRIPTION
Although it is thorough I believe it is unnecessary to set this property twice. Assuming this was a copy and paste or merge error.