### PR TITLE
Make activated Mars Maths survive undo

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -171,8 +171,6 @@ export class Player implements IPlayer {
 
   // The number of actions a player can take this round.
   // It's almost always 2, but certain cards can change this value (Mars Maths, Tool with the First Order)
-  //
-  // This value isn't serialized. Probably ought to be.
   public availableActionsThisRound = 2;
 
   public withinDeflectionZone = false;
@@ -1791,6 +1789,7 @@ export class Player implements IPlayer {
       preservationProgram: this.preservationProgram,
       // This generation / this round
       actionsTakenThisRound: this.actionsTakenThisRound,
+      availableActionsThisRound: this.availableActionsThisRound,
       actionsThisGeneration: Array.from(this.actionsThisGeneration),
       pendingInitialActions: this.pendingInitialActions.map(toName),
       // Cards
@@ -1862,6 +1861,7 @@ export class Player implements IPlayer {
     player.actionsTakenThisGame = d.actionsTakenThisGame;
     player.actionsThisGeneration = new Set(d.actionsThisGeneration);
     player.actionsTakenThisRound = d.actionsTakenThisRound;
+    player.availableActionsThisRound = d.availableActionsThisRound ?? 2;
     player.canUseHeatAsMegaCredits = d.canUseHeatAsMegaCredits;
     player.canUsePlantsAsMegacredits = d.canUsePlantsAsMegaCredits;
     player.canUseTitaniumAsMegacredits = d.canUseTitaniumAsMegacredits;

--- a/src/server/SerializedPlayer.ts
+++ b/src/server/SerializedPlayer.ts
@@ -15,6 +15,7 @@ interface DeprecatedFields {
 export interface SerializedPlayer extends DeprecatedFields{
   actionsTakenThisGame: number;
   actionsTakenThisRound: number;
+  availableActionsThisRound?: number;
   actionsThisGeneration: Array<CardName>;
   alliedParty: AlliedParty | undefined;
   autoPass: boolean;

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -311,18 +311,6 @@ describe('Player', () => {
     expect(newPlayer.colonies.usedTradeFleets).eq(100);
   });
 
-  it('preserves the expanded action budget through serialization', () => {
-    const player = new Player('blue', 'blue', false, 0, 'p-blue');
-    Game.newInstance('gameid', [player], player, 'spectatorid');
-    player.actionsTakenThisRound = 2;
-    player.availableActionsThisRound = 4;
-
-    const newPlayer = Player.deserialize(player.serialize());
-
-    expect(newPlayer.actionsTakenThisRound).eq(2);
-    expect(newPlayer.availableActionsThisRound).eq(4);
-  });
-
   it('pulls self replicating robots target cards', () => {
     const player = new Player('blue', 'blue', false, 0, 'p-blue');
     expect(player.getSelfReplicatingRobotsTargetCards()).is.empty;

--- a/tests/Player.spec.ts
+++ b/tests/Player.spec.ts
@@ -311,6 +311,18 @@ describe('Player', () => {
     expect(newPlayer.colonies.usedTradeFleets).eq(100);
   });
 
+  it('preserves the expanded action budget through serialization', () => {
+    const player = new Player('blue', 'blue', false, 0, 'p-blue');
+    Game.newInstance('gameid', [player], player, 'spectatorid');
+    player.actionsTakenThisRound = 2;
+    player.availableActionsThisRound = 4;
+
+    const newPlayer = Player.deserialize(player.serialize());
+
+    expect(newPlayer.actionsTakenThisRound).eq(2);
+    expect(newPlayer.availableActionsThisRound).eq(4);
+  });
+
   it('pulls self replicating robots target cards', () => {
     const player = new Player('blue', 'blue', false, 0, 'p-blue');
     expect(player.getSelfReplicatingRobotsTargetCards()).is.empty;

--- a/tests/cards/pathfinders/MarsMaths.spec.ts
+++ b/tests/cards/pathfinders/MarsMaths.spec.ts
@@ -1,12 +1,33 @@
 import {expect} from 'chai';
 import {testGame} from '../../TestGame';
+import {TestPlayer} from '../../TestPlayer';
 import {MarsMaths} from '../../../src/server/cards/pathfinders/MarsMaths';
 import {finishGeneration, runAllActions} from '../../TestingUtils';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
+import {OrOptions} from '../../../src/server/inputs/OrOptions';
+import {SelectStandardProjectToPlay} from '../../../src/server/inputs/SelectStandardProjectToPlay';
 import {LunarBeam} from '../../../src/server/cards/base/LunarBeam';
 import {Insulation} from '../../../src/server/cards/base/Insulation';
 import {IoMiningIndustries} from '../../../src/server/cards/base/IoMiningIndustries';
 import {cast} from '../../../src/common/utils/utils';
+import {CardName} from '../../../src/common/cards/CardName';
+import {Phase} from '../../../src/common/Phase';
+import {Game} from '../../../src/server/Game';
+import {assertSelectStandardProject} from '../../assertions';
+
+// Drives a full, real action through `takeAction()`: pops the top-level actions menu,
+// picks the standard project out of it, and lets the resulting callback advance
+// `actionsTakenThisRound` (and the turn, if the round is over) exactly like the server does.
+function takeStandardProjectAction(player: TestPlayer, standardProject: CardName) {
+  player.takeAction();
+  const [waitingFor, cb] = player.popWaitingFor2();
+  const orOptions = cast(waitingFor, OrOptions);
+  const standardProjectOption = cast(
+    orOptions.options.find((option) => option instanceof SelectStandardProjectToPlay),
+    SelectStandardProjectToPlay);
+  assertSelectStandardProject(standardProjectOption, player, standardProject);
+  cb?.();
+}
 
 describe('MarsMaths', () => {
   let card: MarsMaths;
@@ -108,5 +129,102 @@ describe('MarsMaths', () => {
 
     expect(selectCard.cards).has.length(3);
     expect(selectCard.config.max).eq(3);
+  });
+
+  // This test case is just here in comparison to the action test. It's a
+  // baseline to show that without the card action, the player is limited to
+  // two actions per turn.
+  it('Does not take action, limited to two actions', () => {
+    const [game, player, player2] = testGame(2);
+    player.playedCards.push(card);
+    player.megaCredits = 100;
+    game.generation = 2;
+    game.phase = Phase.ACTION;
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player2.id);
+  });
+
+  it('action', () => {
+    const [game, player, player2] = testGame(2);
+    player.playedCards.push(card);
+    player.megaCredits = 100;
+    game.generation = 2;
+    game.phase = Phase.ACTION;
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    card.action(player);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(game.activePlayer.id).eq(player2.id);
+  });
+
+  it('Undo after Mars Maths action, still that player\'s turn', () => {
+    const [game, player /* , player2 */] = testGame(2);
+    player.playedCards.push(card);
+    player.megaCredits = 100;
+    game.generation = 2;
+    game.phase = Phase.ACTION;
+
+    expect(game.activePlayer.id).eq(player.id);
+
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    card.action(player);
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(player.actionsTakenThisRound).eq(2);
+    expect(player.availableActionsThisRound).eq(4);
+    expect(player.megaCredits).eq(78);
+    expect(player.production.energy).eq(2);
+
+    const serialized = game.serialize();
+
+    // Third action: another power plant standard project, to be undone below.
+    takeStandardProjectAction(player, CardName.POWER_PLANT_STANDARD_PROJECT);
+
+    expect(player.production.energy).eq(3);
+    expect(player.megaCredits).eq(67);
+    expect(player.actionsTakenThisRound).eq(3);
+    expect(game.activePlayer.id).eq(player.id);
+
+    // Clicks "Undo last action": the server discards the in-memory game and reloads
+    // the last saved snapshot, re-prompting the active player for their next action
+    // (this is exactly what `Game.deserialize` does when the phase is ACTION).
+    const restoredGame = Game.deserialize(serialized);
+    const restoredPlayer = restoredGame.getPlayerById(player.id);
+
+    // The third standard project's energy bump is rolled back along with everything
+    // else after the snapshot.
+    expect(restoredPlayer.actionsTakenThisRound).eq(2);
+    expect(restoredPlayer.availableActionsThisRound).eq(4);
+    expect(restoredPlayer.megaCredits).eq(78);
+    expect(restoredPlayer.production.energy).eq(2);
+
+    // It's still this player's turn. The restored actionsTakenThisRound (2) happens to
+    // match the *default* budget of 2, but that must not cause the server to think the
+    // turn is over and hand it off to player2.
+    expect(restoredGame.activePlayer.id).eq(player.id);
   });
 });

--- a/tests/cards/pathfinders/MarsMaths.spec.ts
+++ b/tests/cards/pathfinders/MarsMaths.spec.ts
@@ -7,7 +7,6 @@ import {LunarBeam} from '../../../src/server/cards/base/LunarBeam';
 import {Insulation} from '../../../src/server/cards/base/Insulation';
 import {IoMiningIndustries} from '../../../src/server/cards/base/IoMiningIndustries';
 import {cast} from '../../../src/common/utils/utils';
-import {Player} from '../../../src/server/Player';
 
 describe('MarsMaths', () => {
   let card: MarsMaths;
@@ -21,17 +20,6 @@ describe('MarsMaths', () => {
     const previousActions = player.availableActionsThisRound;
     card.action(player);
     expect(player.availableActionsThisRound).eq(previousActions + 2);
-  });
-
-  it('preserves additional actions through serialization', () => {
-    const [/* game */, player] = testGame(1);
-    card.action(player);
-    player.actionsTakenThisRound = 2;
-
-    const restoredPlayer = Player.deserialize(player.serialize());
-
-    expect(restoredPlayer.actionsTakenThisRound).eq(2);
-    expect(restoredPlayer.availableActionsThisRound).eq(4);
   });
 
   it('play - solo', () => {

--- a/tests/cards/pathfinders/MarsMaths.spec.ts
+++ b/tests/cards/pathfinders/MarsMaths.spec.ts
@@ -7,6 +7,7 @@ import {LunarBeam} from '../../../src/server/cards/base/LunarBeam';
 import {Insulation} from '../../../src/server/cards/base/Insulation';
 import {IoMiningIndustries} from '../../../src/server/cards/base/IoMiningIndustries';
 import {cast} from '../../../src/common/utils/utils';
+import {Player} from '../../../src/server/Player';
 
 describe('MarsMaths', () => {
   let card: MarsMaths;
@@ -20,6 +21,17 @@ describe('MarsMaths', () => {
     const previousActions = player.availableActionsThisRound;
     card.action(player);
     expect(player.availableActionsThisRound).eq(previousActions + 2);
+  });
+
+  it('preserves additional actions through serialization', () => {
+    const [/* game */, player] = testGame(1);
+    card.action(player);
+    player.actionsTakenThisRound = 2;
+
+    const restoredPlayer = Player.deserialize(player.serialize());
+
+    expect(restoredPlayer.actionsTakenThisRound).eq(2);
+    expect(restoredPlayer.availableActionsThisRound).eq(4);
   });
 
   it('play - solo', () => {


### PR DESCRIPTION
## Summary
- Persist per-turn action budget across player serialization.
- Covers extra-action turns when the game is restored from a save, including undo.
- Older saves still fall back to the normal 2-action budget.

## Example
Self-contained reproduction covered by `MarsMaths.spec.ts`:

1. A player takes a first action.
2. The player uses Mars Maths, increasing this turn's action budget from 2 to 4.
3. The player takes another action and the game is serialized.
4. The player takes a third action.
5. Undo restores the serialized game state.

Actual before this change: the third action was rolled back, but the restored player had `actionsTakenThisRound = 2` and `availableActionsThisRound` reset to the default 2, so the server treated the turn as finished.

Expected: undo restores the player with `actionsTakenThisRound = 2` and `availableActionsThisRound = 4`, so it is still that player's turn.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts "tests/Player.spec.ts" "tests/cards/pathfinders/MarsMaths.spec.ts"`
- `npx eslint src/server/Player.ts src/server/SerializedPlayer.ts tests/Player.spec.ts tests/cards/pathfinders/MarsMaths.spec.ts`
- `C:\Users\Ruslan\tm\tools\tm-upstream-pr-check.ps1 -TestCommand 'npx mocha --import=tsx --require tests/testing/setup.ts "tests/Player.spec.ts" "tests/cards/pathfinders/MarsMaths.spec.ts"'`