### PR TITLE
Add defineComponent compat shim to reduce Vue 3 migration diff

### DIFF
--- a/src/client/components/AndOptions.vue
+++ b/src/client/components/AndOptions.vue
@@ -17,7 +17,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PlayerViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
 import {AndOptionsModel} from '@/common/models/PlayerInputModel';
 import AppButton from '@/client/components/common/AppButton.vue';
@@ -27,7 +27,7 @@ interface DataModel {
   responded: Array<InputResponse | undefined>,
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'and-options',
   props: {
     playerView: {

--- a/src/client/components/Award.vue
+++ b/src/client/components/Award.vue
@@ -34,13 +34,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {FundedAwardModel, AwardScore} from '@/common/models/FundedAwardModel';
 import {getAward} from '@/client/MilestoneAwardManifest';
 import {playerSymbol} from '@/client/utils/playerSymbol';
 import {Color} from '@/common/Color';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Award',
   props: {
     award: {

--- a/src/client/components/Awards.vue
+++ b/src/client/components/Awards.vue
@@ -47,13 +47,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Award from '@/client/components/Award.vue';
 import {AWARD_COSTS} from '@/common/constants';
 import {FundedAwardModel} from '@/common/models/FundedAwardModel';
 import {Preferences, PreferencesManager} from '@/client/utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Awards',
   components: {Award},
   props: {

--- a/src/client/components/Board.vue
+++ b/src/client/components/Board.vue
@@ -351,7 +351,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as constants from '@/common/constants';
 import BoardSpace from '@/client/components/BoardSpace.vue';
 import {AresData} from '@/common/ares/AresData';
@@ -369,7 +369,7 @@ class GlobalParamLevel {
   }
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'board',
   props: {
     spaces: {

--- a/src/client/components/BoardSpace.vue
+++ b/src/client/components/BoardSpace.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Bonus from '@/client/components/Bonus.vue';
 import BoardSpaceTile from '@/client/components/board/BoardSpaceTile.vue';
 import UndergroundToken from '@/client/components/underworld/UndergroundToken.vue';
@@ -42,7 +42,7 @@ import {getPreferences} from '../utils/PreferencesManager';
 import {ClaimedToken} from '@/common/underworld/UnderworldPlayerData';
 import {getSpaceName} from '@/common/boards/spaces';
 import {SpaceType} from '@/common/boards/SpaceType';
-export default Vue.extend({
+export default defineComponent({
   name: 'board-space',
   props: {
     space: {

--- a/src/client/components/Bonus.vue
+++ b/src/client/components/Bonus.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SpaceBonus} from '@/common/boards/SpaceBonus';
 
 const css: Record<SpaceBonus, string> = {
@@ -31,7 +31,7 @@ const css: Record<SpaceBonus, string> = {
   [SpaceBonus.TEMPERATURE_4MC]: 'bonustemperature4mc',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'bonus',
   props: {
     bonus: {

--- a/src/client/components/GameEnd.vue
+++ b/src/client/components/GameEnd.vue
@@ -212,7 +212,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as constants from '@/common/constants';
 import {paths} from '@/common/app/paths';
 import {GameModel} from '@/common/models/GameModel';
@@ -242,7 +242,7 @@ function getViewModel(playerView: ViewModel | undefined, spectator: ViewModel | 
   throw new Error('Neither playerView nor spectator are defined');
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'game-end',
   props: {
     playerView: {

--- a/src/client/components/GameHome.vue
+++ b/src/client/components/GameHome.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SimpleGameModel} from '@/common/models/SimpleGameModel';
 import AppButton from '@/client/components/common/AppButton.vue';
 import PurgeWarning from '@/client/components/common/PurgeWarning.vue';
@@ -60,7 +60,7 @@ function copyToClipboard(text: string): void {
 }
 const DEFAULT_COPIED_PLAYER_ID = '-1';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'game-home',
   props: {
     game: {

--- a/src/client/components/GameSetupDetail.vue
+++ b/src/client/components/GameSetupDetail.vue
@@ -79,7 +79,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {GameOptionsModel} from '@/common/models/GameOptionsModel';
 import {BoardName} from '@/common/boards/BoardName';
 import {RandomMAOptionType} from '@/common/ma/RandomMAOptionType';
@@ -99,7 +99,7 @@ const boardColorClass: Record<BoardName, string> = {
   [BoardName.HOLLANDIA]: 'game-config board-hollandia map',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'game-setup-detail',
   props: {
     playerNumber: {

--- a/src/client/components/GamesOverview.vue
+++ b/src/client/components/GamesOverview.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as constants from '@/common/constants';
 import GameOverview from '@/client/components/admin/GameOverview.vue';
 import {SimpleGameModel} from '@/common/models/SimpleGameModel';
@@ -28,7 +28,7 @@ type DataModel = {
 // Copied from routes/Game.ts and probably IDatabase. Should be centralized I suppose
 type Response = {gameId: GameId, participants: Array<ParticipantId>};
 
-export default Vue.extend({
+export default defineComponent({
   name: 'games-overview',
   data(): DataModel {
     return {

--- a/src/client/components/GlobalParameterValue.vue
+++ b/src/client/components/GlobalParameterValue.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {MAX_OCEAN_TILES, MAX_OXYGEN_LEVEL, MAX_TEMPERATURE, MAX_VENUS_SCALE} from '@/common/constants';
 import {GlobalParameter} from '@/common/GlobalParameter';
 
@@ -32,7 +32,7 @@ const attributes: Record<BaseGlobalParameter, {max: number, title: string, iconC
   [GlobalParameter.VENUS]: {max: MAX_VENUS_SCALE, title: 'Venus Scale', iconClass: 'venus-tile'},
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'global-parameter-value',
   props: {
     param: {

--- a/src/client/components/KeyboardShortcuts.vue
+++ b/src/client/components/KeyboardShortcuts.vue
@@ -18,11 +18,11 @@
   </PopupPanel>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import PopupPanel from './common/PopupPanel.vue';
 import {getPreferences} from '../utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'KeyboardShortcuts',
   components: {
     PopupPanel,

--- a/src/client/components/LanguageIcon.vue
+++ b/src/client/components/LanguageIcon.vue
@@ -13,12 +13,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import LanguageSelectionDialog from '@/client/components/LanguageSelectionDialog.vue';
 import {LANGUAGES} from '@/common/constants';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LanguageIcon',
   components: {
     'language-selection-dialog': LanguageSelectionDialog,

--- a/src/client/components/LanguageSelectionDialog.vue
+++ b/src/client/components/LanguageSelectionDialog.vue
@@ -17,12 +17,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import {ALL_LANGUAGES, LANGUAGES} from '@/common/constants';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LanguageSelectionDialog',
   props: {
     preferencesManager: {

--- a/src/client/components/LanguageSwitcher.vue
+++ b/src/client/components/LanguageSwitcher.vue
@@ -13,11 +13,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ALL_LANGUAGES, LANGUAGES} from '@/common/constants';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'language-switcher',
   methods: {
     reloadWindow() {

--- a/src/client/components/LoadGameForm.vue
+++ b/src/client/components/LoadGameForm.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as constants from '@/common/constants';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {LoadGameFormModel} from '@/common/models/LoadGameFormModel';
@@ -31,7 +31,7 @@ type LoadGameFormDataModel = {
   rollbackCount: number;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LoadGameForm',
   components: {
     AppButton,

--- a/src/client/components/Milestone.vue
+++ b/src/client/components/Milestone.vue
@@ -33,13 +33,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ClaimedMilestoneModel, MilestoneScore} from '@/common/models/ClaimedMilestoneModel';
 import {getMilestone} from '@/client/MilestoneAwardManifest';
 import {playerSymbol} from '@/client/utils/playerSymbol';
 import {Color} from '@/common/Color';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Milestone',
   props: {
     milestone: {

--- a/src/client/components/Milestones.vue
+++ b/src/client/components/Milestones.vue
@@ -30,13 +30,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {MAX_MILESTONES, MILESTONE_COST} from '@/common/constants';
 import Milestone from '@/client/components/Milestone.vue';
 import {ClaimedMilestoneModel} from '@/common/models/ClaimedMilestoneModel';
 import {Preferences, PreferencesManager} from '@/client/utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Milestones',
   props: {
     milestones: {

--- a/src/client/components/OrOptions.vue
+++ b/src/client/components/OrOptions.vue
@@ -28,7 +28,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {isHTMLElement} from '@/client/utils/vueUtils';
 import {PlayerViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
@@ -38,7 +38,7 @@ import {InputResponse, OrOptionsResponse} from '@/common/inputs/InputResponse';
 
 let unique = 0;
 
-export default Vue.extend({
+export default defineComponent({
   name: 'or-options',
   props: {
     playerView: {

--- a/src/client/components/OtherPlayer.vue
+++ b/src/client/components/OtherPlayer.vue
@@ -35,7 +35,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import StackedCards from '@/client/components/StackedCards.vue';
 import {PublicPlayerModel} from '@/common/models/PlayerModel';
@@ -46,7 +46,7 @@ import {CardType} from '@/common/cards/CardType';
 import {getCardsByType, isCardActivated} from '@/client/utils/CardUtils';
 import {sortActiveCards} from '@/client/utils/ActiveCardsSortingOrder';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'OtherPlayer',
   props: {
     player: {

--- a/src/client/components/Party.vue
+++ b/src/client/components/Party.vue
@@ -18,11 +18,11 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PartyModel} from '@/common/models/TurmoilModel';
 import {PartyName} from '@/common/turmoil/PartyName';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Party',
   props: {
     party: {

--- a/src/client/components/PaymentUnit.vue
+++ b/src/client/components/PaymentUnit.vue
@@ -13,12 +13,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PaymentWidgetMixin} from '@/client/mixins/PaymentWidgetMixin';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SpendableResource} from '@/common/inputs/Spendable';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PaymentUnitComponent',
   props: {
     value: {

--- a/src/client/components/PlayerHome.vue
+++ b/src/client/components/PlayerHome.vue
@@ -272,7 +272,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as raw_settings from '@/genfiles/settings.json';
 
 import Board from '@/client/components/Board.vue';
@@ -322,7 +322,7 @@ class TerraformedAlertDialog {
   static shouldAlert = true;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'player-home',
   data(): PlayerHomeModel {
     const preferences = getPreferences();

--- a/src/client/components/PreferencesIcon.vue
+++ b/src/client/components/PreferencesIcon.vue
@@ -7,11 +7,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PreferencesManager} from '@/client/utils/PreferencesManager';
 import PreferencesDialog from '@/client/components/PreferencesDialog.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PreferencesIcon',
   components: {
     'preferences-dialog': PreferencesDialog,

--- a/src/client/components/SelectAmount.vue
+++ b/src/client/components/SelectAmount.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectAmountModel} from '@/common/models/PlayerInputModel';
 import {SelectAmountResponse} from '@/common/inputs/InputResponse';
@@ -22,7 +22,7 @@ interface DataModel {
   amount: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectAmount',
   components: {
     AppButton,

--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import WarningsComponent from '@/client/components/WarningsComponent.vue';
 import {Color} from '@/common/Color';
@@ -54,7 +54,7 @@ type WidgetDataModel = {
   owners: Map<CardName, Owner>,
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectCard',
   props: {
     playerView: {

--- a/src/client/components/SelectClaimedUndergroundToken.vue
+++ b/src/client/components/SelectClaimedUndergroundToken.vue
@@ -19,7 +19,7 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectClaimedUndergroundTokenModel} from '@/common/models/PlayerInputModel';
 import {SelectClaimedUndergroundTokenResponse} from '@/common/inputs/InputResponse';
@@ -30,7 +30,7 @@ type DataModel = {
   selected: Array<number>,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectClaimedUndergroundToken',
   props: {
     playerView: {

--- a/src/client/components/SelectColony.vue
+++ b/src/client/components/SelectColony.vue
@@ -11,7 +11,7 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Colony from '@/client/components/colonies/Colony.vue';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectColonyModel} from '@/common/models/PlayerInputModel';
@@ -22,7 +22,7 @@ type DataModel = {
   selectedColony: ColonyName | undefined,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectColony',
   props: {
     playerinput: {

--- a/src/client/components/SelectDelegate.vue
+++ b/src/client/components/SelectDelegate.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {ColorWithNeutral} from '@/common/Color';
 import {SelectDelegateModel} from '@/common/models/PlayerInputModel';
@@ -24,7 +24,7 @@ interface DataModel {
   selectedPlayer: ColorWithNeutral | undefined;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectDelegate',
   props: {
     players: {

--- a/src/client/components/SelectGlobalEvent.vue
+++ b/src/client/components/SelectGlobalEvent.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {PlayerViewModel} from '@/common/models/PlayerModel';
 import GlobalEvent from '@/client/components/turmoil/GlobalEvent.vue';
@@ -25,7 +25,7 @@ type DataModel = {
   selected: GlobalEventName | undefined;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectGlobalEvent',
   props: {
     playerView: {

--- a/src/client/components/SelectOption.vue
+++ b/src/client/components/SelectOption.vue
@@ -8,13 +8,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectOptionModel} from '@/common/models/PlayerInputModel';
 import {SelectOptionResponse} from '@/common/inputs/InputResponse';
 import WarningsComponent from './WarningsComponent.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'select-option',
   props: {
     playerinput: {

--- a/src/client/components/SelectParty.vue
+++ b/src/client/components/SelectParty.vue
@@ -13,7 +13,7 @@
     </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectPartyModel} from '@/common/models/PlayerInputModel';
 import Party from '@/client/components/Party.vue';
@@ -22,7 +22,7 @@ import {SelectPartyResponse} from '@/common/inputs/InputResponse';
 import {PlayerViewModel} from '@/common/models/PlayerModel';
 import {TurmoilModel} from '@/common/models/TurmoilModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectParty',
   props: {
     playerView: {

--- a/src/client/components/SelectPayment.vue
+++ b/src/client/components/SelectPayment.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Payment} from '@/common/inputs/Payment';
 import {SpendableResource, SPENDABLE_RESOURCES} from '@/common/inputs/Spendable';
 import {PaymentWidgetMixin, SelectPaymentDataModel} from '@/client/mixins/PaymentWidgetMixin';
@@ -40,7 +40,7 @@ import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectPaymentResponse} from '@/common/inputs/InputResponse';
 import PaymentUnitComponent from '@/client/components/PaymentUnit.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectPayment',
   props: {
     playerView: {
@@ -89,7 +89,7 @@ export default Vue.extend({
     };
   },
   mounted() {
-    Vue.nextTick(() => {
+    this.$nextTick(() => {
       this.setInitialCost();
       this.payment.megaCredits = this.getMegaCreditsMax();
       this.setDefaultValues();

--- a/src/client/components/SelectPlayer.vue
+++ b/src/client/components/SelectPlayer.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectPlayerModel} from '@/common/models/PlayerInputModel';
 import {PublicPlayerModel} from '@/common/models/PlayerModel';
@@ -24,7 +24,7 @@ type DataModel = {
   selectedPlayer: ColorWithNeutral | undefined;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectPlayer',
   props: {
     players: {

--- a/src/client/components/SelectPlayerRow.vue
+++ b/src/client/components/SelectPlayerRow.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PublicPlayerModel} from '@/common/models/PlayerModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectPlayerRow',
   props: {
     player: {

--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -52,7 +52,7 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {SelectProductionToLoseModel} from '@/common/models/PlayerInputModel';
 import {PayProductionModel} from '@/common/models/PayProductionUnitsModel';
@@ -65,7 +65,7 @@ type DataModel = {
   warning: string | undefined;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectProductionToLose',
   props: {
     playerinput: {

--- a/src/client/components/SelectProjectCardToPlay.vue
+++ b/src/client/components/SelectProjectCardToPlay.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import AppButton from '@/client/components/common/AppButton.vue';
 import {Payment} from '@/common/inputs/Payment';
@@ -76,7 +76,7 @@ import {CardName} from '@/common/cards/CardName';
 import {SelectProjectCardToPlayResponse} from '@/common/inputs/InputResponse';
 import WarningsComponent from '@/client/components/WarningsComponent.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectProjectCardToPlay',
   props: {
     playerView: {
@@ -150,7 +150,7 @@ export default Vue.extend({
     WarningsComponent,
   },
   mounted() {
-    Vue.nextTick(() => {
+    this.$nextTick(() => {
       this.card = this.getCard();
       this.cost = this.card.calculatedCost ?? 0;
       this.tags = this.getCardTags(),

--- a/src/client/components/SelectResource.vue
+++ b/src/client/components/SelectResource.vue
@@ -14,13 +14,13 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectResourceModel} from '@/common/models/PlayerInputModel';
 import {SelectResourceResponse} from '@/common/inputs/InputResponse';
 import {PlayerViewModel} from '@/common/models/PlayerModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectResource',
   props: {
     playerView: {

--- a/src/client/components/SelectResources.vue
+++ b/src/client/components/SelectResources.vue
@@ -19,7 +19,7 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {SelectResourcesModel} from '@/common/models/PlayerInputModel';
 import {SelectResourcesResponse} from '@/common/inputs/InputResponse';
@@ -28,7 +28,7 @@ import {Units} from '@/common/Units';
 import PaymentUnitComponent from '@/client/components/PaymentUnit.vue';
 import {sum} from '@/common/utils/utils';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SelectResource',
   props: {
     playerView: {

--- a/src/client/components/ShiftAresGlobalParameters.vue
+++ b/src/client/components/ShiftAresGlobalParameters.vue
@@ -42,7 +42,7 @@
 </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {AresGlobalParametersResponse} from '@/common/inputs/AresGlobalParametersResponse';
 import {ShiftAresGlobalParametersModel} from '@/common/models/PlayerInputModel';
 import {ShiftAresGlobalParametersResponse} from '@/common/inputs/InputResponse';
@@ -52,7 +52,7 @@ type DataModel = AresGlobalParametersResponse & {
   hazardData: HazardData,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ShiftAresGlobalParameters',
   props: {
     playerinput: {

--- a/src/client/components/Sidebar.vue
+++ b/src/client/components/Sidebar.vue
@@ -71,7 +71,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Color} from '@/common/Color';
 import {getPreferences, PreferencesManager} from '@/client/utils/PreferencesManager';
 import {TurmoilModel} from '@/common/models/TurmoilModel';
@@ -85,7 +85,7 @@ import {MoonModel} from '@/common/models/MoonModel';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 import LanguageIcon from '@/client/components/LanguageIcon.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'sidebar',
   props: {
     playerNumber: {

--- a/src/client/components/SortableCards.vue
+++ b/src/client/components/SortableCards.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Card from '@/client/components/card/Card.vue';
 import {CardName} from '@/common/cards/CardName';
 import {CardModel} from '@/common/models/CardModel';
@@ -38,7 +38,7 @@ type DataModel = {
   dragCard: CardName | undefined;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SortableCards',
   components: {
     Card,

--- a/src/client/components/SpectatorHome.vue
+++ b/src/client/components/SpectatorHome.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {GameModel} from '@/common/models/GameModel';
 import {vueRoot} from '@/client/components/vueRoot';
@@ -101,7 +101,7 @@ export interface SpectatorHomeModel {
   waitingForTimeout: number;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SpectatorHome',
   data(): SpectatorHomeModel {
     return {

--- a/src/client/components/StackedCards.vue
+++ b/src/client/components/StackedCards.vue
@@ -8,11 +8,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Card from '@/client/components/card/Card.vue';
 import {CardModel} from '@/common/models/CardModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'stacked-cards',
   props: {
     cards: {

--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -34,14 +34,14 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import LanguageSwitcher from '@/client/components/LanguageSwitcher.vue';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 
 import * as raw_settings from '@/genfiles/settings.json';
 import * as constants from '@/common/constants';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'start-screen',
   components: {
     LanguageSwitcher,

--- a/src/client/components/Tag.vue
+++ b/src/client/components/Tag.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Tag} from '@/common/cards/Tag';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Tag',
   props: {
     tag: {

--- a/src/client/components/TagCount.vue
+++ b/src/client/components/TagCount.vue
@@ -8,7 +8,8 @@
 
 <script lang="ts">
 
-import Vue, {PropType} from 'vue';
+import {PropType} from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Tag from '@/client/components/Tag.vue';
 import UndergroundToken from '@/client/components/underworld/UndergroundToken.vue';
 import {Tag as CardTag} from '@/common/cards/Tag';
@@ -16,7 +17,7 @@ import {SpecialTags} from '@/client/cards/SpecialTags';
 import {TemporaryBonusToken} from '@/common/underworld/UndergroundResourceToken';
 import {ClaimedToken} from '@/common/underworld/UnderworldPlayerData';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'tag-count',
   props: {
     tag: {

--- a/src/client/components/TopBar.vue
+++ b/src/client/components/TopBar.vue
@@ -9,12 +9,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PlayerViewModel} from '@/common/models/PlayerModel';
 import PlayerInfo from '@/client/components/overview/PlayerInfo.vue';
 import {getPreferences, PreferencesManager} from '@/client/utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'top-bar',
   props: {
     playerView: {

--- a/src/client/components/WaitingFor.vue
+++ b/src/client/components/WaitingFor.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 /* global RequestInit */
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import * as constants from '@/common/constants';
 import * as raw_settings from '@/genfiles/settings.json';
 import {vueRoot} from '@/client/components/vueRoot';
@@ -57,7 +57,7 @@ type DataModel = {
 
 const CANNOT_CONTACT_SERVER = 'Unable to reach the server. It may be restarting or down for maintenance.';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'waiting-for',
   props: {
     playerView: {

--- a/src/client/components/WarningsComponent.vue
+++ b/src/client/components/WarningsComponent.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Warning} from '@/common/cards/Warning';
 
 const descriptions: Record<Warning, string> = {
@@ -37,7 +37,7 @@ const descriptions: Record<Warning, string> = {
   'underworldtokendiscard': 'Warning: You will have to discard an underworld resource token you rely on.',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'WarningsComponent',
   props: {
     warnings: {

--- a/src/client/components/admin/AdminHome.vue
+++ b/src/client/components/admin/AdminHome.vue
@@ -9,10 +9,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {paths} from '@/common/app/paths';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'admin-home',
   data() {
     return {

--- a/src/client/components/admin/GameOverview.vue
+++ b/src/client/components/admin/GameOverview.vue
@@ -16,13 +16,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SimpleGameModel} from '@/common/models/SimpleGameModel';
 import {Phase} from '@/common/Phase';
 
 type Status = 'loading' | 'error' | 'done';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'GameOverview',
   data() {
     return {

--- a/src/client/components/auth/LoginHome.vue
+++ b/src/client/components/auth/LoginHome.vue
@@ -13,14 +13,14 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {paths} from '@/common/app/paths';
 
 type Data = {
   user: string | undefined;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'login-home',
   data(): Data {
     return {

--- a/src/client/components/board/BoardSpaceTile.vue
+++ b/src/client/components/board/BoardSpaceTile.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SpaceType} from '@/common/boards/SpaceType';
 import {TileType, tileTypeToString} from '@/common/TileType';
 import {SpaceHighlight, SpaceModel} from '@/common/models/SpaceModel';
@@ -99,7 +99,7 @@ const descriptions: Record<TileType, string> = {
   [TileType.NEW_HOLLAND]: 'New Holland: counts as an ocean and a city',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'board-space-tile',
   props: {
     space: {

--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -11,7 +11,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardMetadata} from '@/common/cards/CardMetadata';
 import CardRequirementsComponent from './CardRequirementsComponent.vue';
 import CardDescription from './CardDescription.vue';
@@ -19,7 +19,7 @@ import CardRenderData from './CardRenderData.vue';
 import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
 import {ICardRenderRoot, isICardRenderRoot} from '@/common/cards/render/Types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardContent',
   props: {
     metadata: {

--- a/src/client/components/card/CardCorporationLogo.vue
+++ b/src/client/components/card/CardCorporationLogo.vue
@@ -646,7 +646,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardName} from '@/common/cards/CardName';
 
 
@@ -752,7 +752,7 @@ const logos: Partial<Record<CardName, 'image' | 'css' | 'bespoke'>> = {
   [CardName.VOLTAGON]: 'bespoke',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardCorporationLogo',
   props: {
     title: {

--- a/src/client/components/card/CardCost.vue
+++ b/src/client/components/card/CardCost.vue
@@ -10,10 +10,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {getPreferences} from '@/client/utils/PreferencesManager';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardCost',
   props: {
     amount: {

--- a/src/client/components/card/CardDescription.vue
+++ b/src/client/components/card/CardDescription.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {isIDescription} from '@/common/cards/render/ICardRenderDescription';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardDescription',
   props: {
     item: {

--- a/src/client/components/card/CardExpansion.vue
+++ b/src/client/components/card/CardExpansion.vue
@@ -6,10 +6,10 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {GameModule} from '@/common/cards/GameModule';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardExpansion',
   props: {
     expansion: {

--- a/src/client/components/card/CardExtraContent.vue
+++ b/src/client/components/card/CardExtraContent.vue
@@ -8,12 +8,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardModel} from '@/common/models/CardModel';
 import {CardName} from '@/common/cards/CardName';
 import {Resource} from '@/common/Resource';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardExtraContent',
   props: {
     card: {

--- a/src/client/components/card/CardHelp.vue
+++ b/src/client/components/card/CardHelp.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardName} from '@/common/cards/CardName';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardHelp',
   props: {
     name: {

--- a/src/client/components/card/CardParty.vue
+++ b/src/client/components/card/CardParty.vue
@@ -6,9 +6,9 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardParty',
   props: {
     party: {

--- a/src/client/components/card/CardProductionBoxComponent.vue
+++ b/src/client/components/card/CardProductionBoxComponent.vue
@@ -12,12 +12,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRenderItemComponent from '@/client/components/card/CardRenderItemComponent.vue';
 import CardRenderSymbolComponent from '@/client/components/card/CardRenderSymbolComponent.vue';
 import {ICardRenderItem} from '@/common/cards/render/Types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardProductionBoxComponent',
   props: {
     rows: {

--- a/src/client/components/card/CardRenderCorpBoxComponent.vue
+++ b/src/client/components/card/CardRenderCorpBoxComponent.vue
@@ -11,13 +11,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRenderItemComponent from '@/client/components/card/CardRenderItemComponent.vue';
 import CardRenderEffectBoxComponent from '@/client/components/card/CardRenderEffectBoxComponent.vue';
 import CardRenderSymbolComponent from '@/client/components/card/CardRenderSymbolComponent.vue';
 import {ICardRenderEffect, ICardRenderItem, ICardRenderSymbol} from '@/common/cards/render/Types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderCorpBoxComponent',
   props: {
     rows: {

--- a/src/client/components/card/CardRenderData.vue
+++ b/src/client/components/card/CardRenderData.vue
@@ -6,11 +6,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ICardRenderRoot} from '@/common/cards/render/Types';
 import CardRowData from '@/client/components/card/CardRowData.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderData',
   props: {
     renderData: {

--- a/src/client/components/card/CardRenderEffectBoxComponent.vue
+++ b/src/client/components/card/CardRenderEffectBoxComponent.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRenderItemComponent from '@/client/components/card/CardRenderItemComponent.vue';
 import CardRenderSymbolComponent from '@/client/components/card/CardRenderSymbolComponent.vue';
 import {ICardRenderEffect, isICardRenderItem, isICardRenderProductionBox} from '@/common/cards/render/Types';
@@ -35,7 +35,7 @@ import {isICardRenderSymbol, isICardRenderTile, ItemType} from '@/common/cards/r
 
 import CardDescription from '@/client/components/card/CardDescription.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderEffectBoxComponent',
   props: {
     effectData: {

--- a/src/client/components/card/CardRenderItemComponent.vue
+++ b/src/client/components/card/CardRenderItemComponent.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardRenderItemType} from '@/common/cards/render/CardRenderItemType';
 import {AltSecondaryTag} from '@/common/cards/render/AltSecondaryTag';
 import {Size} from '@/common/cards/render/Size';
@@ -16,7 +16,7 @@ import {Tag} from '@/common/cards/Tag';
 import {ICardRenderItem, isICardRenderItem} from '@/common/cards/render/Types';
 import {cardResourceCSS} from '../common/cardResources';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderItemComponent',
   props: {
     item: {

--- a/src/client/components/card/CardRenderSymbolComponent.vue
+++ b/src/client/components/card/CardRenderSymbolComponent.vue
@@ -7,7 +7,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardRenderSymbolType} from '@/common/cards/render/CardRenderSymbolType';
 import {ICardRenderSymbol} from '@/common/cards/render/Types';
 import {Size} from '@/common/cards/render/Size';
@@ -36,7 +36,7 @@ const sizes: Record<Size, string> = {
   [Size.LARGE]: 'large',
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderSymbolComponent',
   props: {
     item: {

--- a/src/client/components/card/CardRenderTileComponent.vue
+++ b/src/client/components/card/CardRenderTileComponent.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ICardRenderTile} from '@/common/cards/render/Types';
 import {TileType} from '@/common/TileType';
 
@@ -144,7 +144,7 @@ const TILE_CLASSES: Record<TileType, Classes> = {
   },
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRenderTileComponent',
   props: {
     item: {

--- a/src/client/components/card/CardRequirementComponent.vue
+++ b/src/client/components/card/CardRequirementComponent.vue
@@ -32,14 +32,14 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardRequirementDescriptor, requirementType} from '@/common/cards/CardRequirementDescriptor';
 import {RequirementType} from '@/common/cards/RequirementType';
 import {range} from '@/common/utils/utils';
 import CardParty from '@/client/components/card/CardParty.vue';
 import {PartyName} from '@/common/turmoil/PartyName';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRequirementComponent',
   props: {
     requirement: {

--- a/src/client/components/card/CardRequirementsComponent.vue
+++ b/src/client/components/card/CardRequirementsComponent.vue
@@ -8,11 +8,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRequirementComponent from './CardRequirementComponent.vue';
 import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRequirementsComponent',
   props: {
     requirements: {

--- a/src/client/components/card/CardResourceCounter.vue
+++ b/src/client/components/card/CardResourceCounter.vue
@@ -7,11 +7,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardResource} from '@/common/CardResource';
 import {cardResourceCSS} from '../common/cardResources';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardResourceCounter',
   props: {
     amount: {

--- a/src/client/components/card/CardRowComponent.vue
+++ b/src/client/components/card/CardRowComponent.vue
@@ -11,7 +11,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {isIDescription} from '@/common/cards/render/ICardRenderDescription';
 import {
   ICardRenderCorpBoxAction,
@@ -35,7 +35,7 @@ import CardRenderTileComponent from '@/client/components/card/CardRenderTileComp
 import CardDescription from '@/client/components/card/CardDescription.vue';
 import CardRenderSymbolComponent from '@/client/components/card/CardRenderSymbolComponent.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRowComponent',
   props: {
     componentData: {

--- a/src/client/components/card/CardRowData.vue
+++ b/src/client/components/card/CardRowData.vue
@@ -6,10 +6,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRowComponent from '@/client/components/card/CardRowComponent.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardRowData',
   props: {
     rowData: {

--- a/src/client/components/card/CardTag.vue
+++ b/src/client/components/card/CardTag.vue
@@ -4,10 +4,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Tag} from '@/common/cards/Tag';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardTag',
   props: {
     index: {

--- a/src/client/components/card/CardTags.vue
+++ b/src/client/components/card/CardTags.vue
@@ -11,11 +11,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardTag from '@/client/components/card/CardTag.vue';
 import {Tag} from '@/common/cards/Tag';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardTags',
   props: {
     tags: Array as () => Array<Tag>,

--- a/src/client/components/card/CardTitle.vue
+++ b/src/client/components/card/CardTitle.vue
@@ -10,12 +10,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardType} from '@/common/cards/CardType';
 import {translateText} from '@/client/directives/i18n';
 import CardCorporationLogo from '@/client/components/card/CardCorporationLogo.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardTitle',
   props: {
     title: {

--- a/src/client/components/card/CardVictoryPoints.vue
+++ b/src/client/components/card/CardVictoryPoints.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRenderItemComponent from '@/client/components/card/CardRenderItemComponent.vue';
 import {CardRenderDynamicVictoryPoints} from '@/common/cards/render/CardRenderDynamicVictoryPoints';
 import {CardRenderItemType} from '@/common/cards/render/CardRenderItemType';
@@ -33,7 +33,7 @@ import {CardResource} from '@/common/CardResource';
 import {ICardRenderItem} from '@/common/cards/render/Types';
 import {Size} from '@/common/cards/render/Size';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CardVictoryPoints',
   props: {
     victoryPoints: {

--- a/src/client/components/colonies/BuildBenefit.vue
+++ b/src/client/components/colonies/BuildBenefit.vue
@@ -51,12 +51,12 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {ColonyMetadata} from '@/common/colonies/ColonyMetadata';
 import {ColonyBenefit} from '@/common/colonies/ColonyBenefit';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'BuildBenefit',
   props: {
     metadata: {

--- a/src/client/components/colonies/Colony.vue
+++ b/src/client/components/colonies/Colony.vue
@@ -119,7 +119,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {ColonyModel} from '@/common/models/ColonyModel';
 import {ColonyName} from '@/common/colonies/ColonyName';
@@ -131,7 +131,7 @@ import {ColonyBenefit} from '@/common/colonies/ColonyBenefit';
 import {Resource} from '@/common/Resource';
 import {translateText} from '@/client/directives/i18n';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'colony',
   props: {
     colony: {

--- a/src/client/components/colonies/ColonyRow.vue
+++ b/src/client/components/colonies/ColonyRow.vue
@@ -11,13 +11,13 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {ColonyMetadata} from '@/common/colonies/ColonyMetadata';
 import {ColonyModel} from '@/common/models/ColonyModel';
 import ColonySpace from './ColonySpace.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ColonyRow',
   components: {
     ColonySpace,

--- a/src/client/components/colonies/ColonySpace.vue
+++ b/src/client/components/colonies/ColonySpace.vue
@@ -9,14 +9,14 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {ColonyName} from '@/common/colonies/ColonyName';
 import {ColonyMetadata} from '@/common/colonies/ColonyMetadata';
 import BuildBenefit from './BuildBenefit.vue';
 import {Color} from '@/common/Color';
 
-export default Vue.extend({
+export default defineComponent({
   components: {BuildBenefit},
   name: 'ColonyRow',
   props: {

--- a/src/client/components/colonies/ColonyTradeRow.vue
+++ b/src/client/components/colonies/ColonyTradeRow.vue
@@ -34,13 +34,13 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import {ColonyName} from '@/common/colonies/ColonyName';
 import {ColonyMetadata} from '@/common/colonies/ColonyMetadata';
 import {range} from '@/common/utils/utils';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ColonyTradeRow',
   props: {
     metadata: {

--- a/src/client/components/common/AppButton.vue
+++ b/src/client/components/common/AppButton.vue
@@ -6,12 +6,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {vueRoot} from '@/client/components/vueRoot';
 import {Message} from '@/common/logs/Message';
 import {translateText, translateMessage} from '@/client/directives/i18n';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'AppButton',
   props: {
     title: {

--- a/src/client/components/common/DynamicTitle.vue
+++ b/src/client/components/common/DynamicTitle.vue
@@ -3,11 +3,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {playerColorClass} from '@/common/utils/utils';
 import {Color} from '@/common/Color';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'DynamicTitle',
   props: {
     title: {

--- a/src/client/components/common/PopupPanel.vue
+++ b/src/client/components/common/PopupPanel.vue
@@ -13,9 +13,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PopupPanel',
   methods: {
     onclick() {

--- a/src/client/components/common/PurgeWarning.vue
+++ b/src/client/components/common/PurgeWarning.vue
@@ -10,9 +10,9 @@
 </template>
 <script lang="ts">
 import {translateTextWithParams} from '@/client/directives/i18n';
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PurgeWarning',
   props: {
     expectedPurgeTimeMs: {

--- a/src/client/components/create/ColoniesFilter.vue
+++ b/src/client/components/create/ColoniesFilter.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import PopupPanel from '../common/PopupPanel.vue';
 import {ColonyName} from '@/common/colonies/ColonyName';
 import {COLONY_DESCRIPTIONS} from '@/common/colonies/ColonyDescription';
@@ -51,7 +51,7 @@ type Data = {
 type ColonyModule = 'colonies' | 'community' | 'pathfinders';
 type Group = ColonyModule | 'All';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ColoniesFilter',
   components: {
     PopupPanel,

--- a/src/client/components/create/CorporationsFilter.vue
+++ b/src/client/components/create/CorporationsFilter.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import PopupPanel from '../common/PopupPanel.vue';
 import {CardName} from '@/common/cards/CardName';
@@ -67,7 +67,7 @@ getCards(byType(CardType.CORPORATION)).forEach((card) => {
 });
 GAME_MODULES.forEach((module) => ALL_CARDS_BY_MODULE[module].sort());
 
-export default Vue.extend({
+export default defineComponent({
   name: 'CorporationsFilter',
   components: {
     PopupPanel,

--- a/src/client/components/create/PreludesFilter.vue
+++ b/src/client/components/create/PreludesFilter.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 import PopupPanel from '../common/PopupPanel.vue';
 import {CardName} from '@/common/cards/CardName';
@@ -64,7 +64,7 @@ getCards(byType(CardType.PRELUDE)).forEach((card) => {
 });
 GAME_MODULES.forEach((module) => ALL_CARDS_BY_MODULE[module].sort());
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PreludesFilter',
   components: {
     PopupPanel,

--- a/src/client/components/gameend/VictoryPointChart.vue
+++ b/src/client/components/gameend/VictoryPointChart.vue
@@ -6,7 +6,7 @@
   </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Chart, registerables} from 'chart.js';
 import {Color} from '@/common/Color';
 import {translateText} from '@/client/directives/i18n';
@@ -47,7 +47,7 @@ export type DataSet = {
   color: Color,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'VictoryPointChart',
   data: function() {
     return {};

--- a/src/client/components/help/Help.vue
+++ b/src/client/components/help/Help.vue
@@ -41,7 +41,7 @@
     </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import HelpIconology from '@/client/components/help/HelpIconology.vue';
 import HelpPhases from '@/client/components/help/HelpPhases.vue';
 import HelpStandardProjects from '@/client/components/help/HelpStandardProjects.vue';
@@ -52,7 +52,7 @@ export interface HelpPageModel {
     currentPage: Tab;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Help',
   data(): HelpPageModel {
     return {

--- a/src/client/components/help/HelpIconology.vue
+++ b/src/client/components/help/HelpIconology.vue
@@ -286,8 +286,8 @@
     </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
-export default Vue.extend({
+import {defineComponent} from '@/client/vue3-compat';
+export default defineComponent({
   name: 'HelpIconology',
 });
 </script>

--- a/src/client/components/help/HelpPhases.vue
+++ b/src/client/components/help/HelpPhases.vue
@@ -151,8 +151,8 @@
     </div>
 </template>
 <script lang="ts">
-import Vue from 'vue';
-export default Vue.extend({
+import {defineComponent} from '@/client/vue3-compat';
+export default defineComponent({
   name: 'HelpPhases',
 });
 </script>

--- a/src/client/components/help/HelpStandardProjects.vue
+++ b/src/client/components/help/HelpStandardProjects.vue
@@ -20,11 +20,11 @@
 </template>
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import Card from '@/client/components/card/Card.vue';
 import {CardName} from '@/common/cards/CardName';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'HelpStandardProjects',
   components: {
     Card,

--- a/src/client/components/logpanel/CardPanel.vue
+++ b/src/client/components/logpanel/CardPanel.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {LogMessage} from '@/common/logs/LogMessage';
 import {LogMessageDataType} from '@/common/logs/LogMessageDataType';
 import {CardName} from '@/common/cards/CardName';
@@ -29,7 +29,7 @@ import Colony from '@/client/components/colonies/Colony.vue';
 import {deNull} from '@/common/utils/utils';
 import {GlobalEventName} from '@/common/turmoil/globalEvents/GlobalEventName';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'log-panel',
   props: {
     message: Object as () => LogMessage | undefined,

--- a/src/client/components/logpanel/LogMessageComponent.vue
+++ b/src/client/components/logpanel/LogMessageComponent.vue
@@ -34,7 +34,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Color} from '@/common/Color';
 import {CardName} from '@/common/cards/CardName';
 import {CardType} from '@/common/cards/CardType';
@@ -61,7 +61,7 @@ const cardTypeToCss: Record<CardType, string | undefined> = {
   proxy: undefined,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LogMessageComponent',
   props: {
     message: {

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {paths} from '@/common/app/paths';
 import {LogMessage} from '@/common/logs/LogMessage';
 import {PublicPlayerModel, ViewModel} from '@/common/models/PlayerModel';
@@ -47,7 +47,7 @@ type LogPanelModel = {
   selectedMessage: LogMessage | undefined,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'log-panel',
   props: {
     viewModel: {

--- a/src/client/components/moon/MoonBoard.vue
+++ b/src/client/components/moon/MoonBoard.vue
@@ -74,7 +74,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {MoonModel} from '@/common/models/MoonModel';
 import {SpaceModel} from '@/common/models/SpaceModel';
 import {SpaceType} from '@/common/boards/SpaceType';
@@ -88,7 +88,7 @@ type MoonParamLevel = {
   strValue: string,
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'MoonBoard',
   props: {
     model: {

--- a/src/client/components/moon/MoonGlobalParameterValue.vue
+++ b/src/client/components/moon/MoonGlobalParameterValue.vue
@@ -21,11 +21,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {MAXIMUM_HABITAT_RATE, MAXIMUM_LOGISTICS_RATE, MAXIMUM_MINING_RATE} from '@/common/constants';
 import {MoonModel} from '@/common/models/MoonModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'MoonGlobalParameterValue',
   props: {
     moonData: {

--- a/src/client/components/moon/MoonSpace.vue
+++ b/src/client/components/moon/MoonSpace.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SpaceModel} from '@/common/models/SpaceModel';
 import Bonus from '@/client/components/Bonus.vue';
 import {TileView} from '../board/TileView';
@@ -25,7 +25,7 @@ import BoardSpaceTile from '@/client/components/board/BoardSpaceTile.vue';
 import {getPreferences} from '@/client/utils/PreferencesManager';
 import {getSpaceName} from '@/common/boards/spaces';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'MoonSpace',
   props: {
     space: {

--- a/src/client/components/overview/OverviewSettings.vue
+++ b/src/client/components/overview/OverviewSettings.vue
@@ -7,10 +7,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {vueRoot} from '@/client/components/vueRoot';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'OverviewSettings',
   methods: {
     toggleTagsView() {

--- a/src/client/components/overview/PlayerAlliedParty.vue
+++ b/src/client/components/overview/PlayerAlliedParty.vue
@@ -8,11 +8,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PublicPlayerModel} from '@/common/models/PlayerModel';
 import AlliedPartyAgenda from '@/client/components/turmoil/AlliedPartyAgenda.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerAlliedParty',
   props: {
     player: {

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
 import PlayerResources from '@/client/components/overview/PlayerResources.vue';
 import PlayerTags from '@/client/components/overview/PlayerTags.vue';
@@ -57,7 +57,7 @@ import {Phase} from '@/common/Phase';
 import {ActionLabel} from './ActionLabel';
 import {playerSymbol} from '@/client/utils/playerSymbol';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerInfo',
   props: {
     player: {

--- a/src/client/components/overview/PlayerResource.vue
+++ b/src/client/components/overview/PlayerResource.vue
@@ -18,13 +18,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {DEFAULT_STEEL_VALUE, DEFAULT_TITANIUM_VALUE} from '@/common/constants';
 import {Resource} from '@/common/Resource';
 import {getPreferences} from '@/client/utils/PreferencesManager';
 import {Protection} from '@/common/models/PlayerModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerResource',
   props: {
     type: {

--- a/src/client/components/overview/PlayerResources.vue
+++ b/src/client/components/overview/PlayerResources.vue
@@ -44,13 +44,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {CardName} from '@/common/cards/CardName';
 import {PublicPlayerModel} from '@/common/models/PlayerModel';
 import PlayerResource from '@/client/components/overview/PlayerResource.vue';
 import {Resource} from '@/common/Resource';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerResources',
   props: {
     player: {

--- a/src/client/components/overview/PlayerStatus.vue
+++ b/src/client/components/overview/PlayerStatus.vue
@@ -11,12 +11,12 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ActionLabel} from '@/client/components/overview/ActionLabel';
 import PlayerTimer from '@/client/components/overview/PlayerTimer.vue';
 import {TimerModel} from '@/common/models/TimerModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'player-status',
   props: {
     timer: {

--- a/src/client/components/overview/PlayerTagDiscount.vue
+++ b/src/client/components/overview/PlayerTagDiscount.vue
@@ -7,9 +7,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerTagDiscount',
   props: {
     amount: {

--- a/src/client/components/overview/PlayerTags.vue
+++ b/src/client/components/overview/PlayerTags.vue
@@ -32,7 +32,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import TagCount from '@/client/components/TagCount.vue';
 import {ViewModel, PublicPlayerModel} from '@/common/models/PlayerModel';
 import {GameModel} from '@/common/models/GameModel';
@@ -126,7 +126,7 @@ const getTagCount = (tagName: InterfaceTagsType, player: PublicPlayerModel): num
   }
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerTags',
   props: {
     playerView: {

--- a/src/client/components/overview/PlayerTimer.vue
+++ b/src/client/components/overview/PlayerTimer.vue
@@ -11,11 +11,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {Timer} from '@/common/Timer';
 import {TimerModel} from '@/common/models/TimerModel';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayerTimer',
   props: {
     timer: {

--- a/src/client/components/overview/PlayersOverview.vue
+++ b/src/client/components/overview/PlayersOverview.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import PlayerInfo from '@/client/components/overview/PlayerInfo.vue';
 import OverviewSettings from '@/client/components/overview/OverviewSettings.vue';
 import OtherPlayer from '@/client/components/OtherPlayer.vue';
@@ -49,7 +49,7 @@ export const playerIndex = (
   return -1;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlayersOverview',
   props: {
     playerView: {

--- a/src/client/components/overview/PointsPerTag.vue
+++ b/src/client/components/overview/PointsPerTag.vue
@@ -9,14 +9,14 @@
 const ONE_THIRD = 1/3;
 const TWO_THIRDS = 2/3;
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
 export type Points = {
   points: number;
   halfPoints: number;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PointsPerTag',
   props: {
     points: {

--- a/src/client/components/pathfinders/PlanetaryTrack.vue
+++ b/src/client/components/pathfinders/PlanetaryTrack.vue
@@ -8,13 +8,13 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {range} from '@/common/utils/utils';
 import {PlanetaryTrack as Track} from '@/common/pathfinders/PlanetaryTrack';
 import {GameOptionsModel} from '@/common/models/GameOptionsModel';
 import PlanetaryTrackRewards from './PlanetaryTrackRewards.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlanetaryTrack',
   props: {
     val: {

--- a/src/client/components/pathfinders/PlanetaryTrackReward.vue
+++ b/src/client/components/pathfinders/PlanetaryTrackReward.vue
@@ -8,11 +8,11 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {GameOptionsModel} from '@/common/models/GameOptionsModel';
 import {Reward} from '@/common/pathfinders/Reward';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlanetaryTrackReward',
   props: {
     reward: {

--- a/src/client/components/pathfinders/PlanetaryTrackRewards.vue
+++ b/src/client/components/pathfinders/PlanetaryTrackRewards.vue
@@ -7,13 +7,13 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {GameOptionsModel} from '@/common/models/GameOptionsModel';
 import {PlanetaryTrackSpace} from '@/common/pathfinders/PlanetaryTrack';
 import PlanetaryTrackReward from './PlanetaryTrackReward.vue';
 import {Reward} from '@/common/pathfinders/Reward';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlanetaryTrackRewards',
   props: {
     rewards: {

--- a/src/client/components/pathfinders/PlanetaryTracks.vue
+++ b/src/client/components/pathfinders/PlanetaryTracks.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {GameOptionsModel} from '@/common/models/GameOptionsModel';
 import {PathfindersModel} from '@/common/models/PathfindersModel';
 import {Tag} from '@/common/cards/Tag';
@@ -53,7 +53,7 @@ import {range} from '@/common/utils/utils';
 import PlanetaryTrack from '@/client/components/pathfinders/PlanetaryTrack.vue';
 import {PlanetaryTracks as Tracks} from '@/common/pathfinders/PlanetaryTracks';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlanetaryTracks',
   props: {
     tracks: {

--- a/src/client/components/turmoil/AlliedPartyAgenda.vue
+++ b/src/client/components/turmoil/AlliedPartyAgenda.vue
@@ -43,10 +43,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {PolicyId} from '@/common/turmoil/Types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'AlliedPartyAgenda',
   props: {
     id: {

--- a/src/client/components/turmoil/GlobalEvent.vue
+++ b/src/client/components/turmoil/GlobalEvent.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import CardRenderData from '@/client/components/card/CardRenderData.vue';
 import CardParty from '@/client/components/card/CardParty.vue';
 import {IClientGlobalEvent} from '@/common/turmoil/IClientGlobalEvent';
@@ -37,7 +37,7 @@ type DataModel = {
   current: PartyName;
 };
 
-export default Vue.extend({
+export default defineComponent({
   name: 'global-event',
   components: {
     CardRenderData,

--- a/src/client/components/turmoil/Turmoil.vue
+++ b/src/client/components/turmoil/Turmoil.vue
@@ -82,14 +82,14 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {vueRoot} from '@/client/components/vueRoot';
 import {PartyName} from '@/common/turmoil/PartyName';
 import {TurmoilModel} from '@/common/models/TurmoilModel';
 import TurmoilAgenda from '@/client/components/turmoil/TurmoilAgenda.vue';
 import GlobalEvent from '@/client/components/turmoil/GlobalEvent.vue';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'turmoil',
   props: {
     turmoil: {

--- a/src/client/components/turmoil/TurmoilAgenda.vue
+++ b/src/client/components/turmoil/TurmoilAgenda.vue
@@ -185,9 +185,9 @@
 <script lang="ts">
 
 import {BonusId, PolicyId} from '@/common/turmoil/Types';
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'TurmoilAgenda',
   props: {
     id: {

--- a/src/client/components/underworld/UndergroundToken.vue
+++ b/src/client/components/underworld/UndergroundToken.vue
@@ -8,10 +8,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ClaimedToken} from '@/common/underworld/UnderworldPlayerData';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'UndergroundToken',
   props: {
     token: {

--- a/src/client/components/underworld/UndergroundTokens.vue
+++ b/src/client/components/underworld/UndergroundTokens.vue
@@ -13,10 +13,10 @@
 
 <script lang="ts">
 
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {ClaimedToken, UnderworldPlayerData} from '@/common/underworld/UnderworldPlayerData';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'UndergroundTokens',
   components: {
     UndergroundToken: () => import('./UndergroundToken.vue'),

--- a/src/client/components/waitingFor/GoToMap.vue
+++ b/src/client/components/waitingFor/GoToMap.vue
@@ -5,11 +5,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import {defineComponent} from '@/client/vue3-compat';
 import {SelectSpaceModel} from '@/common/models/PlayerInputModel';
 import {isMarsSpace} from '@/common/boards/spaces';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'GoToMap',
   props: {
     playerinput: {

--- a/src/client/vue3-compat.ts
+++ b/src/client/vue3-compat.ts
@@ -1,0 +1,3 @@
+import Vue from 'vue';
+
+export const defineComponent = Vue.extend.bind(Vue);


### PR DESCRIPTION
Introduce vue3-compat.ts that re-exports Vue.extend as defineComponent. Most components now import defineComponent from the shim instead of Vue directly, so the eventual Vue 3 migration only needs to change the shim's import source rather than every component file.

Components still using Vue directly (WithRefs pattern, Vue.component) are left unchanged. Vue.nextTick calls converted to this.$nextTick.

Claude AI helped with this.