### PR TITLE
Fix optional input timer accounting

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1692,7 +1692,9 @@ export class Player implements IPlayer {
     this.waitingFor = undefined;
     this.waitingForCb = undefined;
     try {
-      this.timer.stop();
+      if (!waitingFor.optional) {
+        this.timer.stop();
+      }
       this.defer(waitingFor.process(input, this));
       waitingForCb();
     } catch (err) {
@@ -1747,9 +1749,12 @@ export class Player implements IPlayer {
   }
 
   public clearWaitingFor(): void {
+    const waitingFor = this.waitingFor;
     this.waitingFor = undefined;
     this.waitingForCb = undefined;
-    this.timer.stop();
+    if (waitingFor !== undefined && !waitingFor.optional) {
+      this.timer.stop();
+    }
   }
 
   public serialize(): SerializedPlayer {

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -37,6 +37,30 @@ import {PhysicsComplex} from '../src/server/cards/base/PhysicsComplex';
 import {GlobalParameter} from '../src/common/GlobalParameter';
 import {EnergyTapping} from '../src/server/cards/base/EnergyTapping';
 import {cast} from '@/common/utils/utils';
+import {Timer} from '../src/common/Timer';
+import {FakeClock} from './common/FakeClock';
+
+function playerWithRunningTimer(): [Player, FakeClock] {
+  const player = new Player('blue', 'blue', false, 0, 'p-blue');
+  Game.newInstance('gameid', [player], player, 'spectatorid');
+  player.clearWaitingFor();
+  const clock = new FakeClock();
+  (Timer as any).lastStoppedAt = 0;
+  player.timer = Timer.newInstance(clock);
+
+  const firstInput = new SelectOption('First input');
+  player.setWaitingFor(firstInput);
+  clock.millis = 1_000;
+  player.process({type: 'option'});
+
+  const secondInput = new SelectOption('Second input');
+  player.setWaitingFor(secondInput);
+  clock.millis = 2_000;
+  player.process({type: 'option'});
+
+  expect(player.timer.getElapsed()).eq(1_000);
+  return [player, clock];
+}
 
 describe('Player', () => {
   it('should initialize with right defaults', () => {
@@ -51,6 +75,32 @@ describe('Player', () => {
     player.clearWaitingFor();
 
     expect(() => player.process({type: 'option'})).to.throw('Not waiting for anything');
+  });
+
+  it('does not stop the timer when processing optional input', () => {
+    const [player, clock] = playerWithRunningTimer();
+    const elapsed = player.timer.getElapsed();
+
+    const optionalInput = new SelectOption('Optional input');
+    optionalInput.optional = true;
+    player.setWaitingFor(optionalInput);
+    clock.millis += 10_000;
+    player.process({type: 'option'});
+
+    expect(player.timer.getElapsed()).eq(elapsed);
+  });
+
+  it('does not stop the timer when clearing optional input', () => {
+    const [player, clock] = playerWithRunningTimer();
+    const elapsed = player.timer.getElapsed();
+
+    const optionalInput = new SelectOption('Optional input');
+    optionalInput.optional = true;
+    player.setWaitingFor(optionalInput);
+    clock.millis += 10_000;
+    player.clearWaitingFor();
+
+    expect(player.timer.getElapsed()).eq(elapsed);
   });
 
   it('Should run select player for PowerSupplyConsortium', () => {
@@ -652,4 +702,3 @@ describe('Player', () => {
     expect(player.megaCredits).eq(14);
   });
 });
-


### PR DESCRIPTION
## Summary
- Do not stop a player timer when processing an optional input.
- Do not stop a player timer when clearing an optional input.
- Add regression tests for both optional input paths.

## Root cause
PR #8151 made optional inputs skip `timer.start()`, but `Player.process` and `Player.clearWaitingFor` still called `timer.stop()` unconditionally. Since `Timer.stop()` calculates elapsed time from the prior `startedAt`, stopping an optional input can incorrectly add stale elapsed time to the player timer.

## Validation
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/Player.spec.ts`
- `npm run make:json && npm run build:test`
- `npm run lint:server -- --no-cache src/server/Player.ts tests/Player.spec.ts`

Note: local npm emitted the existing engine warning because this machine is on Node v25.8.1 while package.json requires Node 22.x.