### PR TITLE
Fix underworld cards sorting numbers stringwise

### DIFF
--- a/src/client/components/SelectClaimedUndergroundToken.vue
+++ b/src/client/components/SelectClaimedUndergroundToken.vue
@@ -72,7 +72,7 @@ export default defineComponent({
       return true;
     },
     saveData() {
-      this.onsave({type: 'claimedUndergroundToken', selected: this.selected.sort()});
+      this.onsave({type: 'claimedUndergroundToken', selected: this.selected});
     },
   },
 });

--- a/src/server/cards/underworld/AeronGenomics.ts
+++ b/src/server/cards/underworld/AeronGenomics.ts
@@ -69,7 +69,9 @@ export class AeronGenomics extends CorporationCard implements ICorporationCard {
         return undefined;
       }));
     andOptions.cb = (() => {
-      const sorted = indexes.slice().sort().reverse();
+      // Remove from the highest index down so earlier removals don't shift the
+      // indexes still to be removed. Sort numerically, not stringwise.
+      const sorted = indexes.slice().sort((a, b) => b - a);
       for (const idx of sorted) {
         UnderworldExpansion.removeClaimedToken(player, idx);
       }

--- a/src/server/cards/underworld/LaggingRegulation.ts
+++ b/src/server/cards/underworld/LaggingRegulation.ts
@@ -36,7 +36,7 @@ export class LaggingRegulation extends GlobalEvent implements IGlobalEvent {
       map.set(tags + influence, player);
     }
     const totals = Array.from(map.keys());
-    totals.sort(); // Largest value at the back.
+    totals.sort((a, b) => a - b); // Largest value at the back.
 
     function reward(value: number | undefined, place: 1 | 2) {
       if (value === undefined || value === 0) {

--- a/tests/cards/underworld/AeronGenomics.spec.ts
+++ b/tests/cards/underworld/AeronGenomics.spec.ts
@@ -84,6 +84,37 @@ describe('AeronGenomics', () => {
     expect(player.underworldData.tokens).has.length(1);
   });
 
+  it('action - removes the correct tokens when an index is double-digit', () => {
+    // Tokens are removed highest-index-first so earlier removals don't shift the
+    // indexes still to be removed. A stringwise sort would order [2, 11] as
+    // [11, 2] then reverse to [2, 11], removing index 2 first and shifting the
+    // token at index 11 out of reach.
+    const birds = new Birds();
+    player.playedCards.push(card, birds);
+    const tokenTypes = [
+      'card1', 'card2', 'corruption1', 'corruption2', 'titanium2', 'plant2',
+      'plant3', 'energy2', 'microbe2', 'tr', 'ocean', 'place6mc',
+    ] as const;
+    for (const token of tokenTypes) {
+      player.underworldData.tokens.push({token, shelter: false, active: false});
+    }
+
+    const andOptions = cast(card.action(player), AndOptions);
+    const selectCard = cast(andOptions.options[0], SelectCard);
+    const selectTokens = cast(andOptions.options[1], SelectClaimedUndergroundToken);
+
+    selectCard.cb([birds]);
+    selectTokens.cb([2, 11]);
+    andOptions.cb(undefined);
+
+    expect(birds.resourceCount).eq(2);
+    // Only the tokens at indexes 2 and 11 are gone.
+    expect(player.underworldData.tokens.map((t) => t.token)).deep.eq([
+      'card1', 'card2', 'corruption2', 'titanium2', 'plant2',
+      'plant3', 'energy2', 'microbe2', 'tr', 'ocean',
+    ]);
+  });
+
   it('effect', () => {
     const birds = new Birds(); // Birds requires 13% oxygen
     player.production.plants = 2; // Card requirement

--- a/tests/cards/underworld/LaggingRegulation.spec.ts
+++ b/tests/cards/underworld/LaggingRegulation.spec.ts
@@ -53,6 +53,16 @@ describe('LaggingRegulation', () => {
       ],
     },
     {
+      // A stringwise sort would order the sums [10, 9, 2] as [10, 2, 9], handing
+      // first place to the player with 9 and second to the player with 2.
+      it: 'sums of ten or more are ranked numerically',
+      values: [
+        {crimeTags: 10, influence: 0, expected: {corruption: 1, mc: 9}},
+        {crimeTags: 9, influence: 0, expected: {corruption: 1, mc: 3}},
+        {crimeTags: 2, influence: 0, expected: {corruption: 0, mc: 0}},
+      ],
+    },
+    {
       it: 'only first',
       values: [
         {crimeTags: 2, influence: 0, expected: {corruption: 1, mc: 9}},


### PR DESCRIPTION
`LaggingRegulation` sorted player score totals with a bare `.sort()`, ranking sums like [10, 9, 2] as [10, 2, 9] and handing first place to a lower score once any total reached ten.

`AeronGenomics` removed claimed tokens highest-index-first via `sort().reverse()`, but the stringwise sort meant a double-digit index was removed in the wrong order, discarding the wrong token.

Also drops the pointless stringwise `.sort()` in `SelectClaimedUndergroundToken.vue`; the server re-sorts where order matters. Adds regression tests for both cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)