### PR TITLE
Mars Nomads: filter destinations by placement-bonus affordability

### DIFF
--- a/src/server/cards/promo/MarsNomads.ts
+++ b/src/server/cards/promo/MarsNomads.ts
@@ -9,6 +9,9 @@ import {intersection} from '../../../common/utils/utils';
 import {message} from '../../logs/MessageBuilder';
 import {AresHandler} from '../../ares/AresHandler';
 import {BoardType} from '../../boards/BoardType';
+import {Space} from '../../boards/Space';
+import {SpaceBonus} from '../../../common/boards/SpaceBonus';
+import * as constants from '../../../common/constants';
 export class MarsNomads extends Card implements IActionCard {
   /*
    * A good page about this card: https://boardgamegeek.com/thread/3154812.
@@ -56,6 +59,30 @@ export class MarsNomads extends Card implements IActionCard {
       });
   }
 
+  private canAffordPlacementBonus(player: IPlayer, space: Space): boolean {
+    // Bonuses are not granted when moving onto a hazard tile.
+    if (AresHandler.hasHazardTile(space)) {
+      return true;
+    }
+    const game = player.game;
+    if (space.bonus.includes(SpaceBonus.OCEAN) && game.canAddOcean()) {
+      if (!player.canAfford({cost: constants.HELLAS_BONUS_OCEAN_COST})) {
+        return false;
+      }
+    }
+    if (space.bonus.includes(SpaceBonus.TEMPERATURE) && game.getTemperature() < constants.MAX_TEMPERATURE) {
+      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST})) {
+        return false;
+      }
+    }
+    if (space.bonus.includes(SpaceBonus.TEMPERATURE_4MC) && game.getTemperature() < constants.MAX_TEMPERATURE) {
+      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_NOVA_BONUS_TEMPERATURE_COST})) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private eliglbleDestinationSpaces(player: IPlayer) {
     const game = player.game;
     const board = game.board;
@@ -66,7 +93,8 @@ export class MarsNomads extends Card implements IActionCard {
     const availableSpaces = board.getNonReservedLandSpaces();
     const currentNomadSpace = board.getSpaceOrThrow(game.nomadSpace);
     const adjacentSpaces = board.getAdjacentSpaces(currentNomadSpace);
-    return intersection(availableSpaces, adjacentSpaces);
+    return intersection(availableSpaces, adjacentSpaces)
+      .filter((space) => this.canAffordPlacementBonus(player, space));
   }
 
   public canAct(player: IPlayer) {

--- a/tests/cards/promo/MarsNomads.spec.ts
+++ b/tests/cards/promo/MarsNomads.spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 import {IGame} from '../../../src/server/IGame';
 import {testGame} from '../../TestGame';
-import {churn, runAllActions} from '../../TestingUtils';
+import {churn, runAllActions, setTemperature} from '../../TestingUtils';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {MarsNomads} from '../../../src/server/cards/promo/MarsNomads';
 import {Networker} from '../../../src/server/milestones/Networker';
@@ -140,6 +140,30 @@ describe('MarsNomads', () => {
     selectSpace.cb(destinationSpace);
     expect(player.megaCredits).to.eq(2);
   });
+
+  for (const run of [
+    {bonus: SpaceBonus.OCEAN, megaCredits: 5, expected: false},
+    {bonus: SpaceBonus.OCEAN, megaCredits: 6, expected: true},
+    {bonus: SpaceBonus.TEMPERATURE, megaCredits: 2, expected: false},
+    {bonus: SpaceBonus.TEMPERATURE, megaCredits: 3, expected: true},
+    {bonus: SpaceBonus.TEMPERATURE_4MC, megaCredits: 3, expected: false},
+    {bonus: SpaceBonus.TEMPERATURE_4MC, megaCredits: 4, expected: true},
+    {bonus: SpaceBonus.TEMPERATURE, megaCredits: 0, temperature: 8, expected: true},
+  ] as const) {
+    it('Destination filtered by placement-bonus affordability (Bug #7326) ' + JSON.stringify(run), () => {
+      const nomadSpace = board.getAvailableSpacesOnLand(player)[12];
+      game.nomadSpace = nomadSpace.id;
+      const destinationSpace = game.board.getAdjacentSpaces(nomadSpace).find((s) => s.spaceType === SpaceType.LAND)!;
+      destinationSpace.bonus = [run.bonus];
+      if (run.temperature) {
+        setTemperature(game, run.temperature);
+      }
+      player.megaCredits = run.megaCredits;
+
+      const spaces = cast(card.action(player), SelectSpace).spaces;
+      expect(spaces.includes(destinationSpace)).to.eq(run.expected);
+    });
+  }
 
   it('Can make initial placement on an ocean bonus space even without the money (Bug #6479)', () => {
     player.megaCredits = 0;


### PR DESCRIPTION
Fixes #7326

Mars Nomads used getNonReservedLandSpaces() for destination selection, which skips the canAfford check that getAvailableSpacesOnLand() applies. Moving onto a space with an OCEAN, TEMPERATURE, or TEMPERATURE_4MC bonus would defer payment and throw when the player couldn't afford the cost. Filter destinations through the same affordability check so unaffordable bonus spaces aren't offered.