### PR TITLE
Unify card tag CSS into a single tag-* namespace

### DIFF
--- a/src/client/components/card/CardRenderItemComponent.vue
+++ b/src/client/components/card/CardRenderItemComponent.vue
@@ -43,11 +43,11 @@ export default defineComponent({
       if (this.item.tag === undefined) {
         return '';
       }
-      return 'card-tag-' + this.item.tag.toLowerCase().replaceAll(' ', '-');
+      return 'tag-' + this.item.tag.toLowerCase().replaceAll(' ', '-');
     },
     tagSizeClass(): string {
       if (this.item.size !== undefined) {
-        return 'card-tag-size--' + this.item.size;
+        return 'tag-size--' + this.item.size;
       }
       return '';
     },
@@ -189,7 +189,7 @@ export default defineComponent({
       case CardRenderItemType.NO_TAGS:
         return ['card-resource-tag', 'card-no-tags'];
       case CardRenderItemType.EMPTY_TAG:
-        return ['card-resource-tag', 'card-tag-empty'];
+        return ['card-resource-tag', 'tag-empty'];
       case CardRenderItemType.CITY:
         return ['card-tile', `city-tile--${this.item.size}`];
       case CardRenderItemType.GREENERY:
@@ -335,7 +335,7 @@ export default defineComponent({
       // Oxygen is handled specially separately.
       const secondaryTag = this.item.secondaryTag;
       if (secondaryTag !== undefined && !previouslyRendered.includes(secondaryTag)) {
-        result += '<div class="card-icon card-tag-' + secondaryTag + '"></div>';
+        result += '<div class="card-icon tag-' + secondaryTag + '"></div>';
       }
       if (this.item.isPlate || this.item.text !== undefined) {
         result += this.item.text || 'n/a';

--- a/src/client/components/card/CardRequirementComponent.vue
+++ b/src/client/components/card/CardRequirementComponent.vue
@@ -120,13 +120,13 @@ export default defineComponent({
       case RequirementType.COLONIES:
         return ['card-resource-colony', 'card-resource-colony--req'];
       case RequirementType.FLOATERS:
-        return ['card-resource-tag--S', 'card-tag-floater'];
+        return ['card-resource-tag--S', 'tag-floater'];
       case RequirementType.CHAIRMAN:
         return ['card-chairman--req'];
       case RequirementType.PARTY_LEADERS:
         return ['card-party-leader--req'];
       case RequirementType.TAG:
-        return ['card-resource-tag--S', 'card-tag-' + this.requirement.tag];
+        return ['card-resource-tag--S', 'tag-' + this.requirement.tag];
       case RequirementType.HABITAT_RATE:
         return ['card-habitat-rate', 'card-habitat-rate--req'];
       case RequirementType.MINING_RATE:

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -510,6 +510,10 @@ input[type="radio"]:checked+.filterDiv::after {
   background-image: url("./assets/underworld/asterisk-tag.png");
 }
 
+.tag-empty {
+  background-image: url("./assets/tags/empty.png");
+}
+
 /************** Style the Content ************/
 .content {
   color: black;

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -514,6 +514,106 @@ input[type="radio"]:checked+.filterDiv::after {
   background-image: url("./assets/tags/empty.png");
 }
 
+// TODO(kberg): floater is a resource, not a tag — this is misnamed as tag-*.
+// (Same for tag-wild-resource below.) Rename to a resource-based class.
+.tag-floater {
+  background-image: url("./assets/resources/floater.png");
+  border-radius: 0px;
+}
+
+.tag-wild-resource {
+  background-image: url("./assets/resources/wild.png");
+  border-radius: 0px;
+}
+
+.tag-diverse {
+  background: linear-gradient(to bottom right, green, yellow, red);
+}
+
+.tag-size--S {
+  height: 22px;
+  width: 22px;
+  background-size: 26px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+/* secondary tags */
+.tag-req {
+  border-radius: 0px;
+  height: 12px;
+  box-shadow: @outline-shadow;
+  background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
+}
+
+.tag-blue {
+  opacity: 0.8;
+  margin-left: 17px;
+  background: #176fe4;
+  width: 16px;
+  top: -7px;
+  height: 16px;
+  border-radius: @radius_circle;
+}
+
+.tag-no_planetary_tag {
+  .tag-clone();
+}
+
+.tag-no_planetary_tag:after {
+  content: '';
+  height: 20px;
+  border-left: 2px dashed #f00;
+  position: absolute;
+  transform: rotate(45deg);
+  margin-left: -1px;
+}
+
+.tag-no_planetary_tag:before {
+  content: '';
+  height: 20px;
+  border-left: 2px dashed #f00;
+  position: absolute;
+  transform: rotate(-45deg);
+  margin-left: -1px;
+}
+
+.tag-turmoil:after {
+  position: absolute;
+  color: @grey_900;
+  border: 1px solid black;
+  left: -1px;
+  background: darkorange;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 16px;
+  width: 20px;
+  height: 20px;
+  text-align: center;
+  border-radius: @radius_circle;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+  content: "\25b2";
+  transform: rotate(180deg);
+}
+
+.tag-no_tags {
+  background:white;
+  font-size: 30px;
+  vertical-align: middle;
+  font-weight: normal
+}
+
+.tag-no_tags:after {
+  content: "X";
+  position: relative;
+  top: 1px;
+  left: 1px;
+}
+
+.tag-ares {
+  background-image: url("./assets/expansion_icons/expansion_icon_ares.png");
+}
+
 /************** Style the Content ************/
 .content {
   color: black;

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1929,25 +1929,17 @@
       margin-left: 2px;
     }
   }
-  // TODO(kberg) This set of tags looks like a duplicate of cards.less.
-  @tags: wild, building, space, power, jovian, venus, earth, city, mars,
-    microbe, plant, animal, event, science, none, moon, crime, empty;
-  // stylelint-disable-next-line @stylistic/indentation
-  each(@tags, {
-    .card-tag-@{value} {
-      background-image: url("./assets/tags/@{value}.png");
-    }
-  })
-
-  .card-tag-floater {
+  // TODO(kberg): floater is a resource, not a tag — this is misnamed as tag-*.
+  // (Same for tag-wild-resource below.) Rename to a resource-based class.
+  .tag-floater {
     background-image: url("./assets/resources/floater.png");
     border-radius: 0px;
   }
-  .card-tag-wild-resource {
+  .tag-wild-resource {
     background-image: url("./assets/resources/wild.png");
     border-radius: 0px;
   }
-  .card-tag-diverse {
+  .tag-diverse {
     background: linear-gradient(to bottom right, green, yellow, red);
   }
   .card-no-tags {
@@ -1956,7 +1948,7 @@
     background:white;
   }
 
-  .card-tag-size--S {
+  .tag-size--S {
     height: 22px;
     width: 22px;
     background-size: 26px;
@@ -1981,13 +1973,13 @@
     }
   }
   /* secondary tags */
-  .card-tag-req {
+  .tag-req {
     border-radius: 0px;
     height: 12px;
     box-shadow: @outline-shadow;
     background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
   }
-  .card-tag-blue {
+  .tag-blue {
     opacity: 0.8;
     margin-left: 17px;
     background: #176fe4;
@@ -1996,10 +1988,10 @@
     height: 16px;
     border-radius: @radius_circle;
   }
-  .card-tag-no_planetary_tag {
+  .tag-no_planetary_tag {
     .tag-clone();
   }
-  .card-tag-no_planetary_tag:after {
+  .tag-no_planetary_tag:after {
     content: '';
     height: 20px;
     border-left: 2px dashed #f00;
@@ -2007,7 +1999,7 @@
     transform: rotate(45deg);
     margin-left: -1px;
   }
-  .card-tag-no_planetary_tag:before {
+  .tag-no_planetary_tag:before {
     content: '';
     height: 20px;
     border-left: 2px dashed #f00;
@@ -2015,7 +2007,7 @@
     transform: rotate(-45deg);
     margin-left: -1px;
   }
-  .card-tag-turmoil:after {
+  .tag-turmoil:after {
     position: absolute;
     color: @grey_900;
     border: 1px solid black;
@@ -2032,19 +2024,19 @@
     content: "\25b2";
     transform: rotate(180deg);
   }
-  .card-tag-no_tags {
+  .tag-no_tags {
     background:white;
     font-size: 30px;
     vertical-align: middle;
     font-weight: normal
   }
-  .card-tag-no_tags:after {
+  .tag-no_tags:after {
     content: "X";
     position: relative;
     top: 1px;
     left: 1px;
   }
-  .card-tag-ares {
+  .tag-ares {
     background-image: url("./assets/expansion_icons/expansion_icon_ares.png");
   }
   /* special case Project requirements */

--- a/src/styles/cards_v2.less
+++ b/src/styles/cards_v2.less
@@ -1929,31 +1929,10 @@
       margin-left: 2px;
     }
   }
-  // TODO(kberg): floater is a resource, not a tag — this is misnamed as tag-*.
-  // (Same for tag-wild-resource below.) Rename to a resource-based class.
-  .tag-floater {
-    background-image: url("./assets/resources/floater.png");
-    border-radius: 0px;
-  }
-  .tag-wild-resource {
-    background-image: url("./assets/resources/wild.png");
-    border-radius: 0px;
-  }
-  .tag-diverse {
-    background: linear-gradient(to bottom right, green, yellow, red);
-  }
   .card-no-tags {
     font-size: 42px;
     vertical-align: middle;
     background:white;
-  }
-
-  .tag-size--S {
-    height: 22px;
-    width: 22px;
-    background-size: 26px;
-    margin-left: 0px;
-    margin-right: 0px;
   }
 
   .card-no-tags:after {
@@ -1971,73 +1950,6 @@
       left: -13px;
       font-weight: bold;
     }
-  }
-  /* secondary tags */
-  .tag-req {
-    border-radius: 0px;
-    height: 12px;
-    box-shadow: @outline-shadow;
-    background: linear-gradient(90deg, rgba(243,161,14,1) 0%, rgba(253,234,37,1) 45%, rgba(253,234,37,1) 55%, rgba(243,161,14,1) 100%);
-  }
-  .tag-blue {
-    opacity: 0.8;
-    margin-left: 17px;
-    background: #176fe4;
-    width: 16px;
-    top: -7px;
-    height: 16px;
-    border-radius: @radius_circle;
-  }
-  .tag-no_planetary_tag {
-    .tag-clone();
-  }
-  .tag-no_planetary_tag:after {
-    content: '';
-    height: 20px;
-    border-left: 2px dashed #f00;
-    position: absolute;
-    transform: rotate(45deg);
-    margin-left: -1px;
-  }
-  .tag-no_planetary_tag:before {
-    content: '';
-    height: 20px;
-    border-left: 2px dashed #f00;
-    position: absolute;
-    transform: rotate(-45deg);
-    margin-left: -1px;
-  }
-  .tag-turmoil:after {
-    position: absolute;
-    color: @grey_900;
-    border: 1px solid black;
-    left: -1px;
-    background: darkorange;
-    font-weight: bold;
-    font-size: 16px;
-    line-height: 16px;
-    width: 20px;
-    height: 20px;
-    text-align: center;
-    border-radius: @radius_circle;
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
-    content: "\25b2";
-    transform: rotate(180deg);
-  }
-  .tag-no_tags {
-    background:white;
-    font-size: 30px;
-    vertical-align: middle;
-    font-weight: normal
-  }
-  .tag-no_tags:after {
-    content: "X";
-    position: relative;
-    top: 1px;
-    left: 1px;
-  }
-  .tag-ares {
-    background-image: url("./assets/expansion_icons/expansion_icon_ares.png");
   }
   /* special case Project requirements */
   .card-project-requirements {
@@ -2797,7 +2709,7 @@
 }
 
 @parties: greens, kelvinists, mars-first, reds, scientists, unity;
-// stylelint-disable-next-line @stylistic/indentation
+/* stylelint-disable @stylistic/indentation */
 each(@parties, {
   .card-party--@{value} {
     background-image: url("./assets/parties/@{value}.png");
@@ -2806,7 +2718,6 @@ each(@parties, {
     height: 30px;
   }
 })
-// stylelint-disable-next-line @stylistic/indentation
 each(@parties, {
   .card-party--@{value}-req {
     background-image: url("./assets/parties/@{value}.png");
@@ -2815,6 +2726,7 @@ each(@parties, {
     height: 34px;
   }
 })
+/* stylelint-enable @stylistic/indentation */
 
 .card-over {
   margin: 0px 0 -59px -59px;
@@ -2837,12 +2749,13 @@ each(@parties, {
   asteroid, disease, preservation, data, syndicate-fleet, cube,
   venusian-habitat, specialized-robot, seed, orbital, agenda, graphene, hydroelectric-resource,
   clone-trooper, director, tool, ware, activist, journalism, supply-chain;
-// stylelint-disable-next-line @stylistic/indentation
+/* stylelint-disable @stylistic/indentation */
 each(@card_resource_types, {
   .card-resource-@{value} {
     background-image: url("./assets/resources/@{value}.png");
   }
 })
+/* stylelint-enable @stylistic/indentation */
 
 .card-resource-cube {
   background-image: url("./assets/cube.png");

--- a/src/styles/language_hacks.less
+++ b/src/styles/language_hacks.less
@@ -1530,7 +1530,7 @@
           width: 20px;
           height: 25px;
         }
-        .card-tag-space {
+        .tag-space {
           width: 15px;
           height: 15px;
           line-height: 20px;

--- a/src/styles/moon.less
+++ b/src/styles/moon.less
@@ -290,10 +290,3 @@
   background-size: 30px;
   margin-left: 2px;
 }
-
-// .card-tag-moon-on-card {
-//   background-image: url(./assets/tags/moon.png);
-//   background-size: 100%;
-//   width: 30px;
-//   height: 30px;
-// }

--- a/src/styles/moon.less
+++ b/src/styles/moon.less
@@ -291,9 +291,9 @@
   margin-left: 2px;
 }
 
-.card-tag-moon-on-card {
-  background-image: url(./assets/tags/moon.png);
-  background-size: 100%;
-  width: 30px;
-  height: 30px;
-}
+// .card-tag-moon-on-card {
+//   background-image: url(./assets/tags/moon.png);
+//   background-size: 100%;
+//   width: 30px;
+//   height: 30px;
+// }

--- a/tests/client/components/card/CardRequirementComponent.spec.ts
+++ b/tests/client/components/card/CardRequirementComponent.spec.ts
@@ -23,6 +23,6 @@ describe('CardRequirementComponent', () => {
         requirement: {tag: Tag.SCIENCE, count: 2},
       },
     });
-    expect(wrapper.find('.card-tag-science').exists()).to.be.true;
+    expect(wrapper.find('.tag-science').exists()).to.be.true;
   });
 });


### PR DESCRIPTION
Tags were styled under two namespaces: tag-* in cards.less and a duplicate card-tag-* in cards_v2.less. Point the card components at the existing tag-* classes, delete the duplicate loop, and rename the remaining card-tag-* specials in place to tag-* (kept nested under .card-container, so rendering is unchanged). The card-tag- prefix is now gone.