### PR TITLE
Add cancel action undo safeguards

### DIFF
--- a/src/client/components/WaitingFor.vue
+++ b/src/client/components/WaitingFor.vue
@@ -14,6 +14,9 @@
       </label>
       <div v-if="showRefresh()">Refresh<span class="reset"></span></div>
     </template>
+    <div v-if="showCancelAction()" class="wf-action-controls">
+      <AppButton @click="reset" size="small" title="Cancel action" />
+    </div>
     <player-input-factory :players="playerView.players"
                           :playerView="playerView"
                           :playerinput="waitingfor"
@@ -45,6 +48,7 @@ import {InputResponse} from '@/common/inputs/InputResponse';
 import {INVALID_RUN_ID, AppErrorResponse} from '@/common/app/AppErrorId';
 import {Color} from '@/common/Color';
 import {gameDocumentTitle} from '../utils/documentTitle';
+import AppButton from '@/client/components/common/AppButton.vue';
 
 let ui_update_timeout_id: number | undefined;
 let documentTitleTimer: number | undefined;
@@ -75,6 +79,9 @@ export default defineComponent({
       suspend: false,
       savedPlayerView: undefined,
     };
+  },
+  components: {
+    AppButton,
   },
   methods: {
     getPlayerName(color: Color): string {
@@ -126,7 +133,7 @@ export default defineComponent({
 
           const showAlert = vueRoot(this).showAlert;
           if (response.status === statusCode.badRequest) {
-            const resp = await response.json() as AppErrorResponse;
+            const resp = await this.readAppError(response);
             let cb = () => {};
             if (resp.id === INVALID_RUN_ID) {
               cb = () => setTimeout(() => window.location.reload(), 100);
@@ -144,6 +151,16 @@ export default defineComponent({
         .finally(() => {
           root.isServerSideRequestInProgress = false;
         });
+    },
+    async readAppError(response: Response): Promise<AppErrorResponse> {
+      try {
+        return await response.clone().json() as AppErrorResponse;
+      } catch (_err) {
+        return {
+          id: undefined,
+          message: await response.text(),
+        };
+      }
     },
     updatePlayerView(playerView: PlayerViewModel | undefined) {
       if (this.suspend === false) {
@@ -237,6 +254,16 @@ export default defineComponent({
     },
     showRefresh(): boolean {
       return this.suspend === true && this.savedPlayerView !== undefined;
+    },
+    showCancelAction(): boolean {
+      return this.playerView.game.phase === Phase.ACTION &&
+        this.playerView.game.gameOptions?.undoOption === true &&
+        this.waitingfor !== undefined &&
+        !this.isMainActionPrompt() &&
+        this.playerView.thisPlayer?.isActive === true;
+    },
+    isMainActionPrompt(): boolean {
+      return this.waitingfor?.type === 'or' && this.waitingfor.buttonLabel === 'Take action';
     },
     playerName(color: Color) {
       const player = this.playerView.players.find((p) => p.color === color);

--- a/src/common/logs/LogMessage.ts
+++ b/src/common/logs/LogMessage.ts
@@ -5,6 +5,7 @@ import {PlayerId} from '../Types';
 
 export class LogMessage implements Message {
   public playerId?: PlayerId;
+  public canceled?: boolean;
   public timestamp = Date.now();
   public type?: LogMessageType;
   constructor(
@@ -27,4 +28,3 @@ export class LogMessage implements Message {
     }
   }
 }
-

--- a/src/server/database/GameLoader.ts
+++ b/src/server/database/GameLoader.ts
@@ -11,6 +11,7 @@ import {timeAsync} from '../utils/timer';
 import {durationToMilliseconds} from '../utils/durations';
 import {CacheConfig} from './CacheConfig';
 import {Clock} from '../../common/Timer';
+import {appendCanceledLogMessages} from '../logs/appendCanceledLogMessages';
 
 const metrics = {
   initialize: new prometheus.Gauge({
@@ -157,6 +158,11 @@ export class GameLoader implements IGameLoader {
     return undefined;
   }
 
+  public async getGameAt(gameId: GameId, saveId: number): Promise<IGame> {
+    const serializedGame = await Database.getInstance().getGameVersion(gameId, saveId);
+    return Game.deserialize(serializedGame);
+  }
+
   public async restoreGameAt(gameId: GameId, saveId: number): Promise<IGame> {
     const current = await this.getGame(gameId);
     if (current === undefined) {
@@ -170,6 +176,7 @@ export class GameLoader implements IGameLoader {
     }
     const serializedGame = await Database.getInstance().getGame(gameId);
     const game = Game.deserialize(serializedGame);
+    appendCanceledLogMessages(current, game);
     await this.add(game);
     game.undoCount++;
     return game;

--- a/src/server/database/IGameLoader.ts
+++ b/src/server/database/IGameLoader.ts
@@ -21,6 +21,14 @@ export interface IGameLoader {
    */
   getGame(id: GameId | PlayerId | SpectatorId, forceLoad?: boolean): Promise<IGame | undefined>;
   /**
+   * Loads a game at a specific saved version without changing cache or deleting
+   * later saves. Use this to validate whether a restore is allowed.
+   *
+   * @param {GameId} gameId the id of the game to retrieve
+   * @param {number} saveId the save id to load
+   */
+  getGameAt(gameId: GameId, saveId: number): Promise<IGame>;
+  /**
    * Reload a game at a specific version, deleting all versions ahead of it.
    *
    * @param {GameId} gameId the id of the game to retrieve

--- a/src/server/game/hasRevealedHiddenInformation.ts
+++ b/src/server/game/hasRevealedHiddenInformation.ts
@@ -1,0 +1,95 @@
+import {ICard} from '../cards/ICard';
+import {IGame} from '../IGame';
+import {IPlayer} from '../IPlayer';
+
+export function hasRevealedHiddenInformation(currentGame: IGame, restoredGame: IGame, player: IPlayer): boolean {
+  if (hasDeckDrawPileChanged(currentGame, restoredGame)) {
+    return true;
+  }
+
+  for (const currentPlayer of currentGame.players) {
+    const restoredPlayer = restoredGame.players.find((candidate) => candidate.id === currentPlayer.id);
+    if (restoredPlayer === undefined) {
+      return true;
+    }
+    if (hasNewPrivateCards(currentPlayer, restoredPlayer)) {
+      return true;
+    }
+  }
+
+  return waitingForShowsUnknownCards(player, restoredGame);
+}
+
+function hasDeckDrawPileChanged(currentGame: IGame, restoredGame: IGame): boolean {
+  return cardNames(currentGame.projectDeck.drawPile).join('|') !== cardNames(restoredGame.projectDeck.drawPile).join('|') ||
+    cardNames(currentGame.preludeDeck.drawPile).join('|') !== cardNames(restoredGame.preludeDeck.drawPile).join('|') ||
+    cardNames(currentGame.corporationDeck.drawPile).join('|') !== cardNames(restoredGame.corporationDeck.drawPile).join('|') ||
+    cardNames(currentGame.ceoDeck.drawPile).join('|') !== cardNames(restoredGame.ceoDeck.drawPile).join('|');
+}
+
+function hasNewPrivateCards(currentPlayer: IPlayer, restoredPlayer: IPlayer): boolean {
+  return hasAddedCards(currentPlayer.cardsInHand, restoredPlayer.cardsInHand) ||
+    hasAddedCards(currentPlayer.dealtProjectCards, restoredPlayer.dealtProjectCards) ||
+    hasAddedCards(currentPlayer.draftHand, restoredPlayer.draftHand) ||
+    hasAddedCards(currentPlayer.draftedCards, restoredPlayer.draftedCards) ||
+    hasAddedCards(currentPlayer.preludeCardsInHand, restoredPlayer.preludeCardsInHand) ||
+    hasAddedCards(Array.from(currentPlayer.ceoCardsInHand), Array.from(restoredPlayer.ceoCardsInHand)) ||
+    hasAddedCards(currentPlayer.dealtCorporationCards, restoredPlayer.dealtCorporationCards) ||
+    hasAddedCards(currentPlayer.dealtPreludeCards, restoredPlayer.dealtPreludeCards) ||
+    hasAddedCards(currentPlayer.dealtCeoCards, restoredPlayer.dealtCeoCards);
+}
+
+function hasAddedCards(currentCards: ReadonlyArray<ICard>, restoredCards: ReadonlyArray<ICard>): boolean {
+  const restoredCounts = countCards(restoredCards);
+  for (const card of currentCards) {
+    const count = restoredCounts.get(card.name) ?? 0;
+    if (count === 0) {
+      return true;
+    }
+    restoredCounts.set(card.name, count - 1);
+  }
+  return false;
+}
+
+function waitingForShowsUnknownCards(player: IPlayer, restoredGame: IGame): boolean {
+  const waitingForModel = player.getWaitingFor()?.toModel(player);
+  if (waitingForModel === undefined || !('cards' in waitingForModel)) {
+    return false;
+  }
+
+  const knownCards = new Set<string>();
+  for (const candidate of restoredGame.players) {
+    for (const cardName of cardNames(candidate.tableau.asArray())) {
+      knownCards.add(cardName);
+    }
+  }
+
+  const restoredPlayer = restoredGame.getPlayerById(player.id);
+  for (const cardName of [
+    ...cardNames(restoredPlayer.cardsInHand),
+    ...cardNames(restoredPlayer.dealtProjectCards),
+    ...cardNames(restoredPlayer.draftHand),
+    ...cardNames(restoredPlayer.draftedCards),
+    ...cardNames(restoredPlayer.preludeCardsInHand),
+    ...cardNames(Array.from(restoredPlayer.ceoCardsInHand)),
+    ...cardNames(restoredPlayer.dealtCorporationCards),
+    ...cardNames(restoredPlayer.dealtPreludeCards),
+    ...cardNames(restoredPlayer.dealtCeoCards),
+  ]) {
+    knownCards.add(cardName);
+  }
+
+  return waitingForModel.cards.some((card) => !knownCards.has(card.name));
+}
+
+function countCards(cards: ReadonlyArray<ICard>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const card of cards) {
+    counts.set(card.name, (counts.get(card.name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function cardNames(cards: ReadonlyArray<ICard>): Array<string> {
+  return cards.map((card) => card.name);
+}

--- a/src/server/logs/appendCanceledLogMessages.ts
+++ b/src/server/logs/appendCanceledLogMessages.ts
@@ -1,0 +1,19 @@
+import {LogMessage} from '../../common/logs/LogMessage';
+import {IGame} from '../IGame';
+
+export function appendCanceledLogMessages(current: IGame, restored: IGame): void {
+  const canceledMessages = current.gameLog.slice(restored.gameLog.length)
+    .filter((message) => message?.canceled !== true)
+    .map((message) => {
+      const copy = JSON.parse(JSON.stringify(message)) as LogMessage;
+      copy.canceled = true;
+      return copy;
+    });
+
+  if (canceledMessages.length === 0) {
+    return;
+  }
+
+  restored.gameLog.push(...canceledMessages);
+  restored.gameAge += canceledMessages.length;
+}

--- a/src/server/routes/PlayerInput.ts
+++ b/src/server/routes/PlayerInput.ts
@@ -15,6 +15,7 @@ import {statusCode} from '../../common/http/statusCode';
 import {InputError} from '../inputs/InputError';
 import {isIProjectCard} from '../cards/IProjectCard';
 import {AppErrorResponse, INVALID_RUN_ID} from '../../common/app/AppErrorId';
+import {hasRevealedHiddenInformation} from '../game/hasRevealedHiddenInformation';
 
 export class PlayerInput extends Handler {
   public static readonly INSTANCE = new PlayerInput();
@@ -69,6 +70,11 @@ export class PlayerInput extends Handler {
      */
     const lastSaveId = player.game.lastSaveId - 2;
     try {
+      const restoredGame = await ctx.gameLoader.getGameAt(player.game.id, lastSaveId);
+      if (hasRevealedHiddenInformation(player.game, restoredGame, player)) {
+        throw new InputError('Cannot undo after hidden information was revealed');
+      }
+
       const game = await ctx.gameLoader.restoreGameAt(player.game.id, lastSaveId);
       if (game === undefined) {
         player.game.log('Unable to perform undo operation. Error retrieving game from database. Please try again.', () => {}, {reservedFor: player});
@@ -77,6 +83,9 @@ export class PlayerInput extends Handler {
         player = game.getPlayerById(player.id);
       }
     } catch (err) {
+      if (err instanceof InputError) {
+        throw err;
+      }
       console.error(err);
     }
     responses.writeJson(res, ctx, Server.getPlayerModel(player));

--- a/src/server/routes/Reset.ts
+++ b/src/server/routes/Reset.ts
@@ -6,6 +6,8 @@ import {IPlayer} from '../IPlayer';
 import {isPlayerId} from '../../common/Types';
 import {Request} from '../Request';
 import {Response} from '../Response';
+import {appendCanceledLogMessages} from '../logs/appendCanceledLogMessages';
+import {hasRevealedHiddenInformation} from '../game/hasRevealedHiddenInformation';
 
 /**
  * Reloads the game from the last action.
@@ -15,7 +17,7 @@ import {Response} from '../Response';
  * I think it's saved after every action when undo is on. So, there's that.
  * But I forget when the game is saved in solo. Probably all will be well.
  *
- * Eventually, this will not be callable once cards are drawn.
+ * It refuses to reload once the current action has revealed hidden information.
  */
 export class Reset extends Handler {
   public static readonly INSTANCE = new Reset();
@@ -42,9 +44,9 @@ export class Reset extends Handler {
       return;
     }
 
-    // While prototyping, this is only available for solo games
-    if (game.players.length > 1) {
-      throw new Error('Reset is only available for solo games at the moment.');
+    if (game.players.length > 1 && game.gameOptions.undoOption !== true) {
+      responses.badRequest(req, res, 'Cancel action requires undo to be enabled');
+      return;
     }
 
     let player: IPlayer | undefined;
@@ -63,10 +65,19 @@ export class Reset extends Handler {
     }
 
     try {
-      const game = await ctx.gameLoader.getGame(player.game.id, /** force reload */ true);
-      if (game !== undefined) {
-        const reloadedPlayer = game.getPlayerById(player.id);
-        game.inputsThisRound = 0;
+      const currentGame = player.game;
+      const reloadedGame = await ctx.gameLoader.getGame(currentGame.id, /** force reload */ true);
+      if (reloadedGame !== undefined) {
+        if (hasRevealedHiddenInformation(currentGame, reloadedGame, player)) {
+          await ctx.gameLoader.add(currentGame);
+          responses.badRequest(req, res, 'Cannot cancel action after hidden information was revealed');
+          return;
+        }
+
+        appendCanceledLogMessages(currentGame, reloadedGame);
+        const reloadedPlayer = reloadedGame.getPlayerById(player.id);
+        reloadedGame.inputsThisRound = 0;
+        reloadedGame.undoCount = Math.max(reloadedGame.undoCount, currentGame.undoCount) + 1;
         responses.writeJson(res, ctx, Server.getPlayerModel(reloadedPlayer));
         return;
       }

--- a/tests/client/components/WaitingFor.spec.ts
+++ b/tests/client/components/WaitingFor.spec.ts
@@ -62,4 +62,99 @@ describe('WaitingFor', () => {
     });
     expect(wrapper.text()).to.include('Not your turn');
   });
+
+  it('shows cancel action for nested active action prompts when undo is enabled', () => {
+    const wrapper = shallowMount(WaitingFor, {
+      ...globalConfig,
+      global: {
+        ...globalConfig.global,
+        stubs: {
+          'player-input-factory': {template: '<div class="stub-pif"></div>'},
+          'AppButton': {props: ['title'], template: '<button>{{ title }}</button>'},
+        },
+      },
+      props: {
+        playerView: {
+          ...playerView,
+          thisPlayer: {...thisPlayer, isActive: true},
+          game: {
+            ...playerView.game,
+            gameOptions: {undoOption: true},
+          },
+        } as PlayerViewModel,
+        waitingfor: {
+          type: 'card',
+          title: 'Choose a card',
+          buttonLabel: 'Choose',
+          cards: [],
+          min: 1,
+          max: 1,
+        },
+      },
+    });
+
+    expect(wrapper.text()).to.include('Cancel action');
+  });
+
+  it('does not show cancel action on the main action prompt', () => {
+    const wrapper = shallowMount(WaitingFor, {
+      ...globalConfig,
+      global: {
+        ...globalConfig.global,
+        stubs: {
+          'player-input-factory': {template: '<div class="stub-pif"></div>'},
+          'AppButton': {props: ['title'], template: '<button>{{ title }}</button>'},
+        },
+      },
+      props: {
+        playerView: {
+          ...playerView,
+          thisPlayer: {...thisPlayer, isActive: true},
+          game: {
+            ...playerView.game,
+            gameOptions: {undoOption: true},
+          },
+        } as PlayerViewModel,
+        waitingfor: {
+          type: 'or',
+          title: 'Take your next action',
+          buttonLabel: 'Take action',
+          options: [],
+        },
+      },
+    });
+
+    expect(wrapper.text()).to.not.include('Cancel action');
+  });
+
+  it('shows cancel action for nested active action option prompts when undo is enabled', () => {
+    const wrapper = shallowMount(WaitingFor, {
+      ...globalConfig,
+      global: {
+        ...globalConfig.global,
+        stubs: {
+          'player-input-factory': {template: '<div class="stub-pif"></div>'},
+          'AppButton': {props: ['title'], template: '<button>{{ title }}</button>'},
+        },
+      },
+      props: {
+        playerView: {
+          ...playerView,
+          thisPlayer: {...thisPlayer, isActive: true},
+          game: {
+            ...playerView.game,
+            gameOptions: {undoOption: true},
+          },
+        } as PlayerViewModel,
+        waitingfor: {
+          type: 'or',
+          title: 'Select one option',
+          buttonLabel: 'Confirm',
+          options: [],
+        },
+      },
+    });
+
+    expect(wrapper.text()).to.include('Cancel action');
+  });
 });

--- a/tests/database/GameLoader.spec.ts
+++ b/tests/database/GameLoader.spec.ts
@@ -228,6 +228,46 @@ describe('GameLoader', () => {
     expect(await database.getSaveIds(game.id)).deep.eq([0, 1, 2]);
   });
 
+  it('getGameAt loads a saved version without restoring it', async () => {
+    game.generation = 12;
+    game.save();
+
+    game.generation = 13;
+    game.save();
+    await instance.add(game);
+
+    const savedGame = await instance.getGameAt(game.id, 1);
+    const currentGame = await instance.getGame(game.id);
+
+    expect(savedGame.generation).eq(12);
+    expect(currentGame!.generation).eq(13);
+    expect(await database.getSaveIds(game.id)).deep.eq([0, 1, 2]);
+  });
+
+  it('restoreGameAt appends canceled log messages from the restored action', async () => {
+    game.gameLog.length = 0;
+    game.gameAge = 0;
+    game.log('Generation ${0}', (b) => b.forNewGeneration().number(1));
+    game.log('Kept action');
+    game.save();
+    const saves = database.games.get(game.id)!;
+    saves[1] = JSON.parse(JSON.stringify(saves[1]));
+
+    game.log('Canceled action');
+    game.save();
+    await instance.add(game);
+
+    const newGame = await instance.restoreGameAt(game.id, 1);
+
+    expect(newGame.gameLog.map((message) => message.message)).deep.eq([
+      'Generation ${0}',
+      'Kept action',
+      'Canceled action',
+    ]);
+    expect(newGame.gameLog[2].canceled).eq(true);
+    expect(newGame.gameAge).eq(3);
+  });
+
   it('saveGame', async () => {
     game.generation = 12;
     instance.saveGame(game);

--- a/tests/routes/FakeGameLoader.ts
+++ b/tests/routes/FakeGameLoader.ts
@@ -29,6 +29,13 @@ export class FakeGameLoader implements IGameLoader {
     }
     return Promise.resolve(undefined);
   }
+  async getGameAt(gameId: GameId, _saveId: number): Promise<IGame> {
+    const game = await this.getGame(gameId);
+    if (game === undefined) {
+      throw new Error('Game not found ' + gameId);
+    }
+    return game;
+  }
   restoreGameAt(_gameId: string, _saveId: number): Promise<Game> {
     throw new Error('Method not implemented.');
   }

--- a/tests/routes/PlayerInput.spec.ts
+++ b/tests/routes/PlayerInput.spec.ts
@@ -56,6 +56,39 @@ describe('PlayerInput', () => {
     expect(model.game.gameAge).eq(undo.gameAge);
   });
 
+  it('blocks undo when the action revealed hidden information', async () => {
+    const player = TestPlayer.BLUE.newPlayer({beginner: true});
+    scaffolding.url = '/player/input?id=' + player.id;
+    const game = Game.newInstance('gameid-hidden-undo', [player], player, 'spectatorid');
+    game.lastSaveId = 4;
+    game.projectDeck.draw(game);
+    player.setWaitingFor(new OrOptions(new UndoActionOption()));
+
+    const undoVersionOfPlayer = TestPlayer.BLUE.newPlayer({beginner: true});
+    const undo = Game.newInstance('gameid-hidden-undo', [undoVersionOfPlayer], undoVersionOfPlayer, 'spectatorid');
+    let restoreCalled = false;
+
+    await scaffolding.ctx.gameLoader.add(game);
+    (scaffolding.ctx.gameLoader as any).getGameAt = (_gameId: string, _lastSaveId: number) => Promise.resolve(undo);
+    scaffolding.ctx.gameLoader.restoreGameAt = (_gameId: string, _lastSaveId: number) => {
+      restoreCalled = true;
+      return Promise.resolve(undo);
+    };
+
+    const post = scaffolding.post(PlayerInput.INSTANCE, res);
+    const emit = Promise.resolve().then(() => {
+      const orOptionsResponse: OrOptionsResponse = {type: 'or', index: 0, response: {type: 'option'}};
+      req.emitter.emit('data', JSON.stringify(orOptionsResponse));
+      req.emitter.emit('end');
+    });
+    await Promise.all(([emit, post]));
+
+    const response = JSON.parse(res.content);
+    expect(res.statusCode).eq(400);
+    expect(response.message).eq('Cannot undo after hidden information was revealed');
+    expect(restoreCalled).eq(false);
+  });
+
   it('reverts to current game instance if undo fails', async () => {
     const player = TestPlayer.BLUE.newPlayer({beginner: true});
     scaffolding.url = '/player/input?id=' + player.id;

--- a/tests/routes/Reset.spec.ts
+++ b/tests/routes/Reset.spec.ts
@@ -1,0 +1,145 @@
+import {expect} from 'chai';
+import {Reset} from '../../src/server/routes/Reset';
+import {Game} from '../../src/server/Game';
+import {TestPlayer} from '../TestPlayer';
+import {MockResponse} from './HttpMocks';
+import {PlayerViewModel} from '../../src/common/models/PlayerModel';
+import {RouteTestScaffolding} from './RouteTestScaffolding';
+import {IGame} from '../../src/server/IGame';
+import {GameId, PlayerId, SpectatorId} from '../../src/common/Types';
+import {GameIdLedger} from '../../src/server/database/IDatabase';
+
+describe('Reset', () => {
+  let scaffolding: RouteTestScaffolding;
+  let res: MockResponse;
+
+  beforeEach(() => {
+    scaffolding = new RouteTestScaffolding();
+    res = new MockResponse();
+  });
+
+  it('reloads multiplayer action state when undo is enabled', async () => {
+    const currentPlayer = TestPlayer.BLACK.newPlayer();
+    const currentOpponent = TestPlayer.RED.newPlayer();
+    const currentGame = Game.newInstance('game-id', [currentPlayer, currentOpponent], currentPlayer, 'spectatorid', {undoOption: true});
+    currentGame.undoCount = 3;
+    currentGame.gameAge = 8;
+    currentPlayer.actionsTakenThisRound = 1;
+
+    const reloadedPlayer = TestPlayer.BLACK.newPlayer();
+    const reloadedOpponent = TestPlayer.RED.newPlayer();
+    const reloadedGame = Game.newInstance('game-id', [reloadedPlayer, reloadedOpponent], reloadedPlayer, 'spectatorid', {undoOption: true});
+    reloadedGame.undoCount = 2;
+    reloadedGame.gameAge = 7;
+    reloadedPlayer.actionsTakenThisRound = 1;
+
+    useReloadingGameLoader(scaffolding, currentGame, reloadedGame);
+    scaffolding.url = '/reset?id=' + currentPlayer.id;
+
+    await scaffolding.get(Reset.INSTANCE, res);
+
+    const response: PlayerViewModel = JSON.parse(res.content);
+    expect(response.id).eq(reloadedPlayer.id);
+    expect(response.game.undoCount).eq(4);
+    expect(response.thisPlayer.actionsTakenThisRound).eq(1);
+  });
+
+  it('blocks multiplayer reset when undo is disabled', async () => {
+    const player = TestPlayer.BLACK.newPlayer();
+    const opponent = TestPlayer.RED.newPlayer();
+    const game = Game.newInstance('game-id', [player, opponent], player, 'spectatorid', {undoOption: false});
+    await scaffolding.ctx.gameLoader.add(game);
+    scaffolding.url = '/reset?id=' + player.id;
+
+    await scaffolding.get(Reset.INSTANCE, res);
+
+    expect(res.content).eq('Bad request: Cancel action requires undo to be enabled');
+  });
+
+  it('does not reload when the current action revealed deck information', async () => {
+    const currentPlayer = TestPlayer.BLACK.newPlayer();
+    const currentOpponent = TestPlayer.RED.newPlayer();
+    const currentGame = Game.newInstance('game-id', [currentPlayer, currentOpponent], currentPlayer, 'spectatorid', {undoOption: true});
+    currentGame.projectDeck.draw(currentGame);
+
+    const reloadedPlayer = TestPlayer.BLACK.newPlayer();
+    const reloadedOpponent = TestPlayer.RED.newPlayer();
+    const reloadedGame = Game.newInstance('game-id', [reloadedPlayer, reloadedOpponent], reloadedPlayer, 'spectatorid', {undoOption: true});
+
+    let addedGame: IGame | undefined;
+    useReloadingGameLoader(scaffolding, currentGame, reloadedGame, (game) => {
+      addedGame = game;
+    });
+    scaffolding.url = '/reset?id=' + currentPlayer.id;
+
+    await scaffolding.get(Reset.INSTANCE, res);
+
+    expect(res.content).eq('Bad request: Cannot cancel action after hidden information was revealed');
+    expect(addedGame).eq(currentGame);
+  });
+
+  it('appends canceled log messages from the current action', async () => {
+    const currentPlayer = TestPlayer.BLACK.newPlayer();
+    const currentOpponent = TestPlayer.RED.newPlayer();
+    const currentGame = Game.newInstance('game-id', [currentPlayer, currentOpponent], currentPlayer, 'spectatorid', {undoOption: true});
+    currentGame.gameLog.length = 0;
+    currentGame.gameAge = 0;
+    currentGame.log('Kept action');
+    currentGame.log('Canceled action');
+
+    const reloadedPlayer = TestPlayer.BLACK.newPlayer();
+    const reloadedOpponent = TestPlayer.RED.newPlayer();
+    const reloadedGame = Game.newInstance('game-id', [reloadedPlayer, reloadedOpponent], reloadedPlayer, 'spectatorid', {undoOption: true});
+    reloadedGame.gameLog.length = 0;
+    reloadedGame.gameAge = 0;
+    reloadedGame.log('Kept action');
+
+    useReloadingGameLoader(scaffolding, currentGame, reloadedGame);
+    scaffolding.url = '/reset?id=' + currentPlayer.id;
+
+    await scaffolding.get(Reset.INSTANCE, res);
+
+    expect(reloadedGame.gameLog.map((message) => message.message)).deep.eq([
+      'Kept action',
+      'Canceled action',
+    ]);
+    expect(reloadedGame.gameLog[1].canceled).eq(true);
+    expect(reloadedGame.gameAge).eq(2);
+  });
+});
+
+function useReloadingGameLoader(
+  scaffolding: RouteTestScaffolding,
+  currentGame: IGame,
+  reloadedGame: IGame,
+  onAdd?: (game: IGame) => void,
+) {
+  scaffolding.ctx.gameLoader = {
+    add(game: IGame): Promise<void> {
+      onAdd?.(game);
+      return Promise.resolve();
+    },
+    getIds(): Promise<Array<GameIdLedger>> {
+      return Promise.resolve([]);
+    },
+    getGame(_id: GameId | PlayerId | SpectatorId, forceLoad?: boolean): Promise<IGame | undefined> {
+      return Promise.resolve(forceLoad === true ? reloadedGame : currentGame);
+    },
+    getGameAt(): Promise<IGame> {
+      return Promise.reject(new Error('not implemented'));
+    },
+    restoreGameAt(): Promise<IGame> {
+      return Promise.reject(new Error('not implemented'));
+    },
+    mark() {},
+    saveGame(): Promise<void> {
+      return Promise.resolve();
+    },
+    completeGame(): Promise<void> {
+      return Promise.resolve();
+    },
+    maintenance(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a `Cancel action` control for active nested action prompts when undo is enabled.
- Keeps the main `Take action` prompt unchanged, and blocks both cancel action and regular undo once the action has revealed hidden information.
- Preserves log messages from canceled actions by appending them back as canceled entries after restore.

## Demo
Screenshots below are from local synthetic games on this branch; no live/player-private game data is used.

### Example 1: nested action prompt can be canceled
Local demo state: `g-cancel-action-demo`, player `p-cancel-action-demo`, action phase, undo enabled. The player is inside a nested `Select one option` prompt, so the new `Cancel action` button appears above the prompt.

![Cancel action visible](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets-cancel-action-undo/screenshots/cancel-action-undo/cancel-action-visible.png)

### Example 2: hidden information prevents rollback
Local demo state: `g-hidden-info-demo`, player `p-hidden-info-demo`. The current action has already changed the project deck draw pile, so cancel/undo must not restore through that revealed information.

![Hidden information guard state](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/pr-assets-cancel-action-undo/screenshots/cancel-action-undo/hidden-info-before-block.png)

The reset route rejects the rollback in this state:

```text
HTTP/1.1 400 Bad Request
Bad request: Cannot cancel action after hidden information was revealed
```

Regular undo uses the same guard and returns `Cannot undo after hidden information was revealed` for the corresponding undo input.

## Testing
- `npm run build:tests`
- `npm run lint`
- `mocha --import=tsx --require tests/testing/setup.ts "tests/routes/Reset.spec.ts" "tests/routes/PlayerInput.spec.ts" "tests/database/GameLoader.spec.ts"`
- `NODE_ENV=development mochapack --require tests/client/components/setup.ts "tests/client/components/WaitingFor.spec.ts"`
- `npm run build:server`
- `npm run build` (for local screenshot capture)

## Notes
- No deploy scripts or custom-server release tooling included.