### PR TITLE
Fixed a typo with Why? on the game setting screen

### DIFF
--- a/src/client/components/common/PurgeWarning.vue
+++ b/src/client/components/common/PurgeWarning.vue
@@ -2,7 +2,7 @@
   <span v-if="expectedPurgeTimeMs != 0">
     <div :class="klass">{{ warningText }}
       <a href="https://github.com/terraforming-mars/terraforming-mars/wiki/FAQ#purge">
-        <span i-18n>Why?</span>
+        <span v-i18n>Why?</span>
       </a>
     </div>
   </span>


### PR DESCRIPTION
Typo caused i18n to not work properly, now it works as intended.