### PR TITLE
Filter unaffordable placement bonuses at selection time.

### DIFF
--- a/src/server/boards/MarsBoard.ts
+++ b/src/server/boards/MarsBoard.ts
@@ -10,6 +10,7 @@ import {SpaceId} from '../../common/Types';
 import {oneWayDifference} from '../../common/utils/utils';
 import {Tile} from '../Tile';
 import {SpaceBonus} from '../../common/boards/SpaceBonus';
+import * as constants from '../../common/constants';
 
 export class MarsBoard extends Board {
   private readonly edges: ReadonlyArray<Space>;
@@ -182,6 +183,42 @@ export class MarsBoard extends Board {
   public getAvailableSpacesForOcean(player: IPlayer): ReadonlyArray<Space> {
     return this.getSpaces(SpaceType.OCEAN)
       .filter((space) => space.tile === undefined && (space.player === undefined || space.player === player));
+  }
+
+  /**
+   * Returns true when the player can afford the M€ (and Reds TR tax) that each of the
+   * space's placement bonuses will charge.
+   *
+   * Used by cards that hand the player a non-tile-placement choice of space and then call
+   * `grantSpaceBonuses` (Mars Nomads, Gagarin Mobile Base, Survey Mission). Without this
+   * filter, picking e.g. the Hellas ocean space without 6 M€ leaves the player stuck on
+   * the ocean-bonus prompt because `SelectPaymentDeferred` throws. See #7218.
+   *
+   * Tile placement itself goes through `Board.canAfford`/`spaceCosts` and is unaffected.
+   */
+  public static canAffordPlacementBonuses(player: IPlayer, space: Space): boolean {
+    const game = player.game;
+    if (space.bonus.includes(SpaceBonus.OCEAN) && game.canAddOcean()) {
+      if (!player.canAfford({cost: constants.HELLAS_BONUS_OCEAN_COST, tr: {oceans: 1}})) {
+        return false;
+      }
+    }
+    if (space.bonus.includes(SpaceBonus.TEMPERATURE) && game.getTemperature() < constants.MAX_TEMPERATURE) {
+      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST, tr: {temperature: 1}})) {
+        return false;
+      }
+    }
+    if (space.bonus.includes(SpaceBonus.TEMPERATURE_4MC) && game.getTemperature() < constants.MAX_TEMPERATURE) {
+      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_NOVA_BONUS_TEMPERATURE_COST, tr: {temperature: 1}})) {
+        return false;
+      }
+    }
+    if (space.bonus.includes(SpaceBonus.COLONY)) {
+      if (!player.canAfford({cost: constants.TERRA_CIMMERIA_COLONY_COST})) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private computeEdges(): ReadonlyArray<Space> {

--- a/src/server/cards/ceos/Jansson.ts
+++ b/src/server/cards/ceos/Jansson.ts
@@ -1,6 +1,6 @@
+import {MarsBoard} from '@/server/boards/MarsBoard';
 import {CardName} from '../../../common/cards/CardName';
 import {IPlayer} from '../../IPlayer';
-// import {PlayerInput} from '../../PlayerInput';
 import {CardRenderer} from '../render/CardRenderer';
 import {CeoCard} from './CeoCard';
 
@@ -18,12 +18,27 @@ export class Jansson extends CeoCard {
     });
   }
 
+  private spaces(player: IPlayer) {
+    return player.game.board.spaces.filter((space) => space.tile !== undefined && space.player === player);
+  }
+
+  public override canAct(player: IPlayer): boolean {
+    if (this.isDisabled) {
+      return false;
+    }
+    for (const space of this.spaces(player)) {
+      if (!MarsBoard.canAffordPlacementBonuses(player, space)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   public action(player: IPlayer): undefined {
     this.isDisabled = true;
-    const spaces = player.game.board.spaces.filter((space) => space.tile !== undefined && space.player === player);
-    spaces.forEach((space) => {
+    for (const space of this.spaces(player)) {
       player.game.grantSpaceBonuses(player, space);
-    });
+    }
     return undefined;
   }
 }

--- a/src/server/cards/pathfinders/GagarinMobileBase.ts
+++ b/src/server/cards/pathfinders/GagarinMobileBase.ts
@@ -9,6 +9,7 @@ import {SelectSpace} from '../../inputs/SelectSpace';
 import {IActionCard} from '../ICard';
 import {BoardType} from '../../boards/BoardType';
 import {Board} from '../../boards/Board';
+import {MarsBoard} from '../../boards/MarsBoard';
 import {message} from '../../logs/MessageBuilder';
 import {ICorporationCard} from '../corporation/ICorporationCard';
 
@@ -69,7 +70,8 @@ export class GagarinMobileBase extends CorporationCard implements ICorporationCa
       .filter((space) => space.spaceType !== SpaceType.COLONY)
       .filter((space) => space.spaceType !== SpaceType.RESTRICTED)
       .filter((space) => space.tile === undefined)
-      .filter((space) => !visited.includes(space.id));
+      .filter((space) => !visited.includes(space.id))
+      .filter((space) => MarsBoard.canAffordPlacementBonuses(player, space));
 
     if (visited[0] === undefined) {
       return availableSpaces;

--- a/src/server/cards/pathfinders/SurveyMission.ts
+++ b/src/server/cards/pathfinders/SurveyMission.ts
@@ -34,9 +34,18 @@ export class SurveyMission extends PreludeCard {
     });
   }
 
-  private validTriplets(board: MarsBoard): Array<Triplet> {
+  private validTriplets(board: MarsBoard, player: IPlayer): Array<Triplet> {
     const spaces = board.getNonReservedLandSpaces().filter((space) => {
-      return space.player === undefined && (space.tile === undefined || space.tile.protectedHazard === true);
+      if (space.player !== undefined) {
+        return false;
+      }
+      if (space.tile !== undefined && space.tile.protectedHazard !== true) {
+        return false;
+      }
+      // Filter out spaces whose placement bonuses the player can't afford (e.g. Hellas ocean
+      // when low on M€). Without this, claiming such a space would queue PlaceOceanTile +
+      // SelectPaymentDeferred and leave the player stuck. See #7218.
+      return MarsBoard.canAffordPlacementBonuses(player, space);
     });
 
     const result: Array<Triplet> = [];
@@ -74,7 +83,7 @@ export class SurveyMission extends PreludeCard {
   }
 
   public override bespokeCanPlay(player: IPlayer) {
-    return this.validTriplets(player.game.board).length > 0;
+    return this.validTriplets(player.game.board, player).length > 0;
   }
 
   private selectSpace(player: IPlayer, iteration: number, triplets: Array<Triplet>): SelectSpace {
@@ -113,7 +122,7 @@ export class SurveyMission extends PreludeCard {
   }
 
   public override bespokePlay(player: IPlayer) {
-    const triplets = this.validTriplets(player.game.board);
+    const triplets = this.validTriplets(player.game.board, player);
     return this.selectSpace(player, 0, triplets);
   }
 }

--- a/src/server/cards/promo/MarsNomads.ts
+++ b/src/server/cards/promo/MarsNomads.ts
@@ -9,9 +9,8 @@ import {intersection} from '../../../common/utils/utils';
 import {message} from '../../logs/MessageBuilder';
 import {AresHandler} from '../../ares/AresHandler';
 import {BoardType} from '../../boards/BoardType';
+import {MarsBoard} from '../../boards/MarsBoard';
 import {Space} from '../../boards/Space';
-import {SpaceBonus} from '../../../common/boards/SpaceBonus';
-import * as constants from '../../../common/constants';
 export class MarsNomads extends Card implements IActionCard {
   /*
    * A good page about this card: https://boardgamegeek.com/thread/3154812.
@@ -64,23 +63,7 @@ export class MarsNomads extends Card implements IActionCard {
     if (AresHandler.hasHazardTile(space)) {
       return true;
     }
-    const game = player.game;
-    if (space.bonus.includes(SpaceBonus.OCEAN) && game.canAddOcean()) {
-      if (!player.canAfford({cost: constants.HELLAS_BONUS_OCEAN_COST})) {
-        return false;
-      }
-    }
-    if (space.bonus.includes(SpaceBonus.TEMPERATURE) && game.getTemperature() < constants.MAX_TEMPERATURE) {
-      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST})) {
-        return false;
-      }
-    }
-    if (space.bonus.includes(SpaceBonus.TEMPERATURE_4MC) && game.getTemperature() < constants.MAX_TEMPERATURE) {
-      if (!player.canAfford({cost: constants.VASTITAS_BOREALIS_NOVA_BONUS_TEMPERATURE_COST})) {
-        return false;
-      }
-    }
-    return true;
+    return MarsBoard.canAffordPlacementBonuses(player, space);
   }
 
   private eliglbleDestinationSpaces(player: IPlayer) {

--- a/tests/boards/MarsBoard.spec.ts
+++ b/tests/boards/MarsBoard.spec.ts
@@ -10,6 +10,12 @@ import {ArcadianCommunities} from '../../src/server/cards/promo/ArcadianCommunit
 import {testGame} from '../TestGame';
 import {AresHandler} from '../../src/server/ares/AresHandler';
 import {toID} from '../../src/common/utils/utils';
+import {IGame} from '../../src/server/IGame';
+import {Space} from '../../src/server/boards/Space';
+import {SpaceBonus} from '../../src/common/boards/SpaceBonus';
+import {maxOutOceans, setRulingParty, setTemperature} from '../TestingUtils';
+import {PartyName} from '../../src/common/turmoil/PartyName';
+import * as constants from '../../src/common/constants';
 
 describe('MarsBoard', () => {
   let board: MarsBoard;
@@ -112,5 +118,106 @@ describe('MarsBoard', () => {
     const space = board.spaces.find(AresHandler.hasHazardTile);
     space!.player = player;
     expect(board.getAvailableSpacesForGreenery(player)).has.length(45);
+  });
+
+  describe('canAffordPlacementBonuses', () => {
+    let game: IGame;
+    let space: Space;
+
+    beforeEach(() => {
+      [game, player] = testGame(1);
+      space = game.board.getSpaceOrThrow('15');
+      space.bonus = [];
+    });
+
+    it('No bonuses is always affordable', () => {
+      player.megaCredits = 0;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('Ignores bonuses not subject to a cost', () => {
+      space.bonus = [SpaceBonus.PLANT, SpaceBonus.STEEL, SpaceBonus.DRAW_CARD, SpaceBonus.HEAT];
+      player.megaCredits = 0;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('OCEAN bonus requires Hellas ocean cost', () => {
+      space.bonus = [SpaceBonus.OCEAN];
+      player.megaCredits = constants.HELLAS_BONUS_OCEAN_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = constants.HELLAS_BONUS_OCEAN_COST;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('OCEAN bonus is free when oceans are maxed out', () => {
+      space.bonus = [SpaceBonus.OCEAN];
+      maxOutOceans(player);
+      player.megaCredits = 0;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('TEMPERATURE bonus requires Vastitas Borealis temperature cost', () => {
+      space.bonus = [SpaceBonus.TEMPERATURE];
+      player.megaCredits = constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('TEMPERATURE bonus is free when temperature is maxed out', () => {
+      space.bonus = [SpaceBonus.TEMPERATURE];
+      setTemperature(game, constants.MAX_TEMPERATURE);
+      player.megaCredits = 0;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('TEMPERATURE_4MC bonus requires Vastitas Borealis Nova temperature cost', () => {
+      space.bonus = [SpaceBonus.TEMPERATURE_4MC];
+      player.megaCredits = constants.VASTITAS_BOREALIS_NOVA_BONUS_TEMPERATURE_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = constants.VASTITAS_BOREALIS_NOVA_BONUS_TEMPERATURE_COST;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('COLONY bonus requires Terra Cimmeria colony cost', () => {
+      space.bonus = [SpaceBonus.COLONY];
+      player.megaCredits = constants.TERRA_CIMMERIA_COLONY_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = constants.TERRA_CIMMERIA_COLONY_COST;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('Sums multiple unaffordable bonuses', () => {
+      space.bonus = [SpaceBonus.OCEAN, SpaceBonus.TEMPERATURE];
+      // Each bonus is checked independently, so M€ shortage on either fails.
+      player.megaCredits = constants.HELLAS_BONUS_OCEAN_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = constants.VASTITAS_BOREALIS_BONUS_TEMPERATURE_COST - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+    });
+
+    it('Reds tax adds to OCEAN cost', () => {
+      [game, player] = testGame(1, {turmoilExtension: true});
+      setRulingParty(game, PartyName.REDS);
+      space = game.board.getSpaceOrThrow('15');
+      space.bonus = [SpaceBonus.OCEAN];
+
+      const redsCost = constants.HELLAS_BONUS_OCEAN_COST + constants.REDS_RULING_POLICY_COST;
+      player.megaCredits = redsCost - 1;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.false;
+      player.megaCredits = redsCost;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
+
+    it('Reds tax not applied when global parameter is maxed', () => {
+      [game, player] = testGame(1, {turmoilExtension: true});
+      setRulingParty(game, PartyName.REDS);
+      space = game.board.getSpaceOrThrow('15');
+      space.bonus = [SpaceBonus.TEMPERATURE];
+      setTemperature(game, constants.MAX_TEMPERATURE);
+
+      player.megaCredits = 0;
+      expect(MarsBoard.canAffordPlacementBonuses(player, space)).is.true;
+    });
   });
 });

--- a/tests/cards/ceo/Jansson.spec.ts
+++ b/tests/cards/ceo/Jansson.spec.ts
@@ -3,6 +3,7 @@ import {Jansson} from '../../../src/server/cards/ceos/Jansson';
 import {addGreenery} from '../../TestingUtils';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
+import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
 
 import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 
@@ -10,16 +11,38 @@ import {MoonExpansion} from '../../../src/server/moon/MoonExpansion';
 describe('Jansson', () => {
   let card: Jansson;
   let player: TestPlayer;
+  let player2: TestPlayer;
 
   beforeEach(() => {
     card = new Jansson();
-    [/* game */, player] = testGame(2);
+    [/* game */, player, player2] = testGame(2);
   });
 
   it('Can only act once per game', () => {
     card.action(player);
     expect(card.isDisabled).is.true;
     expect(card.canAct(player)).is.false;
+  });
+
+  it('canAct is false when an owned tile has an unaffordable placement bonus', () => {
+    const space = player.game.board.getSpaceOrThrow('35');
+    addGreenery(player, space.id);
+    space.bonus = [SpaceBonus.OCEAN];
+
+    player.megaCredits = 5;
+    expect(card.canAct(player)).is.false;
+
+    player.megaCredits = 6;
+    expect(card.canAct(player)).is.true;
+  });
+
+  it('canAct ignores tiles owned by other players', () => {
+    const space = player.game.board.getSpaceOrThrow('35');
+    addGreenery(player2, space.id);
+    space.bonus = [SpaceBonus.OCEAN];
+    player.megaCredits = 0;
+
+    expect(card.canAct(player)).is.true;
   });
 
   it('Takes action', () => {

--- a/tests/cards/pathfinders/GagarinMobileBase.spec.ts
+++ b/tests/cards/pathfinders/GagarinMobileBase.spec.ts
@@ -10,6 +10,8 @@ import {TileType} from '../../../src/common/TileType';
 import {AmazonisBoard} from '../../../src/server/boards/AmazonisBoard';
 import {UnseededRandom} from '../../../src/common/utils/Random';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
+import {BoardName} from '../../../src/common/boards/BoardName';
+import {SpaceName} from '../../../src/common/boards/SpaceName';
 import {cast} from '../../../src/common/utils/utils';
 
 describe('GagarinMobileBase', () => {
@@ -99,5 +101,23 @@ describe('GagarinMobileBase', () => {
 
     expect(player2.cardsInHand).is.empty;
     expect(player.cardsInHand).has.length(1);
+  });
+
+  it('Hellas ocean space is filtered out when player cannot afford bonus', () => {
+    [game, player] = testGame(2, {boardName: BoardName.HELLAS});
+    card = new GagarinMobileBase();
+    player.playedCards.push(card);
+    const board = game.board;
+
+    const gagarinSpace = board.getAdjacentSpaces(board.getSpaceOrThrow(SpaceName.HELLAS_OCEAN_TILE))[0];
+    game.gagarinBase = [gagarinSpace.id];
+
+    player.megaCredits = 5;
+    expect(cast(card.action(player), SelectSpace).spaces.map((s) => s.id))
+      .to.not.include(SpaceName.HELLAS_OCEAN_TILE);
+
+    player.megaCredits = 6;
+    expect(cast(card.action(player), SelectSpace).spaces.map((s) => s.id))
+      .to.include(SpaceName.HELLAS_OCEAN_TILE);
   });
 });

--- a/tests/cards/pathfinders/SurveyMission.spec.ts
+++ b/tests/cards/pathfinders/SurveyMission.spec.ts
@@ -144,4 +144,16 @@ describe('SurveyMission', () => {
     expect(selectSpace.spaces).not.to.include(space04);
     expect(selectSpace.spaces.map(toSpaceIdDigit)).to.have.members([5, 10, 11, 16, 17]);
   });
+
+  it('Spaces with unaffordable placement bonuses are filtered', () => {
+    // Put a Hellas-style ocean bonus on space 04. Space 04 only appears in triplet [4,5,10].
+    const space04 = board.getSpaceOrThrow('04');
+    space04.bonus = [SpaceBonus.OCEAN];
+
+    player.megaCredits = 5;
+    expect(cast(card.play(player), SelectSpace).spaces).not.to.include(space04);
+
+    player.megaCredits = 6;
+    expect(cast(card.play(player), SelectSpace).spaces).to.include(space04);
+  });
 });

--- a/tests/cards/promo/MarsNomads.spec.ts
+++ b/tests/cards/promo/MarsNomads.spec.ts
@@ -2,7 +2,8 @@ import {expect} from 'chai';
 import {TestPlayer} from '../../TestPlayer';
 import {IGame} from '../../../src/server/IGame';
 import {testGame} from '../../TestGame';
-import {churn, runAllActions, setTemperature} from '../../TestingUtils';
+import {churn, runAllActions, setRulingParty, setTemperature} from '../../TestingUtils';
+import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {MarsNomads} from '../../../src/server/cards/promo/MarsNomads';
 import {Networker} from '../../../src/server/milestones/Networker';
@@ -162,6 +163,31 @@ describe('MarsNomads', () => {
 
       const spaces = cast(card.action(player), SelectSpace).spaces;
       expect(spaces.includes(destinationSpace)).to.eq(run.expected);
+    });
+  }
+
+  for (const run of [
+    {bonus: SpaceBonus.OCEAN, mc: 8, expected: false},
+    {bonus: SpaceBonus.OCEAN, mc: 9, expected: true},
+    {bonus: SpaceBonus.TEMPERATURE, mc: 5, expected: false},
+    {bonus: SpaceBonus.TEMPERATURE, mc: 6, expected: true},
+    {bonus: SpaceBonus.TEMPERATURE_4MC, mc: 6, expected: false},
+    {bonus: SpaceBonus.TEMPERATURE_4MC, mc: 7, expected: true},
+  ] as const) {
+    it('Destination filter includes Reds TR tax' + JSON.stringify(run), () => {
+      const [game, player] = testGame(2, {turmoilExtension: true});
+      const card = new MarsNomads();
+      const board = game.board;
+      setRulingParty(game, PartyName.REDS);
+
+      const nomadSpace = board.getAvailableSpacesOnLand(player)[12];
+      game.nomadSpace = nomadSpace.id;
+      const destinationSpace = board.getAdjacentSpaces(nomadSpace).find((s) => s.spaceType === SpaceType.LAND)!;
+      destinationSpace.bonus = [run.bonus];
+      player.megaCredits = run.mc;
+
+      const selectSpace = cast(card.action(player), SelectSpace);
+      expect(selectSpace.spaces.includes(destinationSpace)).to.eq(run.expected);
     });
   }
 


### PR DESCRIPTION
Fixes #7218

Mars Nomads, Gagarin Mobile Base, Survey Mission, and Jansson all hand the player a tile space and then call grantSpaceBonuses, which chains a SelectPaymentDeferred for Hellas ocean / Vastitas temperature / Terra Cimmeria colony bonuses. If the player can't afford the cost, SelectPaymentDeferred throws and the player is stuck on the prompt.

Extract MarsBoard.canAffordPlacementBonuses helper that checks each bonus' M€ cost plus Reds TR tax, and apply it at selection time:

- MarsNomads: replaces the previous filter (which omitted Reds tax)
- GagarinMobileBase: new filter on availableSpaces
- SurveyMission: new filter on validTriplets
- Jansson: canAct returns false when any owned tile would charge more than the player can afford