### PR TITLE
Dcep93/hand preview

### DIFF
--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -192,7 +192,7 @@ export default Vue.extend({
         .reverse();
       return preview.filter(
         (card, index) => card !== preview[index + 1],
-      ) as string[];
+      ) as CardName[];
     },
     isSelfReplicatingRobotsCard(cardName: CardName) {
       for (const player of this.players) {


### PR DESCRIPTION
The UI is rough, and should be iterated on before merging. This opens the conversation and shows the kind of thing I'm imagining. You can already click cards in the log to preview them. What if cards were always previewed?

https://github.com/user-attachments/assets/bae2895a-7b42-404d-a73f-b66ac66359c5

