### PR TITLE
Finally, one command to have a (near-full) responsive dev environment.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "make:cards": "npx tsx src/server/tools/export_card_rendering.ts",
     "make:css": "lessc src/styles/common.less build/styles.css && node src/server/tools/gzip.js",
     "watch:less": "npx tsx scripts/watchcss.ts src/styles",
+    "watch:cards": "npx tsx scripts/watchcards.ts src/server/cards",
+    "dev": "bash scripts/dev.sh",
     "make:json": "npx tsx src/tools/make_static_json.ts",
     "make:static": "npm run make:css && npm run make:json",
     "test": "npm run test:server && npm run test:client",
@@ -98,7 +100,7 @@
     "test:client": "cross-env NODE_ENV=development mochapack --require tests/client/components/setup.ts \"tests/client/**/*.spec.ts\"",
     "test:client:watch": "cross-env NODE_ENV=development mochapack --watch --require tests/client/components/setup.ts \"tests/client/**/*.spec.ts\"",
     "dev:client": "cross-env NODE_ENV=development webpack --watch",
-    "dev:server": "cross-env NODE_ENV=development tsx watch src/server/server.ts"
+    "dev:server": "cross-env NODE_ENV=development tsx watch --clear-screen=false src/server/server.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Runs all dev watchers at once: server, client, CSS, and card JSON.
+# Ctrl+C stops all of them.
+set -euo pipefail
+
+pids=()
+
+cleanup() {
+  trap - INT TERM
+  echo
+  echo "Stopping dev watchers..."
+  for pid in "${pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup INT TERM
+
+npm run dev:server & pids+=($!)
+npm run dev:client & pids+=($!)
+npm run watch:less & pids+=($!)
+npm run watch:cards & pids+=($!)
+
+wait

--- a/scripts/watchcards.ts
+++ b/scripts/watchcards.ts
@@ -1,0 +1,44 @@
+import chokidar from 'chokidar';
+import {exec} from 'child_process';
+
+const directoryToWatch = process.argv[2] ?? 'src/server/cards';
+const pattern = `${directoryToWatch}/**/*.ts`;
+
+let debounceTimeout: NodeJS.Timeout;
+const DEBOUNCE_DELAY = 300;
+
+// Listens to changes of src/server/cards and triggers rebuilding
+// card rendering which is picked up by dev:client. In other words,
+// it applies card changes live.
+//
+// This doesn't respond to some changes from global events, colonies,
+// milestones and awards.
+function runMakeCards(): void {
+  console.log('Running make:cards...');
+  exec('npm run make:cards', (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Error: ${error.message}`);
+      return;
+    }
+    if (stderr) console.error(stderr);
+    if (stdout) console.log(stdout);
+    console.log('Done.');
+  });
+}
+
+function onChange(filePath: string): void {
+  console.log(`Detected change: ${filePath}`);
+  clearTimeout(debounceTimeout);
+  debounceTimeout = setTimeout(runMakeCards, DEBOUNCE_DELAY);
+}
+
+const watcher = chokidar.watch(pattern, {ignoreInitial: true});
+watcher.on('change', onChange);
+watcher.on('add', onChange);
+
+console.log(`Watching for card changes in: ${pattern}`);
+
+process.on('SIGINT', () => {
+  console.log('\nStopping watcher.');
+  watcher.close().then(() => process.exit(0));
+});


### PR DESCRIPTION
Still doesn't respond to some changes from global events, colonies, milestones and awards that are exported by export_card_rendering.