### PR TITLE
fix(i18n): UA тег/ТЕГ sweep leftovers + missing CEO strings

### DIFF
--- a/src/locales/ua/ceo_cards.json
+++ b/src/locales/ua/ceo_cards.json
@@ -57,6 +57,9 @@
   "HAL 9000": "",
   "Once per game, decrease each of your productions 1 step to gain 4 of that resource.": "Один раз за гру зменште кожне зі своїх виробництв на 1, щоб отримати 4 одиниці цього ресурсу.",
 
+  "Huan": "Хуан",
+  "ALL OPPONENTS CANNOT TRADE NEXT GENERATION. Gain 1 Trade Fleet.": "ВСІ СУПЕРНИКИ НЕ МОЖУТЬ ТОРГУВАТИ НАСТУПНОГО ПОКОЛІННЯ. Отримайте 1 торговий флот.",
+
   "Ingrid": "Інгрід",
   "When you take an action that places a tile on Mars THIS GENERATION, draw a card.": "Коли ви виконуєте дію, яка розміщує тайл на Марсі У ЦЬОМУ ПОКОЛІННІ, витягніть картку.",
 
@@ -84,6 +87,7 @@
   "Once per game, increase your M€ production by the value of the LOWEST Moon rate.": "Отримайте 1 M€, коли будь-який гравець грає картку з міткою Місяця. Один раз за гру збільште ваше виробництво M€ на величину НАЙНИЖЧОЇ ставки Місяця.",
 
   "Oscar": "Оскар",
+  "Effect: You have +1 influence": "Ефект: Ви маєте +1 вплив",
   "Once per game, replace the Chairman with one of your delegates.": "У вас +1 вплив. Один раз за гру замініть Голову одним зі своїх делегатів.",
 
   "Petra": "Петра",

--- a/src/locales/ua/community_corporations.json
+++ b/src/locales/ua/community_corporations.json
@@ -1,7 +1,7 @@
 {
   "Agricola Inc": "Агрікола Інк.",
   "You start with 1 plant production, 1 M€ production, 1 heat production and 40 M€.": "Ви починаєте з виробництва 1 рослини, виробництва 1 M€, виробництва 1 тепла та 40 M€.",
-  "Effect: At game end, score -2 / 0 / 1 / 2 VP PER TAG TYPE for 0 / 1-2 / 3-4 / 5+ tags.": "Ефект: В кінці гри отримуйте -2 / 0 / 1 / 2 ПО ЗА ТИП ТЕГУ за 0 / 1-2 / 3-4 / 5+ міток.",
+  "Effect: At game end, score -2 / 0 / 1 / 2 VP PER TAG TYPE for 0 / 1-2 / 3-4 / 5+ tags.": "Ефект: В кінці гри отримуйте -2 / 0 / 1 / 2 ПО ЗА ТИП МІТКИ за 0 / 1-2 / 3-4 / 5+ міток.",
 
   "Project Workshop": "Проектна майстерня",
   "You start with 39 M€, 1 steel and 1 titanium. As your first action, draw a blue card.": "Ви починаєте з 39 M€, 1 сталі та 1 титану. Як вашу першу дію, витягніть синю карту.",

--- a/src/locales/ua/pathfinder_corporations.json
+++ b/src/locales/ua/pathfinder_corporations.json
@@ -1,7 +1,7 @@
 {
   "Adhai High Orbit Constructions": "Адхай Високоорбітальні Конструкції",
-  "(Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.)": "(Ефект: Кожного разу, коли ви граєте карту з космічною міткою, АЛЕ БЕЗ ПЛАНЕТНОГО ТЕГУ (включаючи цю карту), додайте 1 орбіталь на цю карту.)",
-  "Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.": "Ефект: Кожного разу, коли ви граєте карту з космічною міткою, АЛЕ БЕЗ ПЛАНЕТНОГО ТЕГУ (включаючи цю карту), додайте 1 орбіталь на цю карту.",
+  "(Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.)": "(Ефект: Кожного разу, коли ви граєте карту з космічною міткою, АЛЕ БЕЗ ПЛАНЕТНОЇ МІТКИ (включаючи цю карту), додайте 1 орбіталь на цю карту.)",
+  "Effect: Whenever you play a card with a space tag BUT NO PLANETARY TAG (including this) add 1 orbital on this card.": "Ефект: Кожного разу, коли ви граєте карту з космічною міткою, АЛЕ БЕЗ ПЛАНЕТНОЇ МІТКИ (включаючи цю карту), додайте 1 орбіталь на цю карту.",
   "(Effect: For every 2 orbitals on this card, cards with a space tag but with no planetary tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1 M€ less.)": "(Ефект: За кожні 2 орбіталі на цій карті, карти з космічною міткою, але без планетної мітки або СТАНДАРТНИЙ ПРОЕКТ КОЛОНІЇ або ТОРГОВЕЛЬНА ДІЯ коштують на 1M€ менше.)",
   "Effect: For every 2 orbitals on this card, cards with a space tag but with no planetary tag or the STANDARD COLONY PROJECT or TRADE ACTION costs 1 M€ less.": "Ефект: За кожні 2 орбіталі на цій карті, карти з космічною міткою, але без планетної мітки або СТАНДАРТНИЙ ПРОЕКТ КОЛОНІЇ або ТОРГОВЕЛЬНА ДІЯ коштують на 1 M€ менше.",
   "You start with 43 M€.": "Ви починаєте з 43 M€.",

--- a/src/locales/ua/pathfinder_preludes.json
+++ b/src/locales/ua/pathfinder_preludes.json
@@ -5,7 +5,7 @@
   "Crew Training": "Тренування екіпажу",
   "Choose a planet tag. This card counts as having 2 of that tag. Raise the corresponding planetary track 2 steps. Gain 2 TR.": "Виберіть мітку планети. Ця карта вважається маючи 2 таких мітки. Підвищте відповідну планетарну доріжку на 2. Отримайте 2 РТ.",
 
-  "Deep Space Operations": "Операції у глибокому космосі",
+  "Deep Space Operations": "Глибококосмічні операції",
   "Gain 4 titanium. Draw 2 event cards with a space tag.": "Отримайте 4 титану. Витягніть 2 картки подій з космічною міткою.",
 
   "Design Company": "Дизайнерська компанія",
@@ -23,7 +23,7 @@
   "Research Grant:Pathfinders": "Грант на дослідження",
   "Increase your energy production 1 step. Gain 14 M€.": "Збільшити виробництво енергії на 1. Отримайте 14 M€.",
 
-  "Strategic Base Planning": "Страміткуічне базове планування",
+  "Strategic Base Planning": "Стратегічне планування",
   "Pay 8M€. Place a city. Place a colony.": "Заплатіть 8M€. Розмістіть місто. Розмістіть колонію.",
 
   "Survey Mission": "Місія обстеження",

--- a/src/locales/ua/prelude_cards.json
+++ b/src/locales/ua/prelude_cards.json
@@ -6,7 +6,7 @@
   "Cloud Tourism": "Хмарний туризм",
   "Increase your M€ production 1 step for each pair of Earth and Venus tags you own. 1 VP for every 3rd floater on this card.": "Збільште ваше виробництво M€ на 1 за кожну пару земних і венеріанських міток, які ви володієте. 1 VP за кожні 3-ій аеростат на цій карті.",
 
-  "GHG Shipment": "Транспортування парникових газів",
+  "GHG Shipment": "Доставка парникових газів",
   "Requires that Kelvinists are in power or that you have 2 delegates there. Increase your heat production 1 step. Gain 1 heat for each floater you have.": "Вимагає, щоб Кельвіністи були при владі або щоб у вас було 2 делегати там. Збільште ваше виробництво тепла на 1. Отримайте 1 одиницю тепла за кожну аеростат, який у вас є.",
 
   "Ishtar Expedition": "Експедиція Іштар",
@@ -32,7 +32,7 @@
 
   "Research Coordination": "Координація Досліджень",
 
-  "SF Memorial": "Меморіал Наукової Фантастики",
+  "SF Memorial": "Меморіал фантастики",
 
   "Martian Survey": "Марсіанське Дослідження",
 
@@ -51,7 +51,7 @@
   "Envoys From Venus": "Посланці з Венери",
   "Requires 3 Venus tags. Place 2 delegates in 1 party.": "Вимагає 3 мітки Венери. Розмістіть 2 делегатів в 1 партії.",
 
-  "Floating Refinery": "Аеростатний нафтопереробний завод",
+  "Floating Refinery": "Аеростатний НПЗ",
   "Action: Add 1 floater here.": "Дія: Додайте 1 аеростат сюди.",
   "Action: Remove 2 floaters from ANY CARD to gain 1 titanium and 2 M€.": "Дія: Видаліть 2 аеростати з БУДЬ-ЯКОЇ КАРТИ, щоб отримати 1 титан і 2 M€.",
   "Add 1 floater here for each Venus tag you have.": "Додайте 1 аеростат сюди за кожну мітку Венери, який у вас є.",
@@ -63,7 +63,7 @@
   "Requires 2 Jovian tags. Place 2 delegates in 1 party.": "Вимагає 2 мітки Юпітера. Розмістіть 2 делегатів в 1 партії.",
   "Add a resource to 3 different cards that already have resources.": "Додайте ресурс до 3 різних карт, на яких вже є ресурси.",
 
-  "Microgravity Nutrition": "Харчування в мікрогравітації",
+  "Microgravity Nutrition": "Харчування в невагомості",
   "Increase your M€ production 1 step for each colony you have.": "Збільшіть виробництво M€ на 1 за кожну колонію.",
 
   "Soil Studies": "Дослідження ґрунту",
@@ -81,11 +81,11 @@
   "Venus Allies": "Союзники Венери",
   "Raise Venus 2 steps. Gain 4 M€ per colony you have.": "Підвищте рівень Венери на 2. Отримайте 4 M€ за кожну колонію.",
 
-  "Venus Orbital Survey": "Орбітальне дослідження Венери",
+  "Venus Orbital Survey": "Розвідка орбіти Венери",
   "Action: Reveal the top 2 cards, take any venus cards to hand for free. Any other card you either buy or discard": "Дія: Розкрийте 2 верхні карти, візьміть карти Венери безкоштовно. Будь-яку іншу карту або купіть, або скиньте.",
 
   "Venus Shuttles": "Шатли Венери",
-  "Action: Spend 12 M€ to raise Venus 1 step. This cost is REDUCED BY 1 FOR EACH VENUS TAG you have.": "Дія: Заплатіть 12 M€, щоб підвищити рівень Венери на 1. Вартість ЗМЕНШУЄТЬСЯ НА 1 ЗА КОЖЕН ТЕГ ВЕНЕРИ, який у вас є.",
+  "Action: Spend 12 M€ to raise Venus 1 step. This cost is REDUCED BY 1 FOR EACH VENUS TAG you have.": "Дія: Заплатіть 12 M€, щоб підвищити рівень Венери на 1. Вартість ЗМЕНШУЄТЬСЯ НА 1 ЗА КОЖНУ МІТКУ ВЕНЕРИ, який у вас є.",
   "Add 2 floaters to ANY VENUS CARD.": "Додайте 2 аеростати до БУДЬ-ЯКОЇ КАРТИ ВЕНЕРИ.",
 
   "Venus Trade Hub": "Торговий хаб Венери",

--- a/src/locales/ua/turmoil.json
+++ b/src/locales/ua/turmoil.json
@@ -33,5 +33,5 @@
   "Unity (Wants to see humanity prosper in the whole solar system.)": "Єдність (Хоче бачити процвітання людства в усій Сонячній системі.)",
   "Greens (Want to see a new Earth as soon as possible.)": "Зелені (Хочуть побачити нову Землю якомога швидше.)",
   "Reds (Wishes to preserve the red planet.)": "Червоні (Бажають зберегти червону планету.)",
-  "Kelvinists (Pushes for rapid terraforming, usually employing a heat-first strategy.)": "Кельвіністи (Намагаються прискорити терраформування, зазвичай використовуючи страміткуію з пріоритетом на нагрівання.)"
+  "Kelvinists (Pushes for rapid terraforming, usually employing a heat-first strategy.)": "Кельвіністи (Намагаються прискорити терраформування, зазвичай використовуючи стратегію з пріоритетом на нагрівання.)"
 }

--- a/src/locales/ua/venusnext_cards.json
+++ b/src/locales/ua/venusnext_cards.json
@@ -42,13 +42,13 @@
   "Venus Soils": "Венерійські ґрунти",
   "Raise Venus 1 step. Increase your plant production 1 step. Add 2 microbes to ANOTHER card": "Підвищити Венеру на 1. Збільшити виробництво рослин на 1. Додати 2 мікробів на ІНШУ карту",
 
-  "Terraforming Contract": "Контракт на терраформування",
+  "Terraforming Contract": "Контракт терраформування",
   "Requires that you have at least 25 TR. Increase your M€ production 4 steps.": "Вимагає, щоб у вас було щонайменше 25 РТ. Збільшити виробництво M€ на 4.",
 
   "Solarnet": "Сонячна мережа",
   "Requires Venus, Earth and Jovian tags. Draw 2 cards.": "Вимагає міток Венери, Землі та Юпітера. Взяти 2 карти.",
 
-  "Atalanta Planitia Lab": "Лабораторія Аталанта Планітія",
+  "Atalanta Planitia Lab": "Лаб. Аталанта Планітія",
   "Rotator Impacts": "Ротаторний удар",
   "Action: Spend 6 M€ to add an asteroid resource to this card [TITANIUM MAY BE USED].": "Дія: Витратити 6 M€, щоб додати ресурс астероїда на цю карту [МОЖНА ВИКОРИСТОВУВАТИ ТИТАН].",
   "Action: Spend 1 resource from this card to increase Venus 1 step.": "Дія: Витратити 1 ресурс з цієї карти, щоб підвищити Венеру на 1.",
@@ -57,11 +57,11 @@
   "Omnicourt": "Омнікорт",
   "Requires Venus, Earth and Jovian tags. Increase your TR 2 steps.": "Вимагає міток Венери, Землі та Юпітера. Збільшити РТ на 2.",
 
-  "Jet Stream Microscrappers": "Мікроштампувальники зі струмом Джет",
+  "Jet Stream Microscrappers": "Реактивні мікроскрапери",
   "Action: Spend 1 titanium to add 2 floaters here": "Дія: Витратити 1 титан, щоб додати 2 аеростатіви сюди.",
   "Action: Spend 2 floaters here to raise Venus 1 step": "Дія: Витратити 2 аеростати тут, щоб підвищити Венеру на 1.",
 
-  "Spin-Inducing Asteroid": "Астероїд, що викликає обертання",
+  "Spin-Inducing Asteroid": "Астероїд обертання",
   "Venus must be 10% or lower. Raise Venus 2 steps.": "Венера повинна бути 10% або менше. Підвищити Венеру на 2.",
 
   "Dirigibles": "Дирижаблі",
@@ -79,7 +79,7 @@
   "Water to Venus": "Вода на Венеру",
   "Raise Venus 1 step.": "Підвищити Венеру на 1.",
 
-  "GHG Import From Venus": "Імпорт парникових газів з Венери",
+  "GHG Import From Venus": "Парникові гази з Венери",
   "Raise Venus 1 step. Increase your heat production 3 steps.": "Підвищити Венеру на 1. Збільшити виробництво тепла на 3.",
 
   "Aerial Mappers": "Повітряні картографи",
@@ -89,14 +89,14 @@
   "Aerosport Tournament": "Аероспортивний турнір",
   "Requires that you have 5 floaters. Gain 1 M€ per each city tile in play.": "Вимагає, щоб у вас було 5 аеростатів. Отримати 1 M€ за кожен тайл міста в грі.",
 
-  "Air-Scrapping Expedition": "Експедиція з очищення повітря",
+  "Air-Scrapping Expedition": "Очисна експедиція",
   "Raise Venus 1 step. Add 3 floaters to ANY Venus CARD.": "Підвищити Венеру на 1. Додати 3 аеростати на БУДЬ-ЯКУ карту Венери.",
 
   "Atmoscoop": "Атмоскоп",
   "Requires 3 science tags. Either raise the temperature 2 steps, or raise Venus 2 steps. Add 2 floaters to ANY card.": "Вимагає 3 міток науки. Або підвищити температуру на 2, або підвищити Венеру на 2. Додати 2 аеростати на БУДЬ-ЯКУ карту.",
 
   "Comet for Venus": "Комета для Венери",
-  "Raise Venus 1 step. Remove up to 4M€ from any player WITH A VENUS TAG IN PLAY.": "Підвищити Венеру на 1. Вилучити до 4 M€ від будь-якого гравця, ЯКИЙ МАЄ ТЕГ ВЕНЕРИ В ГРІ.",
+  "Raise Venus 1 step. Remove up to 4M€ from any player WITH A VENUS TAG IN PLAY.": "Підвищити Венеру на 1. Вилучити до 4 M€ від будь-якого гравця, ЯКИЙ МАЄ МІТКУ ВЕНЕРИ В ГРІ.",
 
   "Dawn City": "Місто Ранку",
   "Requires 4 science tags. Decrease your energy production 1 step. Increase your titanium production 1 step. Place a city tile on the RESERVED AREA.": "Вимагає 4 міток науки. Зменшити виробництво енергії на 1. Збільшити виробництво титану на 1. Розмістити тайл міста НА ЗАРЕЗЕРВОВАНУ ОБЛАСТЬ.",
@@ -117,7 +117,7 @@
   "10% Venus": "10% Венера",
   "Requires 10% on the Venus track. Add 2 microbes or 2 animals to another Venus card. Production: energy -1, M€ +2.": "Вимагає 10% на треку Венери. Додати 2 мікроби або 2 тварини на іншу карту Венери. Виробництво: енергія -1, M€ +2.",
 
-  "Giant Solar Shade": "Величезна сонячна затінювальна система",
+  "Giant Solar Shade": "Велетенський сонячний щит",
   "Raise Venus 3 steps.": "Підвищити Венеру на 3.",
   "Gyropolis": "Гірополіс",
   "Decrease your energy production 2 steps. Increase your M€ production 1 step for each Venus and Earth tag you have. Place a city tile.": "Зменшити виробництво енергії на 2. Збільшити виробництво M€ на 1 за кожну мітку Венери та Землі, який у вас є. Розмістити тайл міста.",
@@ -139,7 +139,7 @@
   "Action: Add 1 resource to ANOTHER VENUS CARD.": "Дія: Додати 1 ресурс на ІНШУ КАРТУ ВЕНЕРИ.",
   "Requires Venus 12%. Decrease your energy production 1 step. Place a city tile ON THE RESERVED AREA.": "Вимагає 12% Венери. Зменшити виробництво енергії на 1. Розмістити тайл міста НА ЗАРЕЗЕРВОВАНУ ОБЛАСТЬ.",
 
-  "Sister Planet Support": "Підтримка сестринської планети",
+  "Sister Planet Support": "Підтримка планети-сестри",
   "Venus Earth": "Венера Земля",
   "Requires Venus and Earth tags. Increase your M€ production 3 steps.": "Вимагає міток Венери та Землі. Збільшити виробництво M€ на 3.",
 


### PR DESCRIPTION
## Ukrainian locale: `тег→мітка` leftovers + missing CEO strings

Split out from the title-shortening work (#8194) so each concern lands separately.

### `тег → мітка` sweep leftovers
- `Страміткуічне` / `страміткуію` → `Стратегічне` / `стратегію` — the earlier `тег→мітка` replacement wrongly matched `тег` **inside** the words `стратегічне` / `стратегію`.
- 5 all-caps `ТЕГ` occurrences the sweep missed → `МІТКА`, with correct case agreement: `ТИП МІТКИ`, `ПЛАНЕТНОЇ МІТКИ`, `ЗА КОЖНУ МІТКУ ВЕНЕРИ`, `МАЄ МІТКУ ВЕНЕРИ`.

### Missing CEO strings (`ceo_cards.json`)
- **Oscar:** `Effect: You have +1 influence` — the card renders this without a trailing period, so it didn't match the existing period-version key.
- **Huan:** name + `ALL OPPONENTS CANNOT TRADE NEXT GENERATION. Gain 1 Trade Fleet.` description.

### Note
Two of the touched files (`prelude_cards.json`, `venusnext_cards.json`, `pathfinder_preludes.json`) also contain card-title shortenings for cards defined in them (e.g. `Floating Refinery → Аеростатний НПЗ`), kept together rather than split mid-file.

### Validation
All UA locale files are valid JSON; `npm run lint:i18n` (duplicate-key audit) passes.
