### PR TITLE
Add MarsBot Venus track layout

### DIFF
--- a/src/common/automa/AutomaTypes.ts
+++ b/src/common/automa/AutomaTypes.ts
@@ -12,7 +12,9 @@ export type TrackAction =
   | 'ocean'
   | 'city'
   | 'venus' | 'venus2'
-  | `tag_${number}`;
+  | 'floater' | 'floater2'
+  | `tag_${number}`   // Advance track by index
+  | `tag_${string}`;  // Advance track by tag name (e.g. 'tag_microbe')
 
 /** A single track on the MarsBot board (19 positions: 0–18). */
 export type TrackLayout = ReadonlyArray<TrackAction | undefined>;

--- a/src/server/automa/MarsBotBoard.ts
+++ b/src/server/automa/MarsBotBoard.ts
@@ -2,7 +2,6 @@ import {Tag} from '../../common/cards/Tag';
 import {
   TrackAction,
   TrackDefinition,
-  MARSBOT_MAX_TRACK_POSITION,
 } from '../../common/automa/AutomaTypes';
 
 /** Result of advancing a track. */
@@ -20,7 +19,7 @@ export class MarsBotTrack {
   constructor(public readonly definition: TrackDefinition) {}
 
   public canAdvance(): boolean {
-    return this.position < MARSBOT_MAX_TRACK_POSITION;
+    return this.position < this.definition.layout.length - 1;
   }
 
   /** Advance the track by 1. */

--- a/src/server/automa/boards/VenusMarsBot.ts
+++ b/src/server/automa/boards/VenusMarsBot.ts
@@ -1,0 +1,9 @@
+import {Tag} from '../../../common/cards/Tag';
+import {TrackDefinition} from '../../../common/automa/AutomaTypes';
+
+// Venus MarsBot track (positions 0-12, shorter than main tracks)
+export const VENUS_MARSBOT_TRACK: TrackDefinition = {
+  tags: [Tag.VENUS],
+  productions: [],
+  layout: [undefined, 'floater', 'floater2', 'venus', 'floater2', 'venus', undefined, 'floater2', 'venus', 'tag_microbe', 'venus', 'floater2', 'tr5'],
+};

--- a/tests/automa/MarsBotBoard.spec.ts
+++ b/tests/automa/MarsBotBoard.spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import {Tag} from '../../src/common/cards/Tag';
 import {MarsBotBoard, MarsBotTrack} from '../../src/server/automa/MarsBotBoard';
 import {THARSIS_MARSBOT_BOARD} from '../../src/server/automa/boards/TharsisMarsBot';
+import {VENUS_MARSBOT_TRACK} from '../../src/server/automa/boards/VenusMarsBot';
 
 describe('MarsBotBoard', () => {
   let board: MarsBotBoard;
@@ -150,5 +151,41 @@ describe('MarsBotTrack', () => {
     // peek looks at pos 2 which has 'ocean' in layout
     // peek does NOT check regression markers — it shows raw layout
     expect(track.peek()).to.eq('ocean');
+  });
+});
+
+describe('MarsBotBoard with the Venus track', () => {
+  let board: MarsBotBoard;
+
+  beforeEach(() => {
+    board = new MarsBotBoard([...THARSIS_MARSBOT_BOARD, VENUS_MARSBOT_TRACK]);
+  });
+
+  it('has 8 tracks', () => {
+    expect(board.tracks.length).to.eq(8);
+  });
+
+  it('maps Venus tag to track 7', () => {
+    expect(board.getTrackIndexForTag(Tag.VENUS)).to.eq(7);
+  });
+
+  it('Venus track maxes out at position 12', () => {
+    const track = board.tracks[7];
+    for (let i = 0; i < 12; i++) {
+      expect(track.canAdvance()).to.be.true;
+      track.advance();
+    }
+    expect(track.position).to.eq(12);
+    expect(track.canAdvance()).to.be.false;
+    expect(track.advance()).to.deep.eq({type: 'maxed'});
+  });
+
+  it('main tracks still max out at position 18', () => {
+    const track = board.tracks[0];
+    for (let i = 0; i < 18; i++) {
+      track.advance();
+    }
+    expect(track.position).to.eq(18);
+    expect(track.canAdvance()).to.be.false;
   });
 });


### PR DESCRIPTION
Next one file PR for the MarsBot series, see #8001 for context

Adds the Venus track layout for MarsBot plus the two track actions it uses (floater, floater2). The Venus track is shorter than the main ones (13 positions instead of 19) so canAdvance now derives the max from the track's own layout length instead of the global constant

I'm out for the next week so replies will be slow