### PR TITLE
Measure card titles to fit, gated behind experimental UI

### DIFF
--- a/src/client/components/card/CardTitle.vue
+++ b/src/client/components/card/CardTitle.vue
@@ -4,7 +4,7 @@
     <div v-if="isCorporation()" class="corporation-label">corporation</div>
     <div v-if="isCeo()" class="ceo-label">CEO</div>
     <CardCorporationLogo v-if="isCorporation()" :title="title"/>
-    <div v-else :class="getClasses(title)">{{ getCardTitleWithoutSuffix(title) }}</div>
+    <div v-else ref="title" :class="getClasses()">{{ titleWithoutSuffix }}</div>
   </div>
 </template>
 
@@ -15,6 +15,13 @@ import {CardType} from '@/common/cards/CardType';
 import {translateText} from '@/client/directives/i18n';
 import CardCorporationLogo from '@/client/components/card/CardCorporationLogo.vue';
 import {CardName} from '@/common/cards/CardName';
+import {fitTitle} from '@/client/components/card/titleFit';
+import {getPreferences} from '@/client/utils/PreferencesManager';
+
+type Refs = {
+  // Only rendered for non-corporation cards (corporations show a logo instead).
+  title: HTMLElement | undefined;
+};
 
 export default defineComponent({
   name: 'CardTitle',
@@ -31,7 +38,36 @@ export default defineComponent({
   components: {
     CardCorporationLogo,
   },
+  mounted() {
+    this.fitTitle();
+  },
+  watch: {
+    // Re-fit if the title prop changes on a reused instance. Card lists are keyed
+    // by name today, so this is insurance against an unkeyed or index-keyed list.
+    title() {
+      this.fitTitle();
+    },
+  },
   methods: {
+    // Size the title to fit by measuring the rendered text rather than guessing
+    // from its length. Waits for the card font to load so the measurement uses
+    // real glyph widths. Only when the experimental UI is on; otherwise the
+    // length-based classes and language_hacks title overrides handle sizing.
+    fitTitle(): void {
+      if (!getPreferences().experimental_ui || this.isCorporation()) {
+        return;
+      }
+      const el = this.typedRefs.title;
+      if (el === undefined) {
+        return;
+      }
+      // document.fonts is unavailable outside a real browser (e.g. JSDOM tests).
+      if (document.fonts === undefined) {
+        fitTitle(el);
+        return;
+      }
+      document.fonts.ready.then(() => fitTitle(el));
+    },
     isCeo(): boolean {
       return this.type === CardType.CEO;
     },
@@ -41,7 +77,7 @@ export default defineComponent({
     isPrelude(): boolean {
       return this.type === CardType.PRELUDE;
     },
-    getClasses(title: string): string {
+    getClasses(): string {
       const classes: Array<String> = ['card-title'];
 
       if (this.type === CardType.AUTOMATED) {
@@ -58,14 +94,19 @@ export default defineComponent({
         classes.push('background-color-standard-project');
       }
 
-      const localeSpecificTitle = translateText(this.getCardTitleWithoutSuffix(title));
+      // With the experimental UI on, the title is sized by measuring the
+      // rendered text (see fitTitle). Otherwise fall back to a length-based size
+      // class (these carry !important, so they'd override the measured size).
+      if (!getPreferences().experimental_ui) {
+        const localeSpecificTitle = translateText(this.titleWithoutSuffix);
 
-      if (localeSpecificTitle.length > 29) {
-        classes.push('title-smallest');
-      } else if (localeSpecificTitle.length > 26) {
-        classes.push('title-smaller');
-      } else if (localeSpecificTitle.length > 23) {
-        classes.push('title-small');
+        if (localeSpecificTitle.length > 29) {
+          classes.push('title-smallest');
+        } else if (localeSpecificTitle.length > 26) {
+          classes.push('title-smaller');
+        } else if (localeSpecificTitle.length > 23) {
+          classes.push('title-small');
+        }
       }
 
       return classes.join(' ');
@@ -77,8 +118,13 @@ export default defineComponent({
       }
       return classes.join(' ');
     },
-    getCardTitleWithoutSuffix(title: string): string {
-      return title.split(':')[0];
+  },
+  computed: {
+    titleWithoutSuffix(): string {
+      return this.title.split(':')[0];
+    },
+    typedRefs(): Refs {
+      return this.$refs as unknown as Refs;
     },
   },
 });

--- a/src/client/components/card/titleFit.ts
+++ b/src/client/components/card/titleFit.ts
@@ -1,0 +1,70 @@
+// Sizing card titles to fit their box, by measuring the rendered text and
+// shrinking the font until it stops overflowing. This is more accurate than
+// guessing from the title's character count, since glyphs aren't all the same
+// width. It relies on the real font being loaded, so callers should wait on
+// `document.fonts.ready` first.
+//
+// Fitted sizes are persisted by titleFontSizeCache so later visits skip the
+// (layout-forcing) measurement entirely.
+import {getCachedFontSize, setCachedFontSize} from '@/client/components/card/titleFontSizeCache';
+
+// Matches `.card-title` font-size in cards_v2.less.
+const DEFAULT_FONT_SIZE = 16;
+// Don't shrink past the smallest legible size (matches `.title-smallest`).
+const MIN_FONT_SIZE = 10;
+
+// Tracks the cost of fitting titles so the cards list can report how long it
+// took to resize every card.
+class TitleFitMetrics {
+  private totalMs = 0;
+  private count = 0;
+
+  reset(): void {
+    this.totalMs = 0;
+    this.count = 0;
+  }
+
+  record(durationMs: number): void {
+    this.totalMs += durationMs;
+    this.count++;
+  }
+
+  get total(): number {
+    return this.totalMs;
+  }
+
+  get cards(): number {
+    return this.count;
+  }
+}
+
+export const titleFitMetrics = new TitleFitMetrics();
+
+// Shrinks `el`'s font until its text no longer overflows horizontally. Records
+// the time spent so it can be aggregated by the cards list. The fitted size is
+// cached (keyed on the rendered text) so subsequent visits apply it without
+// re-measuring.
+export function fitTitle(el: HTMLElement): void {
+  const start = performance.now();
+  const key = el.textContent ?? '';
+
+  const cached = getCachedFontSize(key);
+  if (cached !== undefined) {
+    el.style.fontSize = `${cached}px`;
+  } else {
+    // Start from the stylesheet default so repeated fits don't ratchet downward.
+    el.style.fontSize = '';
+    let size = DEFAULT_FONT_SIZE;
+    while (el.scrollWidth > el.clientWidth && size > MIN_FONT_SIZE) {
+      size--;
+      el.style.fontSize = `${size}px`;
+    }
+
+    // Cache every result, including titles that already fit at the default size,
+    // so a later visit applies the size from the cache instead of re-measuring.
+    // Re-measuring forces a layout reflow per card, which is the bulk of the cost.
+    setCachedFontSize(key, size);
+  }
+
+  titleFitMetrics.record(performance.now() - start);
+}

--- a/src/client/components/card/titleFontSizeCache.ts
+++ b/src/client/components/card/titleFontSizeCache.ts
@@ -1,0 +1,59 @@
+// Persistent cache of fitted card-title font sizes, keyed on the rendered
+// (translated) title text, which keeps it locale-correct automatically.
+//
+// Stored in localStorage rather than a cookie so it isn't sent to the server on
+// every request. Each title is its own entry, namespaced by a prefix. Entries
+// expire two days after they were written; the expiry is set when an entry is
+// written and is not extended on read.
+const CACHE_PREFIX = 'cardTitleFontSize:';
+const CACHE_TTL_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+type CacheEntry = {size: number, expireMs: number};
+
+function localStorageSupported(): boolean {
+  return typeof localStorage !== 'undefined';
+}
+
+// In-memory mirror of the localStorage entries, loaded once (dropping expired
+// ones). Fitting a full page of cards would otherwise make a synchronous
+// localStorage read per card, which is slow at ~1000 cards.
+const entries = new Map<string, number>();
+if (localStorageSupported()) {
+  const now = Date.now();
+  const keys: Array<string> = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k !== null && k.startsWith(CACHE_PREFIX)) {
+      keys.push(k);
+    }
+  }
+  for (const k of keys) {
+    const raw = localStorage.getItem(k);
+    if (raw === null) {
+      continue;
+    }
+    try {
+      const entry: CacheEntry = JSON.parse(raw);
+      if (Number.isFinite(entry.size) && entry.expireMs > now) {
+        entries.set(k.substring(CACHE_PREFIX.length), entry.size);
+      } else {
+        // Expired or malformed.
+        localStorage.removeItem(k);
+      }
+    } catch {
+      localStorage.removeItem(k);
+    }
+  }
+}
+
+export function getCachedFontSize(key: string): number | undefined {
+  return entries.get(key);
+}
+
+export function setCachedFontSize(key: string, size: number): void {
+  entries.set(key, size);
+  if (localStorageSupported()) {
+    const entry: CacheEntry = {size, expireMs: Date.now() + CACHE_TTL_MS};
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(entry));
+  }
+}

--- a/src/client/components/cardlist/CardList.vue
+++ b/src/client/components/cardlist/CardList.vue
@@ -224,6 +224,7 @@ import TurmoilAgendaContainer from '@/client/components/cardlist/TurmoilAgendaCo
 import {CardResource} from '@/common/CardResource';
 import {cardResourceCSS} from '../common/cardResources';
 import {setDocumentTitle} from '@/client/utils/documentTitle';
+import {titleFitMetrics} from '@/client/components/card/titleFit';
 
 
 type Refs = {
@@ -248,6 +249,7 @@ export default defineComponent({
     setDocumentTitle('Cards List');
     this.typedRefs.filter.focus();
     this.delayedSetLocationHash();
+    this.measureTitleFit();
   },
   computed: {
     typedRefs(): Refs {
@@ -538,6 +540,21 @@ export default defineComponent({
     // experimentalUI might not be used at the moment, but it's fine to just leave it here.
     experimentalUI(): boolean {
       return getPreferences().experimental_ui;
+    },
+    // Reports how long it took to resize every card title once they've all been
+    // fitted. Each CardTitle defers its fit until document.fonts.ready, so we
+    // wait on the same signal: our child components register their fit callbacks
+    // before this parent mounted hook runs, so by the time this resolves they
+    // have all recorded their timings.
+    measureTitleFit(): void {
+      titleFitMetrics.reset();
+      const report = () => console.log(`Resized ${titleFitMetrics.cards} card titles in ${titleFitMetrics.total.toFixed(1)}ms`);
+      // document.fonts is unavailable outside a real browser (e.g. JSDOM tests).
+      if (document.fonts === undefined) {
+        report();
+      } else {
+        document.fonts.ready.then(report);
+      }
     },
     toggleNamesOnly(): void {
       this.namesOnly = !this.namesOnly;

--- a/src/styles/language_hacks.less
+++ b/src/styles/language_hacks.less
@@ -19,7 +19,10 @@
 }
 
 .language-es {
-  .filterDiv {
+  // Title overrides apply only when the experimental UI (measurement-based
+  // title fitting) is off. preferences_experimental_ui lives on <body>, the
+  // same element as language-es, so it's compounded on rather than an ancestor.
+  &:not(.preferences_experimental_ui) .filterDiv {
     .card-title {
       font-size: 15px !important;
       &.title-small {
@@ -33,15 +36,17 @@
 }
 
 .language-ru {
+  // Title overrides apply only when the experimental UI (measurement-based
+  // title fitting) is off; see the note on .language-es above.
+  &:not(.preferences_experimental_ui) .filterDiv .card-title {
+    font-size: 11px !important;
+    &.title-smaller {
+      font-size: 10px !important;
+    }
+  }
   .filterDiv {
     .card-requirements {
       font-size: 13px;
-    }
-    .card-title {
-      font-size: 11px !important;
-      &.title-smaller {
-        font-size: 10px !important;
-      }
     }
 
     &.card-mining-quota, &.card-luxury-foods, &.card-omnicourt, &.card-solarnet {
@@ -398,15 +403,12 @@
 }
 
 .language-hu {
-  .filterDiv {
-
-    /* Project cards */
-    &.card-terraforming-ganymede {
-      .card-title .title-small {
-        font-size: 14px !important;
-      }
+  // Title overrides apply only when the experimental UI (measurement-based
+  // title fitting) is off; see the note on .language-es above.
+  &:not(.preferences_experimental_ui) .filterDiv {
+    &.card-terraforming-ganymede .card-title .title-small {
+      font-size: 14px !important;
     }
-
     &.card-museum-of-early-colonisation,
     &.card-venus-orbital-survey,
     &.card-asteroid-mining-consortium,
@@ -416,17 +418,23 @@
         font-size: 13px !important;
       }
     }
-
     &.card-archimedes-hydroponics-station,
     &.card-power-infrastructure {
       .card-title .title-smaller {
         font-size: 12px !important;
       }
     }
-
     &.card-mining-robots-manuf\.-center .card-title .title-smaller {
       font-size: 11px !important;
     }
+    &.card-supported-research .card-title {
+      font-size: 13px !important;
+    }
+  }
+
+  .filterDiv {
+
+    /* Project cards */
 
     &.card-pride-of-the-earth-arkship,
     &.card-steel-market-monopolists,
@@ -915,10 +923,6 @@
       .resource-card-icon-expansion-container {
         bottom: 42px;
       }
-    }
-
-    &.card-supported-research .card-title {
-      font-size: 13px !important;
     }
 
     &.card-domed-crater .card-content {
@@ -2454,12 +2458,12 @@
 }
 
 .language-ua {
-  .filterDiv {
-    .card-title {
-      font-size: 12px !important;
-      &.title-smaller {
-        font-size: 11px !important;
-      }
+  // Title overrides apply only when the experimental UI (measurement-based
+  // title fitting) is off; see the note on .language-es above.
+  &:not(.preferences_experimental_ui) .filterDiv .card-title {
+    font-size: 12px !important;
+    &.title-smaller {
+      font-size: 11px !important;
     }
   }
 }


### PR DESCRIPTION
Replace the character-count heuristic for sizing card titles with a measurement-based fit: shrink the font until the rendered text stops overflowing its box, which is accurate across fonts and languages.

- titleFit.ts: measure-and-shrink, plus timing metrics.
- titleFontSizeCache.ts: per-title localStorage cache (2-day expiry via expireMs, set on write, not extended on read) so return visits skip the layout-forcing re-measurement.
- CardTitle.vue: fit only when experimental_ui is on; otherwise keep the length-based size classes.
- CardList.vue: log total resize time on /cards open.
- language_hacks.less: gate the title !important overrides to experimental_ui off, so they don't fight the measured size.