### PR TITLE
Log Greens policy greenery bonus

### DIFF
--- a/src/server/turmoil/parties/Greens.ts
+++ b/src/server/turmoil/parties/Greens.ts
@@ -62,6 +62,8 @@ class GreensPolicy01 implements IPolicy {
   onTilePlaced(player: IPlayer, space: Space) {
     if (Board.isGreenerySpace(space) && player.game.phase === Phase.ACTION) {
       player.stock.add(Resource.MEGACREDITS, 4);
+      player.game.log('${0} gained ${1} M€ from Turmoil ${2} policy', (b) =>
+        b.player(player).number(4).partyName(PartyName.GREENS));
     }
   }
 }


### PR DESCRIPTION
## Summary

- Log the 4 M€ bonus gained from placing a greenery while the Greens ruling policy is active.
- Keep the existing M€ amount unchanged; the bonus now has an explicit source in the game log.

## Demo

Scenario: Greens ruling policy is active, blue uses the Greenery standard project and places a greenery on A1.

Before on Heroku: the player receives the +4 M€ policy bonus, but the game log does not show a source line.

![Before: Heroku missing Greens policy log](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-greens-policy-log-assets/greens-policy-log/heroku-log-crop.png)

After on preview: the game log includes the policy source line.

![After: preview logs Greens policy source](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-greens-policy-log-assets/greens-policy-log/preview-log-crop.png)

Preview: https://preview.tm.knightbyte.win/player?id=p3c9f59981413

Before-fix comparison: https://terraforming-mars.herokuapp.com/player?id=p89853207ca42

## Testing

- `npx mocha --import=tsx --require tests/testing/setup.ts tests/turmoil/parties/Greens.spec.ts`
- `npm run build` during preview deploy
- Preview deploy/verify OK on `preview.tm.knightbyte.win`

