### PR TITLE
Maintain player discount from Indentured Workers (and similar) after it is used through Playwrights action

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -707,6 +707,20 @@ export class Player implements IPlayer {
       }
     });
 
+    // Check for discounts from other players' removedFromPlayCards
+    // This allows the original player to still use discounts from cards that Playwrights replayed
+    for (const otherPlayer of this.game.players) {
+      if (otherPlayer === this) continue;
+      otherPlayer.removedFromPlayCards.forEach((removedFromPlayCard) => {
+        if (removedFromPlayCard.getCardDiscount !== undefined) {
+          const originalOwner = (removedFromPlayCard as any).originalOwner;
+          if (originalOwner === this.id) {
+            cost -= removedFromPlayCard.getCardDiscount(this, card);
+          }
+        }
+      });
+    }
+
     // TODO(kberg): put this in a callback.
     if (card.tags.includes(Tag.SPACE) && PartyHooks.shouldApplyPolicy(this, PartyName.UNITY, 'up04')) {
       cost -= 2;

--- a/src/server/cards/community/Playwrights.ts
+++ b/src/server/cards/community/Playwrights.ts
@@ -60,6 +60,9 @@ export class Playwrights extends CorporationCard implements ICorporationCard {
         ([card]) => {
           const selectedCard: IProjectCard = card;
 
+          // Save the original owner before removing the card
+          const originalOwner = players.find((originalPlayer) => originalPlayer.playedCards.get(selectedCard.name))?.id;
+
           players.forEach((p) => {
             if (p.playedCards.get(selectedCard.name)) {
               p.playedCards.remove(card);
@@ -71,6 +74,14 @@ export class Playwrights extends CorporationCard implements ICorporationCard {
             .andThen(() => {
               player.playCard(selectedCard, undefined, 'nothing'); // Play the card but don't add it to played cards
               player.removedFromPlayCards.push(selectedCard); // Remove card from the game
+              // Store ownership information in the card itself for now
+              if (originalOwner) {
+                Object.defineProperty(selectedCard, 'originalOwner', {
+                  value: originalOwner,
+                  enumerable: false,
+                  writable: true,
+                });
+              }
               if (selectedCard.name === CardName.SPECIAL_DESIGN) {
                 player.playedCards.push(new SpecialDesignProxy());
               } else if (selectedCard.name === CardName.LAW_SUIT) {

--- a/tests/cards/community/Playwrights.spec.ts
+++ b/tests/cards/community/Playwrights.spec.ts
@@ -18,6 +18,7 @@ import {ICard} from '../../../src/server/cards/ICard';
 import {GlobalParameter} from '../../../src/common/GlobalParameter';
 import {Worms} from '../../../src/server/cards/base/Worms';
 import {testGame} from '../../TestGame';
+import {CardName} from '../../../src/common/cards/CardName';
 
 describe('Playwrights', () => {
   let card: Playwrights;
@@ -105,6 +106,27 @@ describe('Playwrights', () => {
 
     player.playCard(deimosDown);
     expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost); // no more discount
+  });
+
+  it('Original player can still use discount from Indentured Workers after Playwrights replays their card', () => {
+    // Player2 plays Indentured Workers first
+    const indenturedWorkers = new IndenturedWorkers();
+    player2.playCard(indenturedWorkers);
+    player2.lastCardPlayed = CardName.INDENTURED_WORKERS;
+
+    // Playwrights (player1) replays Indentured Workers
+    const selectCard = cast(card.action(player), SelectCard<IProjectCard>);
+    selectCard.cb([indenturedWorkers]);
+    game.deferredActions.pop()!.execute();
+
+    // Player1 (Playwrights) should have the discount available
+    const deimosDown = new DeimosDown();
+    expect(player.getCardCost(deimosDown)).to.eq(deimosDown.cost - 8);
+    player.playCard(deimosDown);
+
+    // Player2 should have the discount too
+    const worms = new Worms();
+    expect(player2.getCardCost(worms)).to.eq(worms.cost - 8);
   });
 
   it('Works with Law Suit', () => {


### PR DESCRIPTION
Fixes #7080

This is done, in part, by saving the original player of the card to the discarded card. I cannot see any downsides of doing it this way but it is using Javascript functionality I am not familiar with so please evaluate if there are any unforeseen consequences