### PR TITLE
Change "mars is terraformed" from an alert to persistent banner

### DIFF
--- a/src/client/components/PlayerHome.vue
+++ b/src/client/components/PlayerHome.vue
@@ -190,11 +190,7 @@ export type PlayerHomeModel = {
   showEventCards: boolean;
   tileView: TileView;
   keyboardShortcutOpened: boolean;
-  hotkeyTargets: Array<Element>
-}
-
-class TerraformedAlertDialog {
-  static shouldAlert = true;
+  hotkeyTargets: Array<Element>;
 }
 
 export default defineComponent({
@@ -396,11 +392,6 @@ export default defineComponent({
   mounted() {
     setDocumentTitle(this.game.name);
     window.addEventListener('keydown', this.navigatePage);
-    if (this.game.isTerraformed && TerraformedAlertDialog.shouldAlert && getPreferences().show_alerts) {
-      alert('Mars is Terraformed!');
-      // Avoids repeated calls.
-      TerraformedAlertDialog.shouldAlert = false;
-    }
     const targets = this.$el.getElementsByClassName('hotkey-target');
     for (let i = 0; i < targets.length; i++) {
       const element = targets.item(i);

--- a/src/client/components/TopBar.vue
+++ b/src/client/components/TopBar.vue
@@ -1,8 +1,13 @@
 <template>
-    <div :class="formatCssClass()" :key="componentKey">
-      <PlayerInfo v-show="isExpanded()" :player="playerView.thisPlayer" :playerView="playerView" :actionLabel="''" :playerIndex="0" :hideZeroTags="true" :isTopBar="true"/>
-      <div class="top-bar-collapser" v-on:click="toggleBar()">
-        <img src="assets/arrows_left.png">
+    <div class="top-bar-container">
+      <div :class="formatCssClass()" :key="componentKey">
+        <PlayerInfo v-show="isExpanded()" :player="playerView.thisPlayer" :playerView="playerView" :actionLabel="''" :playerIndex="0" :hideZeroTags="true" :isTopBar="true"/>
+        <div class="top-bar-collapser" v-on:click="toggleBar()">
+          <img src="assets/arrows_left.png">
+        </div>
+      </div>
+      <div v-if="playerView.game.isTerraformed" class="terraformed-banner">
+        <span v-i18n>Mars is Terraformed!</span>
       </div>
     </div>
 </template>

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -18,6 +18,30 @@
     }
 }
 
+.terraformed-banner {
+    background: linear-gradient(to right, #e28c22, #ffcc64, #e28c22);
+    color: #000;
+    text-align: center;
+    padding: 12px;
+    font-size: 24px;
+    font-family: Prototype, Ubuntu, Sans-Serif;
+    font-weight: bold;
+    text-transform: uppercase;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
+    z-index: 100;
+    position: relative;
+    border-bottom: 2px solid #805700;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 15px;
+}
+
+@keyframes slide-down {
+    from { transform: translateY(-100%); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
 // text shadows
 .player_shadow_color_red {
     text-shadow: -1px -1px 6px @player_red, 1px 1px 1px #333a;
@@ -881,12 +905,17 @@
   animation:smoth-fade-animation 2000ms infinite;
 }
 
-.top-bar {
+.top-bar-container {
     position: sticky;
-    margin: -40px 0 0 auto;
-    margin-bottom: 15px;
-    z-index: 105;
     top: -12px;
+    z-index: 105;
+    margin-top: -30px;
+    margin-left: -20px;
+}
+
+.top-bar {
+    margin: 0 0 0 auto;
+    margin-bottom: 0;
     display: inline-flex;
 
     .top-bar-collapser {
@@ -922,7 +951,7 @@
 }
 
 .top-bar-collapsed {
-    margin: -32px 0 0 -20px;
+    margin: 0; // Handled by container
 
     .player-info {
         display: none;


### PR DESCRIPTION
The "mars is terraformed" alert is a bit annoying and pops up on every refresh. Instead switch to a banner which is floating and persistent.

Example:

<img width="1090" height="650" alt="image" src="https://github.com/user-attachments/assets/adbd747c-4f7a-4dcf-9d3f-7df79fc98a79" />
