### PR TITLE
Add help annotation for Air Raid

### DIFF
--- a/src/server/cards/colonies/AirRaid.ts
+++ b/src/server/cards/colonies/AirRaid.ts
@@ -20,6 +20,7 @@ export class AirRaid extends Card implements IProjectCard {
 
       metadata: {
         cardNumber: 'C02',
+        hasExternalHelp: true,
         description: 'Requires that you lose 1 floater. Steal 5 M€ from any player.',
         renderData: CardRenderer.builder((b) => {
           b.minus().resource(CardResource.FLOATER);


### PR DESCRIPTION
Refs #8088.

## Summary
- add `hasExternalHelp` to Air Raid so the card links to Card Details
- leave gameplay unchanged: in multiplayer Air Raid still requires a floater and an opponent with at least 5 M€

## Requested Card Details text
@kberg, could you add the corresponding Card Details text when this lands?

Suggested text:

> Air Raid requires removing 1 floater and stealing exactly 5 M€ from one opponent. These are treated as a package deal, so Air Raid cannot be played unless an opponent has at least 5 M€. If no opponent has 5 M€, the card is unavailable even if you have a floater.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/colonies/AirRaid.spec.ts`