### PR TITLE
[REFACTOR] colony benefit execution into a single benefits.ts module

### DIFF
--- a/src/common/colonies/ColonyMetadata.ts
+++ b/src/common/colonies/ColonyMetadata.ts
@@ -5,19 +5,22 @@ import {CardResource} from '../CardResource';
 import {Expansion, GameModule} from '../cards/GameModule';
 import {OneOrArray} from '../utils/types';
 
-type Benefit<S, T> = {
+// Describes a colony benefit: the effect granted when building, trading, or receiving a colony bonus.
+// quantity is OneOrArray<number>: a scalar for colony bonuses, an array indexed by track position for build/trade.
+// resource is OneOrArray<Resource>: a scalar for most benefits, an array indexed by track position for trade benefits.
+export type Benefit = {
   description: string,
   type: ColonyBenefit;
-  quantity: S
-  resource?: T;
+  quantity: OneOrArray<number>;
+  resource?: OneOrArray<Resource>;
 }
 
 export type ColonyMetadata = Readonly<{
   module?: GameModule; // TODO(kberg): attach gameModule to the server colonies themselves.
   name: ColonyName;
-  build: Benefit<Array<number>, Resource>, // Default is [1,1,1]
-  trade: Benefit<Array<number>, OneOrArray<Resource>>, // Default is [1,1,1,1,1,1,1]
-  colony: Benefit<number, Resource>, // Default is 1
+  build: Benefit, // Default quantity is [1,1,1]
+  trade: Benefit, // Default quantity is [1,1,1,1,1,1,1]
+  colony: Benefit, // Default quantity is 1
   cardResource?: CardResource,
   expansion: Expansion | undefined,
 
@@ -35,21 +38,19 @@ export type ColonyMetadata = Readonly<{
   shouldIncreaseTrack: 'yes' | 'no' | 'ask'
 }>;
 
-type InputBenefit<T extends Benefit<any, any>> = {
+type InputBenefit = {
   description: string,
   type: ColonyBenefit,
-  quantity?: T['quantity'],
-  resource?: T['resource'],
+  quantity?: OneOrArray<number>,
+  resource?: OneOrArray<Resource>,
 }
-// {[P in Exclude<keyof T, 'quantity'>]: T[P]} &
-// {quantity?: T['quantity']};
 
 export type InputColonyMetadata = {
   module?: ColonyMetadata['module'],
   name: ColonyMetadata['name'];
-  build: InputBenefit<ColonyMetadata['build']>,
-  trade: InputBenefit<ColonyMetadata['trade']>,
-  colony: InputBenefit<ColonyMetadata['colony']>,
+  build: InputBenefit,
+  trade: InputBenefit,
+  colony: InputBenefit,
   cardResource?: CardResource,
   expansion?: Expansion,
 } & Partial<{
@@ -59,7 +60,7 @@ export type InputColonyMetadata = {
 const DEFAULT_BUILD_QUANTITY = [1, 1, 1];
 const DEFAULT_TRADE_QUANTITY = [1, 1, 1, 1, 1, 1, 1];
 
-export function benefitMetadata<S, T>(partial: InputBenefit<Benefit<S, T>>, defaultQuantity: S): Benefit<S, T> {
+export function benefitMetadata(partial: InputBenefit, defaultQuantity: OneOrArray<number>): Benefit {
   return {
     ...partial,
     quantity: partial.quantity ?? defaultQuantity,

--- a/src/server/colonies/Colony.ts
+++ b/src/server/colonies/Colony.ts
@@ -1,38 +1,22 @@
-import {AddResourcesToCard} from '../deferredActions/AddResourcesToCard';
-import {ColonyBenefit} from '../../common/colonies/ColonyBenefit';
-import {DeferredAction, SimpleDeferredAction} from '../deferredActions/DeferredAction';
-import {Priority} from '../deferredActions/Priority';
-import {DiscardCards} from '../deferredActions/DiscardCards';
-import {DrawCards} from '../deferredActions/DrawCards';
 import {GiveColonyBonus} from '../deferredActions/GiveColonyBonus';
 import {IncreaseColonyTrack} from '../deferredActions/IncreaseColonyTrack';
 import {LogHelper} from '../LogHelper';
 import {MAX_COLONIES_PER_TILE, MAX_COLONY_TRACK_POSITION} from '../../common/constants';
-import {PlaceOceanTile} from '../deferredActions/PlaceOceanTile';
 import {IPlayer} from '../IPlayer';
 import {PlayerId} from '../../common/Types';
 import {PlayerInput} from '../PlayerInput';
+import {Priority} from '../deferredActions/Priority';
 import {Resource} from '../../common/Resource';
-import {ScienceTagCard} from '../cards/community/ScienceTagCard';
-import {SelectColony} from '../inputs/SelectColony';
-import {SelectPlayer} from '../inputs/SelectPlayer';
-import {StealResources} from '../deferredActions/StealResources';
 import {Tag} from '../../common/cards/Tag';
-import {SendDelegateToArea} from '../deferredActions/SendDelegateToArea';
 import {IGame} from '../IGame';
-import {Turmoil} from '../turmoil/Turmoil';
 import {SerializedColony} from '../SerializedColony';
-import {IColony, TradeOptions} from './IColony';
-import {ColonyMetadata, colonyMetadata, InputColonyMetadata} from '../../common/colonies/ColonyMetadata';
+import {IColony, IColonyInternal, TradeOptions} from './IColony';
+import {Benefit, ColonyMetadata, colonyMetadata, InputColonyMetadata} from '../../common/colonies/ColonyMetadata';
 import {ColonyName} from '../../common/colonies/ColonyName';
-import {sum} from '../../common/utils/utils';
-import {message} from '../logs/MessageBuilder';
-import {PlaceHazardTile} from '../deferredActions/PlaceHazardTile';
-import {TileType} from '../../../src/common/TileType';
-import {ErodeSpacesDeferred} from '../underworld/ErodeSpacesDeferred';
 import {CardName} from '../../common/cards/CardName';
+import {benefitExecutors} from './benefits';
 
-export abstract class Colony implements IColony {
+export abstract class Colony implements IColony, IColonyInternal {
   // Players can't build colonies on Miranda until someone has played an Animal card.
   // isActive is the gateway for that action and any other card with that type of constraint
   // also isActive represents when the colony is part of the game, or "back in the box", as it were.
@@ -87,9 +71,9 @@ export abstract class Colony implements IColony {
   public addColony(player: IPlayer, options?: {giveBonusTwice: boolean}): void {
     player.game.log('${0} built a colony on ${1}', (b) => b.player(player).colony(this));
 
-    this.giveBonus(player, this.metadata.build.type, this.metadata.build.quantity[this.colonies.length], this.metadata.build.resource);
+    this.giveBonus(player, this.metadata.build, this.colonies.length);
     if (options?.giveBonusTwice === true) { // Vital Colony hook.
-      this.giveBonus(player, this.metadata.build.type, this.metadata.build.quantity[this.colonies.length], this.metadata.build.resource);
+      this.giveBonus(player, this.metadata.build, this.colonies.length);
     }
 
     this.colonies.push(player.id);
@@ -144,10 +128,8 @@ export abstract class Colony implements IColony {
       .andThen(() => this.handleTrade(player, tradeOptions));
   }
 
-  private handleTrade(player: IPlayer, options: TradeOptions) {
-    const resource = Array.isArray(this.metadata.trade.resource) ? this.metadata.trade.resource[this.trackPosition] : this.metadata.trade.resource;
-
-    this.giveBonus(player, this.metadata.trade.type, this.metadata.trade.quantity[this.trackPosition], resource);
+  public handleTrade(player: IPlayer, options: TradeOptions) {
+    this.giveBonus(player, this.metadata.trade, this.trackPosition);
 
     // !== false because default is true.
     if (options.giveColonyBonuses !== false) {
@@ -173,199 +155,13 @@ export abstract class Colony implements IColony {
   }
 
   public giveColonyBonus(player: IPlayer, isGiveColonyBonus: boolean = false): undefined | PlayerInput {
-    return this.giveBonus(player, this.metadata.colony.type, this.metadata.colony.quantity, this.metadata.colony.resource, isGiveColonyBonus);
+    return this.giveBonus(player, this.metadata.colony, 0, isGiveColonyBonus);
   }
 
-  private giveBonus(player: IPlayer, bonusType: ColonyBenefit, quantity: number, resource: Resource | undefined, isGiveColonyBonus: boolean = false): undefined | PlayerInput {
-    const game = player.game;
-
-    let action: undefined | DeferredAction<any> = undefined;
-    switch (bonusType) {
-    case ColonyBenefit.ADD_RESOURCES_TO_CARD:
-      const cardResource = this.metadata.cardResource;
-      action = new AddResourcesToCard(player, cardResource, {count: quantity});
-      break;
-
-    case ColonyBenefit.ADD_RESOURCES_TO_VENUS_CARD:
-      action = new AddResourcesToCard(
-        player,
-        undefined,
-        {
-          count: quantity,
-          restrictedTag: Tag.VENUS,
-          title: message('Select Venus card to add ${0} resource(s)', (b) => b.number(quantity)),
-        });
-      break;
-
-    case ColonyBenefit.COPY_TRADE:
-      const openColonies = game.colonies.filter((colony) => colony.isActive);
-      action = new SimpleDeferredAction(
-        player,
-        () => new SelectColony('Select colony to gain trade income from', 'Select', openColonies)
-          .andThen((colony) => {
-            game.log('${0} gained ${1} trade bonus', (b) => b.player(player).colony(colony));
-            (colony as Colony).handleTrade(player, {
-              usesTradeFleet: false,
-              decreaseTrackAfterTrade: false,
-              giveColonyBonuses: false,
-            });
-            return undefined;
-          }),
-      );
-      break;
-
-    case ColonyBenefit.DRAW_CARDS:
-      action = DrawCards.keepAll(player, quantity);
-      break;
-
-    case ColonyBenefit.DRAW_CARDS_AND_BUY_ONE:
-      action = DrawCards.keepSome(player, 1, {paying: true, logDrawnCard: true});
-      break;
-
-    case ColonyBenefit.DRAW_CARDS_AND_DISCARD_ONE:
-      player.defer(() => {
-        player.drawCard();
-        player.game.defer(new DiscardCards(player, 1, 1, this.name + ' colony bonus. Select a card to discard'), Priority.SUPERPOWER);
-      });
-      break;
-
-    case ColonyBenefit.DRAW_CARDS_AND_KEEP_ONE:
-      action = DrawCards.keepSome(player, quantity, {keepMax: 1});
-      break;
-
-    case ColonyBenefit.GAIN_CARD_DISCOUNT:
-      player.colonies.cardDiscount += 1;
-      game.log('Cards played by ${0} cost 1 M€ less this generation', (b) => b.player(player));
-      break;
-
-    case ColonyBenefit.GAIN_PRODUCTION:
-      if (resource === undefined) {
-        throw new Error('Resource cannot be undefined');
-      }
-      player.production.add(resource, quantity, {log: true});
-      break;
-
-    case ColonyBenefit.GAIN_RESOURCES:
-      if (resource === undefined) {
-        throw new Error('Resource cannot be undefined');
-      }
-      player.stock.add(resource, quantity, {log: true});
-      break;
-
-    case ColonyBenefit.GAIN_SCIENCE_TAG:
-      player.tags.extraScienceTags += 1;
-      player.playCard(new ScienceTagCard(), undefined, 'nothing');
-      game.log('${0} gained 1 Science tag', (b) => b.player(player));
-      break;
-
-    case ColonyBenefit.GAIN_SCIENCE_TAGS_AND_CLONE_TAG:
-      player.tags.extraScienceTags += 2;
-      player.playCard(new ScienceTagCard(), undefined, 'nothing');
-      game.log('${0} gained 2 Science tags', (b) => b.player(player));
-      break;
-
-    case ColonyBenefit.GAIN_INFLUENCE:
-      Turmoil.ifTurmoil(game, (turmoil) => {
-        turmoil.addInfluenceBonus(player);
-        game.log('${0} gained 1 influence', (b) => b.player(player));
-      });
-      break;
-
-    case ColonyBenefit.PLACE_DELEGATES:
-      Turmoil.ifTurmoil(game, (turmoil) => {
-        const availablePlayerDelegates = turmoil.getAvailableDelegateCount(player);
-        const qty = Math.min(quantity, availablePlayerDelegates);
-        for (let i = 0; i < qty; i++) {
-          game.defer(new SendDelegateToArea(player));
-        }
-      });
-      break;
-
-    case ColonyBenefit.GIVE_MC_PER_DELEGATE:
-      Turmoil.ifTurmoil(game, (turmoil) => {
-        const partyDelegateCount = sum(turmoil.parties.map((party) => party.delegates.get(player)));
-        player.stock.add(Resource.MEGACREDITS, partyDelegateCount, {log: true});
-      });
-      break;
-
-    case ColonyBenefit.PLACE_HAZARD_TILE:
-      const spaces = game.board.getAvailableSpacesOnLand(player)
-        .filter(((space) => space.tile === undefined))
-        .filter((space) => {
-          const adjacentSpaces = game.board.getAdjacentSpaces(space);
-          return adjacentSpaces.filter((space) => space.tile !== undefined).length === 0;
-        });
-
-      game.defer(new PlaceHazardTile(player, TileType.EROSION_MILD, {title: 'Select space next to no other tile for hazard', spaces}));
-      break;
-
-    case ColonyBenefit.ERODE_SPACES_ADJACENT_TO_HAZARDS:
-      game.defer(new ErodeSpacesDeferred(player, quantity));
-      break;
-
-    case ColonyBenefit.GAIN_MC_PER_HAZARD_TILE:
-      player.stock.megacredits += game.board.getHazards().length;
-      break;
-
-    case ColonyBenefit.GAIN_TR:
-      if (quantity > 0) {
-        player.increaseTerraformRating(quantity, {log: true});
-      }
-      break;
-
-    case ColonyBenefit.GAIN_VP:
-      if (quantity > 0) {
-        player.colonies.victoryPoints += quantity;
-        game.log('${0} gained ${1} VP', (b) => b.player(player).number(quantity));
-      }
-      break;
-
-    case ColonyBenefit.INCREASE_VENUS_SCALE:
-      game.increaseVenusScaleLevel(player, quantity as 3|2|1);
-      game.log('${0} increased Venus scale ${1} step(s)', (b) => b.player(player).number(quantity));
-      break;
-
-    case ColonyBenefit.LOSE_RESOURCES:
-      if (resource === undefined) {
-        throw new Error('Resource cannot be undefined');
-      }
-      player.stock.deduct(resource, Math.min(player.stock.get(resource), quantity), {log: true});
-      break;
-
-    case ColonyBenefit.OPPONENT_DISCARD:
-      if (game.isSoloMode()) {
-        break;
-      }
-      action = new SimpleDeferredAction(
-        player,
-        () => {
-          const playersWithCards = game.players.filter((p) => p.cardsInHand.length > 0);
-          if (playersWithCards.length === 0) {
-            return undefined;
-          }
-          return new SelectPlayer(playersWithCards, 'Select player to discard a card', 'Select')
-            .andThen((selectedPlayer) => {
-              game.defer(new DiscardCards(selectedPlayer, 1, 1, this.name + ' colony effect. Select a card to discard'));
-              return undefined;
-            });
-        });
-      break;
-
-    case ColonyBenefit.PLACE_OCEAN_TILE:
-      action = new PlaceOceanTile(player);
-      break;
-
-    case ColonyBenefit.STEAL_RESOURCES:
-      if (resource === undefined) {
-        throw new Error('Resource cannot be undefined');
-      }
-      action = new StealResources(player, resource, quantity);
-      break;
-
-    default:
-      throw new Error('Unsupported benefit type');
-    }
-
+  private giveBonus(player: IPlayer, benefit: Benefit, index: number, isGiveColonyBonus: boolean = false): undefined | PlayerInput {
+    const quantity = Array.isArray(benefit.quantity) ? benefit.quantity[index] : benefit.quantity;
+    const resource = Array.isArray(benefit.resource) ? benefit.resource[index] : benefit.resource;
+    const action = benefitExecutors[benefit.type](player, this, quantity, resource);
     if (action !== undefined) {
       if (isGiveColonyBonus) {
         /*
@@ -374,16 +170,13 @@ export abstract class Colony implements IColony {
          *
          * This is related to how certain colony bonuses require player interaction.
          * The deferred action queue doesn't work well when asking for inputs for
-         * multple players.
+         * multiple players.
          */
         return action.execute();
-      } else {
-        game.defer(action);
-        return undefined;
       }
-    } else {
-      return undefined;
+      player.game.defer(action);
     }
+    return undefined;
   }
 
   public serialize(): SerializedColony {

--- a/src/server/colonies/IColony.ts
+++ b/src/server/colonies/IColony.ts
@@ -13,6 +13,10 @@ export type TradeOptions = {
   selfishTrade?: boolean;
 };
 
+export interface IColonyInternal {
+  handleTrade(player: IPlayer, options: TradeOptions): void;
+}
+
 export interface IColony {
   readonly name: ColonyName;
   readonly metadata: ColonyMetadata;

--- a/src/server/colonies/benefits.ts
+++ b/src/server/colonies/benefits.ts
@@ -1,0 +1,257 @@
+import {AddResourcesToCard} from '../deferredActions/AddResourcesToCard';
+import {ColonyBenefit} from '../../common/colonies/ColonyBenefit';
+import {DeferredAction, SimpleDeferredAction} from '../deferredActions/DeferredAction';
+import {DiscardCards} from '../deferredActions/DiscardCards';
+import {DrawCards} from '../deferredActions/DrawCards';
+import {ErodeSpacesDeferred} from '../underworld/ErodeSpacesDeferred';
+import {IColony, IColonyInternal} from './IColony';
+import {IPlayer} from '../IPlayer';
+import {PlaceHazardTile} from '../deferredActions/PlaceHazardTile';
+import {PlaceOceanTile} from '../deferredActions/PlaceOceanTile';
+import {Priority} from '../deferredActions/Priority';
+import {Resource} from '../../common/Resource';
+import {ScienceTagCard} from '../cards/community/ScienceTagCard';
+import {SelectColony} from '../inputs/SelectColony';
+import {SelectPlayer} from '../inputs/SelectPlayer';
+import {SendDelegateToArea} from '../deferredActions/SendDelegateToArea';
+import {StealResources} from '../deferredActions/StealResources';
+import {Tag} from '../../common/cards/Tag';
+import {TileType} from '../../common/TileType';
+import {Turmoil} from '../turmoil/Turmoil';
+import {message} from '../logs/MessageBuilder';
+import {sum} from '../../common/utils/utils';
+
+export type BenefitExecutor = (
+  player: IPlayer,
+  colony: IColony,
+  quantity: number,
+  resource: Resource | undefined,
+) => DeferredAction<any> | undefined;
+
+function addResourcesToCard(player: IPlayer, colony: IColony, quantity: number): DeferredAction<any> {
+  return new AddResourcesToCard(player, colony.metadata.cardResource, {count: quantity});
+}
+
+function addResourcesToVenusCard(player: IPlayer, _colony: IColony, quantity: number): DeferredAction<any> {
+  return new AddResourcesToCard(player, undefined, {
+    count: quantity,
+    restrictedTag: Tag.VENUS,
+    title: message('Select Venus card to add ${0} resource(s)', (b) => b.number(quantity)),
+  });
+}
+
+function copyTrade(player: IPlayer): DeferredAction<any> {
+  const game = player.game;
+  const openColonies = game.colonies.filter((colony) => colony.isActive);
+  return new SimpleDeferredAction(
+    player,
+    () => new SelectColony('Select colony to gain trade income from', 'Select', openColonies)
+      .andThen((colony: IColony) => {
+        game.log('${0} gained ${1} trade bonus', (b) => b.player(player).colony(colony));
+        (colony as IColony & IColonyInternal).handleTrade(player, {
+          usesTradeFleet: false,
+          decreaseTrackAfterTrade: false,
+          giveColonyBonuses: false,
+        });
+        return undefined;
+      }),
+  );
+}
+
+function drawCards(player: IPlayer, _colony: IColony, quantity: number): DeferredAction<any> {
+  return DrawCards.keepAll(player, quantity);
+}
+
+function drawCardsAndBuyOne(player: IPlayer): DeferredAction<any> {
+  return DrawCards.keepSome(player, 1, {paying: true, logDrawnCard: true});
+}
+
+function drawCardsAndDiscardOne(player: IPlayer, colony: IColony): undefined {
+  player.defer(() => {
+    player.drawCard();
+    player.game.defer(new DiscardCards(player, 1, 1, colony.name + ' colony bonus. Select a card to discard'), Priority.SUPERPOWER);
+  });
+  return undefined;
+}
+
+function drawCardsAndKeepOne(player: IPlayer, _colony: IColony, quantity: number): DeferredAction<any> {
+  return DrawCards.keepSome(player, quantity, {keepMax: 1});
+}
+
+function erodeSpacesAdjacentToHazards(player: IPlayer, _colony: IColony, quantity: number): undefined {
+  player.game.defer(new ErodeSpacesDeferred(player, quantity));
+  return undefined;
+}
+
+function gainCardDiscount(player: IPlayer): undefined {
+  player.colonies.cardDiscount += 1;
+  player.game.log('Cards played by ${0} cost 1 M€ less this generation', (b) => b.player(player));
+  return undefined;
+}
+
+function gainInfluence(player: IPlayer): undefined {
+  Turmoil.ifTurmoil(player.game, (turmoil) => {
+    turmoil.addInfluenceBonus(player);
+    player.game.log('${0} gained 1 influence', (b) => b.player(player));
+  });
+  return undefined;
+}
+
+function gainMcPerHazardTile(player: IPlayer): undefined {
+  player.stock.megacredits += player.game.board.getHazards().length;
+  return undefined;
+}
+
+function gainProduction(player: IPlayer, _colony: IColony, quantity: number, resource: Resource | undefined): undefined {
+  if (resource === undefined) {
+    throw new Error('Resource cannot be undefined');
+  }
+  player.production.add(resource, quantity, {log: true});
+  return undefined;
+}
+
+function gainResources(player: IPlayer, _colony: IColony, quantity: number, resource: Resource | undefined): undefined {
+  if (resource === undefined) {
+    throw new Error('Resource cannot be undefined');
+  }
+  player.stock.add(resource, quantity, {log: true});
+  return undefined;
+}
+
+function gainScienceTag(player: IPlayer): undefined {
+  player.tags.extraScienceTags += 1;
+  player.playCard(new ScienceTagCard(), undefined, 'nothing');
+  player.game.log('${0} gained 1 Science tag', (b) => b.player(player));
+  return undefined;
+}
+
+function gainScienceTagsAndCloneTag(player: IPlayer): undefined {
+  player.tags.extraScienceTags += 2;
+  player.playCard(new ScienceTagCard(), undefined, 'nothing');
+  player.game.log('${0} gained 2 Science tags', (b) => b.player(player));
+  return undefined;
+}
+
+function gainTr(player: IPlayer, _colony: IColony, quantity: number): undefined {
+  if (quantity > 0) {
+    player.increaseTerraformRating(quantity, {log: true});
+  }
+  return undefined;
+}
+
+function gainVp(player: IPlayer, _colony: IColony, quantity: number): undefined {
+  if (quantity > 0) {
+    player.colonies.victoryPoints += quantity;
+    player.game.log('${0} gained ${1} VP', (b) => b.player(player).number(quantity));
+  }
+  return undefined;
+}
+
+function giveMcPerDelegate(player: IPlayer): undefined {
+  Turmoil.ifTurmoil(player.game, (turmoil) => {
+    const partyDelegateCount = sum(turmoil.parties.map((party) => party.delegates.get(player)));
+    player.stock.add(Resource.MEGACREDITS, partyDelegateCount, {log: true});
+  });
+  return undefined;
+}
+
+function increaseVenusScale(player: IPlayer, _colony: IColony, quantity: number): undefined {
+  player.game.increaseVenusScaleLevel(player, quantity as 3|2|1);
+  player.game.log('${0} increased Venus scale ${1} step(s)', (b) => b.player(player).number(quantity));
+  return undefined;
+}
+
+function loseResources(player: IPlayer, _colony: IColony, quantity: number, resource: Resource | undefined): undefined {
+  if (resource === undefined) {
+    throw new Error('Resource cannot be undefined');
+  }
+  player.stock.deduct(resource, Math.min(player.stock.get(resource), quantity), {log: true});
+  return undefined;
+}
+
+function opponentDiscard(player: IPlayer, colony: IColony): DeferredAction<any> | undefined {
+  const game = player.game;
+  if (game.isSoloMode()) {
+    return undefined;
+  }
+  return new SimpleDeferredAction(
+    player,
+    () => {
+      const playersWithCards = game.players.filter((p) => p.cardsInHand.length > 0);
+      if (playersWithCards.length === 0) {
+        return undefined;
+      }
+      return new SelectPlayer(playersWithCards, 'Select player to discard a card', 'Select')
+        .andThen((selectedPlayer) => {
+          game.defer(new DiscardCards(selectedPlayer, 1, 1, colony.name + ' colony effect. Select a card to discard'));
+          return undefined;
+        });
+    });
+}
+
+function placeDelegates(player: IPlayer, _colony: IColony, quantity: number): undefined {
+  Turmoil.ifTurmoil(player.game, (turmoil) => {
+    const availablePlayerDelegates = turmoil.getAvailableDelegateCount(player);
+    const qty = Math.min(quantity, availablePlayerDelegates);
+    for (let i = 0; i < qty; i++) {
+      player.game.defer(new SendDelegateToArea(player));
+    }
+  });
+  return undefined;
+}
+
+function placeHazardTile(player: IPlayer): undefined {
+  const game = player.game;
+  const spaces = game.board.getAvailableSpacesOnLand(player)
+    .filter((space) => space.tile === undefined)
+    .filter((space) => {
+      const adjacentSpaces = game.board.getAdjacentSpaces(space);
+      return adjacentSpaces.filter((space) => space.tile !== undefined).length === 0;
+    });
+  game.defer(new PlaceHazardTile(player, TileType.EROSION_MILD, {title: 'Select space next to no other tile for hazard', spaces}));
+  return undefined;
+}
+
+function placeOceanTile(player: IPlayer): DeferredAction<any> {
+  return new PlaceOceanTile(player);
+}
+
+function raisePlanetaryTrack(): never {
+  throw new Error('raisePlanetaryTrack is not yet implemented');
+}
+
+function stealResources(player: IPlayer, _colony: IColony, quantity: number, resource: Resource | undefined): DeferredAction<any> {
+  if (resource === undefined) {
+    throw new Error('Resource cannot be undefined');
+  }
+  return new StealResources(player, resource, quantity);
+}
+
+export const benefitExecutors: Record<ColonyBenefit, BenefitExecutor> = {
+  [ColonyBenefit.ADD_RESOURCES_TO_CARD]: addResourcesToCard,
+  [ColonyBenefit.ADD_RESOURCES_TO_VENUS_CARD]: addResourcesToVenusCard,
+  [ColonyBenefit.COPY_TRADE]: copyTrade,
+  [ColonyBenefit.DRAW_CARDS]: drawCards,
+  [ColonyBenefit.DRAW_CARDS_AND_BUY_ONE]: drawCardsAndBuyOne,
+  [ColonyBenefit.DRAW_CARDS_AND_DISCARD_ONE]: drawCardsAndDiscardOne,
+  [ColonyBenefit.DRAW_CARDS_AND_KEEP_ONE]: drawCardsAndKeepOne,
+  [ColonyBenefit.ERODE_SPACES_ADJACENT_TO_HAZARDS]: erodeSpacesAdjacentToHazards,
+  [ColonyBenefit.GAIN_CARD_DISCOUNT]: gainCardDiscount,
+  [ColonyBenefit.GAIN_INFLUENCE]: gainInfluence,
+  [ColonyBenefit.GAIN_MC_PER_HAZARD_TILE]: gainMcPerHazardTile,
+  [ColonyBenefit.GAIN_PRODUCTION]: gainProduction,
+  [ColonyBenefit.GAIN_RESOURCES]: gainResources,
+  [ColonyBenefit.GAIN_SCIENCE_TAG]: gainScienceTag,
+  [ColonyBenefit.GAIN_SCIENCE_TAGS_AND_CLONE_TAG]: gainScienceTagsAndCloneTag,
+  [ColonyBenefit.GAIN_TR]: gainTr,
+  [ColonyBenefit.GAIN_VP]: gainVp,
+  [ColonyBenefit.GIVE_MC_PER_DELEGATE]: giveMcPerDelegate,
+  [ColonyBenefit.INCREASE_VENUS_SCALE]: increaseVenusScale,
+  [ColonyBenefit.LOSE_RESOURCES]: loseResources,
+  [ColonyBenefit.OPPONENT_DISCARD]: opponentDiscard,
+  [ColonyBenefit.PLACE_DELEGATES]: placeDelegates,
+  [ColonyBenefit.PLACE_HAZARD_TILE]: placeHazardTile,
+  [ColonyBenefit.PLACE_OCEAN_TILE]: placeOceanTile,
+  [ColonyBenefit.RAISE_PLANETARY_TRACK]: raisePlanetaryTrack,
+  [ColonyBenefit.STEAL_RESOURCES]: stealResources,
+};


### PR DESCRIPTION
Replaces the 200-line switch in Colony.giveBonus with a Record<ColonyBenefit, BenefitExecutor> registry. All 26 benefit executors live in src/server/colonies/benefits.ts (previously split across 29 files in a benefits/ directory). TypeScript enforces exhaustiveness via the Record type.

Simplifies the Benefit type in ColonyMetadata (removing generics) and updates Colony.giveBonus() to accept a Benefit object + index rather than separate parameters. handleTrade is made public (via IColonyInternal) to allow copyTrade to call it without importing the concrete class.