### PR TITLE
Fix problem of clipped science tag in log message

### DIFF
--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -91,7 +91,7 @@
 
 .log-tag {
   display: inline-block;
-  background-position: 0; // Override any tag-specific background position.
+  background-position: 0; // Override any tag-specific background position, which science currently has
   background-size: 18px;
   width: 18px;
   height: 18px;


### PR DESCRIPTION
The science tag is the only tag that currently sets a custom background position.

To reproduce, have a card like Search For Life and draw a card with science tag (as the top card) after activating it.