### PR TITLE
Add language flag above the gear on the start screen

### DIFF
--- a/src/client/components/StartScreen.vue
+++ b/src/client/components/StartScreen.vue
@@ -27,6 +27,7 @@
     </div>
   </div>
   <div class="free-floating-preferences-icon">
+    <LanguageIcon class="corner-language-icon"/>
     <PreferencesIcon/>
   </div>
 </div>
@@ -36,6 +37,7 @@
 
 import {defineComponent} from 'vue';
 import LanguageSwitcher from '@/client/components/LanguageSwitcher.vue';
+import LanguageIcon from '@/client/components/LanguageIcon.vue';
 import PreferencesIcon from '@/client/components/PreferencesIcon.vue';
 
 import raw_settings from '@/genfiles/settings.json';
@@ -45,6 +47,7 @@ export default defineComponent({
   name: 'StartScreen',
   components: {
     LanguageSwitcher,
+    LanguageIcon,
     PreferencesIcon,
   },
   computed: {

--- a/src/client/components/cardlist/CardList.vue
+++ b/src/client/components/cardlist/CardList.vue
@@ -187,7 +187,7 @@
         <div v-show="scrolled" class="sidebar_item card-list-scroll-top" title="Scroll to top" @click="scrollToTop()">
           <div class="card-list-scroll-top-arrow">↑</div>
         </div>
-        <LanguageIcon class="card-list-language-icon"/>
+        <LanguageIcon class="corner-language-icon"/>
         <PreferencesIcon/>
       </div>
   </div>

--- a/src/styles/card_list.less
+++ b/src/styles/card_list.less
@@ -140,28 +140,3 @@
   font-size: 30px;
   line-height: 1;
 }
-
-// LanguageIcon is built for the in-game sidebar: its root is absolutely
-// positioned (bottom: 162px) and its popup opens at bottom: -140px. On the
-// cards page we want it in the bottom-left corner, just above the preferences
-// gear. That gear (.sidebar_item--settings) is position: fixed; bottom: 4px and
-// ~46px tall, so it ignores normal flow and pins itself to the viewport bottom.
-// To sit above it we likewise pin the flag, clearing the gear, and align it flush
-// with the gear's left edge (the free-floating container sits flush in the corner).
-.card-list-language-icon.sidebar_item--language {
-  position: fixed;
-  bottom: 58px;
-  left: 0;
-
-  // The little black connector tab that points back at the sidebar makes no
-  // sense in the corner.
-  .sidebar_icon--language.sidebar_item--is-active::after {
-    display: none;
-  }
-
-  // Open the language popup up-and-to-the-right of the flag so it stays on screen.
-  .preferences_panel.preferences_panel--language-switcher {
-    bottom: 0;
-    left: 100%;
-  }
-}

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -412,6 +412,32 @@
   z-index: 10;
 }
 
+// LanguageIcon is built for the in-game sidebar: its root is absolutely
+// positioned (bottom: 162px) and its popup opens at bottom: -140px. On the
+// non-game pages (the cards list and the start screen) we want it in the
+// bottom-left corner, just above the preferences gear. That gear
+// (.sidebar_item--settings) is position: fixed; bottom: 4px and ~46px tall, so
+// it ignores normal flow and pins itself to the viewport bottom. To sit above
+// it we likewise pin the flag, clearing the gear, and align it flush with the
+// gear's left edge (the free-floating container sits flush in the corner).
+.corner-language-icon.sidebar_item--language {
+  position: fixed;
+  bottom: 58px;
+  left: 0;
+
+  // The little black connector tab that points back at the sidebar makes no
+  // sense in the corner.
+  .sidebar_icon--language.sidebar_item--is-active::after {
+    display: none;
+  }
+
+  // Open the language popup up-and-to-the-right of the flag so it stays on screen.
+  .preferences_panel.preferences_panel--language-switcher {
+    bottom: 0;
+    left: 100%;
+  }
+}
+
 .bug-dialog {
   .center {
     text-align: center;


### PR DESCRIPTION
Match the cards page: place a LanguageIcon flag in the bottom-left corner above the preferences gear on the start screen.

Generalize the corner-flag positioning rule from .card-list-language-icon to .corner-language-icon and move it from card_list.less to preferences.less, next to .free-floating-preferences-icon, since both non-game pages now use it.