### PR TITLE
Remove unused CSS selectors.

### DIFF
--- a/src/styles/colonies.less
+++ b/src/styles/colonies.less
@@ -404,12 +404,6 @@
   display: inline-block;
 }
 
-.deimos-colony-bonus-text {
-  position: relative;
-  top: -3px;
-  left: -3px;
-}
-
 .Terra-title {
   text-transform: uppercase;
   background: linear-gradient(to right, #3343d3, transparent);
@@ -425,12 +419,6 @@
 .terra-colony-bonus {
   display: inline-block;
   padding-right: 50px;
-}
-
-.terra-colony-bonus-text {
-  position: relative;
-  top: -3px;
-  left: 43px;
 }
 
 .Kuiper-title {

--- a/src/styles/colonies_filter.less
+++ b/src/styles/colonies_filter.less
@@ -1,6 +1,0 @@
-.colonies-filter-list {
-  display: inline-block;
-  vertical-align: top;
-  width: 325px;
-  margin: 0 0 25px 25px;
-}

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -141,14 +141,6 @@ h2 {
   white-space: pre;
 }
 
-.mt-5 {
-  margin-top: 5px;
-}
-
-.mt-10 {
-  margin-top: 10px;
-}
-
 // normal backgrounds
 each(@players, {
 @c: ~"player_@{value}";
@@ -185,7 +177,6 @@ each(@players, {
 @import "./start_screen.less";
 @import "./create_game_form.less";
 @import "./corporations_filter.less";
-@import "./colonies_filter.less";
 @import "./cards_filter.less";
 @import "./player_home.less";
 @import "./players_overview.less";

--- a/src/styles/game_home.less
+++ b/src/styles/game_home.less
@@ -35,13 +35,6 @@
   .copied-notice {
     margin-left: 12px;
     font-size: @font_size_normal;
-    .dismissed {
-      font-size: @font_size_small;
-      padding: 1px 3px;
-      border-radius: 2px;
-      color: black;
-      background: #e8e8e8;
-    }
   }
   .spacing-setup{
     padding-bottom: 64px;

--- a/src/styles/help.less
+++ b/src/styles/help.less
@@ -59,11 +59,6 @@
   padding-right: 60px;
 }
 
-.help-icon-column > div {
-  margin-top: 0px;
-  margin-bottom: 5px;
-}
-
 .help-icon-label{
   padding-left: 15px;
   display: inline-block;

--- a/src/styles/log.less
+++ b/src/styles/log.less
@@ -42,11 +42,6 @@
   max-width: 860px;
   background: @grey_900;
   position: relative;
-  .log-panel-actions {
-    position: absolute;
-    top: 20px;
-    right: 60px;
-  }
 
   li {
     margin-top: 0;

--- a/src/styles/other_player.less
+++ b/src/styles/other_player.less
@@ -7,9 +7,6 @@
   margin-right: 20px;
   overflow-y: auto;
   border-radius: 0px 0px 8px 8px;
-  .other_player_close {
-    float: right;
-  }
 }
 
 .other_player_header {

--- a/src/styles/pathfinders.less
+++ b/src/styles/pathfinders.less
@@ -38,14 +38,6 @@
     margin-top: -8px;
   }
 
-  .track-numbers {
-    margin-left: 50px;
-    font-family: 'Prototype', sans-serif;
-    letter-spacing: 1px;
-    color: #707070;
-    font-size: 22px;
-  }
-
   .track-tag {
     width: 60px;
     height: 60px;
@@ -325,9 +317,4 @@
   width: 50px;
   height: 50px;
   background-size: 50px, 50px;
-}
-
-.select-tile-cont {
-  height: 50px;
-  padding: 10px;
 }

--- a/src/styles/player_home.less
+++ b/src/styles/player_home.less
@@ -268,28 +268,6 @@ each(@players, {
   margin-top: 11px;
 }
 
-.icon-vp {
-  text-shadow: 0 0 5px darkorange;
-  color: #000;
-  width: 60px;
-  height: 60px;
-  line-height: 60px;
-  font-size: 28px;
-  background-image: url(./assets/board/mars.png);
-  background-size: 120px 120px;
-  background-position: 88px 92px;
-  border-top: 5px solid #bb8760;
-  border-left: 5px solid #bb8760;
-  border-bottom: 5px solid #744631;
-  border-right: 5px solid #744631;
-}
-
-.player_home_block--resources {
-  position: sticky;
-  top: -13px;
-  z-index: 20;
-}
-
 .player_home_anchor {
   position: relative;
   top: -100px;
@@ -305,13 +283,6 @@ each(@players, {
   text-shadow: 1px 1px 1px @grey_900, -1px -1px 1px #666;
   padding: 1px 10px;
   border-radius: 4px;
-}
-
-.help_tip {
-  color: #aaa;
-  font-size: smaller;
-  text-shadow: none;
-  font-family: Ubuntu, sans-serif;
 }
 
 .player_home_block {
@@ -334,15 +305,6 @@ each(@players, {
     border-radius: 4px;
   }
 
-  .tags_cont {
-    display: inline-block;
-    vertical-align: top;
-
-    .player_name_cont {
-      text-align: left;
-    }
-  }
-
   .player_name_cont {
     text-align: center;
     width: 150px;
@@ -356,27 +318,6 @@ each(@players, {
       margin-right: 5px;
       text-shadow: 1px 1px 1px @grey_900, -1px -1px 1px #666;
     }
-
-    .corporation-name-cont {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-
-      .corporation-name {
-        font-size: 16px;
-      }
-    }
-  }
-  .pin_icon {
-    width: 40px;
-    height: 40px;
-  }
-  .player_pin {
-    cursor: pointer;
-    vertical-align: middle;
-    display: inline-block;
-    width: 40px;
-    height: 40px;
   }
   .other_player {
     display: flex;
@@ -772,11 +713,8 @@ each(@players, {
     }
   }
 
-  .player-status, .player-info-top {
+  .player-status {
     display: none !important;
-  }
-  .player-info-bottom {
-    background: @grey_850 !important;
   }
 
   .player-info {

--- a/src/styles/resources.less
+++ b/src/styles/resources.less
@@ -5,14 +5,6 @@
   filter: grayscale(0.3);
 }
 
-.tags_item_cont {
-  display: inline-block;
-  white-space: nowrap;
-  font-family: Prototype, sans-serif;
-  margin-bottom: 15px;
-  padding: 5px;
-}
-
 .resource_item {
   display: flex;
   border-radius: 5px;

--- a/src/styles/turmoil.less
+++ b/src/styles/turmoil.less
@@ -358,16 +358,6 @@
   transform: scale(0.8);
 }
 
-.label-lobby {
-  width:115px;
-  margin: auto;
-}
-
-.label-5mc {
-  width: 110px;
-  margin: auto;
-}
-
 .count-in-send-delegate {
   font-size: 22px;
 }
@@ -587,11 +577,6 @@
   z-index: 3;
   background-color: @grey_850;
   border-radius: 10px;
-}
-
-.policy-bonus {
-  margin-left: 20px;
-  color: white;
 }
 
 .card-small {


### PR DESCRIPTION
Net change after starting to clean up CSS: went down ~2,150 lines or 15.7% of the total lines of CSS.