### PR TITLE
Add ability to disable animating titlebar

### DIFF
--- a/src/client/components/PreferencesDialog.vue
+++ b/src/client/components/PreferencesDialog.vue
@@ -74,6 +74,15 @@
 
       <div class="preferences_panel_item">
         <label class="form-switch">
+          <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.animated_title" data-test="animated_title">
+          <i class="form-icon"></i>
+          <span v-i18n>Animated Title</span>
+          <span class="tooltip tooltip-left" :data-tooltip="$t('Show spinning circle in window title on your turn.')">&#9432;</span>
+        </label>
+      </div>
+
+      <div class="preferences_panel_item">
+        <label class="form-switch">
           <input type="checkbox" v-on:change="updatePreferences" v-model="prefs.experimental_ui" data-test="experimental_ui">
           <i class="form-icon"></i>
           <span v-i18n>Experimental UI</span>

--- a/src/client/components/WaitingFor.vue
+++ b/src/client/components/WaitingFor.vue
@@ -80,6 +80,10 @@ export default Vue.extend({
   },
   methods: {
     animateTitle() {
+      if (!getPreferences().animated_title) {
+        return;
+      }
+
       const sequence = '\u25D1\u25D2\u25D0\u25D3';
       const first = document.title[0];
       const position = sequence.indexOf(first);

--- a/src/client/utils/PreferencesManager.ts
+++ b/src/client/utils/PreferencesManager.ts
@@ -18,6 +18,7 @@ export type Preferences = {
   hide_animated_sidebar: boolean,
   debug_view: boolean,
   symbol_overlay: boolean,
+  animated_title: boolean,
   experimental_ui: boolean,
   lang: string,
 }
@@ -46,6 +47,7 @@ const defaults: Preferences = {
   hide_animated_sidebar: false,
 
   symbol_overlay: false,
+  animated_title: true,
 
   experimental_ui: false,
   debug_view: false,

--- a/tests/client/PreferencesManager.spec.ts
+++ b/tests/client/PreferencesManager.spec.ts
@@ -21,6 +21,7 @@ describe('PreferencesManager', () => {
     expect(values.hide_active_cards).eq(false);
     expect(values.lang).eq('en');
     expect(values.enable_sounds).eq(true);
+    expect(values.animated_title).eq(true);
   });
 
   it('setter updates storage and references', () => {


### PR DESCRIPTION
This commit adds the ability to disable the title animation to prevent it from interfering with screen readers.

Fixes #7703