### PR TITLE
Log Splice microbe additions

### DIFF
--- a/src/server/cards/promo/Splice.ts
+++ b/src/server/cards/promo/Splice.ts
@@ -61,7 +61,7 @@ export class Splice extends CorporationCard implements ICorporationCard {
     game.defer(new GainResourcesDeferred(player, Resource.MEGACREDITS, {count: gain, log: true, from: {card: this}}));
 
     const gainResource = new SelectOption('Add a microbe resource to this card', 'Add microbe').andThen(() => {
-      cardPlayer.addResourceTo(card);
+      cardPlayer.addResourceTo(card, {log: true});
       return undefined;
     });
 


### PR DESCRIPTION
## Summary
- Log Splice's Add microbe option using the existing card-resource log path.
- No gameplay change.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/promo/Splice.spec.ts`
- `git diff --check upstream/main`