### PR TITLE
Log ocean adjacency bonus

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -1382,11 +1382,12 @@ export class Game implements IGame, Logger {
       this.grantSpaceBonuses(player, space);
     }
 
-    this.board.getAdjacentSpaces(space).forEach((adjacentSpace) => {
-      if (Board.isOceanSpace(adjacentSpace)) {
-        player.megaCredits += player.oceanBonus;
-      }
-    });
+    const adjacentOceanCount = this.board.getAdjacentSpaces(space).filter(Board.isOceanSpace).length;
+    const oceanAdjacencyBonus = adjacentOceanCount * player.oceanBonus;
+    if (oceanAdjacencyBonus > 0) {
+      player.stock.add(Resource.MEGACREDITS, oceanAdjacencyBonus);
+      this.log('${0} gained ${1} M€ from ${2} ocean(s)', (b) => b.player(player).number(oceanAdjacencyBonus).number(adjacentOceanCount));
+    }
 
     // TODO(kberg): these might not apply for some bonuses, e.g. Frontier Town.
     // https://boardgamegeek.com/thread/3344366/article/44658730#44658730


### PR DESCRIPTION
## Summary

- Log the standard M€ bonus gained from placing a tile next to oceans.
- Keep the existing M€ amount unchanged; the bonus now goes through `stock.add(..., {log: true})` so it appears in the game log.

Fixes https://github.com/terraforming-mars/terraforming-mars/issues/7898

## Demo

Same scenario on both servers: Teractor uses Aquifer at `06` / A4, then places Greenery at `12` / B5 adjacent to that ocean.

Heroku production: https://terraforming-mars.herokuapp.com/player?id=pfee4416424f

![Heroku production log](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets/ocean-log-7898/pr-assets/ocean-log/heroku-log-cropped.png)

Preview branch: https://preview.tm.knightbyte.win/player?id=p3d704af83bcb

![Preview branch log](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets/ocean-log-7898/pr-assets/ocean-log/preview-log-cropped.png)

## Testing

- `npx mocha --import=tsx --require tests/testing/setup.ts tests/Game.spec.ts --grep "ocean adjacency bonus logging"`
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/Game.spec.ts`
- `npm run lint:server -- --quiet`
- `npm run build`
- Preview deploy/verify OK on `preview.tm.knightbyte.win`
