### PR TITLE
Make Mars Nomads compatible with Geological Expedition

### DIFF
--- a/src/server/cards/ceos/Ingrid.ts
+++ b/src/server/cards/ceos/Ingrid.ts
@@ -33,6 +33,11 @@ export class Ingrid extends CeoCard {
 
   public onTilePlaced(cardOwner: IPlayer, activePlayer: IPlayer, space: Space, boardType: BoardType) {
     if (this.opgActionIsActive === false) return;
+    // onTilePlaced gets called with Mars Nomads, should be ignored here.
+    if (space.tile === undefined) {
+      return;
+    }
+
     // This filters for tiles only on mars (not moon), and includes Land+Oceans+'Coves'(landoceans)
     if (boardType !== BoardType.MARS || space.spaceType === SpaceType.COLONY) return;
     if (cardOwner.id !== activePlayer.id) return;

--- a/src/server/cards/community/CuriosityII.ts
+++ b/src/server/cards/community/CuriosityII.ts
@@ -50,7 +50,7 @@ export class CuriosityII extends CorporationCard implements ICorporationCard {
     const eligibleBonuses = [SpaceBonus.STEEL, SpaceBonus.TITANIUM, SpaceBonus.HEAT, SpaceBonus.PLANT, SpaceBonus.MEGACREDITS, SpaceBonus.ANIMAL, SpaceBonus.MICROBE, SpaceBonus.ENERGY];
 
     // onTilePlaced gets called with Mars Nomads, should be ignored here.
-    if (space.tile?.tileType === undefined) {
+    if (space.tile === undefined) {
       return;
     }
 

--- a/src/server/cards/community/CuriosityII.ts
+++ b/src/server/cards/community/CuriosityII.ts
@@ -49,6 +49,11 @@ export class CuriosityII extends CorporationCard implements ICorporationCard {
   public onTilePlaced(cardOwner: IPlayer, activePlayer: IPlayer, space: Space) {
     const eligibleBonuses = [SpaceBonus.STEEL, SpaceBonus.TITANIUM, SpaceBonus.HEAT, SpaceBonus.PLANT, SpaceBonus.MEGACREDITS, SpaceBonus.ANIMAL, SpaceBonus.MICROBE, SpaceBonus.ENERGY];
 
+    // onTilePlaced gets called with Mars Nomads, should be ignored here.
+    if (space.tile?.tileType === undefined) {
+      return;
+    }
+
     if (cardOwner.id !== activePlayer.id) return;
     if (cardOwner.game.phase === Phase.SOLAR) return;
     if (space.spaceType === SpaceType.COLONY) return;

--- a/src/server/cards/corporation/MiningGuild.ts
+++ b/src/server/cards/corporation/MiningGuild.ts
@@ -51,6 +51,10 @@ export class MiningGuild extends CorporationCard implements ICorporationCard {
     if (cardOwner.id !== activePlayer.id || cardOwner.game.phase === Phase.SOLAR) {
       return;
     }
+    // Don't grant a bonus for Mars Nomads (no tile actually placed)
+    if (cardOwner.game.nomadSpace === space.id && space.tile === undefined) {
+      return;
+    }
     // Don't grant a bonus if the card is overplaced (like Ares Ocean City)
     if (space.tile?.covers !== undefined) {
       return;

--- a/src/server/cards/pathfinders/Steelaris.ts
+++ b/src/server/cards/pathfinders/Steelaris.ts
@@ -47,6 +47,10 @@ export class Steelaris extends CorporationCard implements ICorporationCard {
       return;
     }
     const tileType = space.tile?.tileType;
+    // onTilePlaced gets called with Mars Nomads, should be ignored here.
+    if (tileType === undefined) {
+      return;
+    }
     if (tileType === TileType.OCEAN || tileType === TileType.GREENERY) {
       return;
     }

--- a/src/server/cards/promo/MarsNomads.ts
+++ b/src/server/cards/promo/MarsNomads.ts
@@ -88,9 +88,10 @@ export class MarsNomads extends Card implements IActionCard {
         const coveringExistingSpace = AresHandler.hasHazardTile(space);
         player.game.grantPlacementBonuses(player, space, coveringExistingSpace);
 
-        // Trigger onTilePlaced callbacks (e.g. Geological Expedition) even though
-        // no actual tile is placed. Cards that require a physical tile (e.g. Mining
-        // Guild, Philares) guard against space.tile === undefined.
+        // Trigger onTilePlaced callbacks even though no actual tile is placed.
+        // e.g. Geological Expedition. This means that all onTilePlaced must
+        // be made aware that space.tile could be undefined. Not a great
+        // abstraction.
         for (const p of player.game.players) {
           for (const playedCard of p.tableau) {
             playedCard.onTilePlaced?.(p, player, space, BoardType.MARS);

--- a/src/server/cards/promo/MarsNomads.ts
+++ b/src/server/cards/promo/MarsNomads.ts
@@ -9,6 +9,7 @@ import {Player} from '../../Player';
 import {intersection} from '../../../common/utils/utils';
 import {message} from '../../logs/MessageBuilder';
 import {AresHandler} from '../../ares/AresHandler';
+import {BoardType} from '../../boards/BoardType';
 export class MarsNomads extends Card implements IActionCard {
   /*
    * A good page about this card: https://boardgamegeek.com/thread/3154812.
@@ -86,6 +87,15 @@ export class MarsNomads extends Card implements IActionCard {
         // to move Mars Nomads onto that space.
         const coveringExistingSpace = AresHandler.hasHazardTile(space);
         player.game.grantPlacementBonuses(player, space, coveringExistingSpace);
+
+        // Trigger onTilePlaced callbacks (e.g. Geological Expedition) even though
+        // no actual tile is placed. Cards that require a physical tile (e.g. Mining
+        // Guild, Philares) guard against space.tile === undefined.
+        for (const p of player.game.players) {
+          for (const playedCard of p.tableau) {
+            playedCard.onTilePlaced?.(p, player, space, BoardType.MARS);
+          }
+        }
 
         return undefined;
       });

--- a/src/server/cards/underworld/ExpeditionVehicles.ts
+++ b/src/server/cards/underworld/ExpeditionVehicles.ts
@@ -32,6 +32,11 @@ export class ExpeditionVehicles extends Card implements IProjectCard {
   }
 
   onTilePlaced(cardOwner: IPlayer, activePlayer: IPlayer, space: Space, boardType: BoardType) {
+    // onTilePlaced gets called with Mars Nomads, should be ignored here.
+    if (space.tile === undefined) {
+      return;
+    }
+
     if (cardOwner === activePlayer) {
       const game = activePlayer.game;
       const board = boardType === BoardType.MARS ? game.board : MoonExpansion.moonData(game).moon;

--- a/tests/cards/promo/MarsNomads.spec.ts
+++ b/tests/cards/promo/MarsNomads.spec.ts
@@ -14,6 +14,10 @@ import {Philares} from '../../../src/server/cards/promo/Philares';
 import {EmptyBoard} from '../../testing/EmptyBoard';
 import {LandClaim} from '../../../src/server/cards/base/LandClaim';
 import {MiningGuild} from '../../../src/server/cards/corporation/MiningGuild';
+import {GeologicalExpedition} from '../../../src/server/cards/pathfinders/GeologicalExpedition';
+import {Steelaris} from '../../../src/server/cards/pathfinders/Steelaris';
+import {CuriosityII} from '../../../src/server/cards/community/CuriosityII';
+import {ExpeditionVehicles} from '../../../src/server/cards/underworld/ExpeditionVehicles';
 import {intersection} from '../../../src/common/utils/utils';
 
 describe('MarsNomads', () => {
@@ -270,6 +274,103 @@ describe('MarsNomads', () => {
       expect(player.steel).eq(1);
       expect(player.production.steel).eq(0);
     });
+  });
+
+  it('Move triggers Geological Expedition bonus', () => {
+    game.board = EmptyBoard.newInstance();
+    const geologicalExpedition = new GeologicalExpedition();
+    player.playedCards.push(geologicalExpedition);
+
+    const firstSpace = game.board.getSpaceOrThrow('05');
+    const space = game.board.getSpaceOrThrow('04');
+    game.nomadSpace = firstSpace.id;
+
+    space.bonus = [SpaceBonus.STEEL];
+    const selectSpace = cast(card.action(player), SelectSpace);
+    expect(selectSpace.spaces).contains(space);
+    selectSpace.cb(space);
+    runAllActions(game);
+
+    // Player gets 1 steel from placement bonus + 1 steel from Geological Expedition
+    expect(player.steel).eq(2);
+  });
+
+  it('Move to empty bonus space grants 1 steel from Geological Expedition', () => {
+    game.board = EmptyBoard.newInstance();
+    const geologicalExpedition = new GeologicalExpedition();
+    player.playedCards.push(geologicalExpedition);
+
+    const firstSpace = game.board.getSpaceOrThrow('05');
+    const space = game.board.getSpaceOrThrow('04');
+    game.nomadSpace = firstSpace.id;
+
+    space.bonus = [];
+    const selectSpace = cast(card.action(player), SelectSpace);
+    expect(selectSpace.spaces).contains(space);
+    selectSpace.cb(space);
+    runAllActions(game);
+
+    // No placement bonus, but Geological Expedition grants 1 steel for empty bonus spaces
+    expect(player.steel).eq(1);
+  });
+
+  it('Compatible with Steelaris', () => {
+    game.board = EmptyBoard.newInstance();
+    const steelaris = new Steelaris();
+    player.playedCards.push(steelaris);
+
+    const firstSpace = game.board.getSpaceOrThrow('05');
+    const space = game.board.getSpaceOrThrow('04');
+    game.nomadSpace = firstSpace.id;
+
+    const selectSpace = cast(card.action(player), SelectSpace);
+    expect(selectSpace.spaces).contains(space);
+    selectSpace.cb(space);
+    runAllActions(game);
+
+    // Move does not trigger Steelaris
+    expect(player.steel).eq(0);
+    expect(player.plants).eq(0);
+  });
+
+  it('Compatible with Curiosity II', () => {
+    game.board = EmptyBoard.newInstance();
+    const curiosityII = new CuriosityII();
+    player.playedCards.push(curiosityII);
+
+    const firstSpace = game.board.getSpaceOrThrow('05');
+    const space = game.board.getSpaceOrThrow('04');
+    game.nomadSpace = firstSpace.id;
+
+    space.bonus = [SpaceBonus.STEEL];
+    const selectSpace = cast(card.action(player), SelectSpace);
+    expect(selectSpace.spaces).contains(space);
+    selectSpace.cb(space);
+    runAllActions(game);
+
+    // Move does not trigger Curiosity II
+    // Only the placement bonus is collected; Curiosity II does not trigger
+    expect(player.steel).eq(1);
+    cast(player.popWaitingFor(), undefined);
+  });
+
+  it('Compatible with Expedition Vehicles', () => {
+    game.board = EmptyBoard.newInstance();
+    const expeditionVehicles = new ExpeditionVehicles();
+    player.playedCards.push(expeditionVehicles);
+
+    const firstSpace = game.board.getSpaceOrThrow('05');
+    const space = game.board.getSpaceOrThrow('04');
+    game.nomadSpace = firstSpace.id;
+
+    // Space is isolated — no adjacent real tiles — but still should not draw a card
+    const selectSpace = cast(card.action(player), SelectSpace);
+    expect(selectSpace.spaces).contains(space);
+    selectSpace.cb(space);
+    runAllActions(game);
+
+    // Expeccted that move does not trigger Expedition Vehicles.0
+    expect(player.cardsInHand).has.length(0);
   });
 
   describe('Compatible with Ares', () => {


### PR DESCRIPTION
Mars Nomads bypassed the normal tile placement flow, calling grantPlacementBonuses directly but never firing onTilePlaced callbacks. This meant Geological Expedition (and similar cards) never triggered on a nomad move.

Added onTilePlaced invocation in MarsNomads after grantPlacementBonuses. Because no tile is actually placed, five cards that don't check space.tile now guard against the nomad case: MiningGuild, Steelaris, CuriosityII, Ingrid, and ExpeditionVehicles.

Fixes #7729