### PR TITLE
Document title i18n

### DIFF
--- a/src/client/components/cardlist/CardList.vue
+++ b/src/client/components/cardlist/CardList.vue
@@ -178,7 +178,7 @@
         <h2 v-i18n>Agendas</h2>
         <div class="player_home_colony_cont">
           <div class="player_home_colony" v-for="id in visibleAgendaIds" :key="id" v-memo="[id]">
-            <TurmoilAgendaContiner :agendaId="id" />
+            <TurmoilAgendaContainer :agendaId="id" />
           </div>
         </div>
       </section>
@@ -220,7 +220,7 @@ import GlobalEvent from '@/client/components/turmoil/GlobalEvent.vue';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 import Milestone from '@/client/components/Milestone.vue';
 import Award from '@/client/components/Award.vue';
-import TurmoilAgendaContiner from '@/client/components/cardlist/TurmoilAgendaContainer.vue';
+import TurmoilAgendaContainer from '@/client/components/cardlist/TurmoilAgendaContainer.vue';
 import {CardResource} from '@/common/CardResource';
 import {cardResourceCSS} from '../common/cardResources';
 import {setDocumentTitle} from '@/client/utils/documentTitle';
@@ -238,7 +238,7 @@ export default defineComponent({
     Colony,
     Milestone,
     Award,
-    TurmoilAgendaContiner,
+    TurmoilAgendaContainer,
     PreferencesIcon,
   },
   data(): CardListModel {

--- a/src/client/components/cardlist/TurmoilAgendaContainer.vue
+++ b/src/client/components/cardlist/TurmoilAgendaContainer.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="turmoil_agenda_item">
+  <div class="container">
   <TurmoilAgenda :id="agendaId" />
-  <div class="turmoil_agenda_line1">{{ agendaId }}</div>
-  <div class="turmoil_agenda_line2">
+  <div class="line1">{{ agendaId }}</div>
+  <div class="line2">
     {{ $t(agenda.name) }} {{ $t(agenda.type) }} {{ agenda.num }}
   </div>
   </div>
@@ -25,7 +25,7 @@ const agenda = computed<AgendaInfo>(() => agendaInfoById(props.agendaId));
 </script>
 
 <style scoped lang="less">
-.turmoil_agenda_item {
+.container {
   padding: 12px;
   background-image: linear-gradient(#9c602d, #25170a);
   border-radius: 8px;
@@ -47,7 +47,7 @@ const agenda = computed<AgendaInfo>(() => agendaInfoById(props.agendaId));
     height: 50px;
   }
 
-  .turmoil_agenda_line1, .turmoil_agenda_line2 {
+  .line1, .line2 {
     text-align: center;
     font-size: 18px;
   }

--- a/src/client/utils/documentTitle.ts
+++ b/src/client/utils/documentTitle.ts
@@ -5,10 +5,10 @@ export function setDocumentTitle(title?: string): void {
   if (title === undefined) {
     document.title = $t(APP_NAME);
   } else {
-    document.title = `${title} | ${$t(APP_NAME)}`;
+    document.title = `${$t(title)} | ${$t(APP_NAME)}`;
   }
 }
 
 export function gameDocumentTitle(game: {name: string}): string {
-  return `${game.name} | ${APP_NAME}`;
+  return `${game.name} | ${$t(APP_NAME)}`;
 }


### PR DESCRIPTION
Besides improving i18n support for page titles, I fixed a typo in an import and addressed your earlier feedback on the CSS class names in PR #8199. If you're not happy with the current naming, I can adjust it.