### PR TITLE
Add required: true to all non-optional Vue component props

### DIFF
--- a/src/client/components/AndOptions.vue
+++ b/src/client/components/AndOptions.vue
@@ -32,21 +32,27 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     playerinput: {
       type: Object as () => AndOptionsModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: AndOptionsResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/Award.vue
+++ b/src/client/components/Award.vue
@@ -53,6 +53,7 @@ export default defineComponent({
     },
     showDescription: {
       type: Boolean,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/Board.vue
+++ b/src/client/components/Board.vue
@@ -374,30 +374,39 @@ export default defineComponent({
   props: {
     spaces: {
       type: Array as () => Array<SpaceModel>,
+      required: true,
     },
     venusScaleLevel: {
       type: Number,
+      required: true,
     },
     altVenusBoard: {
       type: Boolean,
+      required: true,
     },
     boardName: {
       type: String as () => BoardName,
+      required: true,
     },
     oceans_count: {
       type: Number,
+      required: true,
     },
     oxygen_level: {
       type: Number,
+      required: true,
     },
     temperature: {
       type: Number,
+      required: true,
     },
     expansions: {
       type: Object as () => Record<Expansion, boolean>,
+      required: true,
     },
     aresData: {
       type: Object as () => AresData | undefined,
+      required: true,
     },
     tileView: {
       type: String as () => TileView,

--- a/src/client/components/BoardSpace.vue
+++ b/src/client/components/BoardSpace.vue
@@ -47,15 +47,19 @@ export default defineComponent({
   props: {
     space: {
       type: Object as () => SpaceModel,
+      required: true,
     },
     text: {
       type: String,
+      required: true,
     },
     aresExtension: {
       type: Boolean,
+      required: true,
     },
     tileView: {
       type: String as () => TileView,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/Bonus.vue
+++ b/src/client/components/Bonus.vue
@@ -36,6 +36,7 @@ export default defineComponent({
   props: {
     bonus: {
       type: Array as () => Array<SpaceBonus>,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/GameEnd.vue
+++ b/src/client/components/GameEnd.vue
@@ -247,9 +247,11 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel | undefined,
+      required: true,
     },
     spectator: {
       type: Object as () => SpectatorModel | undefined,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/GameHome.vue
+++ b/src/client/components/GameHome.vue
@@ -65,6 +65,7 @@ export default defineComponent({
   props: {
     game: {
       type: Object as () => SimpleGameModel,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/GameSetupDetail.vue
+++ b/src/client/components/GameSetupDetail.vue
@@ -104,12 +104,15 @@ export default defineComponent({
   props: {
     playerNumber: {
       type: Number,
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
     lastSoloGeneration: {
       type: Number,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/GlobalParameterValue.vue
+++ b/src/client/components/GlobalParameterValue.vue
@@ -37,9 +37,11 @@ export default defineComponent({
   props: {
     param: {
       type: String as () => BaseGlobalParameter,
+      required: true,
     },
     value: {
       type: Number,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/LanguageSelectionDialog.vue
+++ b/src/client/components/LanguageSelectionDialog.vue
@@ -27,6 +27,7 @@ export default defineComponent({
   props: {
     preferencesManager: {
       type: Object as () => PreferencesManager,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/Milestone.vue
+++ b/src/client/components/Milestone.vue
@@ -44,6 +44,7 @@ export default defineComponent({
   props: {
     milestone: {
       type: Object as () => ClaimedMilestoneModel,
+      required: true,
     },
     showScores: {
       type: Boolean,
@@ -51,6 +52,7 @@ export default defineComponent({
     },
     showDescription: {
       type: Boolean,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/Milestones.vue
+++ b/src/client/components/Milestones.vue
@@ -41,6 +41,7 @@ export default defineComponent({
   props: {
     milestones: {
       type: Array as () => Array<ClaimedMilestoneModel>,
+      required: true,
     },
     showScores: {
       type: Boolean,

--- a/src/client/components/OrOptions.vue
+++ b/src/client/components/OrOptions.vue
@@ -43,21 +43,27 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     playerinput: {
       type: Object as () => OrOptionsModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: OrOptionsResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/OtherPlayer.vue
+++ b/src/client/components/OtherPlayer.vue
@@ -51,9 +51,11 @@ export default defineComponent({
   props: {
     player: {
       type: Object as () => PublicPlayerModel,
+      required: true,
     },
     playerIndex: {
       type: Number,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/Party.vue
+++ b/src/client/components/Party.vue
@@ -27,12 +27,15 @@ export default defineComponent({
   props: {
     party: {
       type: Object as () => PartyModel,
+      required: true,
     },
     isDominant: {
       type: Boolean,
+      required: true,
     },
     isAvailable: {
       type: Boolean,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/PaymentUnit.vue
+++ b/src/client/components/PaymentUnit.vue
@@ -23,12 +23,15 @@ export default defineComponent({
   props: {
     value: {
       type: Number,
+      required: true,
     },
     unit: {
       type: String as () => SpendableResource,
+      required: true,
     },
     description: {
       type: String,
+      required: true,
     },
     showMax: {
       type: Boolean,

--- a/src/client/components/PlayerHome.vue
+++ b/src/client/components/PlayerHome.vue
@@ -353,9 +353,11 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     settings: {
       type: Object as () => typeof raw_settings,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/PlayerInputFactory.vue
+++ b/src/client/components/PlayerInputFactory.vue
@@ -62,21 +62,27 @@ export default Vue.component('player-input-factory', {
   props: {
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => PlayerInputModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: InputResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/PreferencesDialog.vue
+++ b/src/client/components/PreferencesDialog.vue
@@ -122,6 +122,7 @@ export default (Vue as WithRefs<Refs>).extend({
   props: {
     preferencesManager: {
       type: Object as () => PreferencesManager,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/SelectAmount.vue
+++ b/src/client/components/SelectAmount.vue
@@ -30,15 +30,19 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => SelectAmountModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectAmountResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectCard.vue
+++ b/src/client/components/SelectCard.vue
@@ -59,12 +59,15 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectCardModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectCardResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
@@ -73,6 +76,7 @@ export default defineComponent({
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): WidgetDataModel {

--- a/src/client/components/SelectClaimedUndergroundToken.vue
+++ b/src/client/components/SelectClaimedUndergroundToken.vue
@@ -35,18 +35,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectClaimedUndergroundTokenModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectClaimedUndergroundTokenResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectColony.vue
+++ b/src/client/components/SelectColony.vue
@@ -27,15 +27,19 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => SelectColonyModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectColonyResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectDelegate.vue
+++ b/src/client/components/SelectDelegate.vue
@@ -29,18 +29,23 @@ export default defineComponent({
   props: {
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectDelegateModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectDelegateResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectGlobalEvent.vue
+++ b/src/client/components/SelectGlobalEvent.vue
@@ -30,12 +30,15 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectGlobalEventModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectGlobalEventResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
@@ -44,6 +47,7 @@ export default defineComponent({
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectInitialCards.vue
+++ b/src/client/components/SelectInitialCards.vue
@@ -71,18 +71,23 @@ export default (Vue as WithRefs<Refs>).extend({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectInitialCardsModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectInitialCardsResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
     preferences: {
       type: Object as () => Readonly<Preferences>,

--- a/src/client/components/SelectOption.vue
+++ b/src/client/components/SelectOption.vue
@@ -19,15 +19,19 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => SelectOptionModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectOptionResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/SelectParty.vue
+++ b/src/client/components/SelectParty.vue
@@ -27,18 +27,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectPartyModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectPartyResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/SelectPayment.vue
+++ b/src/client/components/SelectPayment.vue
@@ -45,18 +45,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectPaymentModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectPaymentResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/SelectPlayer.vue
+++ b/src/client/components/SelectPlayer.vue
@@ -29,18 +29,23 @@ export default defineComponent({
   props: {
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectPlayerModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectPlayerResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectPlayerRow.vue
+++ b/src/client/components/SelectPlayerRow.vue
@@ -12,6 +12,7 @@ export default defineComponent({
   props: {
     player: {
       type: Object as () => PublicPlayerModel | undefined,
+      required: true,
     },
   },
 });

--- a/src/client/components/SelectProductionToLose.vue
+++ b/src/client/components/SelectProductionToLose.vue
@@ -70,15 +70,19 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => SelectProductionToLoseModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectProductionToLoseResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SelectProjectCardToPlay.vue
+++ b/src/client/components/SelectProjectCardToPlay.vue
@@ -81,18 +81,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectProjectCardToPlayModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectProjectCardToPlayResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/SelectResource.vue
+++ b/src/client/components/SelectResource.vue
@@ -25,18 +25,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectResourceModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectResourceResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/SelectResources.vue
+++ b/src/client/components/SelectResources.vue
@@ -33,18 +33,23 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     playerinput: {
       type: Object as () => SelectResourcesModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectResourcesResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/SelectSpace.vue
+++ b/src/client/components/SelectSpace.vue
@@ -44,15 +44,19 @@ export default (Vue as WithRefs<Refs>).extend({
   props: {
     playerinput: {
       type: Object as () => SelectSpaceModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: SelectSpaceResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/ShiftAresGlobalParameters.vue
+++ b/src/client/components/ShiftAresGlobalParameters.vue
@@ -57,15 +57,19 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => ShiftAresGlobalParametersModel,
+      required: true,
     },
     onsave: {
       type: Function as unknown as () => (out: ShiftAresGlobalParametersResponse) => void,
+      required: true,
     },
     showsave: {
       type: Boolean,
+      required: true,
     },
     showtitle: {
       type: Boolean,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/Sidebar.vue
+++ b/src/client/components/Sidebar.vue
@@ -90,48 +90,63 @@ export default defineComponent({
   props: {
     playerNumber: {
       type: Number,
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
     acting_player: {
       type: Boolean,
+      required: true,
     },
     player_color: {
       type: String as () => Color,
+      required: true,
     },
     generation: {
       type: Number,
+      required: true,
     },
     coloniesCount: {
       type: Number,
+      required: true,
     },
     temperature: {
       type: Number,
+      required: true,
     },
     oxygen: {
       type: Number,
+      required: true,
     },
     oceans: {
       type: Number,
+      required: true,
     },
     venus: {
       type: Number,
+      required: true,
     },
     moonData: {
       type: Object as () => MoonModel,
+      required: true,
     },
     turmoil: {
       type: Object as () => TurmoilModel || undefined,
+      required: true,
     },
     lastSoloGeneration: {
       type: Number,
+      required: true,
     },
     deckSize: {
       type: Number,
+      required: true,
     },
     discardPileSize: {
       type: Number,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/SortableCards.vue
+++ b/src/client/components/SortableCards.vue
@@ -46,9 +46,11 @@ export default defineComponent({
   props: {
     cards: {
       type: Array as () => Array<CardModel>,
+      required: true,
     },
     playerId: {
       type: String,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/SpectatorHome.vue
+++ b/src/client/components/SpectatorHome.vue
@@ -112,9 +112,11 @@ export default defineComponent({
   props: {
     spectator: {
       type: Object as () => SpectatorModel,
+      required: true,
     },
     settings: {
       type: Object as () => typeof raw_settings,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/StackedCards.vue
+++ b/src/client/components/StackedCards.vue
@@ -17,6 +17,7 @@ export default defineComponent({
   props: {
     cards: {
       type: Array as () => Array<CardModel>,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/Tag.vue
+++ b/src/client/components/Tag.vue
@@ -12,12 +12,15 @@ export default defineComponent({
   props: {
     tag: {
       type: String as () => Tag,
+      required: true,
     },
     size: {
       type: String,
+      required: true,
     },
     type: {
       type: String,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/TagCount.vue
+++ b/src/client/components/TagCount.vue
@@ -22,6 +22,7 @@ export default defineComponent({
   props: {
     tag: {
       type: String as () => CardTag|SpecialTags|'escape',
+      required: true,
     },
     undergroundToken: {
       type: String as () => TemporaryBonusToken | undefined,
@@ -30,12 +31,15 @@ export default defineComponent({
     },
     count: {
       type: [Number, String] as PropType<number | string>,
+      required: true,
     },
     size: {
       type: String,
+      required: true,
     },
     type: {
       type: String,
+      required: true,
     },
     showWhenZero: {
       // When true, show even if the value is zero.

--- a/src/client/components/TopBar.vue
+++ b/src/client/components/TopBar.vue
@@ -19,6 +19,7 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/WaitingFor.vue
+++ b/src/client/components/WaitingFor.vue
@@ -62,15 +62,19 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => PlayerViewModel,
+      required: true,
     },
     players: {
       type: Array as () => Array<PublicPlayerModel>,
+      required: true,
     },
     settings: {
       type: Object as () => typeof raw_settings,
+      required: true,
     },
     waitingfor: {
       type: Object as () => PlayerInputModel | undefined,
+      required: true,
     },
   },
   data(): DataModel {

--- a/src/client/components/admin/GameOverview.vue
+++ b/src/client/components/admin/GameOverview.vue
@@ -31,12 +31,15 @@ export default defineComponent({
   props: {
     status: {
       type: String as () => Status,
+      required: true,
     },
     game: {
       type: Object as () => SimpleGameModel | undefined,
+      required: true,
     },
     id: {
       type: String,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/board/BoardSpaceTile.vue
+++ b/src/client/components/board/BoardSpaceTile.vue
@@ -104,9 +104,11 @@ export default defineComponent({
   props: {
     space: {
       type: Object as () => SpaceModel,
+      required: true,
     },
     aresExtension: {
       type: Boolean,
+      required: true,
     },
     tileView: {
       type: String as () => TileView,

--- a/src/client/components/card/CardContent.vue
+++ b/src/client/components/card/CardContent.vue
@@ -28,6 +28,7 @@ export default defineComponent({
     },
     requirements: {
       type: Array<CardRequirementDescriptor>,
+      required: true,
     },
     isCorporation: {
       type: Boolean,
@@ -35,6 +36,7 @@ export default defineComponent({
     },
     bottomPadding: {
       type: String, // '', 'short', 'long'
+      required: true,
     },
   },
   components: {

--- a/src/client/components/card/CardCost.vue
+++ b/src/client/components/card/CardCost.vue
@@ -18,9 +18,11 @@ export default defineComponent({
   props: {
     amount: {
       type: Number as () => number | undefined,
+      required: true,
     },
     newCost: {
       type: Number as () => number | undefined,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/card/CardHelp.vue
+++ b/src/client/components/card/CardHelp.vue
@@ -12,6 +12,7 @@ export default defineComponent({
   props: {
     name: {
       type: String as () => CardName,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/card/CardRenderItemComponent.vue
+++ b/src/client/components/card/CardRenderItemComponent.vue
@@ -21,6 +21,7 @@ export default defineComponent({
   props: {
     item: {
       type: Object as () => ICardRenderItem,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/colonies/Colony.vue
+++ b/src/client/components/colonies/Colony.vue
@@ -136,6 +136,7 @@ export default defineComponent({
   props: {
     colony: {
       type: Object as () => ColonyModel,
+      required: true,
     },
     active: {
       type: Boolean,

--- a/src/client/components/colonies/ColonyRow.vue
+++ b/src/client/components/colonies/ColonyRow.vue
@@ -29,6 +29,7 @@ export default defineComponent({
     },
     colony: {
       type: Object as () => ColonyModel,
+      required: true,
     },
   },
 });

--- a/src/client/components/colonies/ColonySpace.vue
+++ b/src/client/components/colonies/ColonySpace.vue
@@ -22,6 +22,7 @@ export default defineComponent({
   props: {
     idx: {
       type: Number,
+      required: true,
     },
     metadata: {
       type: Object as () => ColonyMetadata,
@@ -29,9 +30,11 @@ export default defineComponent({
     },
     player: {
       type: String as () => Color | undefined,
+      required: true,
     },
     marker: {
       type: Boolean,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/common/ConfirmDialog.vue
+++ b/src/client/components/common/ConfirmDialog.vue
@@ -30,6 +30,7 @@ export default (Vue as WithRefs<Refs>).extend({
   props: {
     message: {
       type: String,
+      required: true,
     },
     enableDontShowAgainCheckbox: {
       type: Boolean,

--- a/src/client/components/common/PurgeWarning.vue
+++ b/src/client/components/common/PurgeWarning.vue
@@ -17,6 +17,7 @@ export default defineComponent({
   props: {
     expectedPurgeTimeMs: {
       type: Number,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/gameend/VictoryPointChart.vue
+++ b/src/client/components/gameend/VictoryPointChart.vue
@@ -55,15 +55,19 @@ export default defineComponent({
   props: {
     datasets: {
       type: Array as () => Array<DataSet>,
+      required: true,
     },
     generation: {
       type: Number,
+      required: true,
     },
     animation: {
       type: Boolean,
+      required: true,
     },
     id: {
       type: String,
+      required: true,
     },
     yAxisLabel: {
       type: String,

--- a/src/client/components/logpanel/LogMessageComponent.vue
+++ b/src/client/components/logpanel/LogMessageComponent.vue
@@ -66,9 +66,11 @@ export default defineComponent({
   props: {
     message: {
       type: Object as () => LogMessage,
+      required: true,
     },
     viewModel: {
       type: Object as () => ViewModel,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/logpanel/LogPanel.vue
+++ b/src/client/components/logpanel/LogPanel.vue
@@ -52,9 +52,11 @@ export default defineComponent({
   props: {
     viewModel: {
       type: Object as () => ViewModel,
+      required: true,
     },
     color: {
       type: String as () => Color,
+      required: true,
     },
     step: {
       type: Number,

--- a/src/client/components/moon/MoonBoard.vue
+++ b/src/client/components/moon/MoonBoard.vue
@@ -93,6 +93,7 @@ export default defineComponent({
   props: {
     model: {
       type: Object as () => MoonModel,
+      required: true,
     },
     tileView: {
       type: String as () => TileView,

--- a/src/client/components/moon/MoonGlobalParameterValue.vue
+++ b/src/client/components/moon/MoonGlobalParameterValue.vue
@@ -30,6 +30,7 @@ export default defineComponent({
   props: {
     moonData: {
       type: Object as () => MoonModel,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/moon/MoonSpace.vue
+++ b/src/client/components/moon/MoonSpace.vue
@@ -30,6 +30,7 @@ export default defineComponent({
   props: {
     space: {
       type: Object as () => SpaceModel,
+      required: true,
     },
     text: {
       type: String,

--- a/src/client/components/overview/PlayerAlliedParty.vue
+++ b/src/client/components/overview/PlayerAlliedParty.vue
@@ -17,6 +17,7 @@ export default defineComponent({
   props: {
     player: {
       type: Object as () => PublicPlayerModel,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/overview/PlayerInfo.vue
+++ b/src/client/components/overview/PlayerInfo.vue
@@ -62,9 +62,11 @@ export default defineComponent({
   props: {
     player: {
       type: Object as () => PublicPlayerModel,
+      required: true,
     },
     playerView: {
       type: Object as () => ViewModel,
+      required: true,
     },
     firstForGen: {
       type: Boolean,
@@ -76,6 +78,7 @@ export default defineComponent({
     },
     playerIndex: {
       type: Number,
+      required: true,
     },
     hideZeroTags: {
       type: Boolean,

--- a/src/client/components/overview/PlayerResource.vue
+++ b/src/client/components/overview/PlayerResource.vue
@@ -29,12 +29,15 @@ export default defineComponent({
   props: {
     type: {
       type: String as () => Resource,
+      required: true,
     },
     count: {
       type: Number,
+      required: true,
     },
     production: {
       type: Number,
+      required: true,
     },
     resourceProtection: {
       type: String as () => Protection,

--- a/src/client/components/overview/PlayerResources.vue
+++ b/src/client/components/overview/PlayerResources.vue
@@ -55,6 +55,7 @@ export default defineComponent({
   props: {
     player: {
       type: Object as () => PublicPlayerModel,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/overview/PlayerStatus.vue
+++ b/src/client/components/overview/PlayerStatus.vue
@@ -21,15 +21,19 @@ export default defineComponent({
   props: {
     timer: {
       type: Object as () => TimerModel,
+      required: true,
     },
     actionLabel: {
       type: String as () => ActionLabel,
+      required: true,
     },
     showTimer: {
       type: Boolean,
+      required: true,
     },
     liveTimer: {
       type: Boolean,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/overview/PlayerTagDiscount.vue
+++ b/src/client/components/overview/PlayerTagDiscount.vue
@@ -14,6 +14,7 @@ export default defineComponent({
   props: {
     amount: {
       type: Number,
+      required: true,
     },
   },
 });

--- a/src/client/components/overview/PlayerTags.vue
+++ b/src/client/components/overview/PlayerTags.vue
@@ -131,12 +131,15 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => ViewModel,
+      required: true,
     },
     player: {
       type: Object as () => PublicPlayerModel,
+      required: true,
     },
     hideZeroTags: {
       type: Boolean,
+      required: true,
     },
     isTopBar: {
       type: Boolean,

--- a/src/client/components/overview/PlayerTimer.vue
+++ b/src/client/components/overview/PlayerTimer.vue
@@ -20,9 +20,11 @@ export default defineComponent({
   props: {
     timer: {
       type: Object as () => TimerModel,
+      required: true,
     },
     live: {
       type: Boolean,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/overview/PlayersOverview.vue
+++ b/src/client/components/overview/PlayersOverview.vue
@@ -54,6 +54,7 @@ export default defineComponent({
   props: {
     playerView: {
       type: Object as () => ViewModel,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/overview/PointsPerTag.vue
+++ b/src/client/components/overview/PointsPerTag.vue
@@ -21,6 +21,7 @@ export default defineComponent({
   props: {
     points: {
       type: Object as () => Points,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/pathfinders/PlanetaryTrack.vue
+++ b/src/client/components/pathfinders/PlanetaryTrack.vue
@@ -19,13 +19,16 @@ export default defineComponent({
   props: {
     val: {
       type: Number,
+      required: true,
     },
     type: String as () => 'risingPlayer' | 'everyone' | 'mostTags',
     rewards: {
       type: Object as () => Track,
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
   },
   data() {

--- a/src/client/components/pathfinders/PlanetaryTrackReward.vue
+++ b/src/client/components/pathfinders/PlanetaryTrackReward.vue
@@ -17,9 +17,11 @@ export default defineComponent({
   props: {
     reward: {
       type: String as () => Reward,
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/pathfinders/PlanetaryTrackRewards.vue
+++ b/src/client/components/pathfinders/PlanetaryTrackRewards.vue
@@ -18,12 +18,15 @@ export default defineComponent({
   props: {
     rewards: {
       type: Object as () => PlanetaryTrackSpace,
+      required: true,
     },
     type: {
       type: String as () => 'risingPlayer' | 'everyone',
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/pathfinders/PlanetaryTracks.vue
+++ b/src/client/components/pathfinders/PlanetaryTracks.vue
@@ -58,9 +58,11 @@ export default defineComponent({
   props: {
     tracks: {
       type: Object as () => PathfindersModel,
+      required: true,
     },
     gameOptions: {
       type: Object as () => GameOptionsModel,
+      required: true,
     },
   },
   components: {

--- a/src/client/components/turmoil/AlliedPartyAgenda.vue
+++ b/src/client/components/turmoil/AlliedPartyAgenda.vue
@@ -51,6 +51,7 @@ export default defineComponent({
   props: {
     id: {
       type: String as () => PolicyId,
+      required: true,
     },
   },
 });

--- a/src/client/components/turmoil/GlobalEvent.vue
+++ b/src/client/components/turmoil/GlobalEvent.vue
@@ -47,9 +47,11 @@ export default defineComponent({
   props: {
     globalEventName: {
       type: String as () => GlobalEventName,
+      required: true,
     },
     type: {
       type: String as () => RenderType,
+      required: true,
     },
     showDistance: {
       type: Boolean,

--- a/src/client/components/turmoil/Turmoil.vue
+++ b/src/client/components/turmoil/Turmoil.vue
@@ -94,6 +94,7 @@ export default defineComponent({
   props: {
     turmoil: {
       type: Object as () => TurmoilModel,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/turmoil/TurmoilAgenda.vue
+++ b/src/client/components/turmoil/TurmoilAgenda.vue
@@ -192,6 +192,7 @@ export default defineComponent({
   props: {
     id: {
       type: String as () => BonusId | PolicyId | undefined,
+      required: true,
     },
   },
 });

--- a/src/client/components/underworld/UndergroundToken.vue
+++ b/src/client/components/underworld/UndergroundToken.vue
@@ -16,9 +16,11 @@ export default defineComponent({
   props: {
     token: {
       type: Object as () => ClaimedToken,
+      required: true,
     },
     location: {
       type: String as () => 'board' | 'player-home' | 'tag-count',
+      required: true,
     },
   },
   computed: {

--- a/src/client/components/underworld/UndergroundTokens.vue
+++ b/src/client/components/underworld/UndergroundTokens.vue
@@ -24,6 +24,7 @@ export default defineComponent({
   props: {
     underworldData: {
       type: Object as () => UnderworldPlayerData,
+      required: true,
     },
   },
   methods: {

--- a/src/client/components/waitingFor/GoToMap.vue
+++ b/src/client/components/waitingFor/GoToMap.vue
@@ -14,6 +14,7 @@ export default defineComponent({
   props: {
     playerinput: {
       type: Object as () => SelectSpaceModel,
+      required: true,
     },
   },
   methods: {


### PR DESCRIPTION
Mark 234 props across 82 components as explicitly required where they had no required: false or default value. This makes prop contracts explicit and aligns with Vue 3 stricter prop validation.