### PR TITLE
Fix log messages in Moon expansion to use exclusively numeric placeho…

### DIFF
--- a/src/server/moon/MoonExpansion.ts
+++ b/src/server/moon/MoonExpansion.ts
@@ -164,10 +164,10 @@ export class MoonExpansion {
       const increment = Math.min(count, available);
       if (increment > 0) {
         if (player.game.phase === Phase.SOLAR) {
-          player.game.log('${0} acted as World Government and raised the ${field} rate ${1} step(s)', (b) => b.player(player).number(increment));
+          player.game.log('${0} acted as World Government and raised the ${1} rate ${2} step(s)', (b) => b.player(player).string(field).number(increment));
           this.activateLunaFirst(undefined, player.game, increment);
         } else {
-          player.game.log('${0} raised the ${field} rate ${1} step(s)', (b) => b.player(player).number(increment));
+          player.game.log('${0} raised the ${1} rate ${2} step(s)', (b) => b.player(player).string(field).number(increment));
           player.increaseTerraformRating(increment);
           if (this.maybeBonus(moonData[rateData.field], increment, 3)) {
             player.drawCard();


### PR DESCRIPTION
…lders.

Without this, string placeholders like ${field} would get printed to the log verbatim.