### PR TITLE
Add MarsBotTags, tag counting from MarsBot board tracks

### DIFF
--- a/src/server/automa/MarsBotTags.ts
+++ b/src/server/automa/MarsBotTags.ts
@@ -1,0 +1,35 @@
+import {ALL_TAGS, Tag} from '../../common/cards/Tag';
+import {Tags} from '../player/Tags';
+import {IPlayer} from '../IPlayer';
+import {MarsBotBoard} from './MarsBotBoard';
+
+/**
+ * Override tag counting for MarsBot's player.
+ *
+ * Per the automa rules: "If an effect requires you to count the number of something
+ * other or all players have, use the respective tracks on MarsBot's board instead
+ * of its played cards."
+ */
+export class MarsBotTags extends Tags {
+  constructor(player: IPlayer, private readonly board: MarsBotBoard) {
+    super(player);
+  }
+
+  protected override rawCount(tag: Tag, _includeEventsTags: boolean): number {
+    const trackIndex = this.board.getTrackIndexForTag(tag);
+    if (trackIndex !== undefined) {
+      return this.board.tracks[trackIndex].position;
+    }
+    return 0;
+  }
+
+  // countAllTags skips Event and calls getPlayedEventsCount separately,
+  // so we override to route Event through the track as well.
+  public override countAllTags(): Record<Tag, number> {
+    const counts: Record<Tag, number> = {} as Record<Tag, number>;
+    for (const tag of ALL_TAGS) {
+      counts[tag] = this.count(tag, 'raw');
+    }
+    return counts;
+  }
+}

--- a/tests/automa/MarsBotTags.spec.ts
+++ b/tests/automa/MarsBotTags.spec.ts
@@ -1,0 +1,44 @@
+import {expect} from 'chai';
+import {testGame} from '../TestGame';
+import {Tag} from '../../src/common/cards/Tag';
+import {MarsBotBoard} from '../../src/server/automa/MarsBotBoard';
+import {MarsBotTags} from '../../src/server/automa/MarsBotTags';
+import {THARSIS_MARSBOT_BOARD} from '../../src/server/automa/boards/TharsisMarsBot';
+
+describe('MarsBotTags', () => {
+  function setup() {
+    const [, player] = testGame(1);
+    const board = new MarsBotBoard(THARSIS_MARSBOT_BOARD);
+    return {board, tags: new MarsBotTags(player, board)};
+  }
+
+  it('counts a tag from its track position', () => {
+    const {board, tags} = setup();
+    board.tracks[0].advance();
+    board.tracks[0].advance();
+    board.tracks[0].advance();
+    expect(tags.count(Tag.BUILDING, 'raw')).to.eq(3);
+  });
+
+  it('tags sharing a track share the count', () => {
+    const {board, tags} = setup();
+    for (let i = 0; i < 5; i++) {
+      board.tracks[4].advance();
+    }
+    expect(tags.count(Tag.POWER, 'raw')).to.eq(5);
+    expect(tags.count(Tag.JOVIAN, 'raw')).to.eq(5);
+  });
+
+  it('counts the event tag from its track', () => {
+    const {board, tags} = setup();
+    board.tracks[2].advance();
+    expect(tags.count(Tag.EVENT, 'raw')).to.eq(1);
+    expect(tags.countAllTags()[Tag.EVENT]).to.eq(1);
+  });
+
+  it('returns 0 for tags without a track', () => {
+    const {tags} = setup();
+    expect(tags.count(Tag.VENUS, 'raw')).to.eq(0);
+    expect(tags.count(Tag.WILD, 'raw')).to.eq(0);
+  });
+});


### PR DESCRIPTION
Another one file PR for the MarsBot series, see #8001 for context

Adds MarsBotTags, a Tags override so effects that count MarsBot's tags read the board tracks instead of played cards, per the automa rule that tag counts come from the tracks. The test builds it directly against the Tharsis board from #7994

Same note as #8203, I'm out for the next week so replies will be slow