### PR TITLE
Centralize dotenv initialization in src/server/init.ts.

### DIFF
--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -1,0 +1,1 @@
+require('dotenv').config({quiet: true});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,4 +1,4 @@
-require('dotenv').config();
+import '@/server/init';
 require('console-stamp')(
   console,
   {format: ':date(yyyy-mm-dd HH:MM:ss Z)'},

--- a/src/server/tools/analyze_ma.ts
+++ b/src/server/tools/analyze_ma.ts
@@ -1,8 +1,8 @@
-require('dotenv').config();
+import '@/server/init';
 
 import http from 'http';
 import fs from 'fs';
-import * as responses from '../server/responses';
+import * as responses from '@/server/server/responses';
 
 import {chooseMilestonesAndAwards} from '../ma/MilestoneAwardSelector';
 import {DEFAULT_GAME_OPTIONS, GameOptions} from '../game/GameOptions';

--- a/src/server/tools/create_game_ids_table.ts
+++ b/src/server/tools/create_game_ids_table.ts
@@ -1,4 +1,4 @@
-require('dotenv').config();
+import '@/server/init';
 
 import {GameLoader} from '../database/GameLoader';
 import {Database} from '../database/Database';

--- a/src/server/tools/dump_log.ts
+++ b/src/server/tools/dump_log.ts
@@ -1,6 +1,6 @@
 // Prints out the entire game log for review.
 // e.g. node build/src/server/tools/dump_log.js g4940001dbc
-require('dotenv').config();
+import '@/server/init';
 
 import {isGameId} from '../../common/Types';
 import {Database} from '../database/Database';

--- a/src/server/tools/export_card_rendering.ts
+++ b/src/server/tools/export_card_rendering.ts
@@ -1,4 +1,4 @@
-require('dotenv').config();
+import '@/server/init';
 import fs from 'fs';
 
 import {ALL_MODULE_MANIFESTS} from '../cards/AllManifests';

--- a/src/server/tools/ma_synergies.ts
+++ b/src/server/tools/ma_synergies.ts
@@ -1,4 +1,4 @@
-require('dotenv').config();
+import '@/server/init';
 
 import {synergies} from '../ma/MilestoneAwardSynergies';
 import {MilestoneName, milestoneNames} from '../../common/ma/MilestoneName';

--- a/src/server/tools/read_turmoil.ts
+++ b/src/server/tools/read_turmoil.ts
@@ -1,6 +1,6 @@
 // Searches through a game's log for an event.
 // e.g. node build/src/server/tools/read_turmoil.js ge120f6729fca
-require('dotenv').config();
+import '@/server/init';
 
 import {MultiSet} from 'mnemonist';
 import {isGameId} from '../../common/Types';

--- a/src/tools/make_static_json.ts
+++ b/src/tools/make_static_json.ts
@@ -1,5 +1,5 @@
 // Generates the files settings.json and translations.json, stored in src/genfiles
-require('dotenv').config();
+import '@/server/init';
 
 import fs from 'fs';
 import child_process from 'child_process';

--- a/src/tools/translation_audit.ts
+++ b/src/tools/translation_audit.ts
@@ -1,4 +1,4 @@
-require('dotenv').config();
+import '@/server/init';
 import fs from 'fs';
 import path from 'path';
 

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -16,7 +16,7 @@ import {QueryResult} from 'pg';
 import {SelectInitialCards} from '../../src/server/inputs/SelectInitialCards';
 import {cast, range} from '../../src/common/utils/utils';
 
-dotenv.config({path: 'tests/integration/.env', debug: true});
+dotenv.config({path: 'tests/integration/.env', debug: true, quiet: true});
 
 /*
  * This test can be run with `npm run test:integration` as long as the test is set up


### PR DESCRIPTION
Replaces direct require('dotenv').config() calls across server entry points and tools with a side-effect import of the new init module. Also adds quiet:true to suppress dotenv's noisy startup tip.