### PR TITLE
Fix FabricatedScandal checking wrong player's TR affordability

### DIFF
--- a/src/server/cards/underworld/FabricatedScandal.ts
+++ b/src/server/cards/underworld/FabricatedScandal.ts
@@ -43,7 +43,7 @@ export class FabricatedScandal extends Card implements IProjectCard {
 
     const lowestTR = Math.min(...game.players.map(((p) => p.terraformRating)));
     game.players.forEach((p) => {
-      if (p.terraformRating === lowestTR && player.canAfford({cost: 0, tr: {tr: 1}})) {
+      if (p.terraformRating === lowestTR && p.canAfford({cost: 0, tr: {tr: 1}})) {
         p.increaseTerraformRating(1, {log: true});
       }
     });

--- a/tests/cards/underworld/FabricatedScandal.spec.ts
+++ b/tests/cards/underworld/FabricatedScandal.spec.ts
@@ -2,6 +2,8 @@ import {expect} from 'chai';
 import {FabricatedScandal} from '../../../src/server/cards/underworld/FabricatedScandal';
 import {testGame} from '../../TestGame';
 import {cast} from '@/common/utils/utils';
+import {runAllActions, setRulingParty} from '../../TestingUtils';
+import {PartyName} from '../../../src/common/turmoil/PartyName';
 
 describe('FabricatedScandal', () => {
   it('Should play', () => {
@@ -21,5 +23,27 @@ describe('FabricatedScandal', () => {
 
     expect(player.underworldData.corruption).to.eq(1);
     expect(players.map((p) => p.terraformRating)).deep.eq([20, 19, 22, 22]);
+  });
+
+  it('Reds: lowest-TR player gains TR based on their own ability to pay', () => {
+    const card = new FabricatedScandal();
+    const [game, player, player2] = testGame(2, {turmoilExtension: true});
+
+    setRulingParty(game, PartyName.REDS);
+
+    player.setTerraformRating(22);
+    player2.setTerraformRating(18);
+
+    // The lowest-TR player (player2) can afford the Reds tax, but the card-playing
+    // player cannot. The TR gain must depend on player2's funds, not the card player's.
+    player.stock.megacredits = 0;
+    player2.stock.megacredits = 3;
+
+    cast(card.play(player), undefined);
+    runAllActions(game);
+
+    expect(player.terraformRating).eq(21);
+    expect(player2.terraformRating).eq(19);
+    expect(player2.stock.megacredits).eq(0);
   });
 });


### PR DESCRIPTION
When the lowest-TR players gain 1 TR, the "if possible" check (which matters under the Reds turmoil policy that taxes TR gains) used `player.canAfford` -- the player who played the card -- instead of `p.canAfford`, the player actually receiving the TR. GlobalAudit does the equivalent check correctly. Adds a Reds-policy regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)