### PR TITLE
Auto-select card for Soil Enrichment when only one is eligible

### DIFF
--- a/src/server/cards/promo/SoilEnrichment.ts
+++ b/src/server/cards/promo/SoilEnrichment.ts
@@ -37,12 +37,19 @@ export class SoilEnrichment extends Card implements IProjectCard {
   }
 
   public override play(player: IPlayer) {
-    return new SelectCard('Select card to remove 1 microbe from', 'Select', this.eligibleCards(player))
+    const cards = this.eligibleCards(player);
+    const input = new SelectCard('Select card to remove 1 microbe from', 'Select', cards)
       .andThen(([card]) => {
         player.removeResourceFrom(card);
         player.stock.add(Resource.PLANTS, 5);
         player.game.log('${0} removed 1 microbe from ${1} to gain 5 plants', (b) => b.player(player).card(card));
         return undefined;
       });
+
+    if (cards.length === 1) {
+      return input.cb(cards);
+    }
+
+    return input;
   }
 }

--- a/tests/cards/promo/SoilEnrichment.spec.ts
+++ b/tests/cards/promo/SoilEnrichment.spec.ts
@@ -54,4 +54,19 @@ describe('SoilEnrichment', () => {
     expect(tardigrades.resourceCount).eq(0);
     expect(player.plants).eq(5);
   });
+
+  it('play with only one eligible card', () => {
+    const ghgProducingBacteria = new GHGProducingBacteria();
+    ghgProducingBacteria.resourceCount = 1;
+    player.playedCards.push(ghgProducingBacteria);
+
+    player.plants = 0;
+    expect(card.canPlay(player)).is.true;
+
+    const result = card.play(player);
+    expect(result).to.be.undefined;
+
+    expect(ghgProducingBacteria.resourceCount).eq(0);
+    expect(player.plants).eq(5);
+  });
 });


### PR DESCRIPTION
* Skip `SelectCard` prompt in `play` method if only one card has microbes to remove
* Add unit test to verify automatic resource removal and plant gain when one card is eligible