### PR TITLE
Fix literal $t() leaking into the document title

### DIFF
--- a/src/client/utils/documentTitle.ts
+++ b/src/client/utils/documentTitle.ts
@@ -5,7 +5,7 @@ export function setDocumentTitle(title?: string): void {
   if (title === undefined) {
     document.title = $t(APP_NAME);
   } else {
-    document.title = `${title} | $t(${APP_NAME})`;
+    document.title = `${title} | ${$t(APP_NAME)}`;
   }
 }
 


### PR DESCRIPTION
Non-game pages set the browser title through `setDocumentTitle`. The `else` branch builds the title with a template literal but writes `$t(...)` as plain text inside it, so the i18n call never runs. The create-game screen ends up titled `Create New Game | $t(Terraforming Mars)` instead of the translated app name. Only the `title === undefined` branch is correct.

This interpolates `$t(APP_NAME)` the same way that branch does, so the title becomes `Create New Game | Terraforming Mars`.

To reproduce on main: open the new game page and look at the browser tab title