### PR TITLE
Add Planetary track to player setup view and fix cutoff for details section in player setup view.

### DIFF
--- a/src/client/components/PlayerSetupView.vue
+++ b/src/client/components/PlayerSetupView.vue
@@ -87,6 +87,8 @@
 
         <turmoil v-if="game.turmoil" :turmoil="game.turmoil"></turmoil>
 
+        <PlanetaryTracks v-if="game.gameOptions.expansions.pathfinders" :tracks="game.pathfinders" :gameOptions="game.gameOptions"/>
+
         <a name="moonBoard" class="player_home_anchor"></a>
         <MoonBoard v-if="game.moon !== undefined" :model="game.moon" :tileView="tileView"></MoonBoard>
         <DeltaProjectBoard v-if="game.gameOptions.expansions.deltaProject" :players="playerView.players"></DeltaProjectBoard>
@@ -105,6 +107,7 @@ import Awards from '@/client/components/Awards.vue';
 import WaitingFor from '@/client/components/WaitingFor.vue';
 import Turmoil from '@/client/components/turmoil/Turmoil.vue';
 import MoonBoard from '@/client/components/moon/MoonBoard.vue';
+import PlanetaryTracks from '@/client/components/pathfinders/PlanetaryTracks.vue';
 import {playerColorClass} from '@/common/utils/utils';
 import {Phase} from '@/common/Phase';
 import {GameModel} from '@/common/models/GameModel';
@@ -141,6 +144,7 @@ export default defineComponent({
     Milestones,
     Awards,
     'turmoil': Turmoil,
+    PlanetaryTracks,
     MoonBoard,
   },
   methods: {

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -16,6 +16,9 @@
             text-decoration: none;
         }
     }
+    .accordion-body {
+        max-height: none;
+    }
 }
 
 .terraformed-banner {


### PR DESCRIPTION
1. add planetary track to "Board" section in the Player Setup accordion (if Pathfinders is enabled).
2. spectre accordions have a default a default max-height of 50rem which cuts off the board view in the player setup phase. Remove this max-height limit to allow all sections to render.

Before:

<img width="1150" height="589" alt="image" src="https://github.com/user-attachments/assets/e1adb736-16bf-46b3-ae1f-d63b531bc319" />

After:

<img width="1072" height="654" alt="image" src="https://github.com/user-attachments/assets/7ab20a28-0725-4e3f-aa7f-3e77223dff0b" />
