### PR TITLE
Randomize Maria colony choices

### DIFF
--- a/src/server/cards/ceos/Maria.ts
+++ b/src/server/cards/ceos/Maria.ts
@@ -3,6 +3,7 @@ import {IPlayer} from '../../IPlayer';
 import {CardRenderer} from '../render/CardRenderer';
 import {CeoCard} from './CeoCard';
 import {ColoniesHandler} from '../../colonies/ColoniesHandler';
+import {inplaceShuffle} from '../../utils/shuffle';
 
 export class Maria extends CeoCard {
   constructor() {
@@ -29,11 +30,12 @@ export class Maria extends CeoCard {
   public action(player: IPlayer): undefined {
     const game = player.game;
     const count = Math.min(game.discardedColonies.length, player.game.generation);
-    const availableColonies = game.discardedColonies.slice(0, count);
+    const availableColonies = game.discardedColonies.slice();
+    inplaceShuffle(availableColonies, game.rng);
 
     this.isDisabled = true;
     ColoniesHandler.addColonyTile(player, {
-      colonies: availableColonies, cb: (colony) => {
+      colonies: availableColonies.slice(0, count), cb: (colony) => {
         if (colony.isActive) {
           colony.addColony(player);
         }

--- a/tests/cards/ceo/Maria.spec.ts
+++ b/tests/cards/ceo/Maria.spec.ts
@@ -9,7 +9,9 @@ import {Venus} from '../../../src/server/cards/community/Venus';
 import {Celestic} from '../../../src/server/cards/venusNext/Celestic';
 import {IapetusII} from '../../../src/server/cards/pathfinders/IapetusII';
 import {CollegiumCopernicus} from '../../../src/server/cards/pathfinders/CollegiumCopernicus';
-import {cast} from '../../../src/common/utils/utils';
+import {Callisto} from '../../../src/server/colonies/Callisto';
+import {Titan} from '../../../src/server/colonies/Titan';
+import {cast, toName} from '../../../src/common/utils/utils';
 
 describe('Maria', () => {
   let card: Maria;
@@ -35,6 +37,19 @@ describe('Maria', () => {
     selectColony.cb(selectedColony);
     expect(game.colonies).to.contain(selectedColony);
     expect(game.colonies).has.length(coloniesInPlay + 1);
+  });
+
+  it('Draws from discarded colonies without mutating their order', () => {
+    game.discardedColonies = [new Titan(), new Callisto()];
+
+    cast(card.action(player), undefined);
+    runAllActions(player.game);
+
+    const selectColony = cast(player.popWaitingFor(), SelectColony);
+    const drawnColonyNames = selectColony.colonies.map(toName);
+    expect(drawnColonyNames).has.length(1);
+    expect(['Titan', 'Callisto']).contains(drawnColonyNames[0]);
+    expect(game.discardedColonies.map(toName)).deep.eq(['Titan', 'Callisto']);
   });
 
   it('Takes action in Generation 4', () => {


### PR DESCRIPTION
## Summary
- Make Maria draw a shuffled subset of unused colony tiles, then choose one tile from that drawn subset.
- Leave explicit "of your choice" colony-tile effects such as Aridor and Prospecting unchanged.
- Avoid changing discarded-colony serialization or the public game model.

## Demo
- Repro fixture: discarded colonies are `[Titan, Callisto]`, generation is 1, and the RNG is forced so the shuffled offer is `Callisto`.
- Expected behavior: Maria shows only the randomized drawn subset, then the player chooses one tile from that subset.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/ceo/Maria.spec.ts`
- `npx eslint src/server/cards/ceos/Maria.ts tests/cards/ceo/Maria.spec.ts`
- `npm run build`

## Notes
- Replaces the previous broader discarded-colony-order approach with the narrower Maria-only random draw suggested in review.
- No change to Aridor/Prospecting choice behavior.