### PR TITLE
Show Kelvinists 6-heat action in place of the 8-heat one.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -41,6 +41,7 @@ import {MoonExpansion} from './moon/MoonExpansion';
 import {IStandardProjectCard} from './cards/IStandardProjectCard';
 import {ConvertPlants} from './cards/base/standardActions/ConvertPlants';
 import {ConvertHeat} from './cards/base/standardActions/ConvertHeat';
+import {KELVINISTS_POLICY_3} from './turmoil/parties/Kelvinists';
 import {GlobalParameter} from '../common/GlobalParameter';
 import {LogHelper} from './LogHelper';
 import {UndoActionOption} from './inputs/UndoActionOption';
@@ -1573,19 +1574,25 @@ export class Player implements IPlayer {
       action.options.push(convertPlants.action(this));
     }
 
-    // Convert Heat
-    const convertHeat = new ConvertHeat();
-    if (convertHeat.canAct(this)) {
-      const option = new SelectOption('Convert 8 heat into temperature', 'Convert heat').andThen(() => {
-        return convertHeat.action(this);
-      });
-      if (convertHeat.warnings.size > 0) {
-        option.warnings = Array.from(convertHeat.warnings);
-        if (convertHeat.warnings.has('maxtemp')) {
-          option.eligibleForDefault = false;
-        }
+    // Convert Heat. Kelvinists kp03 swaps in a 6-heat variant in this slot.
+    if (PartyHooks.shouldApplyPolicy(this, PartyName.KELVINISTS, 'kp03')) {
+      if (KELVINISTS_POLICY_3.canAct(this)) {
+        action.options.push(KELVINISTS_POLICY_3.action(this));
       }
-      action.options.push(option);
+    } else {
+      const convertHeat = new ConvertHeat();
+      if (convertHeat.canAct(this)) {
+        const option = new SelectOption('Convert 8 heat into temperature', 'Convert heat').andThen(() => {
+          return convertHeat.action(this);
+        });
+        if (convertHeat.warnings.size > 0) {
+          option.warnings = Array.from(convertHeat.warnings);
+          if (convertHeat.warnings.has('maxtemp')) {
+            option.eligibleForDefault = false;
+          }
+        }
+        action.options.push(option);
+      }
     }
 
     // Turmoil

--- a/src/server/turmoil/TurmoilHandler.ts
+++ b/src/server/turmoil/TurmoilHandler.ts
@@ -7,7 +7,7 @@ import {PlayerInput} from '../PlayerInput';
 import {Resource} from '../../common/Resource';
 import {SpaceType} from '../../common/boards/SpaceType';
 import {GREENS_POLICY_2, GREENS_POLICY_3} from './parties/Greens';
-import {KELVINISTS_POLICY_4} from './parties/Kelvinists';
+import {KELVINISTS_POLICY_3, KELVINISTS_POLICY_4} from './parties/Kelvinists';
 import {MARS_FIRST_POLICY_2} from './parties/MarsFirst';
 import {PartyHooks} from './parties/PartyHooks';
 import {PartyName} from '../../common/turmoil/PartyName';
@@ -25,6 +25,11 @@ export class TurmoilHandler {
       return undefined;
     }
     const policy: IPolicy = turmoil.rulingPolicy();
+    // kp03 is rendered in the Convert Heat slot by Player.getActions(); skip
+    // here to avoid double-rendering.
+    if (policy.id === KELVINISTS_POLICY_3.id) {
+      return undefined;
+    }
     if (policy.canAct?.(player)) {
       return new SelectOption(policyDescription(policy, player), 'Pay').andThen(() => policy.action?.(player));
     }

--- a/src/server/turmoil/parties/Kelvinists.ts
+++ b/src/server/turmoil/parties/Kelvinists.ts
@@ -9,6 +9,8 @@ import {SelectPaymentDeferred} from '../../deferredActions/SelectPaymentDeferred
 import {MAX_TEMPERATURE} from '../../../common/constants';
 import {CardName} from '../../../common/cards/CardName';
 import {TITLES} from '../../inputs/titles';
+import {SelectOption} from '../../inputs/SelectOption';
+import {Units} from '../../../common/Units';
 
 export class Kelvinists extends Party implements IParty {
   readonly name = PartyName.KELVINISTS;
@@ -75,23 +77,33 @@ class KelvinistsPolicy02 implements IPolicy {
   readonly description = 'When you raise temperature, gain 3 M€ per step raised';
 }
 
+// Hack: action() returns the SelectOption that Player.getActions() drops into
+// the Convert Heat slot, instead of performing the conversion itself. To avoid
+// rendering it twice, TurmoilHandler.partyAction() skips kp03.
 class KelvinistsPolicy03 implements IPolicy {
   readonly id = 'kp03' as const;
   readonly description = 'Convert 6 heat into temperature (Turmoil Kelvinists)';
 
-  canAct(player: IPlayer) {
-    return player.availableHeat() >= 6 && player.game.getTemperature() < MAX_TEMPERATURE;
+  canAct(player: IPlayer): boolean {
+    return player.availableHeat() >= 6 && player.canAfford({
+      cost: 0,
+      tr: {temperature: 1},
+      reserveUnits: Units.of({heat: 6}),
+    });
   }
 
-  action(player: IPlayer) {
-    const game = player.game;
-    game.log('${0} used Turmoil ${1} action', (b) => b.player(player).partyName(PartyName.KELVINISTS));
-    game.log('${0} spent 6 heat to raise temperature 1 step', (b) => b.player(player));
-
-    return player.spendHeat(6, () => {
-      game.increaseTemperature(player, 1);
-      return undefined;
+  action(player: IPlayer): SelectOption {
+    const option = new SelectOption('Convert 6 heat into temperature (Turmoil Kelvinists)', 'Convert heat').andThen(() => {
+      return player.spendHeat(6, () => {
+        player.game.increaseTemperature(player, 1);
+        return undefined;
+      });
     });
+    if (player.game.getTemperature() === MAX_TEMPERATURE) {
+      option.warnings = ['maxtemp'];
+      option.eligibleForDefault = false;
+    }
+    return option;
   }
 }
 

--- a/src/server/turmoil/parties/Kelvinists.ts
+++ b/src/server/turmoil/parties/Kelvinists.ts
@@ -95,6 +95,8 @@ class KelvinistsPolicy03 implements IPolicy {
   action(player: IPlayer): SelectOption {
     const option = new SelectOption('Convert 6 heat into temperature (Turmoil Kelvinists)', 'Convert heat').andThen(() => {
       return player.spendHeat(6, () => {
+        game.log('${0} used Turmoil ${1} action', (b) => b.player(player).partyName(PartyName.KELVINISTS));
+        game.log('${0} spent 6 heat to raise temperature 1 step', (b) => b.player(player));
         player.game.increaseTemperature(player, 1);
         return undefined;
       });

--- a/src/server/turmoil/parties/Kelvinists.ts
+++ b/src/server/turmoil/parties/Kelvinists.ts
@@ -95,9 +95,10 @@ class KelvinistsPolicy03 implements IPolicy {
   action(player: IPlayer): SelectOption {
     const option = new SelectOption('Convert 6 heat into temperature (Turmoil Kelvinists)', 'Convert heat').andThen(() => {
       return player.spendHeat(6, () => {
+        const game = player.game;
         game.log('${0} used Turmoil ${1} action', (b) => b.player(player).partyName(PartyName.KELVINISTS));
         game.log('${0} spent 6 heat to raise temperature 1 step', (b) => b.player(player));
-        player.game.increaseTemperature(player, 1);
+        game.increaseTemperature(player, 1);
         return undefined;
       });
     });

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -12,7 +12,7 @@ import {SerializedTimer} from '../src/common/SerializedTimer';
 import {Player} from '../src/server/Player';
 import {Color} from '../src/common/Color';
 import {CardName} from '../src/common/cards/CardName';
-import {doWait, getSendADelegateOption, runAllActions} from './TestingUtils';
+import {doWait, getSendADelegateOption, runAllActions, setRulingParty} from './TestingUtils';
 import {SelfReplicatingRobots} from '../src/server/cards/promo/SelfReplicatingRobots';
 import {IProjectCard} from '../src/server/cards/IProjectCard';
 import {Pets} from '../src/server/cards/base/Pets';
@@ -607,6 +607,32 @@ describe('Player', () => {
 
     game.increaseVenusScaleLevel(player2, 2);
     expect(player2.globalParameterSteps[GlobalParameter.VENUS]).eq(2);
+  });
+
+  describe('Convert Heat / Kelvinists kp03 swap', () => {
+    function findOption(player: TestPlayer, title: string): SelectOption | undefined {
+      const actions = cast(player.getActions(), OrOptions);
+      const option = actions.options.find((o) => o.title === title);
+      return option === undefined ? undefined : cast(option, SelectOption);
+    }
+
+    it('kp03 ruling: 6-heat option replaces 8-heat option', () => {
+      const [game, player] = testGame(1, {turmoilExtension: true});
+      setRulingParty(game, PartyName.KELVINISTS, 'kp03');
+      player.stock.add(Resource.HEAT, 10);
+
+      expect(findOption(player, 'Convert 8 heat into temperature')).is.undefined;
+      expect(findOption(player, 'Convert 6 heat into temperature (Turmoil Kelvinists)')).is.not.undefined;
+    });
+
+    it('kp01 ruling: 8-heat option remains, 6-heat is not offered', () => {
+      const [game, player] = testGame(1, {turmoilExtension: true});
+      setRulingParty(game, PartyName.KELVINISTS, 'kp01');
+      player.stock.add(Resource.HEAT, 10);
+
+      expect(findOption(player, 'Convert 8 heat into temperature')).is.not.undefined;
+      expect(findOption(player, 'Convert 6 heat into temperature (Turmoil Kelvinists)')).is.undefined;
+    });
   });
 
   it('run research phase', () => {

--- a/tests/cards/base/standardActions/ConvertHeat.spec.ts
+++ b/tests/cards/base/standardActions/ConvertHeat.spec.ts
@@ -61,4 +61,13 @@ describe('ConvertHeat', () => {
     expect(player.heat).eq(0);
     expect(player.terraformRating).eq(20);
   });
+
+  it('canAct adds maxtemp warning at MAX_TEMPERATURE', () => {
+    player.heat = 8;
+    setTemperature(game, MAX_TEMPERATURE);
+
+    expect(card.warnings.has('maxtemp')).is.false;
+    expect(card.canAct(player)).eq(true);
+    expect(card.warnings.has('maxtemp')).is.true;
+  });
 });

--- a/tests/turmoil/parties/Kelvinists.spec.ts
+++ b/tests/turmoil/parties/Kelvinists.spec.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import {IGame} from '../../../src/server/IGame';
 import {Space} from '../../../src/server/boards/Space';
-import {setRulingParty} from '../../TestingUtils';
+import {setRulingParty, setTemperature} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {KELVINISTS_BONUS_1, KELVINISTS_BONUS_2, KELVINISTS_POLICY_1, KELVINISTS_POLICY_2, KELVINISTS_POLICY_3, KELVINISTS_POLICY_4} from '../../../src/server/turmoil/parties/Kelvinists';
 import {Resource} from '../../../src/common/Resource';
@@ -11,6 +11,7 @@ import {AndOptions} from '../../../src/server/inputs/AndOptions';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
 import {testGame} from '../../TestGame';
 import {PartyName} from '../../../src/common/turmoil/PartyName';
+import {MAX_TEMPERATURE} from '../../../src/common/constants';
 import {cast} from '@/common/utils/utils';
 
 describe('Kelvinists', () => {
@@ -59,14 +60,13 @@ describe('Kelvinists', () => {
   it('Ruling policy 3: Convert 6 heat into temperature', () => {
     setRulingParty(game, PartyName.KELVINISTS, KELVINISTS_POLICY_3.id);
 
-    const kelvinistsPolicy = KELVINISTS_POLICY_3;
-    expect(kelvinistsPolicy.canAct(player)).to.be.false;
+    expect(KELVINISTS_POLICY_3.canAct(player)).is.false;
 
     player.stock.add(Resource.HEAT, 6);
-    expect(kelvinistsPolicy.canAct(player)).to.be.true;
+    expect(KELVINISTS_POLICY_3.canAct(player)).is.true;
 
     const initialTR = player.terraformRating;
-    kelvinistsPolicy.action(player);
+    KELVINISTS_POLICY_3.action(player).cb(undefined);
     expect(player.heat).to.eq(0);
     expect(player.terraformRating).to.eq(initialTR + 1);
     expect(game.getTemperature()).to.eq(-28);
@@ -80,10 +80,9 @@ describe('Kelvinists', () => {
     stormcraft.resourceCount = 2;
     player.stock.add(Resource.HEAT, 8);
 
-    const kelvinistsPolicy = KELVINISTS_POLICY_3;
-    expect(kelvinistsPolicy.canAct(player)).to.be.true;
+    expect(KELVINISTS_POLICY_3.canAct(player)).is.true;
 
-    const action = kelvinistsPolicy.action(player) as AndOptions;
+    const action = cast(KELVINISTS_POLICY_3.action(player).cb(undefined), AndOptions);
     const heatOption = cast(action.options[0], SelectAmount);
     const floaterOption = cast(action.options[1], SelectAmount);
 
@@ -93,7 +92,17 @@ describe('Kelvinists', () => {
 
     expect(player.heat).to.eq(4);
     expect(stormcraft.resourceCount).to.eq(1);
-    expect(kelvinistsPolicy.canAct(player)).to.be.true;
+    expect(KELVINISTS_POLICY_3.canAct(player)).is.true;
+  });
+
+  it('Ruling policy 3: option carries maxtemp warning at MAX_TEMPERATURE', () => {
+    setRulingParty(game, PartyName.KELVINISTS, KELVINISTS_POLICY_3.id);
+    player.stock.add(Resource.HEAT, 10);
+    setTemperature(game, MAX_TEMPERATURE);
+
+    const option = KELVINISTS_POLICY_3.action(player);
+    expect(option.warnings).to.deep.eq(['maxtemp']);
+    expect(option.eligibleForDefault).is.false;
   });
 
   it('Ruling policy 4: When you place a tile, gain 2 heat', () => {


### PR DESCRIPTION
When Kelvinists policy 3 is the ruling agenda, swap in a 6-heat "Convert heat" option in place of the standard 8-heat option, so the strictly-better choice sits in the same slot players already look at.

Fixes #6368