### PR TITLE
Mark New Holland as covering an ocean

### DIFF
--- a/src/server/deferredActions/PlaceTile.ts
+++ b/src/server/deferredActions/PlaceTile.ts
@@ -32,7 +32,7 @@ export class PlaceTile extends DeferredAction<Space> {
     return new SelectSpace(title, availableSpaces)
       .andThen((space: Space) => {
         const tile: Tile = {...this.options.tile};
-        if (this.options.on === 'upgradeable-ocean') {
+        if (this.options.on === 'upgradeable-ocean' || this.options.on === 'upgradeable-ocean-new-holland') {
           tile.covers = space.tile;
         }
         game.addTile(this.player, space, tile);

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -1,16 +1,19 @@
 import {expect} from 'chai';
 import {GeologicalExpedition} from '../../../src/server/cards/pathfinders/GeologicalExpedition';
+import {NewHolland} from '../../../src/server/cards/promo/NewHolland';
 import {IGame} from '../../../src/server/IGame';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
 import {EmptyBoard} from '../../testing/EmptyBoard';
 import {Space} from '../../../src/server/boards/Space';
 import {SpaceBonus} from '../../../src/common/boards/SpaceBonus';
+import {SpaceType} from '../../../src/common/boards/SpaceType';
 import {IProjectCard} from '../../../src/server/cards/IProjectCard';
 import {addCity, fakeCard, runAllActions} from '../../TestingUtils';
 import {CardResource} from '../../../src/common/CardResource';
 import {Units} from '../../../src/common/Units';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
+import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/common/boards/SpaceName';
 import {TileType} from '../../../src/common/TileType';
 import {cast} from '../../../src/common/utils/utils';
@@ -102,6 +105,32 @@ describe('GeologicalExpedition', () => {
     expect(player.stock.asUnits()).deep.eq(Units.EMPTY);
     expect(microbeCard.resourceCount).eq(0);
     expect(scienceCard.resourceCount).eq(2);
+  });
+
+  it('does not grant covered ocean bonuses for New Holland', () => {
+    const newHolland = new NewHolland();
+    [game, player] = testGame(1);
+    player.popWaitingFor();
+
+    const oceanSpace = game.board.spaces.filter((space) => {
+      return space.bonus.length === 1 && space.bonus[0] === SpaceBonus.PLANT && space.spaceType === SpaceType.OCEAN;
+    })[0];
+
+    game.addOcean(player, oceanSpace);
+    expect(player.plants).eq(1);
+    player.plants = 0;
+    player.playedCards.push(card);
+
+    cast(newHolland.play(player), undefined);
+    runAllActions(game);
+    const action = cast(player.popWaitingFor(), SelectSpace);
+    action.cb(oceanSpace);
+    runAllActions(game);
+
+    expect(oceanSpace.tile?.tileType).eq(TileType.NEW_HOLLAND);
+    expect(oceanSpace.tile?.covers?.tileType).eq(TileType.OCEAN);
+    expect(player.plants).eq(0);
+    cast(player.getWaitingFor(), undefined);
   });
 
   it('variety', () => {

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -129,7 +129,11 @@ describe('GeologicalExpedition', () => {
 
     expect(oceanSpace.tile?.tileType).eq(TileType.NEW_HOLLAND);
     expect(oceanSpace.tile?.covers?.tileType).eq(TileType.OCEAN);
+
+    // Covering an existing tile doesn't grant the space bonus, nor does it give the consolation steel.
     expect(player.plants).eq(0);
+    expect(player.steel).eq(0);
+
     cast(player.getWaitingFor(), undefined);
   });
 

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -12,11 +12,9 @@ import {addCity, fakeCard, runAllActions} from '../../TestingUtils';
 import {CardResource} from '../../../src/common/CardResource';
 import {Units} from '../../../src/common/Units';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
-import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/common/boards/SpaceName';
 import {TileType} from '../../../src/common/TileType';
 import {cast} from '../../../src/common/utils/utils';
-import {OceanFarm} from '@/server/cards/ares/OceanFarm';
 
 describe('GeologicalExpedition', () => {
   let card: GeologicalExpedition;
@@ -113,13 +111,7 @@ describe('GeologicalExpedition', () => {
 
     game.simpleAddTile(player, space, {tileType: TileType.OCEAN});
 
-    const oceanFarm = new OceanFarm();
-    cast(oceanFarm.play(player), undefined);
-    runAllActions(game);
-    const action = cast(player.popWaitingFor(), SelectSpace);
-    action.cb(oceanSpace);
-    runAllActions(game);
-    cast(player.getWaitingFor(), undefined);
+    game.addTile(player, oceanSpace, {tileType: TileType.OCEAN_FARM, covers: oceanSpace.tile});
 
     expect(oceanSpace.tile?.tileType).eq(TileType.OCEAN_FARM);
     expect(oceanSpace.tile?.covers?.tileType).eq(TileType.OCEAN);

--- a/tests/cards/pathfinders/GeologicalExpedition.spec.ts
+++ b/tests/cards/pathfinders/GeologicalExpedition.spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {GeologicalExpedition} from '../../../src/server/cards/pathfinders/GeologicalExpedition';
-import {NewHolland} from '../../../src/server/cards/promo/NewHolland';
 import {IGame} from '../../../src/server/IGame';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
@@ -17,6 +16,7 @@ import {SelectSpace} from '../../../src/server/inputs/SelectSpace';
 import {SpaceName} from '../../../src/common/boards/SpaceName';
 import {TileType} from '../../../src/common/TileType';
 import {cast} from '../../../src/common/utils/utils';
+import {OceanFarm} from '@/server/cards/ares/OceanFarm';
 
 describe('GeologicalExpedition', () => {
   let card: GeologicalExpedition;
@@ -34,7 +34,6 @@ describe('GeologicalExpedition', () => {
     microbeCard = fakeCard({resourceType: CardResource.MICROBE});
     scienceCard = fakeCard({resourceType: CardResource.SCIENCE});
     player.playedCards.push(card, microbeCard, scienceCard);
-    player.popWaitingFor();
   });
 
   it('no bonuses, gain 1 steel', () => {
@@ -107,34 +106,27 @@ describe('GeologicalExpedition', () => {
     expect(scienceCard.resourceCount).eq(2);
   });
 
-  it('does not grant covered ocean bonuses for New Holland', () => {
-    const newHolland = new NewHolland();
-    [game, player] = testGame(1);
-    player.popWaitingFor();
+  it('does not grant covered ocean bonuses', () => {
+    const oceanSpace = game.board.getAvailableSpacesOnLand(player)[0];
+    oceanSpace.spaceType = SpaceType.OCEAN;
+    oceanSpace.bonus = [SpaceBonus.PLANT];
 
-    const oceanSpace = game.board.spaces.filter((space) => {
-      return space.bonus.length === 1 && space.bonus[0] === SpaceBonus.PLANT && space.spaceType === SpaceType.OCEAN;
-    })[0];
+    game.simpleAddTile(player, space, {tileType: TileType.OCEAN});
 
-    game.addOcean(player, oceanSpace);
-    expect(player.plants).eq(1);
-    player.plants = 0;
-    player.playedCards.push(card);
-
-    cast(newHolland.play(player), undefined);
+    const oceanFarm = new OceanFarm();
+    cast(oceanFarm.play(player), undefined);
     runAllActions(game);
     const action = cast(player.popWaitingFor(), SelectSpace);
     action.cb(oceanSpace);
     runAllActions(game);
+    cast(player.getWaitingFor(), undefined);
 
-    expect(oceanSpace.tile?.tileType).eq(TileType.NEW_HOLLAND);
+    expect(oceanSpace.tile?.tileType).eq(TileType.OCEAN_FARM);
     expect(oceanSpace.tile?.covers?.tileType).eq(TileType.OCEAN);
 
     // Covering an existing tile doesn't grant the space bonus, nor does it give the consolation steel.
     expect(player.plants).eq(0);
     expect(player.steel).eq(0);
-
-    cast(player.getWaitingFor(), undefined);
   });
 
   it('variety', () => {

--- a/tests/cards/promo/NewHolland.spec.ts
+++ b/tests/cards/promo/NewHolland.spec.ts
@@ -71,6 +71,7 @@ describe('NewHolland', () => {
 
     expect(oceanSpace.player).to.eq(player);
     expect(oceanSpace.tile!.tileType).to.eq(TileType.NEW_HOLLAND);
+    expect(oceanSpace.tile!.covers?.tileType).to.eq(TileType.OCEAN);
   });
 
   it('Cannot place a city next to New Holland', () => {


### PR DESCRIPTION
## Summary
- Mark New Holland's ocean-upgrade placement as covering the existing ocean tile, same as other ocean upgrade placements.
- This prevents covered ocean placement bonuses from being treated as newly received by effects such as Geological Expedition.

## Reproduction
- Custom server game: https://tm.knightbyte.win/game?id=ge01f744258d4
- Tagir played New Holland on ocean space F5, then Geological Expedition granted the covered ocean's plant bonus.
- New Holland does not grant the covered ocean space bonus, so Geological Expedition should not grant an additional copy of that bonus either.

![New Holland log showing the extra plant](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/49c84e10b9dedbea3cc1515ab4acf1e889d66144/docs/pr-assets/new-holland-covered-bonus/new-holland-log.png)

![Geological Expedition card text](https://raw.githubusercontent.com/rusliksu/terraforming-mars-upstream-fork/49c84e10b9dedbea3cc1515ab4acf1e889d66144/docs/pr-assets/new-holland-covered-bonus/geological-expedition-card.png)

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts "tests/cards/pathfinders/GeologicalExpedition.spec.ts" "tests/cards/promo/NewHolland.spec.ts"`
- `npx eslint src/server/deferredActions/PlaceTile.ts tests/cards/pathfinders/GeologicalExpedition.spec.ts`
- `npm run build:server`