### PR TITLE
Persist create game settings

### DIFF
--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -601,6 +601,7 @@ import {RULEBOOK_URLS, WIKI, WIKI_URLS} from '@/client/utils/WikiLinks';
 import {setDocumentTitle} from '@/client/utils/documentTitle';
 
 const REVISED_COUNT_ALGORITHM = false;
+const createGameSettingsStorage = new CreateGameSettingsStorage();
 
 
 type Refs = {
@@ -719,7 +720,7 @@ export default defineComponent({
   },
   methods: {
     restoreLastSettings() {
-      const settings = new CreateGameSettingsStorage().loadSettings();
+      const settings = createGameSettingsStorage.loadSettings();
       if (settings === undefined) {
         return;
       }
@@ -771,7 +772,7 @@ export default defineComponent({
       }
     },
     resetSettings() {
-      new CreateGameSettingsStorage().clearSettings();
+      createGameSettingsStorage.clearSettings();
       Object.assign(this, defaultCreateGameModel(), {
         preludeToggled: false,
         uploading: false,
@@ -1260,7 +1261,7 @@ export default defineComponent({
       if (dataToSend === undefined) {
         return;
       }
-      new CreateGameSettingsStorage().saveSettings(JSON.parse(dataToSend) as JSONObject);
+      createGameSettingsStorage.saveSettings(JSON.parse(dataToSend) as JSONObject);
       const onSuccess = (json: any) => {
         if (json.players.length === 1) {
           window.location.href = 'player?id=' + json.players[0].id;

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -719,17 +719,18 @@ export default defineComponent({
   },
   methods: {
     restoreLastSettings() {
-      const lastSettings = CreateGameSettingsStorage.getLastSettings();
-      if (lastSettings === undefined) {
+      const settings = new CreateGameSettingsStorage().loadSettings();
+      if (settings === undefined) {
         return;
       }
       try {
-        const processor = this.applySettings(lastSettings);
+        const processor = this.applySettings(settings);
         if (processor.warnings.length > 0) {
           this.showSettingsLoadResult('Restore settings', processor);
         }
       } catch (e) {
-        console.warn('Could not restore last game settings:', e);
+        // TODO(rusliksu): show the restore error in the UI instead of logging only to the console.
+        console.warn('Could not restore create game settings:', e);
       }
     },
     applySettings(json: JSONObject): JSONProcessor {
@@ -770,7 +771,7 @@ export default defineComponent({
       }
     },
     resetSettings() {
-      CreateGameSettingsStorage.clearLastSettings();
+      new CreateGameSettingsStorage().clearSettings();
       Object.assign(this, defaultCreateGameModel(), {
         preludeToggled: false,
         uploading: false,
@@ -1259,7 +1260,7 @@ export default defineComponent({
       if (dataToSend === undefined) {
         return;
       }
-      CreateGameSettingsStorage.saveLastSettings(JSON.parse(dataToSend) as JSONObject);
+      new CreateGameSettingsStorage().saveSettings(JSON.parse(dataToSend) as JSONObject);
       const onSuccess = (json: any) => {
         if (json.players.length === 1) {
           window.location.href = 'player?id=' + json.players[0].id;

--- a/src/client/components/create/CreateGameForm.vue
+++ b/src/client/components/create/CreateGameForm.vue
@@ -490,6 +490,7 @@
 
                         <div class="create-game-action">
                             <AppButton title="Create game" size="big" @click="createGame"/>
+                            <AppButton title="Reset" size="big" @click="resetSettings"/>
 
                             <label>
                                 <div class="btn btn-primary btn-action btn-lg"><i class="icon icon-upload"></i></div>
@@ -584,7 +585,7 @@ import CardsFilter from '@/client/components/create/CardsFilter.vue';
 import AppButton from '@/client/components/common/AppButton.vue';
 import {playerColorClass} from '@/common/utils/utils';
 import {RandomMAOptionType} from '@/common/ma/RandomMAOptionType';
-import {GameId} from '@/common/Types';
+import {GameId, JSONObject} from '@/common/Types';
 import {AgendaStyle} from '@/common/turmoil/Types';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 import {getCard} from '@/client/cards/ClientCardManifest';
@@ -594,6 +595,7 @@ import {CreateGameModel} from './CreateGameModel';
 import {paths} from '@/common/app/paths';
 import {JSONProcessor} from './JSONProcessor';
 import {defaultCreateGameModel} from './defaultCreateGameModel';
+import {CreateGameSettingsStorage} from './CreateGameSettingsStorage';
 import {getColony} from '@/client/colonies/ClientColonyManifest';
 import {RULEBOOK_URLS, WIKI, WIKI_URLS} from '@/client/utils/WikiLinks';
 import {setDocumentTitle} from '@/client/utils/documentTitle';
@@ -676,6 +678,7 @@ export default defineComponent({
   },
   mounted() {
     setDocumentTitle('Create New Game');
+    this.restoreLastSettings();
   },
   computed: {
     wikiUrls(): typeof RULEBOOK_URLS & typeof WIKI_URLS {
@@ -715,6 +718,73 @@ export default defineComponent({
     },
   },
   methods: {
+    restoreLastSettings() {
+      const lastSettings = CreateGameSettingsStorage.getLastSettings();
+      if (lastSettings === undefined) {
+        return;
+      }
+      try {
+        const processor = this.applySettings(lastSettings);
+        if (processor.warnings.length > 0) {
+          this.showSettingsLoadResult('Restore settings', processor);
+        }
+      } catch (e) {
+        console.warn('Could not restore last game settings:', e);
+      }
+    },
+    applySettings(json: JSONObject): JSONProcessor {
+      const component: CreateGameModel = this;
+      const refs = this.typedRefs;
+      const processor = new JSONProcessor(component);
+      this.uploading = true;
+      try {
+        processor.applyJSON(json);
+      } catch (e) {
+        this.uploading = false;
+        throw e;
+      }
+      nextTick(() => {
+        try {
+          if (component.showBannedCards && refs.cardsFilter) {
+            refs.cardsFilter.selected = processor.bannedCards;
+          }
+          if (component.showIncludedCards && refs.cardsFilter2) {
+            refs.cardsFilter2.selected = processor.includedCards;
+          }
+          if (!component.seededGame) {
+            component.seed = Math.random();
+          }
+          component.solarPhaseOption = Boolean(processor.solarPhaseOption);
+        } finally {
+          this.uploading = false;
+        }
+      });
+      return processor;
+    },
+    showSettingsLoadResult(title: string, processor: JSONProcessor) {
+      const root = vueRoot(this);
+      if (processor.warnings.length > 0) {
+        root.showAlert(title, 'Settings loaded with these warnings: \n' + processor.warnings.join('\n'));
+      } else {
+        root.showAlert(title, 'Settings loaded.');
+      }
+    },
+    resetSettings() {
+      CreateGameSettingsStorage.clearLastSettings();
+      Object.assign(this, defaultCreateGameModel(), {
+        preludeToggled: false,
+        uploading: false,
+      });
+      nextTick(() => {
+        const refs = this.typedRefs;
+        if (refs.cardsFilter) {
+          refs.cardsFilter.selected = [];
+        }
+        if (refs.cardsFilter2) {
+          refs.cardsFilter2.selected = [];
+        }
+      });
+    },
     async downloadSettings() {
       const serializedData = await this.serializeSettings();
 
@@ -730,44 +800,16 @@ export default defineComponent({
       const refs = this.typedRefs;
       const file = refs.file.files !== null ? refs.file.files[0] : undefined;
       const reader = new FileReader();
-      const component: CreateGameModel = this;
-      const root = vueRoot(this);
-
 
       reader.addEventListener('load', () => {
         try {
           const readerResults = reader.result;
-          const processor = new JSONProcessor(component);
           if (typeof(readerResults) === 'string') {
-            this.uploading = true;
-            const results = JSON.parse(readerResults);
-            processor.applyJSON(results);
-
-            nextTick(() => {
-              try {
-                if (component.showBannedCards) {
-                  refs.cardsFilter.selected = processor.bannedCards;
-                }
-                if (component.showIncludedCards) {
-                  refs.cardsFilter2.selected = processor.includedCards;
-                }
-                if (!component.seededGame) {
-                  component.seed = Math.random();
-                }
-                // set to alter after any watched properties
-                component.solarPhaseOption = Boolean(processor.solarPhaseOption);
-                this.uploading = false;
-              } catch (e) {
-                root.showAlert('Upload settings', 'Error reading JSON ' + e);
-              }
-            });
-          }
-          if (processor.warnings.length > 0) {
-            root.showAlert('Upload settings', 'Settings loaded with these warnings: \n' + processor.warnings.join('\n'));
-          } else {
-            root.showAlert('Upload settings', 'Settings loaded.');
+            const processor = this.applySettings(JSON.parse(readerResults));
+            this.showSettingsLoadResult('Upload settings', processor);
           }
         } catch (e) {
+          const root = vueRoot(this);
           root.showAlert('Upload settings', 'Error loading settings ' + e);
         }
       }, false);
@@ -1217,6 +1259,7 @@ export default defineComponent({
       if (dataToSend === undefined) {
         return;
       }
+      CreateGameSettingsStorage.saveLastSettings(JSON.parse(dataToSend) as JSONObject);
       const onSuccess = (json: any) => {
         if (json.players.length === 1) {
           window.location.href = 'player?id=' + json.players[0].id;

--- a/src/client/components/create/CreateGameSettingsStorage.ts
+++ b/src/client/components/create/CreateGameSettingsStorage.ts
@@ -4,6 +4,7 @@ const SETTINGS_KEY = 'tm_last_game_settings';
 
 function getLocalStorage(): Storage | undefined {
   try {
+    // Access can throw SecurityError for opaque origins.
     return typeof localStorage === 'undefined' ? undefined : localStorage;
   } catch {
     return undefined;
@@ -20,12 +21,8 @@ export class CreateGameSettingsStorage {
   constructor(private readonly storage?: Storage) {
   }
 
-  private getStorage(): Storage | undefined {
-    return this.storage ?? getLocalStorage();
-  }
-
   public saveSettings(settings: JSONObject): void {
-    const storage = this.getStorage();
+    const storage = this.storage ?? getLocalStorage();
     if (storage === undefined) {
       return;
     }
@@ -37,7 +34,7 @@ export class CreateGameSettingsStorage {
   }
 
   public loadSettings(): JSONObject | undefined {
-    const storage = this.getStorage();
+    const storage = this.storage ?? getLocalStorage();
     if (storage === undefined) {
       return undefined;
     }
@@ -54,7 +51,7 @@ export class CreateGameSettingsStorage {
   }
 
   public clearSettings(): void {
-    const storage = this.getStorage();
+    const storage = this.storage ?? getLocalStorage();
     if (storage === undefined) {
       return;
     }

--- a/src/client/components/create/CreateGameSettingsStorage.ts
+++ b/src/client/components/create/CreateGameSettingsStorage.ts
@@ -1,57 +1,67 @@
 import {JSONObject} from '@/common/Types';
 
-const LAST_SETTINGS_KEY = 'tm_last_game_settings';
+const SETTINGS_KEY = 'tm_last_game_settings';
 
-function localStorageAvailable(): boolean {
+function getLocalStorage(): Storage | undefined {
   try {
-    return typeof localStorage !== 'undefined';
+    return typeof localStorage === 'undefined' ? undefined : localStorage;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
-function sanitizeSettings(settings: JSONObject): JSONObject {
-  const sanitized = JSON.parse(JSON.stringify(settings)) as JSONObject;
+function settingsWithoutClonedGameId(settings: JSONObject): JSONObject {
+  const sanitized = {...settings};
   delete sanitized.clonedGamedId;
   return sanitized;
 }
 
 export class CreateGameSettingsStorage {
-  static saveLastSettings(settings: JSONObject): void {
-    if (!localStorageAvailable()) {
+  constructor(private readonly storage?: Storage) {
+  }
+
+  private getStorage(): Storage | undefined {
+    return this.storage ?? getLocalStorage();
+  }
+
+  public saveSettings(settings: JSONObject): void {
+    const storage = this.getStorage();
+    if (storage === undefined) {
       return;
     }
     try {
-      localStorage.setItem(LAST_SETTINGS_KEY, JSON.stringify(sanitizeSettings(settings)));
-    } catch {
-      // Ignore storage quota and privacy-mode failures.
+      storage.setItem(SETTINGS_KEY, JSON.stringify(settingsWithoutClonedGameId(settings)));
+    } catch (err) {
+      console.warn('Unable to save create game settings:', err);
     }
   }
 
-  static getLastSettings(): JSONObject | undefined {
-    if (!localStorageAvailable()) {
+  public loadSettings(): JSONObject | undefined {
+    const storage = this.getStorage();
+    if (storage === undefined) {
       return undefined;
     }
     try {
-      const data = localStorage.getItem(LAST_SETTINGS_KEY);
+      const data = storage.getItem(SETTINGS_KEY);
       if (data === null) {
         return undefined;
       }
-      const settings = JSON.parse(data) as JSONObject;
-      return sanitizeSettings(settings);
-    } catch {
+      return JSON.parse(data) as JSONObject;
+    } catch (err) {
+      console.warn('Unable to load create game settings:', err);
       return undefined;
     }
   }
 
-  static clearLastSettings(): void {
-    if (!localStorageAvailable()) {
+  public clearSettings(): void {
+    const storage = this.getStorage();
+    if (storage === undefined) {
       return;
     }
     try {
-      localStorage.removeItem(LAST_SETTINGS_KEY);
-    } catch {
-      // Ignore privacy-mode failures.
+      storage.removeItem(SETTINGS_KEY);
+    } catch (err) {
+      console.warn('Unable to clear create game settings:', err);
     }
   }
 }

--- a/src/client/components/create/CreateGameSettingsStorage.ts
+++ b/src/client/components/create/CreateGameSettingsStorage.ts
@@ -1,0 +1,57 @@
+import {JSONObject} from '@/common/Types';
+
+const LAST_SETTINGS_KEY = 'tm_last_game_settings';
+
+function localStorageAvailable(): boolean {
+  try {
+    return typeof localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeSettings(settings: JSONObject): JSONObject {
+  const sanitized = JSON.parse(JSON.stringify(settings)) as JSONObject;
+  delete sanitized.clonedGamedId;
+  return sanitized;
+}
+
+export class CreateGameSettingsStorage {
+  static saveLastSettings(settings: JSONObject): void {
+    if (!localStorageAvailable()) {
+      return;
+    }
+    try {
+      localStorage.setItem(LAST_SETTINGS_KEY, JSON.stringify(sanitizeSettings(settings)));
+    } catch {
+      // Ignore storage quota and privacy-mode failures.
+    }
+  }
+
+  static getLastSettings(): JSONObject | undefined {
+    if (!localStorageAvailable()) {
+      return undefined;
+    }
+    try {
+      const data = localStorage.getItem(LAST_SETTINGS_KEY);
+      if (data === null) {
+        return undefined;
+      }
+      const settings = JSON.parse(data) as JSONObject;
+      return sanitizeSettings(settings);
+    } catch {
+      return undefined;
+    }
+  }
+
+  static clearLastSettings(): void {
+    if (!localStorageAvailable()) {
+      return;
+    }
+    try {
+      localStorage.removeItem(LAST_SETTINGS_KEY);
+    } catch {
+      // Ignore privacy-mode failures.
+    }
+  }
+}

--- a/tests/client/components/create/CreateGameForm.spec.ts
+++ b/tests/client/components/create/CreateGameForm.spec.ts
@@ -9,13 +9,14 @@ import {DEFAULT_EXPANSIONS} from '@/common/cards/GameModule';
 import {JSONObject} from '@/common/Types';
 import {defineComponent} from 'vue';
 
-function settings(overrides: JSONObject = {}): JSONObject {
+// Minimal serialized Create Game payload used by settings restore tests.
+function createGameSettings(overrides: JSONObject = {}): JSONObject {
   return {
     players: [
       {name: 'Alice', color: 'red', beginner: false, handicap: 0},
       {name: 'Bob', color: 'blue', beginner: false, handicap: 0},
     ],
-    expansions: {...DEFAULT_EXPANSIONS},
+    expansions: DEFAULT_EXPANSIONS,
     board: BoardName.HELLAS,
     draftVariant: false,
     solarPhaseOption: true,
@@ -43,14 +44,13 @@ describe('CreateGameForm', () => {
   });
 
   it('restores the last saved game settings on load', async () => {
-    CreateGameSettingsStorage.saveLastSettings(settings({
+    new CreateGameSettingsStorage(localStorage).saveSettings(createGameSettings({
       expansions: {...DEFAULT_EXPANSIONS, venus: true},
     }));
 
     const wrapper = shallowMount(CreateGameForm, {
       ...globalConfig,
     });
-    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
 
     expect((wrapper.vm as any).playersCount).eq(2);
@@ -78,7 +78,7 @@ describe('CreateGameForm', () => {
       alerts.push({title, message});
     };
 
-    CreateGameSettingsStorage.saveLastSettings(settings({
+    new CreateGameSettingsStorage(localStorage).saveSettings(createGameSettings({
       customPreludes: ['Bad Prelude Name'],
     }));
 
@@ -92,12 +92,12 @@ describe('CreateGameForm', () => {
   });
 
   it('resets the form and clears saved settings', async () => {
-    CreateGameSettingsStorage.saveLastSettings(settings());
+    const settingsStorage = new CreateGameSettingsStorage(localStorage);
+    settingsStorage.saveSettings(createGameSettings());
 
     const wrapper = shallowMount(CreateGameForm, {
       ...globalConfig,
     });
-    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
 
     expect((wrapper.vm as any).board).eq(BoardName.HELLAS);
@@ -107,7 +107,7 @@ describe('CreateGameForm', () => {
 
     expect((wrapper.vm as any).board).eq(BoardName.THARSIS);
     expect((wrapper.vm as any).draftVariant).eq(true);
-    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+    expect(settingsStorage.loadSettings()).eq(undefined);
     expect(wrapper.findAllComponents({name: 'AppButton'}).map((button) => button.props('title'))).includes('Reset');
   });
 
@@ -116,7 +116,7 @@ describe('CreateGameForm', () => {
       ...globalConfig,
     });
 
-    expect(() => (wrapper.vm as any).applySettings(settings({
+    expect(() => (wrapper.vm as any).applySettings(createGameSettings({
       players: [
         {name: 'Alice', color: 'red', beginner: false, handicap: 0},
         {name: 'Bob', color: 'red', beginner: false, handicap: 0},
@@ -128,11 +128,6 @@ describe('CreateGameForm', () => {
   it('saves current settings before creating a game', async () => {
     const originalFetch = global.fetch;
     const originalAlert = global.alert;
-    const savedSettings: Array<unknown> = [];
-    const originalSaveLastSettings = CreateGameSettingsStorage.saveLastSettings;
-    CreateGameSettingsStorage.saveLastSettings = (settings) => {
-      savedSettings.push(settings);
-    };
     global.fetch = (() => Promise.reject(new Error('stop after saving'))) as typeof fetch;
     global.alert = (() => {}) as typeof alert;
 
@@ -148,11 +143,10 @@ describe('CreateGameForm', () => {
 
       await (wrapper.vm as any).createGame();
 
-      expect(savedSettings).has.length(1);
-      expect((savedSettings[0] as any).board).eq(BoardName.ELYSIUM);
-      expect((savedSettings[0] as any).players.map((player: any) => player.name)).deep.eq(['Alice', 'Bob']);
+      const savedSettings = new CreateGameSettingsStorage(localStorage).loadSettings();
+      expect(savedSettings?.board).eq(BoardName.ELYSIUM);
+      expect((savedSettings?.players as Array<{name: string}>).map((player) => player.name)).deep.eq(['Alice', 'Bob']);
     } finally {
-      CreateGameSettingsStorage.saveLastSettings = originalSaveLastSettings;
       global.fetch = originalFetch;
       global.alert = originalAlert;
     }

--- a/tests/client/components/create/CreateGameForm.spec.ts
+++ b/tests/client/components/create/CreateGameForm.spec.ts
@@ -1,13 +1,160 @@
-import {shallowMount} from '@vue/test-utils';
+import {mount, shallowMount} from '@vue/test-utils';
 import {globalConfig} from '../getLocalVue';
 import {expect} from 'chai';
 import CreateGameForm from '@/client/components/create/CreateGameForm.vue';
+import {CreateGameSettingsStorage} from '@/client/components/create/CreateGameSettingsStorage';
+import {FakeLocalStorage} from '../FakeLocalStorage';
+import {BoardName} from '@/common/boards/BoardName';
+import {DEFAULT_EXPANSIONS} from '@/common/cards/GameModule';
+import {JSONObject} from '@/common/Types';
+import {defineComponent} from 'vue';
+
+function settings(overrides: JSONObject = {}): JSONObject {
+  return {
+    players: [
+      {name: 'Alice', color: 'red', beginner: false, handicap: 0},
+      {name: 'Bob', color: 'blue', beginner: false, handicap: 0},
+    ],
+    expansions: {...DEFAULT_EXPANSIONS},
+    board: BoardName.HELLAS,
+    draftVariant: false,
+    solarPhaseOption: true,
+    ...overrides,
+  };
+}
 
 describe('CreateGameForm', () => {
+  let localStorage: FakeLocalStorage;
+
+  beforeEach(() => {
+    localStorage = new FakeLocalStorage();
+    FakeLocalStorage.register(localStorage);
+  });
+
+  afterEach(() => {
+    FakeLocalStorage.deregister(localStorage);
+  });
+
   it('mounts without errors', () => {
     const wrapper = shallowMount(CreateGameForm, {
       ...globalConfig,
     });
     expect(wrapper.exists()).to.be.true;
+  });
+
+  it('restores the last saved game settings on load', async () => {
+    CreateGameSettingsStorage.saveLastSettings(settings({
+      expansions: {...DEFAULT_EXPANSIONS, venus: true},
+    }));
+
+    const wrapper = shallowMount(CreateGameForm, {
+      ...globalConfig,
+    });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).playersCount).eq(2);
+    expect((wrapper.vm as any).players[0].name).eq('Alice');
+    expect((wrapper.vm as any).players[1].name).eq('Bob');
+    expect((wrapper.vm as any).board).eq(BoardName.HELLAS);
+    expect((wrapper.vm as any).draftVariant).eq(false);
+    expect((wrapper.vm as any).expansions.venus).eq(true);
+    expect((wrapper.vm as any).solarPhaseOption).eq(true);
+  });
+
+  it('shows warnings when restoring saved settings', async () => {
+    const alerts: Array<{title: string, message: string}> = [];
+    const Root = defineComponent({
+      components: {
+        CreateGameForm,
+      },
+      template: '<CreateGameForm ref="form" />',
+    });
+    const wrapper = mount(Root, {
+      ...globalConfig,
+    });
+    const form = wrapper.findComponent(CreateGameForm);
+    (form.vm.$root as any).showAlert = (title: string, message: string) => {
+      alerts.push({title, message});
+    };
+
+    CreateGameSettingsStorage.saveLastSettings(settings({
+      customPreludes: ['Bad Prelude Name'],
+    }));
+
+    (form.vm as any).restoreLastSettings();
+    await form.vm.$nextTick();
+
+    expect(alerts).deep.eq([{
+      title: 'Restore settings',
+      message: "Settings loaded with these warnings: \nUnknown card name 'Bad Prelude Name' in customPreludes",
+    }]);
+  });
+
+  it('resets the form and clears saved settings', async () => {
+    CreateGameSettingsStorage.saveLastSettings(settings());
+
+    const wrapper = shallowMount(CreateGameForm, {
+      ...globalConfig,
+    });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).board).eq(BoardName.HELLAS);
+
+    (wrapper.vm as any).resetSettings();
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).board).eq(BoardName.THARSIS);
+    expect((wrapper.vm as any).draftVariant).eq(true);
+    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+    expect(wrapper.findAllComponents({name: 'AppButton'}).map((button) => button.props('title'))).includes('Reset');
+  });
+
+  it('clears uploading when applying settings throws', () => {
+    const wrapper = shallowMount(CreateGameForm, {
+      ...globalConfig,
+    });
+
+    expect(() => (wrapper.vm as any).applySettings(settings({
+      players: [
+        {name: 'Alice', color: 'red', beginner: false, handicap: 0},
+        {name: 'Bob', color: 'red', beginner: false, handicap: 0},
+      ],
+    }))).throws('Colors are duplicated');
+    expect((wrapper.vm as any).uploading).eq(false);
+  });
+
+  it('saves current settings before creating a game', async () => {
+    const originalFetch = global.fetch;
+    const originalAlert = global.alert;
+    const savedSettings: Array<unknown> = [];
+    const originalSaveLastSettings = CreateGameSettingsStorage.saveLastSettings;
+    CreateGameSettingsStorage.saveLastSettings = (settings) => {
+      savedSettings.push(settings);
+    };
+    global.fetch = (() => Promise.reject(new Error('stop after saving'))) as typeof fetch;
+    global.alert = (() => {}) as typeof alert;
+
+    try {
+      const wrapper = shallowMount(CreateGameForm, {
+        ...globalConfig,
+      });
+      (wrapper.vm as any).playersCount = 2;
+      (wrapper.vm as any).randomFirstPlayer = false;
+      (wrapper.vm as any).players[0].name = 'Alice';
+      (wrapper.vm as any).players[1].name = 'Bob';
+      (wrapper.vm as any).board = BoardName.ELYSIUM;
+
+      await (wrapper.vm as any).createGame();
+
+      expect(savedSettings).has.length(1);
+      expect((savedSettings[0] as any).board).eq(BoardName.ELYSIUM);
+      expect((savedSettings[0] as any).players.map((player: any) => player.name)).deep.eq(['Alice', 'Bob']);
+    } finally {
+      CreateGameSettingsStorage.saveLastSettings = originalSaveLastSettings;
+      global.fetch = originalFetch;
+      global.alert = originalAlert;
+    }
   });
 });

--- a/tests/client/components/create/CreateGameSettingsStorage.spec.ts
+++ b/tests/client/components/create/CreateGameSettingsStorage.spec.ts
@@ -1,0 +1,49 @@
+import {expect} from 'chai';
+import {CreateGameSettingsStorage} from '@/client/components/create/CreateGameSettingsStorage';
+import {FakeLocalStorage} from '../FakeLocalStorage';
+
+describe('CreateGameSettingsStorage', () => {
+  let localStorage: FakeLocalStorage;
+
+  beforeEach(() => {
+    localStorage = new FakeLocalStorage();
+    FakeLocalStorage.register(localStorage);
+  });
+
+  afterEach(() => {
+    FakeLocalStorage.deregister(localStorage);
+  });
+
+  it('saves and reloads the last game settings', () => {
+    CreateGameSettingsStorage.saveLastSettings({
+      players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
+      board: 'hellas',
+      clonedGamedId: 'g123',
+      solarPhaseOption: true,
+    });
+
+    expect(CreateGameSettingsStorage.getLastSettings()).deep.eq({
+      players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
+      board: 'hellas',
+      solarPhaseOption: true,
+    });
+  });
+
+  it('ignores invalid saved data', () => {
+    localStorage.setItem('tm_last_game_settings', '{bad json');
+
+    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+  });
+
+  it('clears saved settings', () => {
+    CreateGameSettingsStorage.saveLastSettings({
+      players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
+      board: 'hellas',
+      solarPhaseOption: true,
+    });
+
+    CreateGameSettingsStorage.clearLastSettings();
+
+    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+  });
+});

--- a/tests/client/components/create/CreateGameSettingsStorage.spec.ts
+++ b/tests/client/components/create/CreateGameSettingsStorage.spec.ts
@@ -4,25 +4,22 @@ import {FakeLocalStorage} from '../FakeLocalStorage';
 
 describe('CreateGameSettingsStorage', () => {
   let localStorage: FakeLocalStorage;
+  let storage: CreateGameSettingsStorage;
 
   beforeEach(() => {
     localStorage = new FakeLocalStorage();
-    FakeLocalStorage.register(localStorage);
+    storage = new CreateGameSettingsStorage(localStorage);
   });
 
-  afterEach(() => {
-    FakeLocalStorage.deregister(localStorage);
-  });
-
-  it('saves and reloads the last game settings', () => {
-    CreateGameSettingsStorage.saveLastSettings({
+  it('saves and reloads game settings', () => {
+    storage.saveSettings({
       players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
       board: 'hellas',
       clonedGamedId: 'g123',
       solarPhaseOption: true,
     });
 
-    expect(CreateGameSettingsStorage.getLastSettings()).deep.eq({
+    expect(storage.loadSettings()).deep.eq({
       players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
       board: 'hellas',
       solarPhaseOption: true,
@@ -30,20 +27,30 @@ describe('CreateGameSettingsStorage', () => {
   });
 
   it('ignores invalid saved data', () => {
+    const warnings: Array<Array<unknown>> = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => {
+      warnings.push(args);
+    };
     localStorage.setItem('tm_last_game_settings', '{bad json');
 
-    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+    try {
+      expect(storage.loadSettings()).eq(undefined);
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings[0][0]).eq('Unable to load create game settings:');
   });
 
   it('clears saved settings', () => {
-    CreateGameSettingsStorage.saveLastSettings({
+    storage.saveSettings({
       players: [{name: 'Alice', color: 'red', beginner: false, handicap: 0}],
       board: 'hellas',
       solarPhaseOption: true,
     });
 
-    CreateGameSettingsStorage.clearLastSettings();
+    storage.clearSettings();
 
-    expect(CreateGameSettingsStorage.getLastSettings()).eq(undefined);
+    expect(storage.loadSettings()).eq(undefined);
   });
 });


### PR DESCRIPTION
## Summary
- Persist the last submitted Create Game setup in browser local storage and restore it when the form opens again.
- Add a Reset button for saved settings and share the upload/restore settings apply path, including warning handling.
- Keep cloned-game IDs out of the saved setup so new games do not accidentally reuse clone state.

## Demo
Preview: https://preview.tm.knightbyte.win/new-game

Create a game with custom players, board, and options, then open Create Game again in the same browser. The form restores the last submitted setup. Click Reset next to Create game to clear the saved setup and return the form to defaults.

## Testing
- `npx cross-env NODE_ENV=development mochapack --require tests/client/components/setup.ts "tests/client/components/create/CreateGameSettingsStorage.spec.ts" "tests/client/components/create/CreateGameForm.spec.ts"`
- `npm run lint:server`
- `npm run lint:client`
- `npm run build`

## Notes
- Client-only persistence; no gameplay or server-side settings storage change.
