### PR TITLE
Replace empty sets in card warnings with single sentinel.

### DIFF
--- a/src/server/Player.ts
+++ b/src/server/Player.ts
@@ -1209,7 +1209,7 @@ export class Player implements IPlayer {
 
     const playableCards: Array<IProjectCard> = [];
     for (const card of candidateCards) {
-      card.warnings.clear();
+      card.clearWarnings();
       card.additionalProjectCosts = undefined;
       if (this.canPlay(card)) {
         playableCards.push(card);
@@ -1264,7 +1264,7 @@ export class Player implements IPlayer {
     if (this.playedCards.has(CardName.PHARMACY_UNION) && card.tags.includes(Tag.MICROBE)) {
       const pharmacyUnion = this.tableau.get(CardName.PHARMACY_UNION);
       if (pharmacyUnion?.isDisabled === false) {
-        card.warnings.add('pharmacyUnion');
+        card.addWarning('pharmacyUnion');
       }
     }
     return true;

--- a/src/server/behavior/Executor.ts
+++ b/src/server/behavior/Executor.ts
@@ -67,22 +67,22 @@ export class Executor implements BehaviorExecutor {
     if (behavior.global !== undefined) {
       const g = behavior.global;
       if (g.temperature !== undefined && game.getTemperature() >= MAX_TEMPERATURE) {
-        card.warnings.add('maxtemp');
+        card.addWarning('maxtemp');
       }
       if (g.oxygen !== undefined && game.getOxygenLevel() >= MAX_OXYGEN_LEVEL) {
         if (g.oxygen < 0) {
-          card.warnings.add('maxoxygen-reduce');
+          card.addWarning('maxoxygen-reduce');
         } else {
-          card.warnings.add('maxoxygen');
+          card.addWarning('maxoxygen');
         }
       }
       if (g.venus !== undefined && game.getVenusScaleLevel() >= MAX_VENUS_SCALE) {
-        card.warnings.add('maxvenus');
+        card.addWarning('maxvenus');
       }
     }
 
     if (behavior.ocean !== undefined && game.board.getOceanSpaces().length >= MAX_OCEAN_TILES) {
-      card.warnings.add('maxoceans');
+      card.addWarning('maxoceans');
     }
 
     if (behavior.stock !== undefined) {
@@ -170,7 +170,7 @@ export class Executor implements BehaviorExecutor {
           return false;
         }
         if (targets.length === 1 && targets[0] === player) {
-          card.warnings.add('decreaseOwnProduction');
+          card.addWarning('decreaseOwnProduction');
         }
       }
     }
@@ -272,13 +272,13 @@ export class Executor implements BehaviorExecutor {
         }
       }
       if ((moon.habitatRate ?? 0) >= MAXIMUM_HABITAT_RATE) {
-        card.warnings.add('maxHabitatRate');
+        card.addWarning('maxHabitatRate');
       }
       if ((moon.miningRate ?? 0) >= MAXIMUM_MINING_RATE) {
-        card.warnings.add('maxMiningRate');
+        card.addWarning('maxMiningRate');
       }
       if ((moon.logisticRate ?? 0) >= MAXIMUM_LOGISTIC_RATE) {
-        card.warnings.add('maxLogisticRate');
+        card.addWarning('maxLogisticRate');
       }
     }
 

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -29,6 +29,8 @@ import {GlobalParameter} from '../../common/GlobalParameter';
 import {Warning} from '../../common/cards/Warning';
 import {Resource} from '@/common/Resource';
 
+const NO_WARNINGS: ReadonlySet<Warning> = new Set();
+
 /**
  * Cards that do not need a cost attribute.
  */
@@ -109,7 +111,8 @@ const cardProperties = new Map<CardName, InternalProperties>();
 export abstract class Card implements ICard {
   protected readonly properties: InternalProperties;
   public resourceCount = 0;
-  public warnings = new Set<Warning>();
+  // Warnings are a read-only set because the X00_000 sets that are just empty consume many MB for no value.
+  public warnings: ReadonlySet<Warning> = NO_WARNINGS;
   public additionalProjectCosts?: AdditionalProjectCosts = undefined;
 
   private internalize(external: StaticCardProperties): InternalProperties {
@@ -450,6 +453,17 @@ export abstract class Card implements ICard {
       return globalParameterRequirementBonus.steps;
     }
     return 0;
+  }
+
+  public addWarning(warning: Warning): void {
+    if (this.warnings === NO_WARNINGS) {
+      this.warnings = new Set();     // allocate only on first real warning
+    }
+    (this.warnings as Set<Warning>).add(warning);
+  }
+
+  public clearWarnings(): void {
+    this.warnings = NO_WARNINGS;      // drop the per-card Set, back to shared empty
   }
 }
 

--- a/src/server/cards/ICard.ts
+++ b/src/server/cards/ICard.ts
@@ -165,7 +165,9 @@ export interface ICard {
    *
    * See: IProjectCard.additionalProjectCosts
    */
-  readonly warnings: Set<Warning>;
+  readonly warnings: ReadonlySet<Warning>;
+  addWarning(warning: Warning): void;
+  clearWarnings(): void;
 
   readonly behavior?: Behavior,
 

--- a/src/server/cards/ProxyCard.ts
+++ b/src/server/cards/ProxyCard.ts
@@ -53,4 +53,8 @@ export class ProxyCard implements IProjectCard {
   public get warnings() {
     return EMPTY_SET;
   }
+  public addWarning(_warning: Warning): void {
+  }
+  public clearWarnings(): void {
+  }
 }

--- a/src/server/cards/base/AquiferPumping.ts
+++ b/src/server/cards/base/AquiferPumping.ts
@@ -32,7 +32,7 @@ export class AquiferPumping extends Card implements IActionCard, IProjectCard {
   public canAct(player: IPlayer): boolean {
     const canAct = player.canAfford({cost: OCEAN_COST, steel: true, tr: {oceans: 1}});
     if (!player.game.canAddOcean()) {
-      this.warnings.add('maxoceans');
+      this.addWarning('maxoceans');
     }
     return canAct;
   }

--- a/src/server/cards/base/AsteroidMiningConsortium.ts
+++ b/src/server/cards/base/AsteroidMiningConsortium.ts
@@ -37,7 +37,7 @@ export class AsteroidMiningConsortium extends Card implements IProjectCard {
     if (player.game.players.length > 1) {
       const eligiblePlayers = player.game.players.filter((p) => p.production.titanium > 0);
       if (eligiblePlayers.length === 1 && eligiblePlayers[0] === player) {
-        this.warnings.add('selfTarget');
+        this.addWarning('selfTarget');
       }
     }
     return true;

--- a/src/server/cards/base/standardActions/ConvertHeat.ts
+++ b/src/server/cards/base/standardActions/ConvertHeat.ts
@@ -23,7 +23,7 @@ export class ConvertHeat extends StandardActionCard {
 
   public canAct(player: IPlayer): boolean {
     if (player.game.getTemperature() === MAX_TEMPERATURE) {
-      this.warnings.add('maxtemp');
+      this.addWarning('maxtemp');
     }
 
     // Strictly speaking, this conditional is not necessary, because canAfford manages reserveUnits.

--- a/src/server/cards/base/standardProjects/AquiferStandardProject.ts
+++ b/src/server/cards/base/standardProjects/AquiferStandardProject.ts
@@ -30,7 +30,7 @@ export class AquiferStandardProject extends StandardProjectCard {
 
   public override canAct(player: IPlayer): boolean {
     if (!player.game.canAddOcean()) {
-      this.warnings.add('maxoceans');
+      this.addWarning('maxoceans');
     }
     return super.canAct(player);
   }

--- a/src/server/cards/base/standardProjects/AsteroidStandardProject.ts
+++ b/src/server/cards/base/standardProjects/AsteroidStandardProject.ts
@@ -31,7 +31,7 @@ export class AsteroidStandardProject extends StandardProjectCard {
 
   public override canAct(player: IPlayer): boolean {
     if (player.game.getTemperature() >= constants.MAX_TEMPERATURE) {
-      this.warnings.add('maxtemp');
+      this.addWarning('maxtemp');
     }
     return super.canAct(player);
   }

--- a/src/server/cards/ceos/CoLeadership.ts
+++ b/src/server/cards/ceos/CoLeadership.ts
@@ -22,7 +22,7 @@ export class CoLeadership extends PreludeCard {
 
   public override bespokeCanPlay(player: IPlayer) {
     if (!player.game.ceoDeck.canDraw(3)) {
-      this.warnings.add('deckTooSmall');
+      this.addWarning('deckTooSmall');
     }
     return true;
   }

--- a/src/server/cards/ceos/Karen.ts
+++ b/src/server/cards/ceos/Karen.ts
@@ -21,7 +21,7 @@ export class Karen extends CeoCard {
 
   public override canAct(player: IPlayer) {
     if (!player.game.preludeDeck.canDraw(player.game.generation)) {
-      this.warnings.add('deckTooSmall');
+      this.addWarning('deckTooSmall');
     }
     return super.canAct(player);
   }

--- a/src/server/cards/ceos/Lowell.ts
+++ b/src/server/cards/ceos/Lowell.ts
@@ -26,7 +26,7 @@ export class Lowell extends CeoCard {
 
   public override canAct(player: IPlayer): boolean {
     if (!player.game.ceoDeck.canDraw(3)) {
-      this.warnings.add('deckTooSmall');
+      this.addWarning('deckTooSmall');
     }
     if (!super.canAct(player)) {
       return false;

--- a/src/server/cards/colonies/MinorityRefuge.ts
+++ b/src/server/cards/colonies/MinorityRefuge.ts
@@ -44,7 +44,7 @@ export class MinorityRefuge extends Card implements IProjectCard {
       if (lunaIsAvailable === false) {
         return false;
       }
-      this.warnings.add('buildOnLuna');
+      this.addWarning('buildOnLuna');
     }
 
     return true;

--- a/src/server/cards/colonies/PioneerSettlement.ts
+++ b/src/server/cards/colonies/PioneerSettlement.ts
@@ -62,7 +62,7 @@ export class PioneerSettlement extends Card implements IProjectCard {
       if (lunaIsAvailable === false) {
         return false;
       }
-      this.warnings.add('buildOnLuna');
+      this.addWarning('buildOnLuna');
     }
 
     return true;

--- a/src/server/cards/prelude2/BoardOfDirectors.ts
+++ b/src/server/cards/prelude2/BoardOfDirectors.ts
@@ -36,7 +36,7 @@ export class BoardOfDirectors extends PreludeCard implements IActionCard {
 
   public canAct(player: IPlayer) {
     if (!player.canAfford(12)) {
-      this.warnings.add('cannotAffordBoardOfDirectors');
+      this.addWarning('cannotAffordBoardOfDirectors');
     }
     return this.resourceCount > 0 && player.game.preludeDeck.canDraw(1);
   }
@@ -54,7 +54,7 @@ export class BoardOfDirectors extends PreludeCard implements IActionCard {
 
     if (player.canAfford(12)) {
       if (prelude.canPlay?.(player, {cost: 12}) === false) {
-        prelude.warnings.add('preludeFizzle');
+        prelude.addWarning('preludeFizzle');
       }
 
       return new SelectCard(

--- a/src/server/cards/prelude2/L1TradeTerminal.ts
+++ b/src/server/cards/prelude2/L1TradeTerminal.ts
@@ -50,7 +50,7 @@ export class L1TradeTerminal extends Card {
   public override bespokeCanPlay(player: IPlayer): boolean {
     const cards = this.getEligibleCards(player);
     if (cards.length === 0) {
-      this.warnings.add('noMatchingCards');
+      this.addWarning('noMatchingCards');
     }
     return true;
   }

--- a/src/server/cards/prelude2/ProjectEden.ts
+++ b/src/server/cards/prelude2/ProjectEden.ts
@@ -30,7 +30,7 @@ export class ProjectEden extends PreludeCard {
   public override bespokeCanPlay(player: IPlayer): boolean {
     if (player.cardsInHand.length >= 3 && player.canAfford({cost: 0, tr: {oceans: 1, oxygen: 1}})) {
       if (!player.game.canAddOcean()) {
-        this.warnings.add('maxoceans');
+        this.addWarning('maxoceans');
       }
       return true;
     }

--- a/src/server/cards/prelude2/VenusShuttles.ts
+++ b/src/server/cards/prelude2/VenusShuttles.ts
@@ -44,7 +44,7 @@ export class VenusShuttles extends Card implements IActionCard {
 
   public canAct(player: IPlayer) {
     if (player.game.getVenusScaleLevel() >= constants.MAX_VENUS_SCALE) {
-      this.warnings.add('maxvenus');
+      this.addWarning('maxvenus');
     }
     return player.canAfford({cost: this.actionCost(player), tr: {venus: 1}});
   }

--- a/src/server/cards/prelude2/WorldGovernmentAdvisor.ts
+++ b/src/server/cards/prelude2/WorldGovernmentAdvisor.ts
@@ -32,7 +32,7 @@ export class WorldGovernmentAdvisor extends PreludeCard implements IActionCard {
   public canAct(player: IPlayer) {
     const orOptions = player.game.worldGovernmentTerraformingInput(player);
     if (orOptions.options.length === 0) {
-      this.warnings.add('marsIsTerraformed');
+      this.addWarning('marsIsTerraformed');
     }
     return true;
   }

--- a/src/server/cards/promo/AstraMechanica.ts
+++ b/src/server/cards/promo/AstraMechanica.ts
@@ -53,7 +53,7 @@ export class AstraMechanica extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer) {
     if (this.hasUnusableCards(player)) {
-      this.warnings.add('unusableEventsForAstraMechanica');
+      this.addWarning('unusableEventsForAstraMechanica');
     }
     return this.getCards(player).length > 0;
   }

--- a/src/server/cards/promo/IcyImpactors.ts
+++ b/src/server/cards/promo/IcyImpactors.ts
@@ -45,7 +45,7 @@ export class IcyImpactors extends Card implements IActionCard {
     }
     if (this.canAffordToPlaceOcean(player)) {
       if (!player.game.canAddOcean()) {
-        this.warnings.add('maxoceans');
+        this.addWarning('maxoceans');
       }
       return true;
     }

--- a/src/server/cards/promo/KaguyaTech.ts
+++ b/src/server/cards/promo/KaguyaTech.ts
@@ -44,7 +44,7 @@ export class KaguyaTech extends Card implements IProjectCard {
   public override bespokeCanPlay(player: IPlayer, canAffordOptions: CanAffordOptions): boolean {
     const availableSpaces = this.availableSpaces(player, canAffordOptions);
     if (availableSpaces.every((space) => space.tile?.tileType !== TileType.GREENERY)) {
-      this.warnings.add('kaguyaTech');
+      this.addWarning('kaguyaTech');
     }
     return availableSpaces.length > 0;
   }

--- a/src/server/cards/promo/NewPartner.ts
+++ b/src/server/cards/promo/NewPartner.ts
@@ -26,7 +26,7 @@ export class NewPartner extends PreludeCard {
   public override bespokeCanPlay(player: IPlayer) {
     const game = player.game;
     if (!game.preludeDeck.canDraw(2)) {
-      this.warnings.add('deckTooSmall');
+      this.addWarning('deckTooSmall');
     }
     return true;
   }

--- a/src/server/cards/underworld/AeronGenomics.ts
+++ b/src/server/cards/underworld/AeronGenomics.ts
@@ -47,7 +47,7 @@ export class AeronGenomics extends CorporationCard implements ICorporationCard {
 
   public canAct(player: IPlayer): boolean {
     if (player.underworldData.tokens.every((t) => t.shelter || t.active)) {
-      this.warnings.add('underworldtokendiscard');
+      this.addWarning('underworldtokendiscard');
     }
     return player.underworldData.tokens.length > 0;
   }

--- a/src/server/cards/underworld/ArtesianAquifer.ts
+++ b/src/server/cards/underworld/ArtesianAquifer.ts
@@ -34,7 +34,7 @@ export class ArtesianAquifer extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer): boolean {
     if (!player.game.canAddOcean()) {
-      this.warnings.add('maxoceans');
+      this.addWarning('maxoceans');
     }
     return this.availableSpaces(player).length > 0;
   }

--- a/src/server/cards/underworld/ClassActionLawsuit.ts
+++ b/src/server/cards/underworld/ClassActionLawsuit.ts
@@ -41,7 +41,7 @@ export class ClassActionLawsuit extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer): boolean {
     if (player.game.isSoloMode()) {
-      this.warnings.add('noEffect');
+      this.addWarning('noEffect');
     } else {
       const analysis = this.analyzeCorruption(player);
       if (analysis.playersWithMaxCorruption.length > 1) {
@@ -49,7 +49,7 @@ export class ClassActionLawsuit extends Card implements IProjectCard {
       }
       if (player.game.players.length > 1) {
         if (analysis.playersWithMaxCorruption.length === 1 && player.underworldData.corruption === analysis.maxCorruption) {
-          this.warnings.add('selfTarget');
+          this.addWarning('selfTarget');
         }
       }
     }

--- a/src/server/cards/underworld/HenkeiGenetics.ts
+++ b/src/server/cards/underworld/HenkeiGenetics.ts
@@ -56,7 +56,7 @@ export class HenkeiGenetics extends CorporationCard implements ICorporationCard,
 
   public canAct(player: IPlayer) {
     if (this.availableCards(player).length === 0) {
-      this.warnings.add('noMatchingCards');
+      this.addWarning('noMatchingCards');
     }
     return player.underworldData.corruption > 0;
   }

--- a/src/server/cards/underworld/MercenarySquad.ts
+++ b/src/server/cards/underworld/MercenarySquad.ts
@@ -37,7 +37,7 @@ export class MercenarySquad extends Card implements IProjectCard {
     }
     if (player.game.players.length > 1) {
       if (!cards.some((card) => player.game.getCardPlayerOrThrow(card.name) !== player)) {
-        this.warnings.add('selfTarget');
+        this.addWarning('selfTarget');
       }
     }
     return true;

--- a/src/server/cards/underworld/MicroGeodesics.ts
+++ b/src/server/cards/underworld/MicroGeodesics.ts
@@ -43,7 +43,7 @@ export class MicroGeodesics extends Card implements IProjectCard, IActionCard {
       return false;
     }
     if (player.underworldData.tokens.every((t) => t.shelter || t.active)) {
-      this.warnings.add('underworldtokendiscard');
+      this.addWarning('underworldtokendiscard');
     }
 
     if (player.getResourceCount(CardResource.MICROBE) <= 0) {

--- a/src/server/cards/underworld/StingOperation.ts
+++ b/src/server/cards/underworld/StingOperation.ts
@@ -41,7 +41,7 @@ export class StingOperation extends Card implements IProjectCard {
   public override bespokeCanPlay(player: IPlayer) {
     const targets = this.targets(player);
     if (targets.length === 1 && targets[0] === player) {
-      this.warnings.add('selfTarget');
+      this.addWarning('selfTarget');
     }
     return targets.length > 0;
   }

--- a/src/server/cards/underworld/SubterraneanSea.ts
+++ b/src/server/cards/underworld/SubterraneanSea.ts
@@ -38,7 +38,7 @@ export class SubterraneanSea extends Card implements IProjectCard {
 
   public override bespokeCanPlay(player: IPlayer) {
     if (!player.game.canAddOcean()) {
-      this.warnings.add('maxoceans');
+      this.addWarning('maxoceans');
     }
     return this.availableSpaces(player, player.getCardCost(this)).length > 0;
   }

--- a/src/server/cards/venusNext/AirScrappingStandardProject.ts
+++ b/src/server/cards/venusNext/AirScrappingStandardProject.ts
@@ -23,7 +23,7 @@ export class AirScrappingStandardProject extends StandardProjectCard {
 
   public override canAct(player: IPlayer): boolean {
     if (player.game.getVenusScaleLevel() >= constants.MAX_VENUS_SCALE) {
-      this.warnings.add('maxvenus');
+      this.addWarning('maxvenus');
     }
     return super.canAct(player);
   }

--- a/src/server/cards/venusNext/ForcedPrecipitation.ts
+++ b/src/server/cards/venusNext/ForcedPrecipitation.ts
@@ -40,7 +40,7 @@ export class ForcedPrecipitation extends Card implements IActionCard {
     }
     if (this.resourceCount > 1 && player.canAfford({cost: 0, tr: {venus: 1}})) {
       if (player.game.getVenusScaleLevel() === MAX_VENUS_SCALE) {
-        this.warnings.add('maxvenus');
+        this.addWarning('maxvenus');
       }
       return true;
     }

--- a/src/server/cards/venusNext/RotatorImpacts.ts
+++ b/src/server/cards/venusNext/RotatorImpacts.ts
@@ -46,7 +46,7 @@ export class RotatorImpacts extends Card implements IActionCard {
 
   public canAct(player: IPlayer): boolean {
     if (player.game.getVenusScaleLevel() === MAX_VENUS_SCALE) {
-      this.warnings.add('maxvenus');
+      this.addWarning('maxvenus');
     }
     return this.canAddResource(player) || this.canSpendResource(player);
   }

--- a/src/server/preludes/PreludesExpansion.ts
+++ b/src/server/preludes/PreludesExpansion.ts
@@ -30,12 +30,12 @@ export class PreludesExpansion {
     // This preps the warning attribute in preludes.
     // All preludes can be presented. Unplayable ones just fizzle.
     for (const card of cards) {
-      card.warnings.clear();
+      card.clearWarnings();
       if (!card.canPlay(player)) {
-        card.warnings.add('preludeFizzle');
+        card.addWarning('preludeFizzle');
       }
       if (card.behavior?.addResources && player.game.inDoubleDown) {
-        card.warnings.add('ineffectiveDoubleDown');
+        card.addWarning('ineffectiveDoubleDown');
       }
     }
 

--- a/src/server/routes/PlayerInput.ts
+++ b/src/server/routes/PlayerInput.ts
@@ -85,7 +85,7 @@ export class PlayerInput extends Handler {
   private processInput(req: Request, res: Response, ctx: Context, player: IPlayer): Promise<void> {
     // TODO(kberg): Find a better place for this optimization.
     for (const card of player.tableau) {
-      card.warnings.clear();
+      card.clearWarnings();
       if (isIProjectCard(card)) {
         card.additionalProjectCosts = undefined;
       }

--- a/tests/TestingUtils.ts
+++ b/tests/TestingUtils.ts
@@ -193,6 +193,12 @@ class FakeCard implements IProjectCard {
   public metadata = {};
   public resourceCount = 0;
   public tilesBuilt = [];
+  public addWarning(warning: Warning): void {
+    this.warnings.add(warning);
+  }
+  public clearWarnings(): void {
+    this.warnings.clear();
+  }
 }
 
 export function fakeCard(attrs: Partial<IProjectCard> = {}): IProjectCard {


### PR DESCRIPTION
Each unique empty set consumes a little memory. With >1,000 games in memory, which can lead to hundreds of thousands of cards in memory, this can mean megabytes of wasted memory. (Estimate is ~11MB, for instance.)

Every empty set of warnings is the same readonly object, so there's one instance instead of hundreds of thousands of them.