### PR TITLE
Make Tosche Station card text clearer

### DIFF
--- a/src/locales/de/starwars_cards.json
+++ b/src/locales/de/starwars_cards.json
@@ -10,7 +10,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "Benötigt, dass Sie Vorsitzender sind. Die derzeitige Regierungspartei wird in der nächsten Sonnenphase automatisch die Regierungspartei sein, und du bleibst der Vorsitzende. (Als ob die derzeitige Regierungspartei dominant wäre und du ihr Parteivorsitzender wärst).",
 
   "Tosche Station (IV)": "Tosche-Station",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "AKTION: Gib X Energie aus und erhalte X-1 Pflanzen (max. 4).",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "AKTION: Gib X Energie (max. 4) aus und erhalte X-1 Pflanzen.",
 
   "Cloud City (V)": "Wolkenstadt (V)",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "Erfordert Venuswertung von 6%. Erhöhe Venuswertung um 1. Füge 2 Schweber zu einer beliebigen Karte hinzu.",

--- a/src/locales/fi/starwars_cards.json
+++ b/src/locales/fi/starwars_cards.json
@@ -10,7 +10,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "Vaatii että olet puheenjohtaja. Nykyinen hallitseva puolue tulee automaattisesti olemaan hallitseva puolue seuraavan aurinkovaiheessa, ja pysyt puheenjohtajana. (Ikään kuin nykyinen hallitseva puolue olisi dominoiva ja olisit sen puoluejohtaja.)",
 
   "Tosche Station (IV)": "Tosche-asema (IV)",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "TOIMINTO: Käytä X energiaa ja saat X-1 kasvia (enintään 4).",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "TOIMINTO: Käytä X energiaa (enintään 4) ja saat X-1 kasvia.",
 
   "Cloud City (V)": "Pilvikaupunki (V)",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "Vaatii Venus 6 %. Nosta Venusta 1 askel. Lisää 2 kellujaa mille kortille tahansa.",

--- a/src/locales/fr/starwars_cards.json
+++ b/src/locales/fr/starwars_cards.json
@@ -7,7 +7,7 @@
   "Behold The Emperor! (III)": "",
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "",
   "Tosche Station (IV)": "",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "",
   "Cloud City (V)": "",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "",
   "Forest Moon (VI)": "",

--- a/src/locales/hu/starwars_cards.json
+++ b/src/locales/hu/starwars_cards.json
@@ -7,7 +7,7 @@
   "Behold The Emperor! (III)": "Íme a császár! (III)",
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "Kijátszási feltétel: elnök vagy. A jelenleg hatalmon lévő párt hatalmon marad a következő Napfázisban, te pedig elnök maradsz. (Mintha a jelenlegi hatalmon lévő párt a domináns lenne, te pedig pártvezető.)",
   "Tosche Station (IV)": "Tosche állomás (IV)",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "Akció: Költs el X energiát és kapsz X-1 palántát (legfeljebb 4)!",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "Akció: Költs el X energiát (legfeljebb 4) és kapsz X-1 palántát!",
   "Cloud City (V)": "Felhőváros (V)",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "Kijátszási feltétel: legalább 6%-os Vénusz szint. Növeld a Vénusz szintet 1 értékkel! Rakj 2 lebegőt egy tetszőleges kártyára!",
   "Forest Moon (VI)": "Erdei Hold (VI)",

--- a/src/locales/jp/starwars_cards.json
+++ b/src/locales/jp/starwars_cards.json
@@ -10,7 +10,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "条件：あなたが議長. 次の太陽系フェイズの間、与党が変わらず、議長も変わらない.",
 
   "Tosche Station (IV)": "",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "アクション：x電力支払い、x-1植物獲得(最大4).",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "アクション：x電力(最大4)支払い、x-1植物獲得.",
   "max 4": "最大4",
 
   "Cloud City (V)": "",

--- a/src/locales/ko/starwars_cards.json
+++ b/src/locales/ko/starwars_cards.json
@@ -9,7 +9,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "",
 
   "Tosche Station (IV)": "",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "",
 
   "Cloud City (V)": "",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "",

--- a/src/locales/nb/starwars_cards.json
+++ b/src/locales/nb/starwars_cards.json
@@ -9,7 +9,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "Krever at du er Styreleder. Det nåværende regjerende partiet vil automatisk være det regjerende partiet under neste solfase, og du vil forbli formann. (Som om det nåværende regjerende partiet var dominerende og du var dets partileder.)",
 
   "Tosche Station (IV)": "Tosche Stasjon (IV)",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "Handling: Bruk X energi og få X-1 planter (maks 4.)",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "Handling: Bruk X energi (maks 4) og få X-1 planter.",
 
   "Cloud City (V)": "",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "Krever Venus 6%. Øk Venus 1 trinn. Legg til 2 svevere på et valgfritt kort.",

--- a/src/locales/ua/starwars_cards.json
+++ b/src/locales/ua/starwars_cards.json
@@ -9,7 +9,7 @@
   "Requires that you are Chairman. The current ruling party will automatically be the ruling party during the next Solar phase, and you will remain the Chairman. (As if the current ruling party were dominant and you were its party leader.)": "Вимагає, щоб ви були Головою. Поточна правляча партія автоматично залишиться правлячою партією під час наступної Сонячної фази, і ви залишитесь Головою. (Ніби поточна правляча партія була домінуючою, а ви її лідером партії.)",
 
   "Tosche Station (IV)": "Станція Тоше (IV)",
-  "Action: Spend X energy and gain X-1 plants (max 4.)": "Дія: Витратити X Енергії та отримати X-1 рослин (макс. 4).",
+  "Action: Spend X energy (max 4) and gain X-1 plants.": "Дія: Витратити X Енергії (макс. 4) та отримати X-1 рослин.",
 
   "Cloud City (V)": "Місто у Хмарах (V)",
   "Requires Venus 6%. Raise Venus 1 step. Add 2 floaters to any card.": "Вимагає 6% Венери. Підвищити Венеру на 1. Додати 2 аеростати об'єкти на будь-яку карту.",

--- a/src/server/cards/starwars/ToscheStation.ts
+++ b/src/server/cards/starwars/ToscheStation.ts
@@ -20,8 +20,8 @@ export class ToscheStation extends Card implements IActionCard, IProjectCard {
       metadata: {
         cardNumber: 'SW04',
         renderData: CardRenderer.builder((b) => {
-          b.action('Spend X energy and gain X-1 plants (max 4.)', (ab) => {
-            ab.text('x').energy(1).startAction.text('x-1').plants(1).text('max 4');
+          b.action('Spend X energy (max 4) and gain X-1 plants.', (ab) => {
+            ab.text('x').energy(1).text('max 4').startAction.text('x-1').plants(1);
           });
         }),
       },


### PR DESCRIPTION
I've been thinking these changes would decrease confusion around this card. It was a very simple change so I thought I would just create a PR & you can be the judge.

Current card:

<img width="181" height="227" alt="Screenshot 2026-06-19 at 06 09 54" src="https://github.com/user-attachments/assets/59865713-d538-4c5d-ac2d-91220383ee23" />

Proposed change:

<img width="195" height="239" alt="Screenshot 2026-06-19 at 06 09 18" src="https://github.com/user-attachments/assets/6ec820c1-1cee-40b9-ad2d-9adac3ac84ba" />
