### PR TITLE
Fix misnumbered card Gas Trust

### DIFF
--- a/src/server/cards/underworld/GasTrust.ts
+++ b/src/server/cards/underworld/GasTrust.ts
@@ -23,7 +23,7 @@ export class GasTrust extends Card implements IProjectCard {
       },
 
       metadata: {
-        cardNumber: 'U092',
+        cardNumber: 'U093',
         renderData: CardRenderer.builder((b) => {
           b.corruption(1).nbsp.nbsp.heat(3, {digit}).slash().tag(Tag.CRIME).asterix();
         }),


### PR DESCRIPTION
Corrects the card number on Gas Trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)