### PR TITLE
Don't re-check canAct for discounted standard projects

### DIFF
--- a/src/server/inputs/SelectStandardProjectToPlay.ts
+++ b/src/server/inputs/SelectStandardProjectToPlay.ts
@@ -28,7 +28,13 @@ export class SelectStandardProjectToPlay extends SelectCardToPlay<IStandardProje
     // server must enforce it too: process() never consults `enabled`, and projects whose
     // requirement isn't just the M€ cost (e.g. Collusion spending corruption) would otherwise
     // execute regardless. See https://github.com/terraforming-mars/terraforming-mars/issues/8238.
-    if (!card.canAct(this.player)) {
+    //
+    // This only matters for menus that offer non-actable projects (the standard projects menu and
+    // Established Methods). A discounted play (overriddenCost set, e.g. Standard Technology) is
+    // already handed a canAct-filtered list, so re-checking here is redundant and, worse, would
+    // re-evaluate affordability at the full undiscounted cost and reject a play the player can
+    // afford at the discount. See https://github.com/terraforming-mars/terraforming-mars/issues/8247.
+    if (details.overriddenCost === undefined && !card.canAct(this.player)) {
       throw new InputError('You cannot play this standard project');
     }
     const canPayWith = card.canPayWith(this.player);

--- a/tests/cards/underworld/StandardTechnology.spec.ts
+++ b/tests/cards/underworld/StandardTechnology.spec.ts
@@ -95,6 +95,27 @@ describe('Underworld / StandardTechnology', () => {
     select.payAndPlay(excavateStandardProject, Payment.of({megacredits: 0}));
   });
 
+  it('process validates discounted cost, not full cost (#8247)', () => {
+    [game, player] = testGame(1, {underworldExpansion: true});
+    player.playedCards.push(card);
+    player.standardProjectsThisGeneration.add(CardName.EXCAVATE_STANDARD_PROJECT);
+    // Excavate costs 7, Standard Technology discounts by 8, floor is 0.
+    // The player can afford the discounted cost (0) but not the full cost (7).
+    player.megaCredits = 6;
+
+    expect(card.canAct(player)).is.true;
+
+    const select = cast(card.action(player), SelectStandardProjectToPlay);
+
+    // process() runs validate(), which must accept the play even though the
+    // full, undiscounted cost (7) exceeds the player's M€.
+    expect(() => select.process({
+      type: 'projectCard',
+      card: CardName.EXCAVATE_STANDARD_PROJECT,
+      payment: Payment.of({megacredits: 0}),
+    })).to.not.throw();
+  });
+
   it('action', () => {
     player.playedCards.push(card);
     player.standardProjectsThisGeneration.add(CardName.ASTEROID_STANDARD_PROJECT);


### PR DESCRIPTION
Fixes #8247

validate()'s canAct gate (added for #8238) re-derived Excavate's cost without Standard Technology's -8 discount, rejecting a discounted play the player couldn't afford at full price. That gate only matters for menus that offer non-actable projects; discounted plays set overriddenCost and get a pre-filtered list, so skip the redundant re-check there.