### PR TITLE
Improve game log details

### DIFF
--- a/src/server/deferredActions/ChooseCards.ts
+++ b/src/server/deferredActions/ChooseCards.ts
@@ -101,7 +101,13 @@ export function keep(player: IPlayer, cards: ReadonlyArray<IProjectCard>, discar
   case LogType.DREW:
   case LogType.BOUGHT:
     player.game.log('${0} ${1} ${2} card(s)', (b) => b.player(player).string(logType).number(cards.length));
-    LogHelper.logDrawnCards(player, cards, /* privateMessage */ true);
+    if (logType === LogType.BOUGHT) {
+      if (cards.length > 0) {
+        player.game.log('You bought ${0}', (b) => b.cards(cards), {reservedFor: player});
+      }
+    } else {
+      LogHelper.logDrawnCards(player, cards, /* privateMessage */ true);
+    }
     break;
   }
 }

--- a/src/server/turmoil/parties/Greens.ts
+++ b/src/server/turmoil/parties/Greens.ts
@@ -108,7 +108,7 @@ class GreensPolicy04 implements IPolicy {
         if (availableMicrobeCards.length === 1) {
           orOptions.options.push(
             new SelectOption(message('Add ${0} microbes to ${1}', (b) => b.number(2).card(availableMicrobeCards[0]))).andThen(() => {
-              player.addResourceTo(availableMicrobeCards[0], {qty: 2, log: true});
+              player.addResourceTo(availableMicrobeCards[0], {qty: 2, log: true, from: {partyName: PartyName.GREENS}});
 
               return undefined;
             }),


### PR DESCRIPTION
## Summary
- Add player-only card names for bought project cards in paid card selection flows.
- Fix the single-card Turmoil Greens microbe action to log Greens as the source, matching the multi-card path.

## Demo
In paid card selection flows, the public log keeps the existing count-only message while the acting player gets the bought card names privately. The Greens single-card microbe action now logs the same source as the multi-card path.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/deferredActions/ChooseCards.spec.ts tests/deferredActions/DrawCards.spec.ts tests/turmoil/parties/Greens.spec.ts`
- `npm run build:server`
- `npm run build:tests`
- `npm run lint:server`

## Notes
- Offered, skipped, draft, and behavior spend/discard logs are intentionally not changed.
- Existing drawn-card private logs are preserved.
- No gameplay behavior change; this only changes scoped log details.