### PR TITLE
Reject standard projects whose canAct is false

### DIFF
--- a/src/server/cards/underworld/CollusionStandardProject.ts
+++ b/src/server/cards/underworld/CollusionStandardProject.ts
@@ -29,7 +29,7 @@ export class CollusionStandardProject extends StandardProjectCard {
   }
 
   public override canAct(player: IPlayer): boolean {
-    if (player.underworldData.corruption === 0) {
+    if (player.underworldData.corruption <= 0) {
       return false;
     }
     const game = player.game;

--- a/src/server/inputs/SelectStandardProjectToPlay.ts
+++ b/src/server/inputs/SelectStandardProjectToPlay.ts
@@ -24,6 +24,13 @@ export class SelectStandardProjectToPlay extends SelectCardToPlay<IStandardProje
   }
 
   public validate(card: IStandardProjectCard, input: SelectProjectCardToPlayResponse, details: PlayCardMetadata) {
+    // The client greys out projects whose canAct is false (via the `enabled` array), but the
+    // server must enforce it too: process() never consults `enabled`, and projects whose
+    // requirement isn't just the M€ cost (e.g. Collusion spending corruption) would otherwise
+    // execute regardless. See https://github.com/terraforming-mars/terraforming-mars/issues/8238.
+    if (!card.canAct(this.player)) {
+      throw new InputError('You cannot play this standard project');
+    }
     const canPayWith = card.canPayWith(this.player);
     const paymentOptions: Partial<PaymentOptions> = {
       heat: this.player.canUseHeatAsMegaCredits,

--- a/tests/cards/underworld/CollusionStandardProject.spec.ts
+++ b/tests/cards/underworld/CollusionStandardProject.spec.ts
@@ -11,6 +11,7 @@ import {PartyName} from '../../../src/common/turmoil/PartyName';
 import {AndOptions} from '../../../src/server/inputs/AndOptions';
 import {SelectAmount} from '../../../src/server/inputs/SelectAmount';
 import {SelectParty} from '../../../src/server/inputs/SelectParty';
+import {SelectStandardProjectToPlay} from '../../../src/server/inputs/SelectStandardProjectToPlay';
 import {MultiSet} from 'mnemonist';
 import {cast} from '../../../src/common/utils/utils';
 
@@ -50,6 +51,18 @@ describe('CollusionStandardProject', () => {
     player.underworldData.corruption = 0;
     turmoil.sendDelegateToParty('NEUTRAL', PartyName.GREENS, game);
     expect(card.canAct(player)).is.false;
+  });
+
+  // Regression for #8238: the server must reject a Collusion submission when canAct is false,
+  // even though the project costs 0 M€ and the client would have greyed out the button.
+  it('cannot be played when canAct is false', () => {
+    player.underworldData.corruption = 0;
+    turmoil.sendDelegateToParty('NEUTRAL', PartyName.GREENS, game);
+
+    const select = new SelectStandardProjectToPlay(player, [card], {enabled: [card.canAct(player)]});
+    expect(() => select.process({type: 'projectCard', card: card.name, payment: Payment.of({megacredits: 0})}))
+      .to.throw(/cannot play this standard project/);
+    expect(player.underworldData.corruption).eq(0);
   });
 
   it('can act', () => {


### PR DESCRIPTION
Fixes #8238

The server's SelectStandardProjectToPlay only validated payment, never canAct. The `enabled` array is sent to the client purely to grey out the button; process() never consults it. For a project whose requirement is not just the M€ cost -- e.g. Collusion, which spends 1 corruption for a 0 M€ cost -- any submission naming the card was accepted, driving corruption negative and producing a negative "Underworld Corruption Bribe" VP at scoring.

Validate canAct in SelectStandardProjectToPlay.validate(), the single chokepoint for both the normal turn action and Established Methods. Also tighten Collusion's canAct corruption check from `=== 0` to `<= 0` so an already-negative save is blocked too.