### PR TITLE
Improve language switcher: highlight current language, faster tooltip, six per row

### DIFF
--- a/src/client/components/LanguageSwitcher.vue
+++ b/src/client/components/LanguageSwitcher.vue
@@ -2,8 +2,8 @@
   <div class="language-switcher">
     <template v-for="lang in ALL_LANGUAGES" :key="lang">
     <div
-      :class="`language-icon language-icon--${lang} language-icon-for-switcher`"
-      :title="title(lang)"
+      :class="[`language-icon language-icon--${lang} language-icon-for-switcher`, {'language-icon--selected': lang === currentLang}]"
+      :data-title="title(lang)"
       @click="switchLanguageTo(lang)"
     ></div>
     &nbsp;
@@ -32,6 +32,9 @@ export default defineComponent({
     },
   },
   computed: {
+    currentLang(): string {
+      return PreferencesManager.INSTANCE.values().lang;
+    },
     ALL_LANGUAGES(): typeof ALL_LANGUAGES {
       return ALL_LANGUAGES;
     },

--- a/src/client/components/LanguageSwitcher.vue
+++ b/src/client/components/LanguageSwitcher.vue
@@ -6,7 +6,6 @@
       :data-title="title(lang)"
       @click="switchLanguageTo(lang)"
     ></div>
-    &nbsp;
     </template>
   </div>
 </template>

--- a/src/styles/language_icon.less
+++ b/src/styles/language_icon.less
@@ -24,12 +24,56 @@
     display: inline-block;
     vertical-align: middle;
     margin: 0 10px 0 0;
+    position: relative;
+
+    // Custom tooltip: the native `title` attribute has a long, browser-controlled
+    // delay, so render our own from `data-title` that appears immediately on hover.
+    &[data-title]::before {
+      content: attr(data-title);
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 3px 8px;
+      border-radius: 4px;
+      background: black;
+      color: white;
+      font-size: 16px;
+      line-height: 1.4;
+      white-space: nowrap;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.1s;
+      z-index: 2;
+    }
+
+    &[data-title]:hover::before {
+      opacity: 1;
+    }
   }
 
   &-for-sidebar {
     transform: scale(.65);
     margin-left: -4px;
     margin-top: 3px;
+  }
+
+  &--selected {
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 54px;
+      height: 40px;
+      transform: translate(-50%, -50%);
+      border: 3px solid white;
+      border-radius: 50%;
+      box-sizing: border-box;
+      pointer-events: none;
+    }
   }
 
   &:hover {

--- a/src/styles/language_icon.less
+++ b/src/styles/language_icon.less
@@ -2,13 +2,15 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   flex-wrap: wrap;
   padding: 4px 0;
   text-align: center;
   position: relative;
   z-index: 1;
   margin: 0 auto;
+  // Exactly six flags per row: 6 * 44px + 5 * 12px gap = 324px.
+  width: 324px;
 }
 
 .language-icon {
@@ -23,7 +25,6 @@
     transition: transform 0.15s;
     display: inline-block;
     vertical-align: middle;
-    margin: 0 10px 0 0;
     position: relative;
 
     // Custom tooltip: the native `title` attribute has a long, browser-controlled

--- a/tests/client/components/LanguageSwitcher.spec.ts
+++ b/tests/client/components/LanguageSwitcher.spec.ts
@@ -11,13 +11,26 @@ describe('LanguageSwitcher', () => {
     ALL_LANGUAGES.forEach((lang) => {
       it('render ' + lang, () => {
         const icon = wrapper.find(`.language-icon--${lang}`);
-        const expected = icon.attributes('title') as string;
+        const expected = icon.attributes('data-title') as string;
         const e = LANGUAGES[lang];
         expect(expected).to.be.a('string');
         expect(expected).to.satisfy((title: string) => title.startsWith(e[0]));
         expect(expected).to.satisfy((title: string) => title.indexOf(e[1], 1) > 0);
       });
     });
+  });
+
+  it('marks the current language as selected', () => {
+    const originalLang = PreferencesManager.INSTANCE.values().lang;
+    PreferencesManager.INSTANCE.set('lang', 'de');
+    try {
+      const wrapper = shallowMount(LanguageSwitcher);
+      expect(wrapper.find('.language-icon--de').classes()).to.include('language-icon--selected');
+      expect(wrapper.find('.language-icon--en').classes()).to.not.include('language-icon--selected');
+      expect(wrapper.findAll('.language-icon--selected')).to.have.lengthOf(1);
+    } finally {
+      PreferencesManager.INSTANCE.set('lang', originalLang);
+    }
   });
 
   it('saves language preference', async () => {


### PR DESCRIPTION
## What

Three small improvements to the language switcher on the start screen:

- **Highlight the current language** with an oval ring matching the flag shape.
- **Faster tooltips.** Replace the native `title` attribute (which has a long, browser-controlled delay) with a custom CSS tooltip from `data-title` that appears immediately on hover.
- **Six flags per row, deterministically.** Previously the per-row count varied by locale (5 or 6) because spacing was built from three stacked sources — the flex `gap`, a per-flag right margin, and a literal `&nbsp;` between flags (a real flex item whose width depends on locale font metrics). This removes the margin and the `&nbsp;`, leaving spacing to the flex `gap` alone, and fixes the switcher width to fit exactly six flags regardless of language.

## Notes

Pure client/CSS change; no server or game-logic impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)