### PR TITLE
Fix PostgreSQL purgeUnfinishedGames deleting finished games

### DIFF
--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -246,7 +246,7 @@ export class PostgreSQL implements IDatabase {
   // Purge unfinished games older than MAX_GAME_DAYS days. If this environment variable is absent, it uses the default of 10 days.
   async purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): Promise<Array<GameId>> {
     const dateToSeconds = daysAgoToSeconds(maxGameDays, 10);
-    const selectResult = await this.client.query('SELECT DISTINCT game_id FROM games WHERE created_time < to_timestamp($1)', [dateToSeconds]);
+    const selectResult = await this.client.query('SELECT DISTINCT game_id FROM games WHERE created_time < to_timestamp($1) AND status = \'running\'', [dateToSeconds]);
     let gameIds = selectResult.rows.map((row) => row.game_id);
     if (gameIds.length > 1000) {
       console.log('Truncated purge to 1000 games.');

--- a/tests/database/databaseSuite.ts
+++ b/tests/database/databaseSuite.ts
@@ -208,6 +208,13 @@ export function describeDatabaseSuite<T extends ITestDatabase>(dtor: DatabaseTes
 
         expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
 
+        // A finished game of the same age must NOT be purged: purgeUnfinishedGames
+        // only removes games still in progress.
+        const finishedPlayer = TestPlayer.BLUE.newPlayer();
+        const finishedGame = Game.newInstance('g-finished-game-id', [finishedPlayer], finishedPlayer, 'spectatorid2');
+        await db.lastSaveGamePromise;
+        await db.markFinished(finishedGame.id);
+
         await db.purgeUnfinishedGames('1');
         expect(await db.getSaveIds(game.id)).has.members([0, 1, 2, 3]);
         const entry = (await db.getParticipants()).find((entry) => entry.gameId === game.id);
@@ -218,6 +225,9 @@ export function describeDatabaseSuite<T extends ITestDatabase>(dtor: DatabaseTes
         expect(await db.getSaveIds(game.id)).is.empty;
         const postPurgeEntry = (await db.getParticipants()).find((entry) => entry.gameId === game.id);
         expect(postPurgeEntry).is.undefined;
+
+        // The finished game survived the purge even though it is just as old.
+        expect(await db.getSaveIds(finishedGame.id)).is.not.empty;
       });
     }
 


### PR DESCRIPTION
`PostgreSQL.purgeUnfinishedGames` lacked the `status = 'running'` filter that SQLite has, so on the production Postgres backend it deleted finished games (and their participant rows) once they aged past `MAX_GAME_DAYS`, despite the method's name. Finished games are meant to be retained (and only compressed by `compressCompletedGames`).

Adds the status filter to match SQLite, and extends the shared database suite's `purgeUnfinishedGames` test to assert a finished game survives the purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)