### PR TITLE
Skip Floating Refinery target prompt for single card

### DIFF
--- a/src/server/cards/prelude2/FloatingRefinery.ts
+++ b/src/server/cards/prelude2/FloatingRefinery.ts
@@ -1,5 +1,5 @@
 import {IProjectCard} from '../IProjectCard';
-import {IActionCard} from '../ICard';
+import {IActionCard, ICard} from '../ICard';
 import {IPlayer} from '../../IPlayer';
 import {Card} from '../Card';
 import {CardType} from '../../../common/cards/CardType';
@@ -54,27 +54,32 @@ export class FloatingRefinery extends Card implements IProjectCard, IActionCard 
       return undefined;
     });
 
-    const remove2floaters = new SelectOption(
+    const remove2FloatersOption = new SelectOption(
       'Remove 2 floaters from ANY CARD to gain 1 titanium and 2 M€',
       'Remove floaters',
     ).andThen(() => {
+      if (floater2Cards.length === 1) {
+        return this.remove2Floaters(player, floater2Cards[0]);
+      }
       return new SelectCard('Remove 2 floaters from ANY CARD to gain 1 titanium and 2 M€',
         'Choose a card to spend 2 floaters from, to gain 1 titanium and 2 M€.',
         floater2Cards,
       ).andThen(
-        ([card]) => {
-          player.removeResourceFrom(card, 2);
-          player.stock.add(Resource.MEGACREDITS, 2, {log: true});
-          player.stock.add(Resource.TITANIUM, 1, {log: true});
-          return undefined;
-        });
+        ([card]) => this.remove2Floaters(player, card));
     });
 
     if (floater2Cards.length > 0) {
-      return new OrOptions(remove2floaters, addFloater);
+      return new OrOptions(remove2FloatersOption, addFloater);
     } else {
       player.addResourceTo(this, {log: true});
       return undefined;
     }
+  }
+
+  private remove2Floaters(player: IPlayer, card: ICard): undefined {
+    player.removeResourceFrom(card, 2);
+    player.stock.add(Resource.MEGACREDITS, 2, {log: true});
+    player.stock.add(Resource.TITANIUM, 1, {log: true});
+    return undefined;
   }
 }

--- a/tests/cards/prelude2/FloatingRefinery.spec.ts
+++ b/tests/cards/prelude2/FloatingRefinery.spec.ts
@@ -59,6 +59,7 @@ describe('FloatingRefinery', () => {
 
   it('act - removes from another card when it is the only eligible target', () => {
     card.resourceCount = 1;
+    // floater1 is the only eligible card.
     floater1.resourceCount = 2;
     floater2.resourceCount = 1;
     other.resourceCount = 1;

--- a/tests/cards/prelude2/FloatingRefinery.spec.ts
+++ b/tests/cards/prelude2/FloatingRefinery.spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {cast} from '@/common/utils/utils';
-import {toName} from '../../../src/common/utils/utils';
 import {FloatingRefinery} from '../../../src/server/cards/prelude2/FloatingRefinery';
 import {OrOptions} from '../../../src/server/inputs/OrOptions';
 import {TestPlayer} from '../../TestPlayer';
@@ -46,17 +45,33 @@ describe('FloatingRefinery', () => {
     expect(card.resourceCount).to.eq(1);
   });
 
-  it('Remove resource - this card', () => {
+  it('act - removes from this card when it is the only eligible target', () => {
     player.playedCards.push(card);
     card.resourceCount = 3;
+
     const orOptions = cast(card.action(player), OrOptions);
-    cast(card.action(player), OrOptions);
-    const selectCard = cast(orOptions.options[0].cb(), SelectCard<ICard>);
-    expect(selectCard.cards.map(toName)).deep.eq([card.name]);
-    selectCard.cb([card]);
+    cast(orOptions.options[0].cb(), undefined);
+
     expect(player.stock.titanium).to.eq(1);
     expect(player.stock.megacredits).to.eq(2);
     expect(card.resourceCount).to.eq(1);
+  });
+
+  it('act - removes from another card when it is the only eligible target', () => {
+    card.resourceCount = 1;
+    floater1.resourceCount = 2;
+    floater2.resourceCount = 1;
+    other.resourceCount = 1;
+
+    const orOptions = cast(card.action(player), OrOptions);
+    cast(orOptions.options[0].cb(), undefined);
+
+    expect(floater1.resourceCount).eq(0);
+    expect(floater2.resourceCount).eq(1);
+    expect(other.resourceCount).eq(1);
+    expect(card.resourceCount).eq(1);
+    expect(player.stock.titanium).to.eq(1);
+    expect(player.stock.megacredits).to.eq(2);
   });
 
   it('act - two cards with 2 floaters - select 1st', () => {


### PR DESCRIPTION
## Summary

- Skip the second target-selection prompt when only one card can spend two floaters.
- Keep the card chooser when multiple eligible targets exist.

## Demo

With Floating Refinery, choose **Remove floaters** while exactly one card has at least two floaters. The two floaters are removed immediately and the player gains 1 titanium and 2 M€.

When multiple cards can pay, the existing target-card prompt is unchanged.

## Testing

- `npx mocha --import=tsx --require tests/testing/setup.ts tests/cards/prelude2/FloatingRefinery.spec.ts`
- `npm run lint:server`
- `npm run lint:client`
- `npm run build`

## Notes

- No resource or payment behavior changes; this only skips a redundant prompt.