### PR TITLE
Reduce font size for even longer card titles.

### DIFF
--- a/src/client/components/card/CardTitle.vue
+++ b/src/client/components/card/CardTitle.vue
@@ -60,7 +60,9 @@ export default defineComponent({
 
       const localeSpecificTitle = translateText(this.getCardTitleWithoutSuffix(title));
 
-      if (localeSpecificTitle.length > 26) {
+      if (localeSpecificTitle.length > 29) {
+        classes.push('title-smallest');
+      } else if (localeSpecificTitle.length > 26) {
         classes.push('title-smaller');
       } else if (localeSpecificTitle.length > 23) {
         classes.push('title-small');

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -206,6 +206,10 @@ input[type="radio"]:checked+.filterDiv::after {
   font-size: 14px !important;
 }
 
+.title-smallest {
+  font-size: 13px !important;
+}
+
 /*********** Background colors************/
 
 .background-color-corporation {


### PR DESCRIPTION
This isn't actually good enough unfortunately. There are slightly more reliable solutions; let's see.