### PR TITLE
Show calculated costs when buying cards

### DIFF
--- a/src/server/deferredActions/ChooseCards.ts
+++ b/src/server/deferredActions/ChooseCards.ts
@@ -54,7 +54,7 @@ export class ChooseCards extends DeferredAction {
     const min = options.paying ? 0 : options.keepMax;
 
     const button = max === 0 ? 'Ok' : (options.paying ? 'Buy' : 'Select');
-    return new SelectCard(msg, button, cards, {max, min})
+    return new SelectCard(msg, button, cards, {max, min, played: !options.paying})
       .andThen((selected) => {
         if (selected.length > max) {
           throw new Error('Selected too many cards');

--- a/tests/deferredActions/ChooseCards.spec.ts
+++ b/tests/deferredActions/ChooseCards.spec.ts
@@ -20,20 +20,28 @@ describe('ChooseCards', () => {
     player.megaCredits = 100;
   });
 
-  it('shows calculated project costs when buying cards', () => {
-    player.cardCost = 7;
+  it('shows calculated project costs when paying for cards', () => {
+    player.megaCredits = player.cardCost;
     player.playedCards.push(newProjectCard(CardName.EARTH_CATAPULT)!);
 
     const selectCard = cast(
       new ChooseCards(player, [aquiferPumping, ioMiningIndustries], {paying: true}).execute(),
-      SelectCard,
+      SelectCard<IProjectCard>,
     );
+
+    expect(selectCard.config.min).to.eq(0);
+    expect(selectCard.config.max).to.eq(1);
+    expect(selectCard.config.played).is.false;
+    expect(selectCard.cards.map((card) => card.name)).deep.eq([
+      CardName.AQUIFER_PUMPING,
+      CardName.IO_MINING_INDUSTRIES,
+    ]);
 
     const model = selectCard.toModel(player);
 
-    expect(model.cards).has.length(2);
-    expect(model.cards[0].calculatedCost).to.eq(player.getCardCost(aquiferPumping));
-    expect(model.cards[1].calculatedCost).to.eq(player.getCardCost(ioMiningIndustries));
-    expect(model.cards[0].calculatedCost).not.to.eq(player.cardCost);
+    expect(model.cards.map((card) => ({name: card.name, calculatedCost: card.calculatedCost}))).deep.eq([
+      {name: CardName.AQUIFER_PUMPING, calculatedCost: 16},
+      {name: CardName.IO_MINING_INDUSTRIES, calculatedCost: 39},
+    ]);
   });
 });

--- a/tests/deferredActions/ChooseCards.spec.ts
+++ b/tests/deferredActions/ChooseCards.spec.ts
@@ -1,0 +1,39 @@
+import {expect} from 'chai';
+import {cast} from '@/common/utils/utils';
+import {CardName} from '../../src/common/cards/CardName';
+import {IProjectCard} from '../../src/server/cards/IProjectCard';
+import {newProjectCard} from '../../src/server/createCard';
+import {ChooseCards} from '../../src/server/deferredActions/ChooseCards';
+import {SelectCard} from '../../src/server/inputs/SelectCard';
+import {testGame} from '../TestGame';
+import {TestPlayer} from '../TestPlayer';
+
+describe('ChooseCards', () => {
+  let player: TestPlayer;
+  let aquiferPumping: IProjectCard;
+  let ioMiningIndustries: IProjectCard;
+
+  beforeEach(() => {
+    [/* game */, player] = testGame(1);
+    aquiferPumping = newProjectCard(CardName.AQUIFER_PUMPING)!;
+    ioMiningIndustries = newProjectCard(CardName.IO_MINING_INDUSTRIES)!;
+    player.megaCredits = 100;
+  });
+
+  it('shows calculated project costs when buying cards', () => {
+    player.cardCost = 7;
+    player.playedCards.push(newProjectCard(CardName.EARTH_CATAPULT)!);
+
+    const selectCard = cast(
+      new ChooseCards(player, [aquiferPumping, ioMiningIndustries], {paying: true}).execute(),
+      SelectCard,
+    );
+
+    const model = selectCard.toModel(player);
+
+    expect(model.cards).has.length(2);
+    expect(model.cards[0].calculatedCost).to.eq(player.getCardCost(aquiferPumping));
+    expect(model.cards[1].calculatedCost).to.eq(player.getCardCost(ioMiningIndustries));
+    expect(model.cards[0].calculatedCost).not.to.eq(player.cardCost);
+  });
+});


### PR DESCRIPTION
## Summary
- show calculated project card costs in buy-card selections
- add a regression test covering card-cost discounts during card buying

## Demo
Same setup on current Heroku and the PR preview: Earth Catapult is already in play, then research card buying offers Io Mining Industries and Aquifer Pumping.

![Heroku current vs PR preview calculated card costs](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-8111-assets/demo/public-heroku-vs-preview-pr.png)

- Current Heroku: https://terraforming-mars.herokuapp.com/player?id=pbf838a6db9ed
- PR preview: https://preview.tm.knightbyte.win/player?id=pcostdemo8088buy

## Notes
- No gameplay change; this only affects the card model sent to the client for buy-card choices.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/deferredActions/ChooseCards.spec.ts`
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/deferredActions/DrawCards.spec.ts tests/deferredActions/ChooseCards.spec.ts`
- `npx eslint src/server/deferredActions/ChooseCards.ts tests/deferredActions/ChooseCards.spec.ts`
- `npm run build:tests`
