### PR TITLE
Add LocalStorage to the shared database suite and fix getSaveIds prefix matching

### DIFF
--- a/src/server/database/LocalStorage.ts
+++ b/src/server/database/LocalStorage.ts
@@ -90,10 +90,13 @@ export class LocalStorage implements IDatabase {
     const results: Array<number> = [];
     for (let i = 0; i < storage.length; i++) {
       const key = storage.key(i);
-      if (key === null || key === 'game:' + gameId) {
+      if (key === null) {
         continue;
       }
-      if (key.startsWith('game:' + gameId)) {
+      // The trailing ':' is required so this doesn't also match the save ids of
+      // another game whose id has this gameId as a prefix (game ids are
+      // variable-length, so 'g1' is a prefix of 'g1a').
+      if (key.startsWith('game:' + gameId + ':')) {
         const parts = key.split(':');
         results.push(Number(parts[2]));
       }

--- a/tests/database/LocalStorage.spec.ts
+++ b/tests/database/LocalStorage.spec.ts
@@ -1,0 +1,48 @@
+import {describeDatabaseSuite} from './databaseSuite';
+import {IGame} from '../../src/server/IGame';
+import {LocalStorage} from '../../src/server/database/LocalStorage';
+import {GameId} from '../../src/common/Types';
+import {ITestDatabase, Status} from './ITestDatabase';
+
+class TestLocalStorage extends LocalStorage implements ITestDatabase {
+  public lastSaveGamePromise: Promise<void> = Promise.resolve();
+
+  constructor() {
+    super();
+    // LocalStorage's backing store is process-global, so reset it for each test.
+    this.clear();
+  }
+
+  public override saveGame(game: IGame): Promise<void> {
+    this.lastSaveGamePromise = super.saveGame(game);
+    return this.lastSaveGamePromise;
+  }
+
+  // markFinished, purgeUnfinishedGames, and sessions aren't supported by
+  // LocalStorage, so the tests that depend on these are omitted, and they're
+  // the only callers of these three methods.
+  public status(_gameId: GameId): Promise<Status> {
+    throw new Error('not implemented');
+  }
+
+  public completedTime(_gameId: GameId): Promise<number | undefined> {
+    throw new Error('not implemented');
+  }
+
+  public setCompletedTime(_gameId: GameId, _timestampSeconds: number): Promise<unknown> {
+    throw new Error('not implemented');
+  }
+}
+
+describeDatabaseSuite({
+  name: 'LocalStorage',
+  constructor: () => new TestLocalStorage(),
+  omit: {
+    markFinished: true,
+    purgeUnfinishedGames: true,
+    sessions: true,
+  },
+  stats: {
+    type: 'Local Storage',
+  },
+});

--- a/tests/database/databaseSuite.ts
+++ b/tests/database/databaseSuite.ts
@@ -110,6 +110,25 @@ export function describeDatabaseSuite<T extends ITestDatabase>(dtor: DatabaseTes
       expect(allSaveIds).has.members([0, 1, 2, 3]);
     });
 
+    it('getSaveIds returns only the requested game, not games sharing its id prefix', async () => {
+      // One game's id can be a prefix of another's, since ids are variable-length
+      // ('game-id-1' is a prefix of 'game-id-12'). getSaveIds must return only the
+      // requested game's saves, not those of the longer-named game.
+      const player1 = TestPlayer.BLACK.newPlayer();
+      const game1 = Game.newInstance('game-id-1', [player1], player1, 'spectatorid1');
+      await db.lastSaveGamePromise;
+      await db.saveGame(game1);
+
+      const player2 = TestPlayer.BLUE.newPlayer();
+      const game2 = Game.newInstance('game-id-12', [player2], player2, 'spectatorid2');
+      await db.lastSaveGamePromise;
+      await db.saveGame(game2);
+      await db.saveGame(game2);
+
+      expect(await db.getSaveIds('game-id-1')).has.members([0, 1]);
+      expect(await db.getSaveIds('game-id-12')).has.members([0, 1, 2]);
+    });
+
     if (dtor.omit?.markFinished !== true) {
       it('markFinished', async () => {
         const player = TestPlayer.BLACK.newPlayer();


### PR DESCRIPTION
Two related LocalStorage commits:

**Add LocalStorage to the shared database suite.** Gives LocalStorage the test coverage it previously lacked by running it through the database suite, omitting markFinished, purgeUnfinishedGames, and sessions, which LocalStorage doesn't support.

**Fix LocalStorage.getSaveIds matching other games by id prefix.** Game ids are variable-length, so `getSaveIds(gameId)` also matched the save keys of any game whose id had `gameId` as a prefix. Requires the trailing `:` delimiter, and adds a test to the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)