### PR TITLE
Allow Aurorai data for colony side effects

### DIFF
--- a/src/server/cards/colonies/BuildColonyStandardProject.ts
+++ b/src/server/cards/colonies/BuildColonyStandardProject.ts
@@ -21,7 +21,9 @@ export class BuildColonyStandardProject extends StandardProjectCard {
   }
 
   public override canAct(player: IPlayer): boolean {
-    return super.canAct(player) && player.colonies.getPlayableColonies(/* allowDuplicate= */ false, this.cost).length > 0;
+    const canPlayOptions = this.canPlayOptions(player);
+    return super.canAct(player) &&
+      player.colonies.getPlayableColonies(/* allowDuplicate= */ false, canPlayOptions).length > 0;
   }
 
   actionEssence(player: IPlayer): void {

--- a/src/server/player/Colonies.ts
+++ b/src/server/player/Colonies.ts
@@ -2,7 +2,7 @@ import {MAX_FLEET_SIZE} from '../../common/constants';
 import {CardName} from '../../common/cards/CardName';
 import {ColoniesHandler} from '../colonies/ColoniesHandler';
 import {AndOptions} from '../inputs/AndOptions';
-import {IPlayer} from '../IPlayer';
+import {CanAffordOptions, IPlayer} from '../IPlayer';
 import {ENERGY_TRADE_COST, MC_TRADE_COST, TITANIUM_TRADE_COST} from '../../common/constants';
 import {IColony} from '../colonies/IColony';
 import {SelectPaymentDeferred} from '../deferredActions/SelectPaymentDeferred';
@@ -101,7 +101,9 @@ export class Colonies {
       .setButtonLabel('Trade');
   }
 
-  public getPlayableColonies(allowDuplicate: boolean = false, cost: number = 0) {
+  public getPlayableColonies(allowDuplicate: boolean = false, canAffordOptions: number | CanAffordOptions = 0) {
+    const options: CanAffordOptions = typeof canAffordOptions === 'number' ? {cost: canAffordOptions} : canAffordOptions;
+
     return this.player.game.colonies
       .filter((colony) => {
         if (colony.isActive === false) {
@@ -113,15 +115,15 @@ export class Colonies {
         if (!allowDuplicate && colony.colonies.includes(this.player.id)) {
           return false;
         }
-        if (colony.name === ColonyName.VENUS && !this.player.canAfford({cost: cost, tr: {venus: 1}})) {
+        if (colony.name === ColonyName.VENUS && !this.player.canAfford({...options, tr: {venus: 1}})) {
           return false;
         }
-        if (colony.name === ColonyName.EUROPA && !this.player.canAfford({cost: cost, tr: {oceans: 1}})) {
+        if (colony.name === ColonyName.EUROPA && !this.player.canAfford({...options, tr: {oceans: 1}})) {
           return false;
         }
         if (colony.name === ColonyName.LEAVITT) {
           const pharmacyUnion = this.player.tableau.get(CardName.PHARMACY_UNION);
-          if ((pharmacyUnion?.resourceCount ?? 0) > 0 && !this.player.canAfford({cost: cost, tr: {tr: 1}})) {
+          if ((pharmacyUnion?.resourceCount ?? 0) > 0 && !this.player.canAfford({...options, tr: {tr: 1}})) {
             return false;
           }
         }

--- a/tests/cards/pathfinders/Aurorai.spec.ts
+++ b/tests/cards/pathfinders/Aurorai.spec.ts
@@ -9,6 +9,8 @@ import {AsteroidStandardProject} from '../../../src/server/cards/base/standardPr
 import {SelectStandardProjectToPlay} from '../../../src/server/inputs/SelectStandardProjectToPlay';
 import {Payment} from '../../../src/common/inputs/Payment';
 import {CardName} from '../../../src/common/cards/CardName';
+import {BuildColonyStandardProject} from '../../../src/server/cards/colonies/BuildColonyStandardProject';
+import {Europa} from '../../../src/server/colonies/Europa';
 
 describe('Aurorai', () => {
   let card: Aurorai;
@@ -68,5 +70,16 @@ describe('Aurorai', () => {
     expect(game.getTemperature()).eq(-28);
     expect(player.megaCredits).eq(2);
     expect(player.getSpendable('auroraiData')).eq(1);
+  });
+
+  it('can use data for build colony standard project on Europa', () => {
+    [game, player] = testGame(1, {coloniesExtension: true});
+    player.playedCards.push(card);
+    game.colonies.push(new Europa());
+
+    player.megaCredits = 14;
+    card.resourceCount = 1;
+
+    expect(new BuildColonyStandardProject().canAct(player)).is.true;
   });
 });


### PR DESCRIPTION
## Summary
- Pass Build Colony's standard-project payment options into the playable-colony filter.
- Preserve the existing Europa, Venus, and Leavitt side-effect affordability checks while allowing Aurorai data and Spire science to count toward the standard-project cost.

## Demo
Repro state: Aurorai has 1 data, the player has 14 M€, and Europa is available as the colony tile. Build Colony costs 17 M€ and is enabled because the standard-project payment options are passed through to the colony filter.

![Build Colony enabled](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/assets-aurorai-build-colony-20260531/pr-assets/aurorai-build-colony/aurorai-build-colony-standard-projects.png)

![Build Colony selected](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/assets-aurorai-build-colony-20260531/pr-assets/aurorai-build-colony/aurorai-build-colony-after-click.png)

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/pathfinders/Aurorai.spec.ts`
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/colonies/Europa.spec.ts tests/colonies/Colony.spec.ts`
- `npm run build:server`
- Fork CI: build-linux, build-windows, build-docker passed.

## Notes
Scope is intentionally narrow: only Build Colony's playable-colony filter receives the existing standard-project payment options.