### PR TITLE
Make terraformRating public, readonly

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -358,7 +358,7 @@ export class Game implements IGame, Logger {
     // Give them their corporation cards, other cards, starting production,
     // handicaps.
     for (const player of game.getPlayersInGenerationOrder()) {
-      player.setTerraformRating(player.getTerraformRating() + player.handicap);
+      player.setTerraformRating(player.terraformRating + player.handicap);
       if (!gameOptions.corporateEra) {
         player.production.override({
           megacredits: 1,
@@ -570,7 +570,7 @@ export class Game implements IGame, Logger {
   public isSoloModeWin(): boolean {
     // Solo TR victory condition
     if (this.gameOptions.soloTR) {
-      return this.players[0].getTerraformRating() >= 63;
+      return this.players[0].terraformRating >= 63;
     }
 
     // Complete terraforing victory condition.

--- a/src/server/IPlayer.ts
+++ b/src/server/IPlayer.ts
@@ -74,7 +74,7 @@ export interface IPlayer {
   colonies: Colonies;
   readonly production: Production;
   readonly stock: Stock;
-
+  readonly terraformRating: number;
 
   // Used only during set-up
   pickedCorporationCard?: ICorporationCard;
@@ -194,6 +194,7 @@ export interface IPlayer {
   getSteelValue(): number;
   increaseSteelValue(): void;
   decreaseSteelValue(): void;
+  /** @deprecated use #terraformRating. */
   getTerraformRating(): number;
   increaseTerraformRating(steps?: number, opts?: {log?: boolean}): void;
   decreaseTerraformRating(steps?: number, opts?: {log?: boolean}): void;

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -103,7 +103,7 @@ export class Player implements IPlayer {
   public pickedCorporationCard?: ICorporationCard;
 
   // Terraforming Rating
-  private terraformRating: number = 20;
+  public terraformRating: number = 20;
   public hasIncreasedTerraformRatingThisGeneration: boolean = false;
 
 

--- a/src/server/awards/Benefactor.ts
+++ b/src/server/awards/Benefactor.ts
@@ -5,6 +5,6 @@ export class Benefactor implements IAward {
   public readonly name = 'Benefactor';
   public readonly description = 'Have the highest terraform rating';
   public getScore(player: IPlayer): number {
-    return player.getTerraformRating();
+    return player.terraformRating;
   }
 }

--- a/src/server/cards/requirements/TRRequirement.ts
+++ b/src/server/cards/requirements/TRRequirement.ts
@@ -8,6 +8,6 @@ import {RequirementType} from '../../../common/cards/RequirementType';
 export class TRRequirement extends InequalityRequirement {
   public readonly type = RequirementType.TR;
   public override getScore(player: IPlayer): number {
-    return player.getTerraformRating();
+    return player.terraformRating;
   }
 }

--- a/src/server/cards/underworld/FabricatedScandal.ts
+++ b/src/server/cards/underworld/FabricatedScandal.ts
@@ -34,16 +34,16 @@ export class FabricatedScandal extends Card implements IProjectCard {
 
   public override bespokePlay(player: IPlayer) {
     const game = player.game;
-    const highestTR = Math.max(...game.getPlayers().map(((p) => p.getTerraformRating())));
+    const highestTR = Math.max(...game.getPlayers().map(((p) => p.terraformRating)));
     game.getPlayers().forEach((p) => {
-      if (p.getTerraformRating() === highestTR) {
+      if (p.terraformRating === highestTR) {
         p.decreaseTerraformRating(1, {log: true});
       }
     });
 
-    const lowestTR = Math.min(...game.getPlayers().map(((p) => p.getTerraformRating())));
+    const lowestTR = Math.min(...game.getPlayers().map(((p) => p.terraformRating)));
     game.getPlayers().forEach((p) => {
-      if (p.getTerraformRating() === lowestTR && player.canAfford({cost: 0, tr: {tr: 1}})) {
+      if (p.terraformRating === lowestTR && player.canAfford({cost: 0, tr: {tr: 1}})) {
         p.increaseTerraformRating(1, {log: true});
       }
     });

--- a/src/server/game/calculateVictoryPoints.ts
+++ b/src/server/game/calculateVictoryPoints.ts
@@ -34,7 +34,7 @@ export function calculateVictoryPoints(player: IPlayer) {
   }
 
   // Victory points from TR
-  builder.setVictoryPoints('terraformRating', player.getTerraformRating());
+  builder.setVictoryPoints('terraformRating', player.terraformRating);
 
   // Victory points from awards
   giveAwards(player, builder);

--- a/src/server/milestones/Terraformer.ts
+++ b/src/server/milestones/Terraformer.ts
@@ -11,7 +11,7 @@ export class Terraformer implements IMilestone {
     this.description = 'Have a terraform rating of 35 (or 26 with Turmoil.)';
   }
   public getScore(player: IPlayer): number {
-    return player.getTerraformRating();
+    return player.terraformRating;
   }
   public canClaim(player: IPlayer): boolean {
     const target = Turmoil.ifTurmoilElse(player.game, () => this.terraformRatingTurmoil, () => this.terraformRating);

--- a/src/server/models/ServerModel.ts
+++ b/src/server/models/ServerModel.ts
@@ -245,7 +245,7 @@ export class Server {
       steelProduction: player.production.steel,
       steelValue: player.getSteelValue(),
       tags: player.tags.countAllTags(),
-      terraformRating: player.getTerraformRating(),
+      terraformRating: player.terraformRating,
       timer: player.timer.serialize(),
       titanium: player.titanium,
       titaniumProduction: player.production.titanium,

--- a/src/server/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/server/turmoil/globalEvents/GenerousFunding.ts
@@ -25,7 +25,7 @@ export class GenerousFunding extends GlobalEvent implements IGlobalEvent {
 
   public resolve(game: IGame, turmoil: Turmoil) {
     game.getPlayersInGenerationOrder().forEach((player) => {
-      const trSets = Math.max(0, Math.floor((player.getTerraformRating() - 15) / 5));
+      const trSets = Math.max(0, Math.floor((player.terraformRating - 15) / 5));
       const maxTRSets = 5;
       const totalSets = Math.min(maxTRSets, trSets) + turmoil.getPlayerInfluence(player);
       player.stock.add(Resource.MEGACREDITS, 2 * totalSets, {log: true, from: this.name});

--- a/src/server/turmoil/globalEvents/RedInfluence.ts
+++ b/src/server/turmoil/globalEvents/RedInfluence.ts
@@ -25,7 +25,7 @@ export class RedInfluence extends GlobalEvent implements IGlobalEvent {
   }
   public resolve(game: IGame, turmoil: Turmoil) {
     game.getPlayersInGenerationOrder().forEach((player) => {
-      const sets = Math.floor((player.getTerraformRating() - 10)/5);
+      const sets = Math.floor((player.terraformRating - 10)/5);
       if (sets > 0) {
         const amount = Math.min(sets, 5);
         player.stock.deduct(Resource.MEGACREDITS, amount * 3, {log: true, from: this.name});

--- a/src/server/turmoil/parties/Reds.ts
+++ b/src/server/turmoil/parties/Reds.ts
@@ -29,12 +29,12 @@ class RedsBonus01 extends Bonus {
     const game = player.game;
     const players = [...game.getPlayersInGenerationOrder()];
 
-    if (game.isSoloMode() && players[0].getTerraformRating() <= 20) return 1;
+    if (game.isSoloMode() && players[0].terraformRating <= 20) return 1;
 
-    players.sort((p1, p2) => p1.getTerraformRating() - p2.getTerraformRating());
-    const min = players[0].getTerraformRating();
+    players.sort((p1, p2) => p1.terraformRating - p2.terraformRating);
+    const min = players[0].terraformRating;
 
-    if (player.getTerraformRating() === min) return 1;
+    if (player.terraformRating === min) return 1;
     return 0;
   }
 
@@ -64,12 +64,12 @@ class RedsBonus02 implements IBonus {
     const game = player.game;
     const players = [...game.getPlayersInGenerationOrder()];
 
-    if (game.isSoloMode() && players[0].getTerraformRating() > 20) return -1;
+    if (game.isSoloMode() && players[0].terraformRating > 20) return -1;
 
-    players.sort((p1, p2) => p2.getTerraformRating() - p1.getTerraformRating());
-    const max = players[0].getTerraformRating();
+    players.sort((p1, p2) => p2.terraformRating - p1.terraformRating);
+    const max = players[0].terraformRating;
 
-    if (player.getTerraformRating() === max) return -1;
+    if (player.terraformRating === max) return -1;
     return 0;
   }
 

--- a/tests/Game.spec.ts
+++ b/tests/Game.spec.ts
@@ -123,19 +123,19 @@ describe('Game', () => {
     const game = Game.newInstance('game-id', [player, player2], player);
 
     setTemperature(game, 6);
-    let initialTR = player.getTerraformRating();
+    let initialTR = player.terraformRating;
     game.increaseTemperature(player, 2);
 
     expect(game.getTemperature()).to.eq(constants.MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).to.eq(initialTR + 1);
+    expect(player.terraformRating).to.eq(initialTR + 1);
 
-    initialTR = player.getTerraformRating();
+    initialTR = player.terraformRating;
     setTemperature(game, 6);
 
     // Try 3 steps increase
     game.increaseTemperature(player, 3);
     expect(game.getTemperature()).to.eq(constants.MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).to.eq(initialTR + 1);
+    expect(player.terraformRating).to.eq(initialTR + 1);
   });
 
   it('Disallows to set oxygenLevel more than allowed maximum', () => {
@@ -144,11 +144,11 @@ describe('Game', () => {
     const game = Game.newInstance('game-id', [player, player2], player);
 
     setOxygenLevel(game, 13);
-    const initialTR = player.getTerraformRating();
+    const initialTR = player.terraformRating;
     game.increaseOxygenLevel(player, 2);
 
     expect(game.getOxygenLevel()).to.eq(constants.MAX_OXYGEN_LEVEL);
-    expect(player.getTerraformRating()).to.eq(initialTR + 1);
+    expect(player.terraformRating).to.eq(initialTR + 1);
   });
 
   it('Draft round for 2 players', () => {
@@ -397,7 +397,7 @@ describe('Game', () => {
     expect(game.isSoloModeWin()).is.not.true;
 
     // Don't give TR or raise oxygen for final greenery placements
-    expect(player.getTerraformRating()).to.eq(20);
+    expect(player.terraformRating).to.eq(20);
     expect(game.getOxygenLevel()).to.eq(12);
   });
 

--- a/tests/ares/AresHandler.spec.ts
+++ b/tests/ares/AresHandler.spec.ts
@@ -169,28 +169,28 @@ describe('AresHandler', () => {
     const space = game.board.getAvailableSpacesOnLand(player)[0];
     AresHazards.putHazardAt(space, TileType.EROSION_MILD);
     player.megaCredits = 8;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     game.addTile(player, space, {tileType: TileType.GREENERY});
     game.deferredActions.peek()!.execute();
 
     expect(space.tile!.tileType).eq(TileType.GREENERY);
     expect(player.megaCredits).is.eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('cover severe hazard', () => {
     const space = game.board.getAvailableSpacesOnLand(player)[0];
     AresHazards.putHazardAt(space, TileType.EROSION_SEVERE);
     player.megaCredits = 16;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     game.addTile(player, space, {tileType: TileType.GREENERY});
     game.deferredActions.peek()!.execute();
 
     expect(space.tile!.tileType).eq(TileType.GREENERY);
     expect(player.megaCredits).is.eq(0);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 
   it('Placing on top of an ocean does not regrant bonuses', () => {
@@ -262,7 +262,7 @@ describe('AresHandler', () => {
     const space = game.board.getAvailableSpacesOnLand(player)[0];
     AresHazards.putHazardAt(space, TileType.EROSION_SEVERE);
     player.megaCredits = 8;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     game.phase = Phase.SOLAR;
 
     game.addTile(player, space, {tileType: TileType.GREENERY});
@@ -271,7 +271,7 @@ describe('AresHandler', () => {
 
     // No costs or benefits
     expect(player.megaCredits).is.eq(8);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 });
 
@@ -306,14 +306,14 @@ describe('Hazard tests', () => {
     let tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(3);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).is.undefined;
-    const prior = player.getTerraformRating();
+    const prior = player.terraformRating;
 
     addOcean(player);
 
     tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player));
     expect(tiles.get(TileType.DUST_STORM_MILD)).is.undefined;
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).is.undefined;
-    expect(player.getTerraformRating()).eq(prior + 2); // One for the ocean, once for the dust storm event.
+    expect(player.terraformRating).eq(prior + 2); // One for the ocean, once for the dust storm event.
   });
 
   it('dust storms disappear after the sixth ocean, desperate measures changes that', () => {
@@ -331,14 +331,14 @@ describe('Hazard tests', () => {
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
     cast(new DesperateMeasures().play(player), SelectSpace).cb(protectedDustStorm);
 
-    const priorTr = player.getTerraformRating();
+    const priorTr = player.terraformRating;
 
     addOcean(player);
 
     tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player));
     expect(tiles.get(TileType.DUST_STORM_MILD)).has.lengthOf(1);
     expect(tiles.get(TileType.DUST_STORM_SEVERE)).is.undefined;
-    expect(player.getTerraformRating()).eq(priorTr + 2); // One for the ocean, once for the dust storm event.
+    expect(player.terraformRating).eq(priorTr + 2); // One for the ocean, once for the dust storm event.
   });
 
   it('dust storms amplify at 5% oxygen', () => {

--- a/tests/behavior/Executor.spec.ts
+++ b/tests/behavior/Executor.spec.ts
@@ -237,15 +237,15 @@ describe('Executor', () => {
   });
 
   it('tr', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     executor.execute({tr: 2}, player, fake);
 
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
 
     executor.execute({tr: -1}, player, fake);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('add resources to specific card', () => {
@@ -506,11 +506,11 @@ describe('Executor', () => {
     const behavior: Behavior = {spend: {energy: 1}, tr: 1};
     expect(executor.canExecute(behavior, player, fake)).is.false;
     player.energy = 1;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(executor.canExecute(behavior, player, fake)).is.true;
     executor.execute(behavior, player, fake);
     expect(player.energy).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('spend - energy, raise TR, reds in power', () => {
@@ -549,11 +549,11 @@ describe('Executor', () => {
     const behavior: Behavior = {spend: {heat: 1}, tr: 1};
     expect(executor.canExecute(behavior, player, fake)).is.false;
     player.heat = 1;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(executor.canExecute(behavior, player, fake)).is.true;
     executor.execute(behavior, player, fake);
     expect(player.heat).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('spend - heat, raise TR, reds in power', () => {
@@ -594,7 +594,7 @@ describe('Executor', () => {
     const behavior = {spend: {heat: 3}, tr: 1};
     player.heat = 3;
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(executor.canExecute(behavior, player, fake)).is.true;
 
     setRulingParty(game, PartyName.REDS);
@@ -610,7 +610,7 @@ describe('Executor', () => {
     expect(player.heat).eq(3);
     const selectPayment = cast(player.popWaitingFor(), SelectPayment);
     selectPayment.cb(Payment.of({heat: 3}));
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.heat).eq(0);
   });
 

--- a/tests/cards/ares/ButterflyEffect.spec.ts
+++ b/tests/cards/ares/ButterflyEffect.spec.ts
@@ -22,10 +22,10 @@ describe('ButterflyEffect', () => {
   });
 
   it('play', () => {
-    const priorTerraformingRating = player.getTerraformRating();
+    const priorTerraformingRating = player.terraformRating;
 
     const input = cast(churn(card.play(player), player), ShiftAresGlobalParameters);
-    expect(player.getTerraformRating()).eq(priorTerraformingRating + 1);
+    expect(player.terraformRating).eq(priorTerraformingRating + 1);
 
     const originalHazardData = game.aresData!.hazardData;
     expect(originalHazardData.erosionOceanCount.threshold).eq(3);
@@ -56,9 +56,9 @@ describe('ButterflyEffect', () => {
       }
     });
 
-    const priorTerraformingRating = player.getTerraformRating();
+    const priorTerraformingRating = player.terraformRating;
 
     expect(churn(card.play(player), player)).is.undefined;
-    expect(player.getTerraformRating()).eq(priorTerraformingRating + 1);
+    expect(player.terraformRating).eq(priorTerraformingRating + 1);
   });
 });

--- a/tests/cards/ares/DesperateMeasures.spec.ts
+++ b/tests/cards/ares/DesperateMeasures.spec.ts
@@ -22,11 +22,11 @@ describe('DesperateMeasures', () => {
     const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player));
     const protectedDustStorm = tiles.get(TileType.DUST_STORM_MILD)![0];
 
-    const priorTr = player.getTerraformRating();
+    const priorTr = player.terraformRating;
 
     cast(card.play(player), SelectSpace).cb(protectedDustStorm);
 
-    expect(player.getTerraformRating()).eq(priorTr + 1);
+    expect(player.terraformRating).eq(priorTr + 1);
     expect(game.getOxygenLevel()).eq(1);
   });
 
@@ -39,12 +39,12 @@ describe('DesperateMeasures', () => {
     const tiles = AresTestHelper.byTileType(AresTestHelper.getHazards(player));
     const protectedErosion = tiles.get(TileType.EROSION_MILD)![0];
 
-    const priorTr = player.getTerraformRating();
+    const priorTr = player.terraformRating;
     const priorTemp = game.getTemperature();
 
     cast(card.play(player), SelectSpace).cb(protectedErosion);
 
-    expect(player.getTerraformRating()).eq(priorTr + 1);
+    expect(player.terraformRating).eq(priorTr + 1);
     expect(game.getTemperature()).eq(priorTemp + 2);
   });
 

--- a/tests/cards/ares/MagneticFieldGeneratorsAres.spec.ts
+++ b/tests/cards/ares/MagneticFieldGeneratorsAres.spec.ts
@@ -39,7 +39,7 @@ describe('MagneticFieldGeneratorsAres', () => {
     action.cb(space);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
 
     player.megaCredits = 0;
     player.plants = 0;

--- a/tests/cards/base/BlackPolarDust.spec.ts
+++ b/tests/cards/base/BlackPolarDust.spec.ts
@@ -30,7 +30,7 @@ describe('BlackPolarDust', () => {
     expect(game.deferredActions).has.lengthOf(1);
     const selectSpace = cast(game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.spaces[0]);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Cannot place ocean if no oceans left', () => {

--- a/tests/cards/base/BribedCommittee.spec.ts
+++ b/tests/cards/base/BribedCommittee.spec.ts
@@ -8,6 +8,6 @@ describe('BribedCommittee', () => {
     const [/* game */, player] = testGame(2);
     card.play(player);
     expect(card.getVictoryPoints(player)).to.eq(-2);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 });

--- a/tests/cards/base/CaretakerContract.spec.ts
+++ b/tests/cards/base/CaretakerContract.spec.ts
@@ -41,7 +41,7 @@ describe('CaretakerContract', () => {
     player.heat = 8;
     card.action(player);
     expect(player.heat).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Cannot act if cannot afford reds tax', () => {

--- a/tests/cards/base/Comet.spec.ts
+++ b/tests/cards/base/Comet.spec.ts
@@ -29,7 +29,7 @@ describe('Comet', () => {
 
     const selectSpace = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.spaces[0]);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
 
     const orOptions = cast(game.deferredActions.pop()!.execute(), OrOptions);
     orOptions.options[0].cb();

--- a/tests/cards/base/EquatorialMagnetizer.spec.ts
+++ b/tests/cards/base/EquatorialMagnetizer.spec.ts
@@ -23,6 +23,6 @@ describe('EquatorialMagnetizer', () => {
 
     card.action(player);
     expect(player.production.energy).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 });

--- a/tests/cards/base/GiantIceAsteroid.spec.ts
+++ b/tests/cards/base/GiantIceAsteroid.spec.ts
@@ -40,7 +40,7 @@ describe('GiantIceAsteroid', () => {
     expect(player3.plants).to.eq(0);
 
     expect(game.getTemperature()).to.eq(-26);
-    expect(player.getTerraformRating()).to.eq(24);
+    expect(player.terraformRating).to.eq(24);
   });
 
   const redsRuns = [

--- a/tests/cards/base/ImportedNitrogen.spec.ts
+++ b/tests/cards/base/ImportedNitrogen.spec.ts
@@ -23,7 +23,7 @@ describe('ImportedNitrogen', () => {
 
   it('Should play without animals and microbes', () => {
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.plants).to.eq(4);
   });
 
@@ -39,7 +39,7 @@ describe('ImportedNitrogen', () => {
     addAnimals.cb([pets]);
     expect(pets.resourceCount).to.eq(2);
 
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.plants).to.eq(4);
   });
 
@@ -55,7 +55,7 @@ describe('ImportedNitrogen', () => {
 
     expect(game.deferredActions.pop()!.execute()).is.undefined;
 
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.plants).to.eq(4);
   });
 
@@ -75,7 +75,7 @@ describe('ImportedNitrogen', () => {
     addAnimals.cb([pets]);
     expect(pets.resourceCount).to.eq(2);
 
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.plants).to.eq(4);
   });
 });

--- a/tests/cards/base/LakeMarineris.spec.ts
+++ b/tests/cards/base/LakeMarineris.spec.ts
@@ -30,7 +30,7 @@ describe('LakeMarineris', () => {
     firstOcean.cb(firstOcean.spaces[0]);
     const secondOcean = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     secondOcean.cb(secondOcean.spaces[1]);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
 
     expect(card.getVictoryPoints(player)).to.eq(2);
   });

--- a/tests/cards/base/MagneticFieldDome.spec.ts
+++ b/tests/cards/base/MagneticFieldDome.spec.ts
@@ -24,6 +24,6 @@ describe('MagneticFieldDome', () => {
     card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(1);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 });

--- a/tests/cards/base/MagneticFieldGenerators.spec.ts
+++ b/tests/cards/base/MagneticFieldGenerators.spec.ts
@@ -24,6 +24,6 @@ describe('MagneticFieldGenerators', () => {
     card.play(player);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
   });
 });

--- a/tests/cards/base/NitriteReducingBacteria.spec.ts
+++ b/tests/cards/base/NitriteReducingBacteria.spec.ts
@@ -37,6 +37,6 @@ describe('NitriteReducingBacteria', () => {
 
     expect(churn(() => orOptions.options[0].cb(), player)).is.undefined;
     expect(card.resourceCount).to.eq(2);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 });

--- a/tests/cards/base/NitrogenRichAsteroid.spec.ts
+++ b/tests/cards/base/NitrogenRichAsteroid.spec.ts
@@ -8,12 +8,12 @@ describe('NitrogenRichAsteroid', () => {
     const card = new NitrogenRichAsteroid();
     const [game, player] = testGame(2);
     cast(card.play(player), undefined);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
     expect(game.getTemperature()).to.eq(-28);
     expect(player.production.plants).to.eq(1);
     player.tagsForTest = {plant: 3};
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(26);
+    expect(player.terraformRating).to.eq(26);
     expect(game.getTemperature()).to.eq(-26);
     expect(player.production.plants).to.eq(5);
   });

--- a/tests/cards/base/RadChemFactory.spec.ts
+++ b/tests/cards/base/RadChemFactory.spec.ts
@@ -23,6 +23,6 @@ describe('RadChemFactory', () => {
 
     card.play(player);
     expect(player.production.energy).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 });

--- a/tests/cards/base/ReleaseOfInertGases.spec.ts
+++ b/tests/cards/base/ReleaseOfInertGases.spec.ts
@@ -8,6 +8,6 @@ describe('ReleaseOfInertGases', () => {
     const card = new ReleaseOfInertGases();
     const [/* game */, player] = testGame(2);
     cast(card.play(player), undefined);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 });

--- a/tests/cards/base/TerraformingGanymede.spec.ts
+++ b/tests/cards/base/TerraformingGanymede.spec.ts
@@ -21,7 +21,7 @@ describe('TerraformingGanymede', () => {
     cast(card.play(player), undefined);
     expect(card.getVictoryPoints(player)).to.eq(2);
     player.playedCards.push(card);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('canPlay with Reds', () => {

--- a/tests/cards/base/WaterImportFromEuropa.spec.ts
+++ b/tests/cards/base/WaterImportFromEuropa.spec.ts
@@ -38,7 +38,7 @@ describe('WaterImportFromEuropa', () => {
     expect(game.deferredActions).has.lengthOf(1);
     const selectOcean = cast(game.deferredActions.peek()!.execute(), SelectSpace);
     selectOcean.cb(selectOcean.spaces[0]);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Can act if can pay even after oceans are maxed', () => {

--- a/tests/cards/base/standardActions/ConvertHeat.spec.ts
+++ b/tests/cards/base/standardActions/ConvertHeat.spec.ts
@@ -51,13 +51,13 @@ describe('ConvertHeat', () => {
 
     setTemperature(game, MAX_TEMPERATURE);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(card.canAct(player)).eq(true);
 
     cast(card.action(player), undefined);
 
     expect(game.getTemperature()).eq(MAX_TEMPERATURE);
     expect(player.heat).eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 });

--- a/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/AquiferStandardProject.spec.ts
@@ -31,7 +31,7 @@ describe('AquiferStandardProject', () => {
 
     assertPlaceOcean(player, churn(card.action(player), player));
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.board.getOceanSpaces()).has.length(1);
   });
 
@@ -42,14 +42,14 @@ describe('AquiferStandardProject', () => {
     maxOutOceans(player);
 
     player.megaCredits = 18;
-    expect(player.getTerraformRating()).eq(23);
+    expect(player.terraformRating).eq(23);
     expect(card.canAct(player)).eq(true);
 
     cast(card.action(player), undefined);
     runAllActions(game);
 
     expect(game.board.getOceanSpaces()).has.length(9);
-    expect(player.getTerraformRating()).eq(23);
+    expect(player.terraformRating).eq(23);
     expect(player.megaCredits).eq(0);
   });
 

--- a/tests/cards/base/standardProjects/AsteroidStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/AsteroidStandardProject.spec.ts
@@ -32,7 +32,7 @@ describe('AsteroidStandardProject', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.getTemperature()).eq(-28);
   });
 
@@ -42,14 +42,14 @@ describe('AsteroidStandardProject', () => {
 
     setTemperature(game, MAX_TEMPERATURE);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(card.canAct(player)).eq(true);
 
     cast(card.action(player), undefined);
     runAllActions(game);
 
     expect(game.getTemperature()).eq(MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.megaCredits).eq(0);
   });
 

--- a/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
+++ b/tests/cards/base/standardProjects/GreeneryStandardProject.spec.ts
@@ -36,7 +36,7 @@ describe('GreeneryStandardProject', () => {
     assertPlaceTile(player, churn(card.action(player), player), TileType.GREENERY);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.getOxygenLevel()).eq(1);
   });
 

--- a/tests/cards/ceo/Greta.spec.ts
+++ b/tests/cards/ceo/Greta.spec.ts
@@ -105,9 +105,9 @@ describe('Greta', () => {
     turmoil.endGeneration(game);
     runAllActions(game);
     expect(turmoil.chairman).to.eq(player);
-    expect(player.getTerraformRating()).to.eq(20);
+    expect(player.terraformRating).to.eq(20);
     expect(player.megaCredits).to.eq(0);
-    expect(player2.getTerraformRating()).to.eq(19);
+    expect(player2.terraformRating).to.eq(19);
     expect(player2.megaCredits).to.eq(0);
   });
 

--- a/tests/cards/ceo/Oscar.spec.ts
+++ b/tests/cards/ceo/Oscar.spec.ts
@@ -68,22 +68,22 @@ describe('Oscar', () => {
   });
 
   it('OPG does not gain TR', () => {
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     card.action(player);
     runAllActions(game);
     expect(turmoil.chairman).eq(player);
-    expect(player.getTerraformRating()).is.eq(tr);
+    expect(player.terraformRating).is.eq(tr);
   });
 
   it('OPG gains 1 TR with Tempest Consultancy', () => {
     const tempcons = new TempestConsultancy();
     player.corporations.push(tempcons);
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     card.action(player);
     runAllActions(game);
 
     expect(turmoil.chairman).eq(player);
-    expect(player.getTerraformRating()).is.eq(tr+1);
+    expect(player.terraformRating).is.eq(tr+1);
   });
 
   it('OPG Counts for POLITICAN Award', () => {

--- a/tests/cards/colonies/JovianLanterns.spec.ts
+++ b/tests/cards/colonies/JovianLanterns.spec.ts
@@ -15,7 +15,7 @@ describe('JovianLanterns', () => {
 
   it('Should play', () => {
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Can not act', () => {

--- a/tests/cards/colonies/NitrogenFromTitan.spec.ts
+++ b/tests/cards/colonies/NitrogenFromTitan.spec.ts
@@ -20,9 +20,9 @@ describe('NitrogenFromTitan', () => {
   });
 
   it('Can play without floaters', () => {
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(tr + 2);
+    expect(player.terraformRating).to.eq(tr + 2);
     const input = game.deferredActions.peek()!.execute();
     expect(input).is.undefined;
   });

--- a/tests/cards/colonies/TitanAirScrapping.spec.ts
+++ b/tests/cards/colonies/TitanAirScrapping.spec.ts
@@ -28,7 +28,7 @@ describe('TitanAirScrapping', () => {
     const orOptions = cast(card.action(player), OrOptions);
     orOptions.options[0].cb();
 
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(card.resourceCount).to.eq(5);
     expect(card.getVictoryPoints(player)).to.eq(2);
   });
@@ -39,7 +39,7 @@ describe('TitanAirScrapping', () => {
     expect(card.canAct(player)).is.true;
 
     card.action(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(card.resourceCount).to.eq(0);
   });
 });

--- a/tests/cards/community/Eris.spec.ts
+++ b/tests/cards/community/Eris.spec.ts
@@ -31,7 +31,7 @@ describe('Eris', () => {
   it('Can act', () => {
     const action = cast(card.action(player), OrOptions);
     const initialHazardsCount = game.board.getHazards().length;
-    const initialTR = player.getTerraformRating();
+    const initialTR = player.terraformRating;
 
     // Place a hazard tile
     action.options[0].cb();
@@ -46,7 +46,7 @@ describe('Eris', () => {
     removeHazard.cb(removeHazard.spaces[0]);
     expect(removeHazard.spaces[0].tile).is.undefined;
     expect(game.board.getHazards()).has.length(initialHazardsCount);
-    expect(player.getTerraformRating()).eq(initialTR + 1);
+    expect(player.terraformRating).eq(initialTR + 1);
   });
 
   it('Respects Reds', () => {

--- a/tests/cards/community/Midas.spec.ts
+++ b/tests/cards/community/Midas.spec.ts
@@ -12,10 +12,10 @@ describe('Midas', () => {
   });
 
   it('Starts with correct TR', () => {
-    const initialTR = player.getTerraformRating();
+    const initialTR = player.terraformRating;
 
     card.play(player);
     player.corporations.push(card);
-    expect(player.getTerraformRating()).to.eq(initialTR - 7);
+    expect(player.terraformRating).to.eq(initialTR - 7);
   });
 });

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -40,11 +40,11 @@ describe('Playwrights', () => {
 
   it('Can replay own event', () => {
     const event = new ReleaseOfInertGases();
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     event.play(player);
     player.playedCards.push(event);
 
-    expect(player.getTerraformRating()).to.eq(tr + 2);
+    expect(player.terraformRating).to.eq(tr + 2);
     expect(card.canAct(player)).is.not.true;
 
     player.megaCredits = event.cost;
@@ -56,7 +56,7 @@ describe('Playwrights', () => {
     game.deferredActions.pop()!.execute(); // SelectPayment
     runAllActions(game);
 
-    expect(player.getTerraformRating()).to.eq(tr + 4);
+    expect(player.terraformRating).to.eq(tr + 4);
     expect(player.megaCredits).eq(0);
     expect(player.playedCards.asArray()).has.members([card]);
     expect(player.removedFromPlayCards).has.lengthOf(1);
@@ -64,7 +64,7 @@ describe('Playwrights', () => {
 
   it('Can replay other player\'s event', () => {
     const event = new ReleaseOfInertGases();
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     event.play(player2);
     player2.playedCards.push(event);
 
@@ -76,7 +76,7 @@ describe('Playwrights', () => {
     game.deferredActions.pop()!.execute(); // SelectPayment
     runAllActions(game);
 
-    expect(player.getTerraformRating()).to.eq(tr + 2);
+    expect(player.terraformRating).to.eq(tr + 2);
     expect(player.megaCredits).eq(0);
     expect(player2.playedCards.length).eq(0);
     expect(player.removedFromPlayCards).has.lengthOf(1);

--- a/tests/cards/community/ProjectWorkshop.spec.ts
+++ b/tests/cards/community/ProjectWorkshop.spec.ts
@@ -100,24 +100,24 @@ describe('ProjectWorkshop', () => {
     const extremophiles = new Extremophiles();
     player.addResourceTo(extremophiles, 11);
 
-    const originalTR = player.getTerraformRating();
+    const originalTR = player.terraformRating;
     player.playedCards.push(smallAnimals, extremophiles);
 
     const selectOption = cast(card.action(player), SelectOption);
     const selectCard = cast(selectOption.cb(undefined), SelectCard<ICard>);
 
     selectCard.cb([smallAnimals]);
-    expect(player.getTerraformRating()).to.eq(originalTR + 2);
+    expect(player.terraformRating).to.eq(originalTR + 2);
     expect(player.cardsInHand).has.lengthOf(2);
 
     selectCard.cb([extremophiles]);
-    expect(player.getTerraformRating()).to.eq(originalTR + 5);
+    expect(player.terraformRating).to.eq(originalTR + 5);
     expect(player.cardsInHand).has.lengthOf(4);
   });
 
   it('Converts VP to TR correctly when counting tags', () => {
     const waterImportFromEuropa = new WaterImportFromEuropa();
-    const originalTR = player.getTerraformRating();
+    const originalTR = player.terraformRating;
 
     player.playedCards.push(waterImportFromEuropa);
     player.actionsThisGeneration.add(waterImportFromEuropa.name);
@@ -126,14 +126,14 @@ describe('ProjectWorkshop', () => {
     const selectOption = cast(card.action(player), SelectOption);
     cast(selectOption.cb(undefined), undefined);
 
-    expect(player.getTerraformRating()).to.eq(originalTR + 2);
+    expect(player.terraformRating).to.eq(originalTR + 2);
     expect(player.playedCards).does.not.include(waterImportFromEuropa);
   });
 
 
   it('Converts VP to TR correctly when counting wild tags', () => {
     const waterImportFromEuropa = new WaterImportFromEuropa();
-    const originalTR = player.getTerraformRating();
+    const originalTR = player.terraformRating;
 
     player.playedCards.push(waterImportFromEuropa);
     player.actionsThisGeneration.add(waterImportFromEuropa.name);
@@ -143,7 +143,7 @@ describe('ProjectWorkshop', () => {
     const selectOption = cast(card.action(player), SelectOption);
     cast(selectOption.cb(undefined), undefined);
 
-    expect(player.getTerraformRating()).to.eq(originalTR + 3);
+    expect(player.terraformRating).to.eq(originalTR + 3);
     expect(player.playedCards).does.not.include(waterImportFromEuropa);
   });
 
@@ -158,7 +158,7 @@ describe('ProjectWorkshop', () => {
     const ancientShipyards = new AncientShipyards();
     player.addResourceTo(ancientShipyards, 5);
 
-    const originalTR = player.getTerraformRating();
+    const originalTR = player.terraformRating;
     player.playedCards.push(ancientShipyards);
 
     const selectOption = cast(card.action(player), SelectOption);
@@ -166,7 +166,7 @@ describe('ProjectWorkshop', () => {
     expect(selectOption.cb(undefined)).is.undefined;
     expect(player.playedCards.asArray()).deep.eq([card]);
 
-    expect(player.getTerraformRating()).to.eq(originalTR - 5);
+    expect(player.terraformRating).to.eq(originalTR - 5);
     expect(player.cardsInHand).has.lengthOf(2);
   });
 
@@ -208,7 +208,7 @@ describe('ProjectWorkshop', () => {
     player.megaCredits = 6;
     expect(selectCard().cards).has.members([smallAnimals, birds]);
 
-    const originalTR = player.getTerraformRating();
+    const originalTR = player.terraformRating;
     player.megaCredits = 5;
 
     const orOptions = cast(card.action(player), OrOptions);
@@ -217,7 +217,7 @@ describe('ProjectWorkshop', () => {
 
     expect(player.playedCards.asArray()).has.members([card, smallAnimals, extremophiles]);
     expect(game.projectDeck.discardPile).contains(birds);
-    expect(player.getTerraformRating()).to.eq(originalTR + 1);
+    expect(player.terraformRating).to.eq(originalTR + 1);
     expect(player.megaCredits).eq(2); // Spent 3MC for the reds tax.
   });
 

--- a/tests/cards/community/UnitedNationsMissionOne.spec.ts
+++ b/tests/cards/community/UnitedNationsMissionOne.spec.ts
@@ -20,12 +20,12 @@ describe('UnitedNationsMissionOne', () => {
   });
 
   it('Initializes correctly', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.megaCredits).eq(0);
 
     player.playCorporationCard(card);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(40);
   });
 
@@ -62,7 +62,7 @@ describe('UnitedNationsMissionOne', () => {
 
     const election = new Election();
     election.resolve(game, turmoil);
-    expect(player2.getTerraformRating()).eq(22);
+    expect(player2.terraformRating).eq(22);
     expect(player.megaCredits).eq(0); // no increase
   });
 });

--- a/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
+++ b/tests/cards/corporation/UnitedNationsMarsInitiative.spec.ts
@@ -38,7 +38,7 @@ describe('UnitedNationsMarsInitiative', () => {
     card.action(player);
     runAllActions(game);
     expect(player.megaCredits).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 
   it('Helion + UNMI', () => {
@@ -47,7 +47,7 @@ describe('UnitedNationsMarsInitiative', () => {
     player.corporations.push(helion);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     player.megaCredits = 2;
     expect(card.canAct(player)).is.false;
     player.heat = 1;
@@ -58,7 +58,7 @@ describe('UnitedNationsMarsInitiative', () => {
 
     const selectPayment = cast(churn(card.action(player), player), SelectPayment);
     selectPayment.cb({...Payment.EMPTY, megaCredits: 1, heat: 2});
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
     expect(player.megaCredits).to.eq(1);
     expect(player.heat).to.eq(3);
   });

--- a/tests/cards/moon/AIControlledMineNetwork.spec.ts
+++ b/tests/cards/moon/AIControlledMineNetwork.spec.ts
@@ -31,12 +31,12 @@ describe('AIControlledMineNetwork', () => {
 
   it('play', () => {
     expect(moonData.logisticRate).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/AlgaeBioreactors.spec.ts
+++ b/tests/cards/moon/AlgaeBioreactors.spec.ts
@@ -33,7 +33,7 @@ describe('AlgaeBioreactors', () => {
 
   it('play', () => {
     player.production.override({plants: 1});
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(game.getOxygenLevel()).eq(0);
     moonData.habitatRate = 0;
 
@@ -42,7 +42,7 @@ describe('AlgaeBioreactors', () => {
     expect(player.production.plants).eq(0);
     expect(moonData.habitatRate).eq(1);
     expect(game.getOxygenLevel()).eq(1);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 
   it('canPlay when Reds are in power', () => {

--- a/tests/cards/moon/AristarchusRoadNetwork.spec.ts
+++ b/tests/cards/moon/AristarchusRoadNetwork.spec.ts
@@ -33,7 +33,7 @@ describe('AristarchusRoadNetwork', () => {
   it('play', () => {
     player.steel = 2;
     expect(player.production.megacredits).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.logisticRate).eq(0);
 
     card.play(player);
@@ -45,7 +45,7 @@ describe('AristarchusRoadNetwork', () => {
     expect(moonData.logisticRate).eq(0);
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_ROAD);
 
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.logisticRate).eq(1);
   });
 });

--- a/tests/cards/moon/BasicInfrastructure.spec.ts
+++ b/tests/cards/moon/BasicInfrastructure.spec.ts
@@ -22,7 +22,7 @@ describe('BasicInfrastructure', () => {
 
   it('play', () => {
     expect(player.production.megacredits).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.logisticRate).eq(0);
     expect(player.colonies.getFleetSize()).eq(1);
 
@@ -31,7 +31,7 @@ describe('BasicInfrastructure', () => {
     placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.colonies.getFleetSize()).eq(2);
   });
 });

--- a/tests/cards/moon/ColonistShuttles.spec.ts
+++ b/tests/cards/moon/ColonistShuttles.spec.ts
@@ -41,13 +41,13 @@ describe('ColonistShuttles', () => {
     player.titanium = 1;
     player.megaCredits = 0;
 
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     card.play(player);
 
     expect(player.titanium).eq(0);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.habitatRate).eq(1);
     expect(player.megaCredits).eq(14);
   });

--- a/tests/cards/moon/CopernicusTower.spec.ts
+++ b/tests/cards/moon/CopernicusTower.spec.ts
@@ -39,10 +39,10 @@ describe('CopernicusTower', () => {
 
     // The first option decreases resource count by 1 and raise the TR 1 step.
     input = cast(churn(card.action(player), player), OrOptions);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     churn(() => input.options[0].cb(), player);
     expect(card.resourceCount).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('victory points', () => {

--- a/tests/cards/moon/CoreMine.spec.ts
+++ b/tests/cards/moon/CoreMine.spec.ts
@@ -22,7 +22,7 @@ describe('CoreMine', () => {
 
   it('play', () => {
     expect(player.production.titanium).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -31,7 +31,7 @@ describe('CoreMine', () => {
     placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/DarksideMeteorBombardment.spec.ts
+++ b/tests/cards/moon/DarksideMeteorBombardment.spec.ts
@@ -28,14 +28,14 @@ describe('DarksideMeteorBombardment', () => {
     player.titanium = 0;
     player.steel = 0;
     moonData.miningRate = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(player.titanium).eq(2);
     expect(player.titanium).eq(2);
     expect(moonData.miningRate).eq(2);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 });
 

--- a/tests/cards/moon/DarksideMiningSyndicate.spec.ts
+++ b/tests/cards/moon/DarksideMiningSyndicate.spec.ts
@@ -29,25 +29,25 @@ describe('DarksideMiningSyndicate', () => {
   it('play', () => {
     expect(player.production.titanium).eq(0);
     expect(moonData.miningRate).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
     expect(moonData.miningRate).eq(1);
 
     expect(player.production.titanium).eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     card.play(player);
     expect(moonData.miningRate).eq(2);
 
     expect(player.production.titanium).eq(4);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
 
     card.play(player);
     expect(moonData.miningRate).eq(3);
 
     expect(player.production.titanium).eq(5);
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
   });
 
   const redsRuns = [

--- a/tests/cards/moon/DeepLunarMining.spec.ts
+++ b/tests/cards/moon/DeepLunarMining.spec.ts
@@ -30,14 +30,14 @@ describe('DeepLunarMining', () => {
   it('play', () => {
     player.titanium = 3;
     expect(player.production.titanium).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
 
     expect(player.titanium).eq(2);
     expect(player.production.titanium).eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
   });
 });

--- a/tests/cards/moon/FirstLunarSettlement.spec.ts
+++ b/tests/cards/moon/FirstLunarSettlement.spec.ts
@@ -22,7 +22,7 @@ describe('FirstLunarSettlement', () => {
 
   it('play', () => {
     expect(player.production.megacredits).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     card.play(player);
@@ -30,7 +30,7 @@ describe('FirstLunarSettlement', () => {
     placeTileAction.execute()!.cb(moonData.moon.spaces[2]);
 
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/HE3ProductionQuotas.spec.ts
+++ b/tests/cards/moon/HE3ProductionQuotas.spec.ts
@@ -53,7 +53,7 @@ describe('HE3ProductionQuotas', () => {
     spaces[1].tile = {tileType: TileType.MOON_MINE};
     spaces[2].tile = {tileType: TileType.MOON_MINE};
     moonData.miningRate = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.steel = 5;
     player.heat = 0;
@@ -62,7 +62,7 @@ describe('HE3ProductionQuotas', () => {
     expect(player.steel).eq(2);
     expect(player.heat).eq(12);
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/Habitat14.spec.ts
+++ b/tests/cards/moon/Habitat14.spec.ts
@@ -37,7 +37,7 @@ describe('Habitat14', () => {
   it('play', () => {
     player.titanium = 1;
     player.production.override({megacredits: 1, energy: 1});
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 

--- a/tests/cards/moon/HeavyDutyRovers.spec.ts
+++ b/tests/cards/moon/HeavyDutyRovers.spec.ts
@@ -30,7 +30,7 @@ describe('HeavyDutyRovers', () => {
   it('play', () => {
     player.megaCredits = 0;
     moonData.logisticRate = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     moonData.moon.getSpaceOrThrow('m07')!.tile = {tileType: TileType.MOON_MINE};
     moonData.moon.getSpaceOrThrow('m06')!.tile = {tileType: TileType.MOON_ROAD};
@@ -40,7 +40,7 @@ describe('HeavyDutyRovers', () => {
 
     expect(player.megaCredits).eq(8);
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('issues/5065', () => {

--- a/tests/cards/moon/ImprovedMoonConcrete.spec.ts
+++ b/tests/cards/moon/ImprovedMoonConcrete.spec.ts
@@ -33,13 +33,13 @@ describe('ImprovedMoonConcrete', () => {
 
   it('play', () => {
     player.steel = 12;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
 
     expect(player.steel).eq(10);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
   });
 

--- a/tests/cards/moon/LTFHeadquarters.spec.ts
+++ b/tests/cards/moon/LTFHeadquarters.spec.ts
@@ -20,7 +20,7 @@ describe('LTFHeadquarters', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     expect(player.colonies.getFleetSize()).eq(1);
@@ -31,7 +31,7 @@ describe('LTFHeadquarters', () => {
     expect(action).is.instanceof(BuildColony);
 
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     expect(player.colonies.getFleetSize()).eq(2);
   });

--- a/tests/cards/moon/LunaEcumenopolis.spec.ts
+++ b/tests/cards/moon/LunaEcumenopolis.spec.ts
@@ -70,7 +70,7 @@ describe('LunaEcumenopolis', () => {
   it('Place 2 colony tiles', () => {
     moonData.habitatRate = 2;
     const moon = moonData.moon;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     moon.getSpaceOrThrow('m12').tile = {tileType: TileType.MOON_HABITAT};
     moon.getSpaceOrThrow('m19').tile = {tileType: TileType.MOON_HABITAT};
@@ -80,14 +80,14 @@ describe('LunaEcumenopolis', () => {
     expect(input1.spaces.map(toID)).deep.eq(['m13', 'm18']);
     input1.cb(moon.getSpaceOrThrow('m18'));
     expect(moonData.habitatRate).eq(3);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     const input2 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input2.spaces.map(toID)).deep.eq(['m13', 'm17']);
     input1.cb(moon.getSpaceOrThrow('m13'));
     expect(moonData.habitatRate).eq(4);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(18);
+    expect(player.terraformRating).eq(18);
   });
 
   it('can play next to Lunar Mine Urbanization', () => {
@@ -108,7 +108,7 @@ describe('LunaEcumenopolis', () => {
   it('Place 2 colony tiles next to Lunar Mine Urbanization', () => {
     moonData.habitatRate = 2;
     const moon = moonData.moon;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     moon.getSpaceOrThrow('m12').tile = {tileType: TileType.LUNAR_MINE_URBANIZATION};
     moon.getSpaceOrThrow('m19').tile = {tileType: TileType.MOON_HABITAT};
@@ -118,14 +118,14 @@ describe('LunaEcumenopolis', () => {
     expect(input1.spaces.map(toID)).deep.eq(['m13', 'm18']);
     input1.cb(moon.getSpaceOrThrow('m18'));
     expect(moonData.habitatRate).eq(3);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     const input2 = cast(game.deferredActions.pop()!.execute(), SelectSpace);
     expect(input2.spaces.map(toID)).deep.eq(['m13', 'm17']);
     input1.cb(moon.getSpaceOrThrow('m13'));
     expect(moonData.habitatRate).eq(4);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(18);
+    expect(player.terraformRating).eq(18);
   });
 
   it('Compatible with Subterranean Habitats', () => {

--- a/tests/cards/moon/LunaMiningHub.spec.ts
+++ b/tests/cards/moon/LunaMiningHub.spec.ts
@@ -49,7 +49,7 @@ describe('LunaMiningHub', () => {
     player.titanium = 3;
     player.steel = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -57,7 +57,7 @@ describe('LunaMiningHub', () => {
     expect(player.titanium).eq(2);
     expect(player.production.steel).eq(1);
     expect(player.production.titanium).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
 
     const placeTileAction = game.deferredActions.pop() as PlaceSpecialMoonTile;
@@ -65,7 +65,7 @@ describe('LunaMiningHub', () => {
     placeTileAction.execute()!.cb(space);
 
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     expect(space.player).eq(player);
     expect(space.tile!.tileType).eq(TileType.LUNA_MINING_HUB);

--- a/tests/cards/moon/LunaResort.spec.ts
+++ b/tests/cards/moon/LunaResort.spec.ts
@@ -53,7 +53,7 @@ describe('LunaResort', () => {
   it('play', () => {
     player.titanium = 3;
     player.production.override({energy: 1, megacredits: 0});
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     card.play(player);
@@ -61,7 +61,7 @@ describe('LunaResort', () => {
     expect(player.titanium).eq(1);
     expect(player.production.energy).eq(0);
     expect(player.production.megacredits).eq(3);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.habitatRate).eq(1);
   });
 });

--- a/tests/cards/moon/LunaStagingStation.spec.ts
+++ b/tests/cards/moon/LunaStagingStation.spec.ts
@@ -38,13 +38,13 @@ describe('LunaStagingStation', () => {
   it('play', () => {
     player.titanium = 1;
     moonData.logisticRate = 2;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(player.titanium).eq(0);
     expect(moonData.logisticRate).eq(4);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 });
 

--- a/tests/cards/moon/LunaTradeFederation.spec.ts
+++ b/tests/cards/moon/LunaTradeFederation.spec.ts
@@ -36,7 +36,7 @@ describe('LunaTradeFederation', () => {
   //   player.corporations.push(lunaTradeFederation);
   //   player.production.override(Units.EMPTY);
   //   expect(moonData.miningRate).eq(0);
-  //   expect(player.getTerraformRating()).eq(20);
+  //   expect(player.terraformRating).eq(20);
 
   //   player.runInitialAction(lunaTradeFederation);
 
@@ -46,7 +46,7 @@ describe('LunaTradeFederation', () => {
   //   runAllActions(game);
 
   //   expect(moonData.miningRate).eq(1);
-  //   expect(player.getTerraformRating()).eq(21);
+  //   expect(player.terraformRating).eq(21);
   //   expect(player.production.asUnits()).deep.eq(Units.of({titanium: 1}));
   // });
 

--- a/tests/cards/moon/LunaTrainStation.spec.ts
+++ b/tests/cards/moon/LunaTrainStation.spec.ts
@@ -41,14 +41,14 @@ describe('LunaTrainStation', () => {
   it('play', () => {
     player.steel = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
 
     expect(player.steel).eq(1);
     expect(player.production.megacredits).eq(4);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.logisticRate).eq(1);
 
     const space = moonData.moon.spaces[2];

--- a/tests/cards/moon/LunarDustProcessingPlant.spec.ts
+++ b/tests/cards/moon/LunarDustProcessingPlant.spec.ts
@@ -33,13 +33,13 @@ describe('LunarDustProcessingPlant', () => {
 
   it('play', () => {
     player.titanium = 3;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.logisticRate).eq(0);
 
     card.play(player);
 
     expect(player.titanium).eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.logisticRate).eq(1);
   });
 

--- a/tests/cards/moon/LunarIndustryComplex.spec.ts
+++ b/tests/cards/moon/LunarIndustryComplex.spec.ts
@@ -35,7 +35,7 @@ describe('LunarIndustryComplex', () => {
   it('play', () => {
     player.production.override(Units.EMPTY);
     expect(moonData.miningRate).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.titanium = 2;
 
     card.play(player);
@@ -44,7 +44,7 @@ describe('LunarIndustryComplex', () => {
     placeMineTile.execute()!.cb(moonData.moon.getSpaceOrThrow('m02'));
 
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     expect(player.titanium).eq(0);
     expect(player.production.steel).eq(1);

--- a/tests/cards/moon/LunarMineUrbanization.spec.ts
+++ b/tests/cards/moon/LunarMineUrbanization.spec.ts
@@ -49,7 +49,7 @@ describe('LunarMineUrbanization', () => {
 
     player.production.override({megacredits: 0});
     moonData.habitatRate = 0;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.heat).eq(0);
     player.titanium = 1;
 
@@ -65,7 +65,7 @@ describe('LunarMineUrbanization', () => {
     expect(MoonExpansion.spaces(player.game, TileType.MOON_MINE)).eql([space]);
     expect(MoonExpansion.spaces(player.game, TileType.MOON_HABITAT)).eql([space]);
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.heat).eq(1); // Ensures placement bonus.
   });
 
@@ -98,7 +98,7 @@ describe('LunarMineUrbanization', () => {
 
     player.production.override({megacredits: 0});
     moonData.habitatRate = 0;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     player.titanium = 1;
 
     const action = cast(card.play(player), SelectSpace);
@@ -113,7 +113,7 @@ describe('LunarMineUrbanization', () => {
     expect(MoonExpansion.spaces(player.game, TileType.MOON_MINE)).eql([priorLMUSpace, space]);
     expect(MoonExpansion.spaces(player.game, TileType.MOON_HABITAT)).eql([priorLMUSpace, space]);
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('computeVictoryPoints', () => {

--- a/tests/cards/moon/LunarSecurityStations.spec.ts
+++ b/tests/cards/moon/LunarSecurityStations.spec.ts
@@ -59,12 +59,12 @@ describe('LunarSecurityStations', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(moonData.logisticRate).eq(0);
 
     card.play(player);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 });

--- a/tests/cards/moon/LunarTradeFleet.spec.ts
+++ b/tests/cards/moon/LunarTradeFleet.spec.ts
@@ -31,14 +31,14 @@ describe('LunarTradeFleet', () => {
 
   it('play', () => {
     player.production.override({megacredits: 0});
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     moonData.logisticRate = 0;
 
     card.play(player);
 
     player.production.override({megacredits: 2});
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/MareImbriumMine.spec.ts
+++ b/tests/cards/moon/MareImbriumMine.spec.ts
@@ -35,7 +35,7 @@ describe('MareImbriumMine', () => {
   it('play', () => {
     player.titanium = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -44,7 +44,7 @@ describe('MareImbriumMine', () => {
     expect(player.titanium).eq(2);
     expect(player.production.steel).eq(1);
     expect(player.production.titanium).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
 
     const mareImbrium = moonData.moon.getSpaceOrThrow(NamedMoonSpaces.MARE_IMBRIUM);

--- a/tests/cards/moon/MareNectarisMine.spec.ts
+++ b/tests/cards/moon/MareNectarisMine.spec.ts
@@ -33,7 +33,7 @@ describe('MareNectarisMine', () => {
   it('play', () => {
     player.titanium = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -41,7 +41,7 @@ describe('MareNectarisMine', () => {
 
     expect(player.titanium).eq(2);
     expect(player.production.steel).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
 
     const mareNectaris = moonData.moon.getSpaceOrThrow(NamedMoonSpaces.MARE_NECTARIS);

--- a/tests/cards/moon/MareNubiumMine.spec.ts
+++ b/tests/cards/moon/MareNubiumMine.spec.ts
@@ -36,7 +36,7 @@ describe('MareNubiumMine', () => {
   it('play', () => {
     player.titanium = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -44,7 +44,7 @@ describe('MareNubiumMine', () => {
 
     expect(player.titanium).eq(2);
     expect(player.production.titanium).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
 
     const mareNubium = moonData.moon.getSpaceOrThrow(NamedMoonSpaces.MARE_NUBIUM);

--- a/tests/cards/moon/MareSerenitatisMine.spec.ts
+++ b/tests/cards/moon/MareSerenitatisMine.spec.ts
@@ -43,7 +43,7 @@ describe('MareSerenitatisMine', () => {
     player.steel = 3;
     expect(player.production.steel).eq(0);
     expect(player.production.titanium).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
@@ -52,7 +52,7 @@ describe('MareSerenitatisMine', () => {
     expect(player.steel).eq(2);
     expect(player.production.steel).eq(1);
     expect(player.production.titanium).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.miningRate).eq(1);
 
     const mareSerenitatis = moonData.moon.getSpaceOrThrow(NamedMoonSpaces.MARE_SERENITATIS);
@@ -65,7 +65,7 @@ describe('MareSerenitatisMine', () => {
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_ROAD);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 });
 

--- a/tests/cards/moon/MiningComplex.spec.ts
+++ b/tests/cards/moon/MiningComplex.spec.ts
@@ -31,7 +31,7 @@ describe('MiningComplex', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
     expect(moonData.logisticRate).eq(0);
     player.megaCredits = 7;
@@ -44,7 +44,7 @@ describe('MiningComplex', () => {
     placeMineTile.execute()!.cb(moonData.moon.getSpaceOrThrow('m06'));
 
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     const placeRoadTile = cast(game.deferredActions.pop(), PlaceMoonRoadTile);
     const selectSpace = cast(placeRoadTile.execute(), SelectSpace);
@@ -53,6 +53,6 @@ describe('MiningComplex', () => {
     selectSpace.cb(spaces[0]);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 });

--- a/tests/cards/moon/MiningRobotsManufCenter.spec.ts
+++ b/tests/cards/moon/MiningRobotsManufCenter.spec.ts
@@ -29,13 +29,13 @@ describe('MiningRobotsManufCenter', () => {
 
   it('play', () => {
     player.titanium = 3;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.miningRate).eq(0);
 
     card.play(player);
 
     expect(player.titanium).eq(2);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
     expect(moonData.miningRate).eq(2);
   });
 });

--- a/tests/cards/moon/MomentumViriumHabitat.spec.ts
+++ b/tests/cards/moon/MomentumViriumHabitat.spec.ts
@@ -35,7 +35,7 @@ describe('MomentumViriumHabitat', () => {
     player.titanium = 1;
     expect(player.production.megacredits).eq(0);
     expect(player.production.heat).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     card.play(player);
@@ -48,7 +48,7 @@ describe('MomentumViriumHabitat', () => {
     expect(momentumVirium.player).eq(player);
     expect(momentumVirium.tile!.tileType).eq(TileType.MOON_HABITAT);
 
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.habitatRate).eq(1);
   });
 });

--- a/tests/cards/moon/MoonHabitatStandardProject.spec.ts
+++ b/tests/cards/moon/MoonHabitatStandardProject.spec.ts
@@ -52,7 +52,7 @@ describe('MoonHabitatStandardProject', () => {
 
   it('act', () => {
     player.titanium = 3;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(player.production.megacredits).eq(0);
     player.megaCredits = 22;
 
@@ -66,7 +66,7 @@ describe('MoonHabitatStandardProject', () => {
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_HABITAT);
 
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('can act when Reds are in power', () => {

--- a/tests/cards/moon/MoonMineStandardProject.spec.ts
+++ b/tests/cards/moon/MoonMineStandardProject.spec.ts
@@ -52,7 +52,7 @@ describe('MoonMineStandardProject', () => {
 
   it('act', () => {
     player.titanium = 3;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(player.production.steel).eq(0);
     player.megaCredits = 20;
 
@@ -66,7 +66,7 @@ describe('MoonMineStandardProject', () => {
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_MINE);
 
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('can act when Reds are in power', () => {

--- a/tests/cards/moon/MoonRoadStandardProject.spec.ts
+++ b/tests/cards/moon/MoonRoadStandardProject.spec.ts
@@ -52,7 +52,7 @@ describe('MoonRoadStandardProject', () => {
 
   it('act', () => {
     player.steel = 3;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.megaCredits = 18;
 
     cast(card.action(player), undefined);
@@ -64,7 +64,7 @@ describe('MoonRoadStandardProject', () => {
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_ROAD);
 
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
 

--- a/tests/cards/moon/NewColonyPlanningInitiatives.spec.ts
+++ b/tests/cards/moon/NewColonyPlanningInitiatives.spec.ts
@@ -31,11 +31,11 @@ describe('NewColonyPlanningInitiatives', () => {
 
   it('play', () => {
     moonData.habitatRate = 2;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.habitatRate).eq(3);
   });
 });

--- a/tests/cards/moon/OffWorldCityLiving.spec.ts
+++ b/tests/cards/moon/OffWorldCityLiving.spec.ts
@@ -30,7 +30,7 @@ describe('OffWorldCityLiving', () => {
 
   it('play', () => {
     expect(moonData.habitatRate).eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.production.megacredits).eq(0);
 
     const colonySpaces = player.game.board.spaces.filter((s) => s.spaceType === SpaceType.COLONY);
@@ -45,7 +45,7 @@ describe('OffWorldCityLiving', () => {
     card.play(player);
 
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.production.megacredits).eq(2);
   });
 

--- a/tests/cards/moon/RoverDriversUnion.spec.ts
+++ b/tests/cards/moon/RoverDriversUnion.spec.ts
@@ -32,13 +32,13 @@ describe('RoverDriversUnion', () => {
 
   it('play', () => {
     moonData.logisticRate = 2;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.production.override({megacredits: 0});
 
     card.play(player);
 
     expect(moonData.logisticRate).eq(3);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.production.megacredits).eq(3);
 
     player.production.override({megacredits: 0});
@@ -46,7 +46,7 @@ describe('RoverDriversUnion', () => {
     card.play(player);
 
     expect(moonData.logisticRate).eq(4);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
     expect(player.production.megacredits).eq(4);
   });
 

--- a/tests/cards/moon/SmallDutyRovers.spec.ts
+++ b/tests/cards/moon/SmallDutyRovers.spec.ts
@@ -36,7 +36,7 @@ describe('SmallDutyRovers', () => {
 
   it('play', () => {
     expect(moonData.logisticRate).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.titanium = 1;
     player.megaCredits = 0;
 
@@ -52,7 +52,7 @@ describe('SmallDutyRovers', () => {
     expect(player.titanium).eq(0);
     expect(player.megaCredits).eq(6);
     expect(moonData.logisticRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('compatible with Lunar Mine Urbanization', () => {

--- a/tests/cards/moon/SphereHabitats.spec.ts
+++ b/tests/cards/moon/SphereHabitats.spec.ts
@@ -25,7 +25,7 @@ describe('SphereHabitats', () => {
   it('play', () => {
     player.titanium = 3;
     expect(player.production.steel).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 

--- a/tests/cards/moon/StagingStationBehemoth.spec.ts
+++ b/tests/cards/moon/StagingStationBehemoth.spec.ts
@@ -33,7 +33,7 @@ describe('StagingStationBehemoth', () => {
 
     expect(moonData.logisticRate).eq(1);
     expect(player.colonies.getFleetSize()).to.eq(3);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/SubterraneanHabitats.spec.ts
+++ b/tests/cards/moon/SubterraneanHabitats.spec.ts
@@ -34,13 +34,13 @@ describe('SubterraneanHabitats', () => {
 
   it('play', () => {
     player.steel = 12;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.habitatRate).eq(0);
 
     card.play(player);
 
     expect(player.steel).eq(10);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.habitatRate).eq(1);
   });
 

--- a/tests/cards/moon/TempestConsultancy.spec.ts
+++ b/tests/cards/moon/TempestConsultancy.spec.ts
@@ -91,13 +91,13 @@ describe('TempestConsultancy', () => {
     player.corporations.push(card);
     turmoil.dominantParty = new Greens();
     turmoil.dominantParty.partyLeader = player;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     turmoil.setRulingParty(game);
     runAllActions(game);
 
     expect(turmoil.chairman).eq(player);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 
   it('With Vote of No Confidence', () => {
@@ -107,7 +107,7 @@ describe('TempestConsultancy', () => {
     const greens = turmoil.getPartyByName(PartyName.GREENS);
     greens.partyLeader = player;
 
-    expect(player.getTerraformRating()).to.eq(20);
+    expect(player.terraformRating).to.eq(20);
 
     const voteOfNoConfidence = new VoteOfNoConfidence();
     voteOfNoConfidence.play(player);
@@ -115,7 +115,7 @@ describe('TempestConsultancy', () => {
     expect(turmoil.chairman).eq(player);
     runAllActions(game);
     // With Vote of No Confidence, player becomes chairman and gains 1 TR. Tempest gives player a second TR.
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 });
 

--- a/tests/cards/moon/TheArchaicFoundationInstitute.spec.ts
+++ b/tests/cards/moon/TheArchaicFoundationInstitute.spec.ts
@@ -26,41 +26,41 @@ describe('TheArchaicFoundationInstitute', () => {
 
   it('effect', () => {
     card.resourceCount = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.onCardPlayedForCorps(player, new MicroMills());
     expect(card.resourceCount).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.onCardPlayedForCorps(player, new HE3ProductionQuotas());
     expect(card.resourceCount).eq(1);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.onCardPlayedForCorps(player, new CosmicRadiation());
     expect(card.resourceCount).eq(2);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.onCardPlayedForCorps(player, new GeodesicTents());
     expect(card.resourceCount).eq(0);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     card.onCardPlayedForCorps(player, new DeepLunarMining());
     expect(card.resourceCount).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
 
     card.onCardPlayedForCorps(player, new Habitat14());
     expect(card.resourceCount).eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     // Two moon tags
     card.onCardPlayedForCorps(player, new LunaTradeStation());
     expect(card.resourceCount).eq(1);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 
   it('Cannot automatically deduct when player cannot afford reds cost', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.megaCredits = 0;
     card.resourceCount = 2;
 
@@ -69,13 +69,13 @@ describe('TheArchaicFoundationInstitute', () => {
     // Two moon tags
     card.onCardPlayedForCorps(player, new LunaTradeStation());
     expect(card.resourceCount).eq(4);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     expect(card.canAct(player)).is.false;
   });
 
   it('When reds are in power, can autodeduct with enough MC.', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.megaCredits = 4;
     card.resourceCount = 2;
 
@@ -85,7 +85,7 @@ describe('TheArchaicFoundationInstitute', () => {
     card.onCardPlayedForCorps(player, new LunaTradeStation());
     expect(card.resourceCount).eq(1);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.megaCredits).eq(1);
   });
 
@@ -98,7 +98,7 @@ describe('TheArchaicFoundationInstitute', () => {
     runAllActions(game);
 
     expect(card.resourceCount).eq(2);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 
   it('Reds in effect, 8 resources, enough MC to raise once.', () => {
@@ -113,7 +113,7 @@ describe('TheArchaicFoundationInstitute', () => {
     runAllActions(game);
 
     expect(card.resourceCount).eq(5);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.megaCredits).eq(0);
   });
 
@@ -127,7 +127,7 @@ describe('TheArchaicFoundationInstitute', () => {
     runAllActions(game);
 
     expect(card.resourceCount).eq(2);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
     expect(player.megaCredits).eq(4);
   });
 });

--- a/tests/cards/moon/TheWomb.spec.ts
+++ b/tests/cards/moon/TheWomb.spec.ts
@@ -33,7 +33,7 @@ describe('TheWomb', () => {
   it('play', () => {
     player.production.override({energy: 2});
     player.titanium = 2;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 

--- a/tests/cards/moon/ThoriumRush.spec.ts
+++ b/tests/cards/moon/ThoriumRush.spec.ts
@@ -33,7 +33,7 @@ describe('ThoriumRush', () => {
     moonData.habitatRate = 0;
     moonData.logisticRate = 0;
     moonData.miningRate = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
@@ -44,7 +44,7 @@ describe('ThoriumRush', () => {
     expect(moonData.habitatRate).eq(1);
     expect(moonData.habitatRate).eq(1);
     expect(moonData.habitatRate).eq(1);
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
   });
 
   it('canPlay when Reds are in power', () => {

--- a/tests/cards/moon/TychoRoadNetwork.spec.ts
+++ b/tests/cards/moon/TychoRoadNetwork.spec.ts
@@ -33,7 +33,7 @@ describe('TychoRoadNetwork', () => {
   it('play', () => {
     player.steel = 1;
     expect(player.production.megacredits).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(moonData.logisticRate).eq(0);
 
     card.play(player);
@@ -45,7 +45,7 @@ describe('TychoRoadNetwork', () => {
 
     assertPlaceTile(player, player.popWaitingFor(), TileType.MOON_ROAD);
 
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(moonData.logisticRate).eq(1);
   });
 });

--- a/tests/cards/moon/UndergroundDetonators.spec.ts
+++ b/tests/cards/moon/UndergroundDetonators.spec.ts
@@ -28,14 +28,14 @@ describe('UndergroundDetonators', () => {
     player.steel = 0;
     player.titanium = 0;
     moonData.miningRate = 0;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(player.titanium).eq(1);
     expect(player.steel).eq(1);
     expect(moonData.miningRate).eq(1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });
 

--- a/tests/cards/moon/WaterTreatmentComplex.spec.ts
+++ b/tests/cards/moon/WaterTreatmentComplex.spec.ts
@@ -40,14 +40,14 @@ describe('WaterTreatmentComplex', () => {
 
   it('play', () => {
     expect(moonData.habitatRate).eq(0);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.titanium = 1;
 
     card.play(player);
 
     expect(player.titanium).eq(0);
     expect(moonData.habitatRate).eq(2);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 });
 

--- a/tests/cards/pathfinders/Ambient.spec.ts
+++ b/tests/cards/pathfinders/Ambient.spec.ts
@@ -32,13 +32,13 @@ describe('Ambient', () => {
 
   it('initialAction', () => {
     expect(game.getVenusScaleLevel()).eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     player.defer(card.initialAction(player));
     runAllActions(game);
 
     expect(game.getVenusScaleLevel()).eq(4);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 
   it('effect', () => {
@@ -80,13 +80,13 @@ describe('Ambient', () => {
     player.heat = 9;
     setTemperature(game, MAX_TEMPERATURE);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     card.action(player);
 
     expect(player.heat).eq(1);
     expect(game.getTemperature()).eq(MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('action is repeatable', () => {
@@ -102,13 +102,13 @@ describe('Ambient', () => {
 
     expect(getBlueActions()!.cards.map(toName)).deep.eq([card.name]);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     getBlueActions()!.cb([card]);
 
     expect(player.heat).eq(8);
     expect(game.getTemperature()).eq(MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     expect(getBlueActions()).is.undefined;
     runAllActions(game);
@@ -118,7 +118,7 @@ describe('Ambient', () => {
 
     expect(player.heat).eq(0);
     expect(game.getTemperature()).eq(MAX_TEMPERATURE);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
 
     expect(getBlueActions()).is.undefined;
     runAllActions(game);

--- a/tests/cards/pathfinders/BreedingFarms.spec.ts
+++ b/tests/cards/pathfinders/BreedingFarms.spec.ts
@@ -30,12 +30,12 @@ describe('BreedingFarms', () => {
   }
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(player.game.getTemperature()).eq(-30);
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.game.getTemperature()).eq(-28);
   });
 

--- a/tests/cards/pathfinders/CrewTraining.spec.ts
+++ b/tests/cards/pathfinders/CrewTraining.spec.ts
@@ -19,12 +19,12 @@ describe('CrewTraining', () => {
   });
 
   it('Should play', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(card.tags).deep.eq([Tag.CLONE, Tag.CLONE]);
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
 
     expect(game.deferredActions).has.length(1);
     const action = cast(game.deferredActions.pop(), DeclareCloneTag);

--- a/tests/cards/pathfinders/CultivationOfVenus.spec.ts
+++ b/tests/cards/pathfinders/CultivationOfVenus.spec.ts
@@ -23,13 +23,13 @@ describe('CultivationOfVenus', () => {
 
   it('act', () => {
     player.plants = 5;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.action(player);
 
     expect(player.plants).eq(2);
     expect(game.getVenusScaleLevel()).to.eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('victoryPoints', () => {

--- a/tests/cards/pathfinders/DustStorm.spec.ts
+++ b/tests/cards/pathfinders/DustStorm.spec.ts
@@ -15,7 +15,7 @@ describe('DustStorm', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.game.getTemperature()).eq(-30);
 
     player.energy = 5;
@@ -24,7 +24,7 @@ describe('DustStorm', () => {
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
     expect(player.game.getTemperature()).eq(-26);
     expect(player.energy).eq(0);
     expect(player2.energy).eq(0);

--- a/tests/cards/pathfinders/ExpeditionToTheSurfaceVenus.spec.ts
+++ b/tests/cards/pathfinders/ExpeditionToTheSurfaceVenus.spec.ts
@@ -16,13 +16,13 @@ describe('ExpeditiontotheSurfaceVenus', () => {
 
   it('play', () => {
     player.cardsInHand = [];
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(player.cardsInHand).has.lengthOf(2);
     player.production.override({energy: 1});
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(game.getVenusScaleLevel()).eq(2);
     expect(player.megaCredits).eq(1);
 

--- a/tests/cards/pathfinders/HuygensObservatory.spec.ts
+++ b/tests/cards/pathfinders/HuygensObservatory.spec.ts
@@ -80,12 +80,12 @@ describe('HuygensObservatory', () => {
   });
 
   it('play, simple case (place colony, trade with it)', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     const action = card.play(player);
 
     cast(action, undefined);
     expect(player.production.asUnits()).deep.eq(Units.EMPTY);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     runAllActions(game);
 

--- a/tests/cards/pathfinders/MarsFrontierAlliance.spec.ts
+++ b/tests/cards/pathfinders/MarsFrontierAlliance.spec.ts
@@ -106,14 +106,14 @@ describe('MarsFrontierAlliance', () => {
     const reds = game.turmoil!.getPartyByName(PartyName.REDS);
     player.setAlliedParty(reds);
     player.megaCredits = 3;
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     addOcean(player);
     runNextAction(game);
-    expect(player.getTerraformRating()).to.equal(tr + 1);
+    expect(player.terraformRating).to.equal(tr + 1);
     expect(player.megaCredits).to.equal(3);
     player.megaCredits = 0;
     addOcean(player);
-    expect(player.getTerraformRating()).to.equal(tr + 2);
+    expect(player.terraformRating).to.equal(tr + 2);
   });
 
   it('Passive effect from Greens party should be applied', () => {

--- a/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
+++ b/tests/cards/pathfinders/MartianDustProcessingPlant.spec.ts
@@ -22,11 +22,11 @@ describe('MartianDustProcessingPlant', () => {
 
   it('play', () => {
     player.production.override({energy: 1});
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     card.play(player);
 
     expect(player.production.asUnits()).deep.eq(Units.of({steel: 2}));
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });

--- a/tests/cards/pathfinders/MuseumofEarlyColonisation.spec.ts
+++ b/tests/cards/pathfinders/MuseumofEarlyColonisation.spec.ts
@@ -44,11 +44,11 @@ describe('MuseumofEarlyColonisation', () => {
 
   it('play', () => {
     player.production.override({energy: 1});
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     card.play(player);
 
     expect(player.production.asUnits()).deep.eq(Units.of({steel: 1, titanium: 1, plants: 1}));
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 });

--- a/tests/cards/pathfinders/OzoneGenerators.spec.ts
+++ b/tests/cards/pathfinders/OzoneGenerators.spec.ts
@@ -31,10 +31,10 @@ describe('OzoneGenerators', () => {
   });
 
   it('action', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     player.energy = 3;
     card.action(player);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.energy).eq(0);
   });
 });

--- a/tests/cards/pathfinders/SecretLabs.spec.ts
+++ b/tests/cards/pathfinders/SecretLabs.spec.ts
@@ -93,10 +93,10 @@ describe('SecretLabs', () => {
     maxOutOceans(player);
     const orOptions = cast(card.play(player), OrOptions);
     expect(orOptions.options[0].title).eq('Add 2 microbes to ANY card.');
-    const tr = player.getTerraformRating();
+    const tr = player.terraformRating;
     cast(orOptions.options[0].cb(), undefined);
     runAllActions(player.game);
-    expect(player.getTerraformRating()).eq(tr);
+    expect(player.terraformRating).eq(tr);
     expect(whales.resourceCount).eq(1);
   });
 });

--- a/tests/cards/pathfinders/SmallComet.spec.ts
+++ b/tests/cards/pathfinders/SmallComet.spec.ts
@@ -21,7 +21,7 @@ describe('SmallComet', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.game.getTemperature()).eq(-30);
     player.plants = 5;
     player2.plants = 15;
@@ -41,7 +41,7 @@ describe('SmallComet', () => {
 
     runAllActions(game);
 
-    expect(player.getTerraformRating()).eq(23);
+    expect(player.terraformRating).eq(23);
     expect(player.game.getTemperature()).eq(-28);
     expect(player.game.getOxygenLevel()).eq(1);
     expect(player.plants).eq(3);

--- a/tests/cards/pathfinders/SocialEvents.spec.ts
+++ b/tests/cards/pathfinders/SocialEvents.spec.ts
@@ -46,42 +46,42 @@ describe('SocialEvents', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.tagsForTest = {mars: 0};
     card.play(player);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.tagsForTest = {mars: 1};
     card.play(player);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     player.tagsForTest = {mars: 3};
     card.play(player);
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
   });
 
   it('play - reds', () => {
     turmoil.rulingParty = new Reds();
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.megaCredits = 10;
     player.tagsForTest = {mars: 0};
     card.play(player);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(player.megaCredits).eq(10);
 
     player.tagsForTest = {mars: 1};
     card.play(player);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(player.megaCredits).eq(7); // -3 MC
 
     player.tagsForTest = {mars: 3};
     card.play(player);
     runAllActions(game);
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
     expect(player.megaCredits).eq(1); // -6 MC
   });
 });

--- a/tests/cards/pathfinders/SolarStorm.spec.ts
+++ b/tests/cards/pathfinders/SolarStorm.spec.ts
@@ -27,7 +27,7 @@ describe('SolarStorm', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.game.getTemperature()).eq(-30);
 
     player.plants = 5;
@@ -36,7 +36,7 @@ describe('SolarStorm', () => {
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.game.getTemperature()).eq(-28);
     expect(player.plants).eq(3);
     expect(player2.plants).eq(13);

--- a/tests/cards/pathfinders/TerraformingControlStation.spec.ts
+++ b/tests/cards/pathfinders/TerraformingControlStation.spec.ts
@@ -16,9 +16,9 @@ describe('TerraformingControlStation', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     card.play(player);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 
   it('card discount', () => {

--- a/tests/cards/pathfinders/Wetlands.spec.ts
+++ b/tests/cards/pathfinders/Wetlands.spec.ts
@@ -97,7 +97,7 @@ describe('Wetlands', () => {
     expect(card.canPlay(player)).is.true;
     expect(card.availableSpaces(player).map(toID)).deep.eq(['09', '23']);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     const action = card.play(player);
     expect(player.plants).eq(3);
@@ -113,7 +113,7 @@ describe('Wetlands', () => {
     runAllActions(game);
 
     expect(game.getOxygenLevel()).eq(1);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 
   it('Wetlands does not count toward global parameters', () => {

--- a/tests/cards/prelude/BufferGasStandardProject.spec.ts
+++ b/tests/cards/prelude/BufferGasStandardProject.spec.ts
@@ -30,7 +30,7 @@ describe('BufferGasStandardProject', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('Test reds', () => {

--- a/tests/cards/prelude/HugeAsteroid.spec.ts
+++ b/tests/cards/prelude/HugeAsteroid.spec.ts
@@ -22,7 +22,7 @@ describe('HugeAsteroid', () => {
   it('Should play', () => {
     player.megaCredits = 5;
     expect(card.canPlay(player)).is.true;
-    const initialTR = player.getTerraformRating();
+    const initialTR = player.terraformRating;
 
     card.play(player);
 
@@ -31,6 +31,6 @@ describe('HugeAsteroid', () => {
 
     expect(player.megaCredits).to.eq(0);
     expect(player.production.heat).to.eq(1);
-    expect(player.getTerraformRating()).to.eq(initialTR + 3);
+    expect(player.terraformRating).to.eq(initialTR + 3);
   });
 });

--- a/tests/cards/prelude/NitrogenShipment.spec.ts
+++ b/tests/cards/prelude/NitrogenShipment.spec.ts
@@ -11,7 +11,7 @@ describe('NitrogenShipment', () => {
     const action = card.play(player);
 
     cast(action, undefined);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.production.plants).to.eq(1);
     expect(player.megaCredits).to.eq(5);
   });

--- a/tests/cards/prelude/UNMIContractor.spec.ts
+++ b/tests/cards/prelude/UNMIContractor.spec.ts
@@ -8,7 +8,7 @@ describe('UNMIContractor', () => {
     const card = new UNMIContractor();
     card.play(player);
 
-    expect(player.getTerraformRating()).to.eq(17);
+    expect(player.terraformRating).to.eq(17);
     expect(player.cardsInHand).has.lengthOf(1);
   });
 });

--- a/tests/cards/prelude2/CorridorsOfPower.spec.ts
+++ b/tests/cards/prelude2/CorridorsOfPower.spec.ts
@@ -21,7 +21,7 @@ describe('CorridorsOfPower', () => {
 
   it('play', () => {
     card.play(player);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(4);
   });
 

--- a/tests/cards/prelude2/HighCircles.spec.ts
+++ b/tests/cards/prelude2/HighCircles.spec.ts
@@ -28,7 +28,7 @@ describe('HighCircles', () => {
 
   it('TR check', () => {
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Delegates check', () => {

--- a/tests/cards/prelude2/PlanetaryAlliance.spec.ts
+++ b/tests/cards/prelude2/PlanetaryAlliance.spec.ts
@@ -10,7 +10,7 @@ describe('PlanetaryAlliance', () => {
     const [/* game*/, player] = testGame(1, {venusNextExtension: true});
     card.play(player);
 
-    expect(player.getTerraformRating()).to.eq(16);
+    expect(player.terraformRating).to.eq(16);
     expect(player.cardsInHand).has.lengthOf(2);
 
     const jovianCards = (c: IProjectCard) => c.tags.includes(Tag.JOVIAN);

--- a/tests/cards/prelude2/PreservationProgram.spec.ts
+++ b/tests/cards/prelude2/PreservationProgram.spec.ts
@@ -19,7 +19,7 @@ describe('PreservationProgram', () => {
 
   it('play', () => {
     card.play(player);
-    expect(player.getTerraformRating()).eq(25);
+    expect(player.terraformRating).eq(25);
   });
 
   it('Blocks first TR of each generation', () => {
@@ -28,24 +28,24 @@ describe('PreservationProgram', () => {
 
     game.phase = Phase.ACTION;
 
-    expect(player.getTerraformRating()).eq(25);
+    expect(player.terraformRating).eq(25);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).eq(25);
+    expect(player.terraformRating).eq(25);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).eq(26);
+    expect(player.terraformRating).eq(26);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).eq(27);
+    expect(player.terraformRating).eq(27);
 
     forceGenerationEnd(game);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).eq(27);
+    expect(player.terraformRating).eq(27);
 
     player.increaseTerraformRating();
-    expect(player.getTerraformRating()).eq(28);
+    expect(player.terraformRating).eq(28);
   });
 
   it('Allows multi TR to go partially through', () => {
@@ -54,10 +54,10 @@ describe('PreservationProgram', () => {
 
     game.phase = Phase.ACTION;
 
-    expect(player.getTerraformRating()).eq(25);
+    expect(player.terraformRating).eq(25);
 
     player.increaseTerraformRating(3);
-    expect(player.getTerraformRating()).eq(27);
+    expect(player.terraformRating).eq(27);
   });
 
   it('Compatible with Reds', () => {

--- a/tests/cards/prelude2/SponsoringNation.spec.ts
+++ b/tests/cards/prelude2/SponsoringNation.spec.ts
@@ -22,11 +22,11 @@ describe('SponsoringNation', () => {
     const card = new SponsoringNation();
     const [game, player] = testGame(1, {turmoilExtension: true});
 
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     cast(card.play(player), undefined);
 
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
 
     runAllActions(game);
 

--- a/tests/cards/prelude2/TerraformingDeal.spec.ts
+++ b/tests/cards/prelude2/TerraformingDeal.spec.ts
@@ -54,9 +54,9 @@ describe('TerraformingDeal', () => {
 
     const election = new Election();
     election.resolve(game, turmoil);
-    expect(player2.getTerraformRating()).eq(22);
+    expect(player2.terraformRating).eq(22);
     expect(player2.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(2);
   });
 
@@ -69,7 +69,7 @@ describe('TerraformingDeal', () => {
     turmoil.setNewChairman(player, game);
     runAllActions(game);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(2);
   });
 });

--- a/tests/cards/prelude2/VenusContract.spec.ts
+++ b/tests/cards/prelude2/VenusContract.spec.ts
@@ -18,13 +18,13 @@ describe('VenusContract', () => {
   });
 
   it('play', () => {
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     player.cardsInHand.length = 0;
     player.playedCards.set();
 
     card.play(player);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.cardsInHand).length(1);
     expect(player.cardsInHand[0].tags).includes(Tag.VENUS);
   });

--- a/tests/cards/prelude2/VenusShuttles.spec.ts
+++ b/tests/cards/prelude2/VenusShuttles.spec.ts
@@ -65,7 +65,7 @@ describe('VenusShuttles', () => {
 
   it('action', () => {
     player.megaCredits = 13;
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(game.getVenusScaleLevel()).eq(0);
 
     cast(card.action(player), undefined);
@@ -74,7 +74,7 @@ describe('VenusShuttles', () => {
 
     expect(player.megaCredits).eq(1);
     expect(game.getVenusScaleLevel()).eq(2);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 
   it('Action 15 venus tags', () => {

--- a/tests/cards/prelude2/WorldGovernmentAdvisor.spec.ts
+++ b/tests/cards/prelude2/WorldGovernmentAdvisor.spec.ts
@@ -23,7 +23,7 @@ describe('WorldGovernmentAdvisor', () => {
 
   it('play', () => {
     cast(card.play(player), undefined);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
     expect(player.cardsInHand).has.length(1);
   });
 
@@ -33,7 +33,7 @@ describe('WorldGovernmentAdvisor', () => {
 
     expect(game.phase).eq(Phase.SOLAR);
     expect(orOptions.options[0].title).eq('Increase temperature');
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     orOptions.options[0].cb();
     orOptions.cb(undefined);
@@ -42,12 +42,12 @@ describe('WorldGovernmentAdvisor', () => {
 
     cast(player.popWaitingFor(), undefined);
     expect(game.phase).eq(Phase.ACTION);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(game.getTemperature()).eq(-28);
 
     // After this player raises temperature and it rewards them.
     game.increaseTemperature(player, 1);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
     expect(game.getTemperature()).eq(-26);
   });
 
@@ -65,7 +65,7 @@ describe('WorldGovernmentAdvisor', () => {
     runAllActions(game);
 
     cast(player.popWaitingFor(), undefined);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
   });
 
   it('action - placing an ocean', () => {
@@ -82,7 +82,7 @@ describe('WorldGovernmentAdvisor', () => {
     runAllActions(game);
 
     cast(player.popWaitingFor(), undefined);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(player.megaCredits).eq(0);
   });
 
@@ -99,7 +99,7 @@ describe('WorldGovernmentAdvisor', () => {
     runAllActions(game);
 
     cast(player.popWaitingFor(), undefined);
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
   });
 
   it('canAct - game is at maximum', () => {

--- a/tests/cards/promo/CometAiming.spec.ts
+++ b/tests/cards/promo/CometAiming.spec.ts
@@ -41,7 +41,7 @@ describe('CometAiming', () => {
     expect(player.game.deferredActions).has.lengthOf(1);
     const selectSpace = cast(player.game.deferredActions.peek()!.execute(), SelectSpace);
     selectSpace.cb(selectSpace.spaces[0]);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Should act - multiple action choices, multiple targets', () => {
@@ -63,12 +63,12 @@ describe('CometAiming', () => {
     maxOutOceans(player2);
 
     expect(card.canAct(player)).is.true;
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     card.action(player);
     runAllActions(game);
 
     expect(card.resourceCount).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 });

--- a/tests/cards/promo/DirectedImpactors.spec.ts
+++ b/tests/cards/promo/DirectedImpactors.spec.ts
@@ -45,7 +45,7 @@ describe('DirectedImpactors', () => {
 
     // can remove resource to raise temperature
     card.action(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.game.getTemperature()).to.eq(-28);
     expect(card.resourceCount).to.eq(0);
   });
@@ -62,7 +62,7 @@ describe('DirectedImpactors', () => {
 
     // can remove resource to raise temperature
     action.options[0].cb();
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(player.game.getTemperature()).to.eq(-28);
     expect(card.resourceCount).to.eq(0);
 

--- a/tests/cards/promo/DiversitySupport.spec.ts
+++ b/tests/cards/promo/DiversitySupport.spec.ts
@@ -40,7 +40,7 @@ describe('DiversitySupport', () => {
 
     expect(card.canPlay(player)).is.true;
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Works with corruption', () => {

--- a/tests/cards/promo/IcyImpactors.spec.ts
+++ b/tests/cards/promo/IcyImpactors.spec.ts
@@ -48,7 +48,7 @@ describe('IcyImpactors', () => {
     const selectSpace = cast(player.popWaitingFor(), SelectSpace);
     selectSpace.cb(selectSpace.spaces[0]);
     expect(selectSpace.spaces[0].tile?.tileType).eq(TileType.OCEAN);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(card.resourceCount).eq(0);
   });
 
@@ -73,7 +73,7 @@ describe('IcyImpactors', () => {
     const selectSpace = cast(player.popWaitingFor(), SelectSpace);
     selectSpace.cb(selectSpace.spaces[0]);
     expect(selectSpace.spaces[0].tile?.tileType).eq(TileType.OCEAN);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(card.resourceCount).eq(0);
   });
 
@@ -89,6 +89,6 @@ describe('IcyImpactors', () => {
     runAllActions(game);
     expect(player.game.deferredActions).has.lengthOf(0);
     expect(card.resourceCount).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(20);
+    expect(player.terraformRating).to.eq(20);
   });
 });

--- a/tests/cards/promo/JovianEmbassy.spec.ts
+++ b/tests/cards/promo/JovianEmbassy.spec.ts
@@ -8,7 +8,7 @@ describe('JovianEmbassy', () => {
     const [/* game */, player] = testGame(2);
 
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
     expect(card.getVictoryPoints(player)).to.eq(1);
   });
 });

--- a/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
+++ b/tests/cards/promo/MagneticFieldGeneratorsPromo.spec.ts
@@ -31,6 +31,6 @@ describe('MagneticFieldGeneratorsPromo', () => {
     cast(player.popWaitingFor(), SelectSpace);
     expect(player.production.energy).to.eq(0);
     expect(player.production.plants).to.eq(2);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
   });
 });

--- a/tests/cards/promo/MagneticShield.spec.ts
+++ b/tests/cards/promo/MagneticShield.spec.ts
@@ -26,6 +26,6 @@ describe('MagneticShield', () => {
   }
   it('Should play', () => {
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(24);
+    expect(player.terraformRating).to.eq(24);
   });
 });

--- a/tests/cards/promo/MarsNomads.spec.ts
+++ b/tests/cards/promo/MarsNomads.spec.ts
@@ -147,14 +147,14 @@ describe('MarsNomads', () => {
     selectSpace.cb(space3);
     runAllActions(game);
     cast(player.popWaitingFor(), undefined);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     space3.bonus = [SpaceBonus.TEMPERATURE];
     selectSpace.cb(space3);
     runAllActions(game);
     cast(player.popWaitingFor(), undefined);
     expect(game.getTemperature()).eq(-30);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 
   it('Compatible with Land Claim on placement', () => {

--- a/tests/cards/promo/MoholeLake.spec.ts
+++ b/tests/cards/promo/MoholeLake.spec.ts
@@ -27,7 +27,7 @@ describe('MoholeLake', () => {
 
     expect(player.game.getTemperature()).to.eq(-28);
     expect(player.game.board.getOceanSpaces()).has.length(1);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
     expect(player.plants).to.eq(3);
   });
 

--- a/tests/cards/promo/PharmacyUnion.spec.ts
+++ b/tests/cards/promo/PharmacyUnion.spec.ts
@@ -88,12 +88,12 @@ describe('PharmacyUnion', () => {
     game.deferredActions.pop();
 
     expect(pharmacyUnion.resourceCount).to.eq(1);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
 
     player2.playCard(new LagrangeObservatory());
     expect(game.deferredActions).has.lengthOf(0);
     expect(pharmacyUnion.resourceCount).to.eq(1);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   it('Works correctly with Research', () => {
@@ -109,7 +109,7 @@ describe('PharmacyUnion', () => {
     game.deferredActions.pop();
 
     expect(pharmacyUnion.resourceCount).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 
   it('Can turn card face down once per game to gain 3 TR if no diseases on card', () => {
@@ -124,14 +124,14 @@ describe('PharmacyUnion', () => {
     game.deferredActions.pop();
     orOptions.options[0].cb();
 
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
     expect(pharmacyUnion.isDisabled).is.true;
     expect(player.getPlayedEventsCount()).to.eq(1); // Counts as a played event
 
     // Cannot trigger once per game effect a second time
     player.playCard(new AntiGravityTechnology());
     expect(game.deferredActions).has.lengthOf(0);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
   });
 
   it('Corporation tags do not count when corporation is disabled', () => {
@@ -221,7 +221,7 @@ describe('PharmacyUnion', () => {
     runAllActions(game);
 
     expect(pharmacyUnion.resourceCount).to.eq(1);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 
   describe('Prioritize effect order', () => {
@@ -352,12 +352,12 @@ describe('PharmacyUnion', () => {
     // Pharmacy Union science tag benefit.
     runNextAction(game);
     expect(player.megaCredits).eq(4);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     // Pay for the reds cost and gain TR benefit
     runNextAction(game);
     expect(player.megaCredits).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     // Plays the microbe tag cost, costs 4MC, player no longer has money
     runNextAction(game);
@@ -408,12 +408,12 @@ describe('PharmacyUnion', () => {
     // Pharmacy Union science tag benefit lines up the TR bump.
     runNextAction(game);
     expect(player.megaCredits).eq(4);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     // // Pay for the reds cost and gain TR benefit
     runNextAction(game);
     expect(player.megaCredits).eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     // And that's it.
     expect(game.deferredActions).has.length(0);
@@ -452,6 +452,6 @@ describe('PharmacyUnion', () => {
 
     expect(player.tags.count(Tag.SCIENCE)).eq(1);
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 });

--- a/tests/cards/promo/Philares.spec.ts
+++ b/tests/cards/promo/Philares.spec.ts
@@ -146,7 +146,7 @@ describe('Philares', () => {
 
     const action = cast(philaresPlayer.popWaitingFor(), SelectSpace);
     action.cb(action.spaces[0]);
-    expect(philaresPlayer.getTerraformRating()).to.eq(21);
+    expect(philaresPlayer.terraformRating).to.eq(21);
   });
 
   it('Can place final greenery if gains enough plants from earlier players placing adjacent greeneries', () => {

--- a/tests/cards/starwars/BeholdTheEmperor.spec.ts
+++ b/tests/cards/starwars/BeholdTheEmperor.spec.ts
@@ -68,8 +68,8 @@ describe('BeholdTheEmperor', () => {
     runAllActions(game);
 
     expect(turmoil.chairman).to.eq(player);
-    expect(player.getTerraformRating()).to.eq(20);
-    expect(player2.getTerraformRating()).to.eq(19);
+    expect(player.terraformRating).to.eq(20);
+    expect(player2.terraformRating).to.eq(19);
 
     expect(turmoil.rulingParty).to.eq(kelvinists);
     expect(turmoil.dominantParty).to.eq(reds);

--- a/tests/cards/starwars/ToolWithTheFirstOrder.spec.ts
+++ b/tests/cards/starwars/ToolWithTheFirstOrder.spec.ts
@@ -46,7 +46,7 @@ describe('ToolWithTheFirstOrder', () => {
     cb!();
     runAllActions(game);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     expect(player.actionsTakenThisRound).eq(1);
     expect(game.activePlayer).eq(player.id);

--- a/tests/cards/turmoil/PROffice.spec.ts
+++ b/tests/cards/turmoil/PROffice.spec.ts
@@ -21,6 +21,6 @@ describe('PROffice', () => {
     player.playedCards.push(card2, card3);
     card.play(player);
     expect(player.megaCredits).to.eq(3);
-    expect(player.getTerraformRating()).to.eq(15);
+    expect(player.terraformRating).to.eq(15);
   });
 });

--- a/tests/cards/turmoil/PoliticalAlliance.spec.ts
+++ b/tests/cards/turmoil/PoliticalAlliance.spec.ts
@@ -32,6 +32,6 @@ describe('PoliticalAlliance', () => {
     expect(card.canPlay(player)).is.true;
 
     card.play(player);
-    expect(player.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
   });
 });

--- a/tests/cards/turmoil/TerralabsResearch.spec.ts
+++ b/tests/cards/turmoil/TerralabsResearch.spec.ts
@@ -21,7 +21,7 @@ describe('TerralabsResearch', () => {
     // 14 starting MC - 1 for each card select at the start (total: 2)
     expect(player.megaCredits).to.eq(12);
     // 14 Solo TR - 1
-    expect(player.getTerraformRating()).to.eq(13);
+    expect(player.terraformRating).to.eq(13);
 
     player.playedCards.push(card3);
     expect(card3.action(player)).is.undefined;

--- a/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
+++ b/tests/cards/turmoil/VoteOfNoConfidence.spec.ts
@@ -21,7 +21,7 @@ describe('VoteOfNoConfidence', () => {
     card.play(player);
     expect(turmoil.chairman).to.eq(player);
     runAllActions(game);
-    expect(player.getTerraformRating()).to.eq(15);
+    expect(player.terraformRating).to.eq(15);
   });
 
   it('Neutral Delegate returns to Reserve', () => {

--- a/tests/cards/underworld/AnubisSecurities.spec.ts
+++ b/tests/cards/underworld/AnubisSecurities.spec.ts
@@ -92,7 +92,7 @@ describe('AnubisSecurities', () => {
 
       expect(player.megaCredits).eq(run.expected.mc[0]);
       expect(player2.megaCredits).eq(run.expected.mc[1]);
-      expect(player.getTerraformRating()).eq(run.expected.tr);
+      expect(player.terraformRating).eq(run.expected.tr);
     });
   }
 });

--- a/tests/cards/underworld/CloudVortexOutpost.spec.ts
+++ b/tests/cards/underworld/CloudVortexOutpost.spec.ts
@@ -13,13 +13,13 @@ describe('CloudVortexOutpost', () => {
     const card = new CloudVortexOutpost();
     const [game, player] = testGame(1, {venusNextExtension: true});
 
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
     expect(game.getVenusScaleLevel()).eq(0);
 
     cast(card.play(player), undefined);
 
     expect(game.getVenusScaleLevel()).eq(4);
-    expect(player.getTerraformRating()).eq(16);
+    expect(player.terraformRating).eq(16);
   });
 
   it('onCardPlayed', () => {

--- a/tests/cards/underworld/ExploitationOfVenus.spec.ts
+++ b/tests/cards/underworld/ExploitationOfVenus.spec.ts
@@ -41,6 +41,6 @@ describe('ExploitationOfVenus', () => {
 
     expect(game.getVenusScaleLevel()).eq(2);
     expect(player.megaCredits).eq(2);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 });

--- a/tests/cards/underworld/FabricatedScandal.spec.ts
+++ b/tests/cards/underworld/FabricatedScandal.spec.ts
@@ -20,6 +20,6 @@ describe('FabricatedScandal', () => {
     cast(card.play(player), undefined);
 
     expect(player.underworldData.corruption).to.eq(1);
-    expect(players.map((p) => p.getTerraformRating())).deep.eq([20, 19, 22, 22]);
+    expect(players.map((p) => p.terraformRating)).deep.eq([20, 19, 22, 22]);
   });
 });

--- a/tests/cards/underworld/GeologistTeam.spec.ts
+++ b/tests/cards/underworld/GeologistTeam.spec.ts
@@ -25,14 +25,14 @@ describe('GeologistTeam', () => {
     game.underworldData.tokens.push('corruption1');
     const spaces = UnderworldExpansion.identifiableSpaces(player);
     UnderworldExpansion.identify(game, spaces[0], player);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     game.underworldData.tokens.push('ocean');
     UnderworldExpansion.identify(game, spaces[1], player);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     game.underworldData.tokens.push('ocean');
     UnderworldExpansion.identify(game, spaces[2], player2);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 });

--- a/tests/cards/underworld/GlobalAudit.spec.ts
+++ b/tests/cards/underworld/GlobalAudit.spec.ts
@@ -16,10 +16,10 @@ describe('GlobalAudit', () => {
 
     cast(card.play(player), undefined);
 
-    expect(player.getTerraformRating()).eq(21);
-    expect(player2.getTerraformRating()).eq(20);
-    expect(player3.getTerraformRating()).eq(21);
-    expect(player4.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(21);
+    expect(player2.terraformRating).eq(20);
+    expect(player3.terraformRating).eq(21);
+    expect(player4.terraformRating).eq(20);
   });
 
   it('Should play - reds', () => {
@@ -44,13 +44,13 @@ describe('GlobalAudit', () => {
     cast(player3.popWaitingFor(), undefined);
     cast(player4.popWaitingFor(), undefined);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(1);
-    expect(player2.getTerraformRating()).eq(21);
+    expect(player2.terraformRating).eq(21);
     expect(player2.megaCredits).eq(0);
-    expect(player3.getTerraformRating()).eq(20);
+    expect(player3.terraformRating).eq(20);
     expect(player3.megaCredits).eq(2);
-    expect(player4.getTerraformRating()).eq(20);
+    expect(player4.terraformRating).eq(20);
     expect(player4.megaCredits).eq(1);
   });
 });

--- a/tests/cards/underworld/HyperspaceDrivePrototype.spec.ts
+++ b/tests/cards/underworld/HyperspaceDrivePrototype.spec.ts
@@ -41,11 +41,11 @@ describe('HyperspaceDrivePrototype', () => {
       if (run.science) {
         player.playedCards.push(scienceCard);
       }
-      expect(player.getTerraformRating()).eq(20);
+      expect(player.terraformRating).eq(20);
       cast(card.play(player), undefined);
       runAllActions(game);
       expect(player.stock.titanium).eq(run.titanium);
-      expect(player.getTerraformRating()).eq(run.tr);
+      expect(player.terraformRating).eq(run.tr);
       expect(fighterCard.resourceCount).eq(run.fighter ? 1 : 0);
       expect(scienceCard.resourceCount).eq(run.science ? 1 : 0);
     });

--- a/tests/cards/underworld/MediaStir.spec.ts
+++ b/tests/cards/underworld/MediaStir.spec.ts
@@ -42,7 +42,7 @@ describe('MediaStir', () => {
       card.resolve(game, turmoil);
 
       expect(player.megaCredits).eq(run.expect.mc);
-      expect(player.getTerraformRating()).eq(run.expect.tr);
+      expect(player.terraformRating).eq(run.expect.tr);
     });
   }
 });

--- a/tests/cards/underworld/PlanetaryRightsBuyout.spec.ts
+++ b/tests/cards/underworld/PlanetaryRightsBuyout.spec.ts
@@ -13,11 +13,11 @@ describe('PlanetaryRightsBuyout', () => {
     player.underworldData.corruption = 5;
     expect(card.canPlay(player)).is.true;
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     cast(card.play(player), undefined);
     runAllActions(game);
 
-    expect(player.getTerraformRating()).eq(27);
+    expect(player.terraformRating).eq(27);
   });
 });

--- a/tests/cards/underworld/PrivateInvestigator.spec.ts
+++ b/tests/cards/underworld/PrivateInvestigator.spec.ts
@@ -14,13 +14,13 @@ describe('PrivateInvestigator', () => {
     player3.underworldData.corruption = 0;
     player4.underworldData.corruption = 3;
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
 
     player.playCard(card);
     runAllActions(game);
     const selectPlayer = cast(player.popWaitingFor(), SelectPlayer);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
 
     expect(selectPlayer.players).to.have.members([player2, player4]);
     selectPlayer.cb(player2);

--- a/tests/cards/underworld/StandardTechnology.spec.ts
+++ b/tests/cards/underworld/StandardTechnology.spec.ts
@@ -89,13 +89,13 @@ describe('Underworld / StandardTechnology', () => {
     const selectCard2 = cast(card.action(player), SelectCard);
     expect((selectCard2.cards.map(toName))).deep.eq([CardName.ASTEROID_STANDARD_PROJECT, CardName.AQUIFER_STANDARD_PROJECT]);
 
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     selectCard2.cb([selectCard2.cards[0]]);
     runAllActions(game);
 
     expect(player.megaCredits).eq(4);
     expect(game.getTemperature()).eq(-28);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
   });
 });

--- a/tests/cards/underworld/UndergroundRailway.spec.ts
+++ b/tests/cards/underworld/UndergroundRailway.spec.ts
@@ -33,6 +33,6 @@ describe('UndergroundRailway', () => {
     player.setTerraformRating(20);
     cast(card.play(player), undefined);
     expect(player.production.energy).eq(0);
-    expect(player.getTerraformRating()).eq(22);
+    expect(player.terraformRating).eq(22);
   });
 });

--- a/tests/cards/venusNext/AirScrappingStandardProject.spec.ts
+++ b/tests/cards/venusNext/AirScrappingStandardProject.spec.ts
@@ -32,7 +32,7 @@ describe('AirScrappingStandardProject', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.getVenusScaleLevel()).eq(2);
   });
 
@@ -42,14 +42,14 @@ describe('AirScrappingStandardProject', () => {
 
     setVenusScaleLevel(game, MAX_VENUS_SCALE);
 
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(card.canAct(player)).eq(true);
 
     cast(card.action(player), undefined);
     runAllActions(game);
 
     expect(game.getVenusScaleLevel()).eq(MAX_VENUS_SCALE);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     expect(player.megaCredits).eq(0);
   });
 

--- a/tests/cards/venusNext/AirScrappingStandardProjectVariant.spec.ts
+++ b/tests/cards/venusNext/AirScrappingStandardProjectVariant.spec.ts
@@ -81,7 +81,7 @@ describe('AirScrappingStandardProjectVariant', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(3);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.getVenusScaleLevel()).eq(2);
   });
 
@@ -95,7 +95,7 @@ describe('AirScrappingStandardProjectVariant', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(5);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(game.getVenusScaleLevel()).eq(2);
   });
 

--- a/tests/cards/venusNext/GiantSolarShade.spec.ts
+++ b/tests/cards/venusNext/GiantSolarShade.spec.ts
@@ -21,7 +21,7 @@ describe('GiantSolarShade', () => {
   it('Should play', () => {
     cast(card.play(player), undefined);
     expect(game.getVenusScaleLevel()).to.eq(6);
-    expect(player.getTerraformRating()).to.eq(23);
+    expect(player.terraformRating).to.eq(23);
   });
 
   it('Should play with Reds and Dirigibles', () => {

--- a/tests/cards/venusNext/Omnicourt.spec.ts
+++ b/tests/cards/venusNext/Omnicourt.spec.ts
@@ -31,6 +31,6 @@ describe('Omnicourt', () => {
     expect(card.canPlay(player)).is.true;
 
     cast(card.play(player), undefined);
-    expect(player.getTerraformRating()).to.eq(22);
+    expect(player.terraformRating).to.eq(22);
   });
 });

--- a/tests/cards/venusNext/RotatorImpacts.spec.ts
+++ b/tests/cards/venusNext/RotatorImpacts.spec.ts
@@ -67,7 +67,7 @@ describe('RotatorImpacts', () => {
     card.action(player);
     expect(card.resourceCount).to.eq(0);
     expect(game.getVenusScaleLevel()).eq(2);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('Should act', () => {

--- a/tests/colonies/Europa.spec.ts
+++ b/tests/colonies/Europa.spec.ts
@@ -50,7 +50,7 @@ describe('Europa', () => {
     runAllActions(game);
     cast(player.popWaitingFor(), undefined);
 
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
     expect(player.megaCredits).eq(0);
   });
 

--- a/tests/database/Cloner.spec.ts
+++ b/tests/database/Cloner.spec.ts
@@ -24,10 +24,10 @@ describe('Cloner', () => {
     expect(newPlayerZero.color).eq('red');
     expect(newPlayerZero.beginner).is.true;
 
-    expect(player.getTerraformRating()).eq(23);
+    expect(player.terraformRating).eq(23);
     expect(player.handicap).eq(9);
 
-    expect(newPlayerZero.getTerraformRating()).eq(17);
+    expect(newPlayerZero.terraformRating).eq(17);
     expect(newPlayerZero.handicap).eq(3);
 
     expect(player.dealtCorporationCards, 'dealtCorporationCards').deep.eq(newPlayerZero.dealtCorporationCards);

--- a/tests/globalEvents/Election.spec.ts
+++ b/tests/globalEvents/Election.spec.ts
@@ -25,9 +25,9 @@ describe('Election', () => {
 
     card.resolve(game, turmoil);
 
-    expect(player.getTerraformRating()).to.eq(21);
-    expect(player2.getTerraformRating()).to.eq(22);
-    expect(player3.getTerraformRating()).to.eq(21);
+    expect(player.terraformRating).to.eq(21);
+    expect(player2.terraformRating).to.eq(22);
+    expect(player3.terraformRating).to.eq(21);
   });
 
 
@@ -39,32 +39,32 @@ describe('Election', () => {
     const fake = fakeCard({tags: [Tag.BUILDING, Tag.BUILDING, Tag.BUILDING, Tag.BUILDING]});
     player.playedCards.push(fake);
 
-    expect(player.getTerraformRating()).to.eq(14);
+    expect(player.terraformRating).to.eq(14);
     expect(card.getScore(player, turmoil, game)).eq(4);
 
     card.resolve(game, turmoil);
 
-    expect(player.getTerraformRating()).to.eq(14);
+    expect(player.terraformRating).to.eq(14);
 
     player.playedCards.push(fakeCard({tags: [Tag.BUILDING]}));
     expect(card.getScore(player, turmoil, game)).eq(5);
 
     card.resolve(game, turmoil);
 
-    expect(player.getTerraformRating()).to.eq(15);
+    expect(player.terraformRating).to.eq(15);
 
     player.playedCards.push(fakeCard({tags: [Tag.BUILDING, Tag.BUILDING, Tag.BUILDING, Tag.BUILDING]}));
     expect(card.getScore(player, turmoil, game)).eq(9);
 
     card.resolve(game, turmoil);
 
-    expect(player.getTerraformRating()).to.eq(16);
+    expect(player.terraformRating).to.eq(16);
 
     player.playedCards.push(fakeCard({tags: [Tag.BUILDING]}));
     expect(card.getScore(player, turmoil, game)).eq(10);
 
     card.resolve(game, turmoil);
 
-    expect(player.getTerraformRating()).to.eq(18);
+    expect(player.terraformRating).to.eq(18);
   });
 });

--- a/tests/globalEvents/Revolution.spec.ts
+++ b/tests/globalEvents/Revolution.spec.ts
@@ -29,15 +29,15 @@ describe('Revolution', () => {
     player2.playedCards.push(new Sponsors());
 
     card.resolve(game, turmoil);
-    expect(player.getTerraformRating()).to.eq(19);
-    expect(player2.getTerraformRating()).to.eq(18);
+    expect(player.terraformRating).to.eq(19);
+    expect(player2.terraformRating).to.eq(18);
   });
 
   it('doesn not reduce TR for players with 0 Earth tags + influence', () => {
     player2.playedCards.push(new Sponsors());
 
     card.resolve(game, turmoil);
-    expect(player.getTerraformRating()).to.eq(20);
-    expect(player2.getTerraformRating()).to.eq(18);
+    expect(player.terraformRating).to.eq(20);
+    expect(player2.terraformRating).to.eq(18);
   });
 });

--- a/tests/globalEvents/WarOnEarth.spec.ts
+++ b/tests/globalEvents/WarOnEarth.spec.ts
@@ -18,7 +18,7 @@ describe('WarOnEarth', () => {
     player2.setTerraformRating(15);
 
     card.resolve(game, turmoil);
-    expect(player.getTerraformRating()).to.eq(11);
-    expect(player2.getTerraformRating()).to.eq(14);
+    expect(player.terraformRating).to.eq(11);
+    expect(player2.terraformRating).to.eq(14);
   });
 });

--- a/tests/moon/MoonExpansion.spec.ts
+++ b/tests/moon/MoonExpansion.spec.ts
@@ -65,26 +65,26 @@ describe('MoonExpansion', () => {
 
   it('raiseMiningRate', () => {
     expect(moonData.miningRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseMiningRate(player);
     expect(moonData.miningRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('raiseHabitatRate', () => {
     expect(moonData.habitatRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseHabitatRate(player);
     expect(moonData.habitatRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('raiseLogisticsRate', () => {
     expect(moonData.logisticRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseLogisticRate(player);
     expect(moonData.logisticRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(21);
+    expect(player.terraformRating).eq(21);
   });
 
   it('computeVictoryPoints', () => {
@@ -188,27 +188,27 @@ describe('MoonExpansion', () => {
   it('raiseMiningRate during WGT', () => {
     game.phase = Phase.SOLAR;
     expect(moonData.miningRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseMiningRate(player);
     expect(moonData.miningRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 
   it('raiseHabitatRate during WGT', () => {
     game.phase = Phase.SOLAR;
     expect(moonData.habitatRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseHabitatRate(player);
     expect(moonData.habitatRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 
   it('raiseLogisticsRate during WGT', () => {
     game.phase = Phase.SOLAR;
     expect(moonData.logisticRate).to.eq(0);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
     MoonExpansion.raiseLogisticRate(player);
     expect(moonData.logisticRate).to.eq(1);
-    expect(player.getTerraformRating()).eq(20);
+    expect(player.terraformRating).eq(20);
   });
 });

--- a/tests/pathfinders/PathfindersExpansion.spec.ts
+++ b/tests/pathfinders/PathfindersExpansion.spec.ts
@@ -73,14 +73,14 @@ describe('PathfindersExpansion', () => {
     player1.tagsForTest = {venus: 4};
     player2.tagsForTest = {venus: 3};
 
-    expect(player1.getTerraformRating()).eq(20);
-    expect(player2.getTerraformRating()).eq(20);
+    expect(player1.terraformRating).eq(20);
+    expect(player2.terraformRating).eq(20);
 
     PathfindersExpansion.raiseTrack(Tag.VENUS, player2, 1);
 
     // Player 2 gets the terraformiing bump
-    expect(player1.getTerraformRating()).eq(20);
-    expect(player2.getTerraformRating()).eq(21);
+    expect(player1.terraformRating).eq(20);
+    expect(player2.terraformRating).eq(21);
 
     // Player 1 gets the 2VP.
     expect(player1.getVictoryPoints().total).eq(22);

--- a/tests/turmoil/Turmoil.spec.ts
+++ b/tests/turmoil/Turmoil.spec.ts
@@ -166,8 +166,8 @@ describe('Turmoil', () => {
 
     expect(turmoil.chairman).to.eq(player);
     // both players lose 1 TR; player gains 1 TR from Reds ruling bonus, 1 TR from chairman
-    expect(player.getTerraformRating()).to.eq(21);
-    expect(player2.getTerraformRating()).to.eq(20);
+    expect(player.terraformRating).to.eq(21);
+    expect(player2.terraformRating).to.eq(20);
 
     expect(turmoil.getAvailableDelegateCount(player)).eq(4);
     expect(turmoil.getAvailableDelegateCount(player2)).eq(6);
@@ -626,14 +626,14 @@ describe('Turmoil', () => {
     turmoil.rulingParty = new Reds();
     PoliticalAgendas.setNextAgenda(turmoil, game);
 
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.megaCredits = 2;
     player.increaseTerraformRating();
     runAllActions(game);
 
     expect(player.megaCredits).eq(2); // No change
-    expect(player.getTerraformRating()).eq(14);
+    expect(player.terraformRating).eq(14);
 
     player.megaCredits = 3;
     player.increaseTerraformRating();
@@ -641,28 +641,28 @@ describe('Turmoil', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     player.megaCredits = 3;
     player.increaseTerraformRating(2);
     runAllActions(game);
 
     expect(player.megaCredits).eq(3); // No change
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     player.megaCredits = 5;
     player.increaseTerraformRating(2);
     runAllActions(game);
 
     expect(player.megaCredits).eq(5); // No change
-    expect(player.getTerraformRating()).eq(15);
+    expect(player.terraformRating).eq(15);
 
     player.megaCredits = 6;
     player.increaseTerraformRating(2);
     runAllActions(game);
 
     expect(player.megaCredits).eq(0);
-    expect(player.getTerraformRating()).eq(17);
+    expect(player.terraformRating).eq(17);
 
     // This doesn't apply outside of the ACTION phase
     game.phase = Phase.SOLAR;
@@ -672,7 +672,7 @@ describe('Turmoil', () => {
     runAllActions(game);
 
     expect(player.megaCredits).eq(6);
-    expect(player.getTerraformRating()).eq(19);
+    expect(player.terraformRating).eq(19);
   });
 
   it('deserialization', () => {

--- a/tests/turmoil/parties/Kelvinists.spec.ts
+++ b/tests/turmoil/parties/Kelvinists.spec.ts
@@ -64,10 +64,10 @@ describe('Kelvinists', () => {
     player.stock.add(Resource.HEAT, 6);
     expect(kelvinistsPolicy.canAct(player)).to.be.true;
 
-    const initialTR = player.getTerraformRating();
+    const initialTR = player.terraformRating;
     kelvinistsPolicy.action(player);
     expect(player.heat).to.eq(0);
-    expect(player.getTerraformRating()).to.eq(initialTR + 1);
+    expect(player.terraformRating).to.eq(initialTR + 1);
     expect(game.getTemperature()).to.eq(-28);
   });
 

--- a/tests/turmoil/parties/Reds.spec.ts
+++ b/tests/turmoil/parties/Reds.spec.ts
@@ -20,37 +20,37 @@ describe('Reds', () => {
   it('Ruling bonus 1: The player(s) with the lowest TR gains 1 TR', () => {
     player.increaseTerraformRating();
 
-    const secondPlayerInitialTR = secondPlayer.getTerraformRating();
+    const secondPlayerInitialTR = secondPlayer.terraformRating;
     const bonus = REDS_BONUS_1;
     bonus.grant(game);
-    expect(secondPlayer.getTerraformRating()).to.eq(secondPlayerInitialTR + 1);
+    expect(secondPlayer.terraformRating).to.eq(secondPlayerInitialTR + 1);
   });
 
   it('Ruling bonus 1: Ties for lowest TR are resolved correctly', () => {
-    const initialPlayerTR = player.getTerraformRating();
+    const initialPlayerTR = player.terraformRating;
     const bonus = REDS_BONUS_1;
 
     bonus.grant(game);
-    expect(player.getTerraformRating()).to.eq(initialPlayerTR + 1);
-    expect(secondPlayer.getTerraformRating()).to.eq(initialPlayerTR + 1);
+    expect(player.terraformRating).to.eq(initialPlayerTR + 1);
+    expect(secondPlayer.terraformRating).to.eq(initialPlayerTR + 1);
   });
 
   it('Ruling bonus 2: The player(s) with the highest TR loses 1 TR', () => {
     player.increaseTerraformRating();
 
-    const playerInitialTR = player.getTerraformRating();
+    const playerInitialTR = player.terraformRating;
     const bonus = REDS_BONUS_2;
     bonus.grant(game);
-    expect(player.getTerraformRating()).to.eq(playerInitialTR - 1);
+    expect(player.terraformRating).to.eq(playerInitialTR - 1);
   });
 
   it('Ruling bonus 2: Ties for highest TR are resolved correctly', () => {
-    const initialPlayerTR = player.getTerraformRating();
+    const initialPlayerTR = player.terraformRating;
     const bonus = REDS_BONUS_2;
 
     bonus.grant(game);
-    expect(player.getTerraformRating()).to.eq(initialPlayerTR - 1);
-    expect(secondPlayer.getTerraformRating()).to.eq(initialPlayerTR - 1);
+    expect(player.terraformRating).to.eq(initialPlayerTR - 1);
+    expect(secondPlayer.terraformRating).to.eq(initialPlayerTR - 1);
   });
 
   it('Ruling policy 1: When you take an action that raises TR, you MUST pay 3 M€ per step raised', () => {

--- a/tests/underworld/UnderworldExpansion.spec.ts
+++ b/tests/underworld/UnderworldExpansion.spec.ts
@@ -295,9 +295,9 @@ describe('UnderworldExpansion', () => {
   });
 
   it('grant bonus - tr', () => {
-    expect(player1.getTerraformRating()).eq(20);
+    expect(player1.terraformRating).eq(20);
     UnderworldExpansion.grant(player1, 'tr');
-    expect(player1.getTerraformRating()).eq(21);
+    expect(player1.terraformRating).eq(21);
   });
 
   // it('grant bonus - ocean', () => {


### PR DESCRIPTION
The getter isn't necessary, and this makes things slightly faster and more efficient.