### PR TITLE
Skip Floating Trade Hub target prompt for single card

### DIFF
--- a/src/server/cards/prelude2/FloatingTradeHub.ts
+++ b/src/server/cards/prelude2/FloatingTradeHub.ts
@@ -37,11 +37,11 @@ export class FloatingTradeHub extends PreludeCard implements IActionCard {
 
   public action(player: IPlayer) {
     const floaterCards = player.getResourceCards(CardResource.FLOATER);
-    if (this.resourceCount === 0 && floaterCards.length === 1) {
-      this.add2Floaters(player, floaterCards[0]);
-      return undefined;
+    const floatingTradeHub = floaterCards.find((card) => card.name === this.name);
+    if (this.resourceCount === 0 && floaterCards.length === 1 && floatingTradeHub !== undefined) {
+      return this.add2Floaters(player, floatingTradeHub);
     }
-    const add2Floaters = this.add2FloatersOption(player, floaterCards);
+    const add2Floaters = this.add2FloatersOption(player, floaterCards, floatingTradeHub);
     const selectResource = new SelectResource('Select resource to gain');
     const selectAmount = new SelectAmount('Select amount of floaters to remove', undefined, 1, this.resourceCount, true);
     const removeFloaters = new AndOptions(selectAmount, selectResource)
@@ -58,20 +58,19 @@ export class FloatingTradeHub extends PreludeCard implements IActionCard {
     return new OrOptions(add2Floaters, removeFloaters);
   }
 
-  private add2FloatersOption(player: IPlayer, floaterCards: Array<ICard>) {
-    if (floaterCards.length === 1) {
+  private add2FloatersOption(player: IPlayer, floaterCards: Array<ICard>, floatingTradeHub: ICard | undefined) {
+    if (floaterCards.length === 1 && floatingTradeHub !== undefined) {
       return new SelectOption('Add 2 floaters to Floating Trade Hub', 'Add floaters').andThen(() => {
-        this.add2Floaters(player, floaterCards[0]);
-        return undefined;
+        return this.add2Floaters(player, floatingTradeHub);
       });
     }
     return new SelectCard('Select card to gain 2 floaters', undefined, floaterCards).andThen(([card]) => {
-      this.add2Floaters(player, card);
-      return undefined;
+      return this.add2Floaters(player, card);
     });
   }
 
-  private add2Floaters(player: IPlayer, card: ICard) {
+  private add2Floaters(player: IPlayer, card: ICard): undefined {
     player.addResourceTo(card, {qty: 2, log: true});
+    return undefined;
   }
 }

--- a/src/server/cards/prelude2/FloatingTradeHub.ts
+++ b/src/server/cards/prelude2/FloatingTradeHub.ts
@@ -2,11 +2,12 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardName} from '../../../common/cards/CardName';
 import {CardRenderer} from '../render/CardRenderer';
 import {CardResource} from '../../../common/CardResource';
-import {IActionCard} from '../ICard';
+import {IActionCard, ICard} from '../ICard';
 import {PreludeCard} from '../prelude/PreludeCard';
 import {IPlayer} from '../../IPlayer';
 import {OrOptions} from '../../inputs/OrOptions';
 import {SelectCard} from '../../inputs/SelectCard';
+import {SelectOption} from '../../inputs/SelectOption';
 import {AndOptions} from '../../inputs/AndOptions';
 import {SelectAmount} from '../../inputs/SelectAmount';
 import {SelectResource} from '../../inputs/SelectResource';
@@ -35,10 +36,12 @@ export class FloatingTradeHub extends PreludeCard implements IActionCard {
   }
 
   public action(player: IPlayer) {
-    const add2Floaters = new SelectCard('Select card to gain 2 floaters', undefined, player.getResourceCards(CardResource.FLOATER)).andThen(([card]) => {
-      player.addResourceTo(card, {qty: 2, log: true});
+    const floaterCards = player.getResourceCards(CardResource.FLOATER);
+    if (this.resourceCount === 0 && floaterCards.length === 1) {
+      this.add2Floaters(player, floaterCards[0]);
       return undefined;
-    });
+    }
+    const add2Floaters = this.add2FloatersOption(player, floaterCards);
     const selectResource = new SelectResource('Select resource to gain');
     const selectAmount = new SelectAmount('Select amount of floaters to remove', undefined, 1, this.resourceCount, true);
     const removeFloaters = new AndOptions(selectAmount, selectResource)
@@ -53,5 +56,22 @@ export class FloatingTradeHub extends PreludeCard implements IActionCard {
       return add2Floaters;
     }
     return new OrOptions(add2Floaters, removeFloaters);
+  }
+
+  private add2FloatersOption(player: IPlayer, floaterCards: Array<ICard>) {
+    if (floaterCards.length === 1) {
+      return new SelectOption('Add 2 floaters to Floating Trade Hub', 'Add floaters').andThen(() => {
+        this.add2Floaters(player, floaterCards[0]);
+        return undefined;
+      });
+    }
+    return new SelectCard('Select card to gain 2 floaters', undefined, floaterCards).andThen(([card]) => {
+      this.add2Floaters(player, card);
+      return undefined;
+    });
+  }
+
+  private add2Floaters(player: IPlayer, card: ICard) {
+    player.addResourceTo(card, {qty: 2, log: true});
   }
 }

--- a/tests/cards/prelude2/FloatingTradeHub.spec.ts
+++ b/tests/cards/prelude2/FloatingTradeHub.spec.ts
@@ -24,6 +24,10 @@ describe('FloatingTradeHub', () => {
     player.playedCards.push(card);
   });
 
+  it('canAct', () => {
+    expect(card.canAct()).is.true;
+  });
+
   it('adds floaters immediately when Floating Trade Hub is the only target', () => {
     cast(card.action(player), undefined);
 
@@ -42,7 +46,7 @@ describe('FloatingTradeHub', () => {
     expect(card.resourceCount).eq(2);
   });
 
-  it('Act - select resource', () => {
+  it('act - select resource', () => {
     card.resourceCount = 5;
 
     const orOptions = cast(card.action(player), OrOptions);
@@ -65,7 +69,7 @@ describe('FloatingTradeHub', () => {
     expect(card.resourceCount).to.eq(1);
   });
 
-  it('Act - add resources branch autoselects the only target card when converting floaters is available', () => {
+  it('act - add resources branch autoselects the only target card when converting floaters is available', () => {
     card.resourceCount = 5;
 
     const orOptions = cast(card.action(player), OrOptions);
@@ -76,7 +80,7 @@ describe('FloatingTradeHub', () => {
     expect(card.resourceCount).eq(7);
   });
 
-  it('Act - add resources branch prompts when multiple targets and converting floaters are available', () => {
+  it('act - add resources branch prompts when multiple targets and converting floaters are available', () => {
     card.resourceCount = 5;
     player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
 

--- a/tests/cards/prelude2/FloatingTradeHub.spec.ts
+++ b/tests/cards/prelude2/FloatingTradeHub.spec.ts
@@ -24,70 +24,72 @@ describe('FloatingTradeHub', () => {
     player.playedCards.push(card);
   });
 
-  it('adds floaters immediately when Floating Trade Hub is the only target', () => {
-    cast(card.action(player), undefined);
+  describe('when converting floaters is not available', () => {
+    it('adds floaters immediately when Floating Trade Hub is the only target', () => {
+      cast(card.action(player), undefined);
 
-    expect(card.resourceCount).eq(2);
+      expect(card.resourceCount).eq(2);
+    });
+
+    it('prompts for a floater card when multiple targets are available', () => {
+      player.playedCards.push(newProjectCard(CardName.TARDIGRADES)!);
+      player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
+      const selectCard = cast(card.action(player), SelectCard);
+
+      expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
+
+      selectCard.cb([card]);
+
+      expect(card.resourceCount).eq(2);
+    });
   });
 
+  describe('when converting floaters is available', () => {
+    beforeEach(() => {
+      card.resourceCount = 5;
+    });
 
-  it('prompts for a floater card when multiple targets are available', () => {
-    player.playedCards.push(newProjectCard(CardName.TARDIGRADES)!);
-    player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
-    const selectCard = cast(card.action(player), SelectCard);
+    it('Act - select resource', () => {
+      const orOptions = cast(card.action(player), OrOptions);
 
-    expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
+      expect(orOptions.options).has.length(2);
+      const andOptions = cast(orOptions.options[1], AndOptions);
+      const selectAmount = cast(andOptions.options[0], SelectAmount);
+      const selectResource = cast(andOptions.options[1], SelectResource);
 
-    selectCard.cb([card]);
+      expect(selectAmount.min).eq(1);
+      expect(selectAmount.max).eq(5);
+      expect(selectResource.include).deep.eq(Units.keys);
 
-    expect(card.resourceCount).eq(2);
-  });
+      andOptions.process({type: 'and', responses: [
+        {type: 'amount', amount: 4},
+        {type: 'resource', resource: 'plants'},
+      ]}, player);
 
-  it('Act - select resource', () => {
-    card.resourceCount = 5;
+      expect(player.stock.asUnits()).deep.eq(Units.of({plants: 4}));
+      expect(card.resourceCount).to.eq(1);
+    });
 
-    const orOptions = cast(card.action(player), OrOptions);
+    it('Act - add resources branch autoselects the only target card', () => {
+      const orOptions = cast(card.action(player), OrOptions);
+      const selectOption = cast(orOptions.options[0], SelectOption);
 
-    expect(orOptions.options).has.length(2);
-    const andOptions = cast(orOptions.options[1], AndOptions);
-    const selectAmount = cast(andOptions.options[0], SelectAmount);
-    const selectResource = cast(andOptions.options[1], SelectResource);
+      selectOption.cb(undefined);
 
-    expect(selectAmount.min).eq(1);
-    expect(selectAmount.max).eq(5);
-    expect(selectResource.include).deep.eq(Units.keys);
+      expect(card.resourceCount).eq(7);
+    });
 
-    andOptions.process({type: 'and', responses: [
-      {type: 'amount', amount: 4},
-      {type: 'resource', resource: 'plants'},
-    ]}, player);
+    it('Act - add resources branch prompts when multiple targets are available', () => {
+      player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
 
-    expect(player.stock.asUnits()).deep.eq(Units.of({plants: 4}));
-    expect(card.resourceCount).to.eq(1);
-  });
+      const orOptions = cast(card.action(player), OrOptions);
+      const selectCard = cast(orOptions.options[0], SelectCard);
 
-  it('Act - add resources branch autoselects the only target card', () => {
-    card.resourceCount = 5;
+      expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
 
-    const orOptions = cast(card.action(player), OrOptions);
-    const selectOption = cast(orOptions.options[0], SelectOption);
+      selectCard.cb([card]);
 
-    selectOption.cb(undefined);
-
-    expect(card.resourceCount).eq(7);
-  });
-
-  it('Act - add resources branch prompts when multiple targets are available', () => {
-    card.resourceCount = 5;
-    player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
-
-    const orOptions = cast(card.action(player), OrOptions);
-    const selectCard = cast(orOptions.options[0], SelectCard);
-
-    expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
-
-    selectCard.cb([card]);
-
-    expect(card.resourceCount).eq(7);
+      expect(card.resourceCount).eq(7);
+    });
   });
 });

--- a/tests/cards/prelude2/FloatingTradeHub.spec.ts
+++ b/tests/cards/prelude2/FloatingTradeHub.spec.ts
@@ -24,72 +24,69 @@ describe('FloatingTradeHub', () => {
     player.playedCards.push(card);
   });
 
-  describe('when converting floaters is not available', () => {
-    it('adds floaters immediately when Floating Trade Hub is the only target', () => {
-      cast(card.action(player), undefined);
+  it('adds floaters immediately when Floating Trade Hub is the only target', () => {
+    cast(card.action(player), undefined);
 
-      expect(card.resourceCount).eq(2);
-    });
-
-    it('prompts for a floater card when multiple targets are available', () => {
-      player.playedCards.push(newProjectCard(CardName.TARDIGRADES)!);
-      player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
-      const selectCard = cast(card.action(player), SelectCard);
-
-      expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
-
-      selectCard.cb([card]);
-
-      expect(card.resourceCount).eq(2);
-    });
+    expect(card.resourceCount).eq(2);
   });
 
-  describe('when converting floaters is available', () => {
-    beforeEach(() => {
-      card.resourceCount = 5;
-    });
+  it('prompts for a floater card when multiple targets are available', () => {
+    player.playedCards.push(newProjectCard(CardName.TARDIGRADES)!);
+    player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
+    const selectCard = cast(card.action(player), SelectCard);
 
-    it('Act - select resource', () => {
-      const orOptions = cast(card.action(player), OrOptions);
+    expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
 
-      expect(orOptions.options).has.length(2);
-      const andOptions = cast(orOptions.options[1], AndOptions);
-      const selectAmount = cast(andOptions.options[0], SelectAmount);
-      const selectResource = cast(andOptions.options[1], SelectResource);
+    selectCard.cb([card]);
 
-      expect(selectAmount.min).eq(1);
-      expect(selectAmount.max).eq(5);
-      expect(selectResource.include).deep.eq(Units.keys);
+    expect(card.resourceCount).eq(2);
+  });
 
-      andOptions.process({type: 'and', responses: [
-        {type: 'amount', amount: 4},
-        {type: 'resource', resource: 'plants'},
-      ]}, player);
+  it('Act - select resource', () => {
+    card.resourceCount = 5;
 
-      expect(player.stock.asUnits()).deep.eq(Units.of({plants: 4}));
-      expect(card.resourceCount).to.eq(1);
-    });
+    const orOptions = cast(card.action(player), OrOptions);
 
-    it('Act - add resources branch autoselects the only target card', () => {
-      const orOptions = cast(card.action(player), OrOptions);
-      const selectOption = cast(orOptions.options[0], SelectOption);
+    expect(orOptions.options).has.length(2);
+    const andOptions = cast(orOptions.options[1], AndOptions);
+    const selectAmount = cast(andOptions.options[0], SelectAmount);
+    const selectResource = cast(andOptions.options[1], SelectResource);
 
-      selectOption.cb(undefined);
+    expect(selectAmount.min).eq(1);
+    expect(selectAmount.max).eq(5);
+    expect(selectResource.include).deep.eq(Units.keys);
 
-      expect(card.resourceCount).eq(7);
-    });
+    andOptions.process({type: 'and', responses: [
+      {type: 'amount', amount: 4},
+      {type: 'resource', resource: 'plants'},
+    ]}, player);
 
-    it('Act - add resources branch prompts when multiple targets are available', () => {
-      player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
+    expect(player.stock.asUnits()).deep.eq(Units.of({plants: 4}));
+    expect(card.resourceCount).to.eq(1);
+  });
 
-      const orOptions = cast(card.action(player), OrOptions);
-      const selectCard = cast(orOptions.options[0], SelectCard);
+  it('Act - add resources branch autoselects the only target card when converting floaters is available', () => {
+    card.resourceCount = 5;
 
-      expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
+    const orOptions = cast(card.action(player), OrOptions);
+    const selectOption = cast(orOptions.options[0], SelectOption);
 
-      selectCard.cb([card]);
+    selectOption.cb(undefined);
 
-      expect(card.resourceCount).eq(7);
-    });
+    expect(card.resourceCount).eq(7);
+  });
+
+  it('Act - add resources branch prompts when multiple targets and converting floaters are available', () => {
+    card.resourceCount = 5;
+    player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
+
+    const orOptions = cast(card.action(player), OrOptions);
+    const selectCard = cast(orOptions.options[0], SelectCard);
+
+    expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
+
+    selectCard.cb([card]);
+
+    expect(card.resourceCount).eq(7);
   });
 });

--- a/tests/cards/prelude2/FloatingTradeHub.spec.ts
+++ b/tests/cards/prelude2/FloatingTradeHub.spec.ts
@@ -6,6 +6,7 @@ import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
 import {testGame} from '../../TestGame';
 import {SelectCard} from '../../../src/server/inputs/SelectCard';
+import {SelectOption} from '../../../src/server/inputs/SelectOption';
 import {newProjectCard} from '../../../src/server/createCard';
 import {CardName} from '../../../src/common/cards/CardName';
 import {AndOptions} from '../../../src/server/inputs/AndOptions';
@@ -24,9 +25,7 @@ describe('FloatingTradeHub', () => {
   });
 
   it('Add resources, simple', () => {
-    const selectCard = cast(card.action(player), SelectCard);
-    expect(selectCard.cards).deep.eq([card]);
-    selectCard.cb([card]);
+    cast(card.action(player), undefined);
     expect(card.resourceCount).eq(2);
   });
 
@@ -63,5 +62,16 @@ describe('FloatingTradeHub', () => {
 
     expect(player.stock.asUnits()).deep.eq(Units.of({plants: 4}));
     expect(card.resourceCount).to.eq(1);
+  });
+
+  it('Act - add resources branch autoselects the only target card', () => {
+    card.resourceCount = 5;
+
+    const orOptions = cast(card.action(player), OrOptions);
+    const addFloaters = cast(orOptions.options[0], SelectOption);
+
+    addFloaters.cb(undefined);
+
+    expect(card.resourceCount).eq(7);
   });
 });

--- a/tests/cards/prelude2/FloatingTradeHub.spec.ts
+++ b/tests/cards/prelude2/FloatingTradeHub.spec.ts
@@ -24,13 +24,14 @@ describe('FloatingTradeHub', () => {
     player.playedCards.push(card);
   });
 
-  it('Add resources, simple', () => {
+  it('adds floaters immediately when Floating Trade Hub is the only target', () => {
     cast(card.action(player), undefined);
+
     expect(card.resourceCount).eq(2);
   });
 
 
-  it('Add resources', () => {
+  it('prompts for a floater card when multiple targets are available', () => {
     player.playedCards.push(newProjectCard(CardName.TARDIGRADES)!);
     player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
     const selectCard = cast(card.action(player), SelectCard);
@@ -47,6 +48,7 @@ describe('FloatingTradeHub', () => {
 
     const orOptions = cast(card.action(player), OrOptions);
 
+    expect(orOptions.options).has.length(2);
     const andOptions = cast(orOptions.options[1], AndOptions);
     const selectAmount = cast(andOptions.options[0], SelectAmount);
     const selectResource = cast(andOptions.options[1], SelectResource);
@@ -68,9 +70,23 @@ describe('FloatingTradeHub', () => {
     card.resourceCount = 5;
 
     const orOptions = cast(card.action(player), OrOptions);
-    const addFloaters = cast(orOptions.options[0], SelectOption);
+    const selectOption = cast(orOptions.options[0], SelectOption);
 
-    addFloaters.cb(undefined);
+    selectOption.cb(undefined);
+
+    expect(card.resourceCount).eq(7);
+  });
+
+  it('Act - add resources branch prompts when multiple targets are available', () => {
+    card.resourceCount = 5;
+    player.playedCards.push(newProjectCard(CardName.AERIAL_MAPPERS)!);
+
+    const orOptions = cast(card.action(player), OrOptions);
+    const selectCard = cast(orOptions.options[0], SelectCard);
+
+    expect(selectCard.cards.map(toName)).deep.eq([card.name, CardName.AERIAL_MAPPERS]);
+
+    selectCard.cb([card]);
 
     expect(card.resourceCount).eq(7);
   });


### PR DESCRIPTION
## Summary
- Auto-select the only available floater card when Floating Trade Hub adds 2 floaters.
- Keep the multi-target flow unchanged, and keep the convert-floaters branch available when Floating Trade Hub already has floaters.

## Demo
Scenario: play Floating Trade Hub when it is the only card that can hold floaters. Using the action now adds 2 floaters immediately instead of asking which card should receive them.

If another floater card is in play, the existing target-card prompt still appears.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/prelude2/FloatingTradeHub.spec.ts`
- `npx eslint src/server/cards/prelude2/FloatingTradeHub.ts tests/cards/prelude2/FloatingTradeHub.spec.ts`
- `npm run make:static && npm run build:tests`
- proof PR CI passed: build-linux, build-windows, build-docker

## Notes
- No resource outcome change; this only skips a redundant prompt when there is exactly one legal target.
