### PR TITLE
Save the game in between final greenery placements.

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -1113,6 +1113,7 @@ export class Game implements IGame, Logger {
 
       if (this.canPlaceGreenery(player)) {
         this.activePlayer = player;
+        this.save();
         player.takeActionForFinalGreenery();
         return;
       } else if (player.getWaitingFor() !== undefined) {
@@ -1780,6 +1781,10 @@ export class Game implements IGame, Logger {
       newStandardDraft(game).restoreDraft();
     } else if (game.phase === Phase.RESEARCH) {
       game.gotoResearchPhase();
+    } else if (game.phase === Phase.PRODUCTION) {
+      if (game.gameIsOver() && game.isDoneWithFinalProduction()) {
+        game.takeNextFinalGreeneryAction();
+      }
     } else if (game.phase === Phase.END) {
       // There's nowhere that we need to go for end game.
     } else {


### PR DESCRIPTION
This prevents a failure case where someone takes so long to take their final turn that the app resets and the former players lose their progress.