### PR TITLE
Fix Mars Maths research cap with short decks

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -647,6 +647,8 @@ export class Player implements IPlayer {
       this.draftedCards = newStandardDraft(this.game).draw(this);
     }
 
+    // If there are 4 cards to choose from, choose 4. If there are 5 because of Mars maths or Luna Project Office,
+    // choose 4. If there are fewer cards because of an exhausted draw pile, draw whatever is available.
     let selectable = this.draftedCards.length;
     if (this.playedCards.has(CardName.MARS_MATHS) && !this.playedCards.has(CardName.LUNA_PROJECT_OFFICE)) {
       selectable = Math.min(selectable, 4);

--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -649,7 +649,7 @@ export class Player implements IPlayer {
 
     let selectable = this.draftedCards.length;
     if (this.playedCards.has(CardName.MARS_MATHS) && !this.playedCards.has(CardName.LUNA_PROJECT_OFFICE)) {
-      selectable--;
+      selectable = Math.min(selectable, 4);
     }
 
     const cards = copyAndClear(this.draftedCards);

--- a/tests/cards/pathfinders/MarsMaths.spec.ts
+++ b/tests/cards/pathfinders/MarsMaths.spec.ts
@@ -3,6 +3,9 @@ import {testGame} from '../../TestGame';
 import {MarsMaths} from '../../../src/server/cards/pathfinders/MarsMaths';
 import {cast, finishGeneration, runAllActions} from '../../TestingUtils';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
+import {LunarBeam} from '../../../src/server/cards/base/LunarBeam';
+import {Insulation} from '../../../src/server/cards/base/Insulation';
+import {IoMiningIndustries} from '../../../src/server/cards/base/IoMiningIndustries';
 
 describe('MarsMaths', () => {
   let card: MarsMaths;
@@ -87,5 +90,22 @@ describe('MarsMaths', () => {
     expect(selectCard.config.max).eq(4);
     const selectCard2 = cast(player2.popWaitingFor(), SelectCard);
     expect(selectCard2.cards).has.length(4);
+  });
+
+  it('does not reduce research selection when fewer than five cards were drawn', () => {
+    const [game, player] = testGame(1, {skipInitialCardSelection: true, skipInitialShuffling: true});
+    game.generation = 2;
+    player.megaCredits = 20;
+    player.playedCards.push(new MarsMaths());
+    game.projectDeck.drawPile = [new LunarBeam(), new Insulation(), new IoMiningIndustries()];
+    game.projectDeck.discardPile = [];
+
+    game.gotoResearchPhase();
+
+    const selectCard = cast(player.popWaitingFor(), SelectCard);
+    const model = selectCard.toModel(player);
+
+    expect(selectCard.cards).has.length(3);
+    expect(model.max).eq(3);
   });
 });

--- a/tests/cards/pathfinders/MarsMaths.spec.ts
+++ b/tests/cards/pathfinders/MarsMaths.spec.ts
@@ -95,6 +95,7 @@ describe('MarsMaths', () => {
   it('does not reduce research selection when fewer than five cards were drawn', () => {
     const [game, player] = testGame(1, {skipInitialCardSelection: true, skipInitialShuffling: true});
     game.generation = 2;
+    // Enough to afford all 3 drawn cards, so only the Mars Maths cap is under test.
     player.megaCredits = 20;
     player.playedCards.push(new MarsMaths());
     game.projectDeck.drawPile = [new LunarBeam(), new Insulation(), new IoMiningIndustries()];
@@ -103,9 +104,8 @@ describe('MarsMaths', () => {
     game.gotoResearchPhase();
 
     const selectCard = cast(player.popWaitingFor(), SelectCard);
-    const model = selectCard.toModel(player);
 
     expect(selectCard.cards).has.length(3);
-    expect(model.max).eq(3);
+    expect(selectCard.config.max).eq(3);
   });
 });


### PR DESCRIPTION
## Summary

Mars Maths should let the player draw 5 cards during research but still buy at most 4 cards.

The previous implementation reduced the buy limit by 1 unconditionally. That worked when 5 cards were actually drawn, but it undercounted the allowed purchases when the deck had fewer than 5 cards remaining.

This change caps the purchase limit at 4 instead of always subtracting 1.

## Example

Before this patch:
- draw 4 cards with Mars Maths -> could only buy 3
- draw 3 cards with Mars Maths -> could only buy 2

After this patch:
- draw 4 cards with Mars Maths -> can buy 4
- draw 3 cards with Mars Maths -> can buy 3

## Tests

- added a regression test for Mars Maths with a short project deck in `tests/cards/pathfinders/MarsMaths.spec.ts`