### PR TITLE
Log Greens policy greenery bonus

### DIFF
--- a/src/server/turmoil/parties/Greens.ts
+++ b/src/server/turmoil/parties/Greens.ts
@@ -62,6 +62,8 @@ class GreensPolicy01 implements IPolicy {
   onTilePlaced(player: IPlayer, space: Space) {
     if (Board.isGreenerySpace(space) && player.game.phase === Phase.ACTION) {
       player.stock.add(Resource.MEGACREDITS, 4);
+      player.game.log('${0} gained ${1} M€ from Turmoil ${2} policy', (b) =>
+        b.player(player).number(4).partyName(PartyName.GREENS));
     }
   }
 }


### PR DESCRIPTION
## Summary

- Log the 4 M€ bonus gained from placing a greenery while the Greens ruling policy is active.
- Keep the existing M€ amount unchanged; the bonus now has an explicit source in the game log.

## Demo

Scenario: Greens ruling policy is active, blue places a greenery during the action phase.

Before: the player gained 4 M€ with no source line.

After:

`blue gained 4 M€ from Turmoil Greens policy`

## Testing

- `npx mocha --import=tsx --require tests/testing/setup.ts tests/turmoil/parties/Greens.spec.ts`
- `npm run build:server`