### PR TITLE
Fix Rey Skywalker space incorrectly allowing underworld tokens

### DIFF
--- a/src/server/underworld/UnderworldExpansion.ts
+++ b/src/server/underworld/UnderworldExpansion.ts
@@ -112,8 +112,8 @@ export class UnderworldExpansion {
       return false;
     }
     if (space.tile !== undefined) {
-      // Players may still identify on Martian Nature Wonders and Rey Skywalker
-      if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS && space.tile.tileType !== TileType.REY_SKYWALKER) {
+      // Players may still identify on Martian Nature Wonders (but not Rey Skywalker, which blocks tokens)
+      if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS) {
         return false;
       }
     }
@@ -201,8 +201,8 @@ export class UnderworldExpansion {
       }
 
       if (space.tile !== undefined) {
-        // Players may still excavate from Martian Nature Wonders and Rey Skywalker
-        if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS && space.tile.tileType !== TileType.REY_SKYWALKER) {
+        // Players may still excavate from Martian Nature Wonders (but not Rey Skywalker, which blocks tokens)
+        if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS) {
           return false;
         }
       }
@@ -254,8 +254,8 @@ export class UnderworldExpansion {
     const game = player.game;
     validateUnderworldExpansion(game);
     if (space.tile !== undefined) {
-      // Players may still excavate from Martian Nature Wonders and Rey Skywalker
-      if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS && space.tile.tileType !== TileType.REY_SKYWALKER) {
+      // Players may still excavate from Martian Nature Wonders (but not Rey Skywalker, which blocks tokens)
+      if (space.tile.tileType !== TileType.MARTIAN_NATURE_WONDERS) {
         throw new Error(`cannot excavate space ${space.id} which has a tile.`);
       }
     }

--- a/tests/underworld/UnderworldExpansion.spec.ts
+++ b/tests/underworld/UnderworldExpansion.spec.ts
@@ -397,16 +397,14 @@ describe('UnderworldExpansion', () => {
     expect(UnderworldExpansion.excavatableSpaces(player1)).contains(space);
   });
 
-  it('Rey Skywalker space is identifiable and excavatable', () => {
+  it('Rey Skywalker space is not identifiable or excavatable', () => {
     const space = UnderworldExpansion.identifiableSpaces(player1)[0];
     game.simpleAddTile(player1, space, {tileType: TileType.REY_SKYWALKER});
 
-    expect(UnderworldExpansion.identifiableSpaces(player1)).contains(space);
-    expect(UnderworldExpansion.excavatableSpaces(player1)).contains(space);
+    expect(UnderworldExpansion.identifiableSpaces(player1)).not.contains(space);
+    expect(UnderworldExpansion.excavatableSpaces(player1)).not.contains(space);
 
-    UnderworldExpansion.excavate(player1, space);
-
-    expect(space.excavator?.id).eq(player1.id);
+    expect(() => UnderworldExpansion.excavate(player1, space)).to.throw();
   });
 
   it('Martian Nature Wonders space is identifiable and excavatable', () => {


### PR DESCRIPTION
Rey Skywalker's card text says "No tile or token may be placed on that space," but the space was treated the same as Martian Nature Wonders (which only blocks tiles). This allowed players to identify and excavate the space, causing a game-blocking error when it was the only excavatable space.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Fixes #7760