### PR TITLE
Show Law Suit eligible targets

### DIFF
--- a/src/server/cards/promo/LawSuit.ts
+++ b/src/server/cards/promo/LawSuit.ts
@@ -40,7 +40,9 @@ export class LawSuit extends Card implements IProjectCard {
   }
 
   public override bespokePlay(player: IPlayer) {
-    return new SelectPlayer(this.targets(player), 'Select player to sue (steal 3 M€ from)', 'Steal M€')
+    const targets = this.targets(player);
+    const targetNames = targets.map((player) => player.name).join(', ');
+    return new SelectPlayer(targets, `Select player to sue. Eligible targets: ${targetNames}`, 'Steal M€')
       .andThen((suedPlayer: IPlayer) => {
         const amount = Math.min(3, suedPlayer.megaCredits);
         if (amount === 0) {
@@ -71,4 +73,3 @@ export class LawSuit extends Card implements IProjectCard {
     }
   }
 }
-

--- a/tests/cards/promo/LawSuit.spec.ts
+++ b/tests/cards/promo/LawSuit.spec.ts
@@ -51,6 +51,14 @@ describe('LawSuit', () => {
     expect(play).instanceOf(SelectPlayer);
   });
 
+  it('Names eligible targets in player selection', () => {
+    player.removingPlayers.push(player2.id);
+
+    const play = cast(card.play(player), SelectPlayer);
+
+    expect(play.title).eq('Select player to sue. Eligible targets: player2');
+  });
+
   it('Steals resources correctly', () => {
     // This part sets up player2 as a thief whom you will sue.
     player.removingPlayers.push(player2.id);


### PR DESCRIPTION
## Summary
- Show Law Suit's eligible target names directly in the player-selection prompt.
- Keep Law Suit target validation and steal behavior unchanged.

## Demo
Before, the prompt was generic:

![Law Suit target prompt before](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/assets-law-suit-target-prompt-20260621/pr-assets/law-suit-target-prompt/before.png)

After, the prompt names the eligible target players:

![Law Suit target prompt after](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/assets-law-suit-target-prompt-20260621/pr-assets/law-suit-target-prompt/after.png)

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/promo/LawSuit.spec.ts`
- `git diff --check`

## Notes
- No gameplay change; this only clarifies the existing player-selection prompt.