### PR TITLE
Alter button text for Public Plans

### DIFF
--- a/src/server/cards/promo/PublicPlans.ts
+++ b/src/server/cards/promo/PublicPlans.ts
@@ -31,7 +31,7 @@ export class PublicPlans extends Card implements IProjectCard {
       return undefined;
     }
 
-    return new SelectCard('Select cards to reveal', undefined, player.cardsInHand, {
+    return new SelectCard('Select cards to reveal', 'Reveal', player.cardsInHand, {
       min: 0,
       max: player.cardsInHand.length,
     }).andThen((cards) => {


### PR DESCRIPTION
<img width="706" height="423" alt="Screenshot 2026-02-06 at 16 20 11" src="https://github.com/user-attachments/assets/770a0638-0910-4180-9044-d5938bb7ce9c" />

I just thought it would look better if it said 'Reveal' instead of 'Save'.