### PR TITLE
Return full current-generation logs when explicitly requested

### DIFF
--- a/src/server/routes/GameLogs.ts
+++ b/src/server/routes/GameLogs.ts
@@ -40,12 +40,12 @@ export class GameLogs {
       }
     };
 
-    // for most recent generation pull last 50 log messages
-    if (generation === null || Number(generation) === game.generation) {
+    // Default view keeps the payload small. An explicit generation request should
+    // always return the full generation, including the current one.
+    if (generation === null) {
       return game.gameLog.filter(messagesForPlayer).slice(-50);
-    } else { // pull all logs for generation
-      return this.getLogsForGeneration(game.gameLog, Number(generation)).filter(messagesForPlayer);
     }
+    return this.getLogsForGeneration(game.gameLog, Number(generation)).filter(messagesForPlayer);
   }
 
   public getLogsForGameEnd(game: IGame): Array<string> {

--- a/tests/routes/ApiGameLogs.spec.ts
+++ b/tests/routes/ApiGameLogs.spec.ts
@@ -62,6 +62,26 @@ describe('ApiGameLogs', () => {
     expect(messages[messages.length - 1].data[0].value).eq('50');
   });
 
+  it('pulls full current generation when explicitly requested', async () => {
+    const player = TestPlayer.BLACK.newPlayer();
+    const game = Game.newInstance('game-id', [player], player);
+    await scaffolding.ctx.gameLoader.add(game);
+
+    game.gameLog.length = 0;
+    game.log('Generation ${0}', (b) => b.forNewGeneration().number(1));
+    for (let i = 0; i < 60; i++) {
+      game.log(`Log ${i}`);
+    }
+
+    scaffolding.url = '/api/game/logs?id=' + player.id + '&generation=1';
+    await scaffolding.get(ApiGameLogs.INSTANCE, res);
+    const messages = JSON.parse(res.content);
+
+    expect(messages).has.length(61);
+    expect(messages[0].message).eq('Generation ${0}');
+    expect(messages[messages.length - 1].message).eq('Log 59');
+  });
+
   it('pulls logs for first generation', async () => {
     const player = TestPlayer.BLACK.newPlayer();
     scaffolding.url = '/api/game/logs?id=' + player.id;


### PR DESCRIPTION
## Summary

When the client explicitly requests the current generation, the server should return the full generation log instead of truncating it to the last 50 messages.

The default log view still keeps the lightweight tail behavior.

## Why

In larger games, the current generation can exceed 50 log entries. That makes the beginning of the current generation unreachable even when the user clicks the current generation explicitly.

## Validation

- `npx mocha --import=tsx --require tests/testing/setup.ts tests/routes/ApiGameLogs.spec.ts`
- result: `13 passing`