### PR TITLE
Stabilize hand card drag insertion

### DIFF
--- a/src/client/components/SortableCards.vue
+++ b/src/client/components/SortableCards.vue
@@ -6,8 +6,7 @@
     </label>
   </div>
   <div class="sortable-cards">
-    <div ref="draggers" :class="{ 'dragging': Boolean(dragCard) }" v-for="(card, index) in getSortedCards()" :key="card.name" draggable="true" @dragend="onDragEnd()" @dragstart="onDragStart(card.name)">
-      <div v-if="dragCard" ref="droppers" class="drop-target" @dragover="onDragOver(card.name)"></div>
+    <div ref="draggers" :class="{ 'dragging': Boolean(dragCard) }" v-for="(card, index) in getSortedCards()" :key="card.name" draggable="true" @dragend="onDragEnd()" @dragstart="onDragStart(card.name)" @dragover.prevent="onDragOver(card.name, $event)">
       <div ref="cardbox" class="cardbox" @click="clickMethod">
         <Card :card="card"/>
         <div v-if="showReorder" class="reorder-banners-container">
@@ -16,7 +15,6 @@
         </div>
       </div>
     </div>
-    <div v-if="dragCard" ref="dropend" class="drop-target" @dragover="onDragOver('end')"></div>
   </div>
 </div>
 </template>
@@ -89,29 +87,22 @@ export default defineComponent({
     onDragEnd(): void {
       this.dragCard = undefined;
     },
-    onDragOver(source: CardName | 'end'): void {
+    onDragOver(source: CardName, event: DragEvent): void {
       if (this.dragCard === undefined || source === this.dragCard) {
         return;
       }
-      // put the card at the end of the list
-      if (source === 'end') {
-        let max = 0;
-        const keys = Object.keys(this.cardOrder);
-        for (const key of keys) {
-          max = Math.max(max, this.cardOrder[key]);
-        }
-        this.cardOrder[this.dragCard] = max + 1;
-      } else {
-        // place it ahead of the card
-        const temp = this.cardOrder[source];
-        const keys = Object.keys(this.cardOrder);
-        for (const key of keys) {
-          if (this.cardOrder[key] >= temp) {
-            this.cardOrder[key]++;
-          }
-        }
-        this.cardOrder[this.dragCard] = temp;
+
+      const cardNames = this.getSortedCards().map((card) => card.name);
+      const dragIndex = cardNames.indexOf(this.dragCard);
+      if (dragIndex === -1) {
+        return;
       }
+
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      const insertAfter = event.clientX >= rect.left + rect.width / 2;
+      const draggedCard = cardNames.splice(dragIndex, 1)[0];
+      cardNames.splice(cardNames.indexOf(source) + (insertAfter ? 1 : 0), 0, draggedCard);
+      cardNames.forEach((cardName, index) => this.cardOrder[cardName] = index + 1);
       CardOrderStorage.updateCardOrder(this.playerId, this.cardOrder);
     },
     doNotDragAndDropOnReorder() {

--- a/src/styles/cards.less
+++ b/src/styles/cards.less
@@ -1112,15 +1112,6 @@ input[type="radio"]:checked+.filterDiv::after {
     vertical-align: top;
   }
 
-  .drop-target {
-    width: 10px;
-    height: 350px;
-    display: inline-block;
-    vertical-align: top;
-    z-index: 1;
-    position: absolute;
-  }
-
   .reorder-banners-container {
     display: flex;
     align-items: center;

--- a/src/styles/preferences.less
+++ b/src/styles/preferences.less
@@ -351,6 +351,11 @@
     transform: none;
   }
 
+  .sortable-cards > div:active .filterDiv {
+    transition: none;
+    transform: none;
+  }
+
   .cards-stack:hover,
   .cards-stack-first:hover {
     z-index: 2;

--- a/tests/client/components/SortableCards.spec.ts
+++ b/tests/client/components/SortableCards.spec.ts
@@ -35,10 +35,9 @@ describe('SortableCards', () => {
     expect(cards[0].props().card.name).to.eq(CardName.ANTS);
     expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
     const draggers = sortable.findAll('[draggable=true]');
+    draggers[0].element.getBoundingClientRect = () => ({left: 0, width: 200} as DOMRect);
     await draggers[1].trigger('dragstart');
-    await sortable.vm.$nextTick();
-    const droppers = sortable.findAll('.drop-target');
-    await droppers[0].trigger('dragover');
+    await draggers[0].trigger('dragover', {clientX: 50});
     await draggers[1].trigger('dragend');
     cards = sortable.findAllComponents({
       name: 'Card',
@@ -79,23 +78,22 @@ describe('SortableCards', () => {
     expect(cards[1].props().card.name).to.eq(CardName.ANTS);
     expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
     const draggers = sortable.findAll('[draggable=true]');
+    draggers[2].element.getBoundingClientRect = () => ({left: 0, width: 200} as DOMRect);
     await draggers[0].trigger('dragstart');
-    await sortable.vm.$nextTick();
-    const droppers = sortable.findAll('.drop-target');
-    await droppers[2].trigger('dragover');
+    await draggers[2].trigger('dragover', {clientX: 150});
     await draggers[0].trigger('dragend');
     cards = sortable.findAllComponents({
       name: 'Card',
     });
     expect(cards[0].props().card.name).to.eq(CardName.ANTS);
-    expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
-    expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
+    expect(cards[1].props().card.name).to.eq(CardName.BIRDS);
+    expect(cards[2].props().card.name).to.eq(CardName.CARTEL);
     const order = localStorage.getItem('cardOrderfoo');
     expect(order).not.to.be.undefined;
     expect(JSON.parse(order!)).to.deep.eq({
-      [CardName.ANTS]: 2,
+      [CardName.ANTS]: 1,
       [CardName.CARTEL]: 3,
-      [CardName.BIRDS]: 4,
+      [CardName.BIRDS]: 2,
     });
   });
 });

--- a/tests/client/components/SortableCards.spec.ts
+++ b/tests/client/components/SortableCards.spec.ts
@@ -1,9 +1,23 @@
-import {mount} from '@vue/test-utils';
+import {mount, VueWrapper} from '@vue/test-utils';
 import {globalConfig} from './getLocalVue';
 import {expect} from 'chai';
 import {CardName} from '@/common/cards/CardName';
 import SortableCards from '@/client/components/SortableCards.vue';
 import {FakeLocalStorage} from './FakeLocalStorage';
+
+type DropPosition = 'before' | 'after';
+
+async function dragCard(sortable: VueWrapper<InstanceType<typeof SortableCards>>, sourceIndex: number, targetIndex: number, position: DropPosition) {
+  const draggers = sortable.findAll('[draggable=true]');
+  const target = draggers[targetIndex];
+  const bounds = {left: 0, width: 2};
+  // jsdom does not calculate element bounds.
+  target.element.getBoundingClientRect = () => bounds as DOMRect;
+
+  await draggers[sourceIndex].trigger('dragstart');
+  await target.trigger('dragover', {clientX: position === 'before' ? bounds.left : bounds.left + bounds.width});
+  await draggers[sourceIndex].trigger('dragend');
+}
 
 describe('SortableCards', () => {
   let localStorage: FakeLocalStorage;
@@ -34,11 +48,7 @@ describe('SortableCards', () => {
     expect(cards).has.length(2);
     expect(cards[0].props().card.name).to.eq(CardName.ANTS);
     expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
-    const draggers = sortable.findAll('[draggable=true]');
-    draggers[0].element.getBoundingClientRect = () => ({left: 0, width: 200} as DOMRect);
-    await draggers[1].trigger('dragstart');
-    await draggers[0].trigger('dragover', {clientX: 50});
-    await draggers[1].trigger('dragend');
+    await dragCard(sortable, 0, 1, 'after');
     cards = sortable.findAllComponents({
       name: 'Card',
     });
@@ -77,23 +87,19 @@ describe('SortableCards', () => {
     expect(cards[0].props().card.name).to.eq(CardName.CARTEL);
     expect(cards[1].props().card.name).to.eq(CardName.ANTS);
     expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
-    const draggers = sortable.findAll('[draggable=true]');
-    draggers[2].element.getBoundingClientRect = () => ({left: 0, width: 200} as DOMRect);
-    await draggers[0].trigger('dragstart');
-    await draggers[2].trigger('dragover', {clientX: 150});
-    await draggers[0].trigger('dragend');
+    await dragCard(sortable, 0, 2, 'before');
     cards = sortable.findAllComponents({
       name: 'Card',
     });
     expect(cards[0].props().card.name).to.eq(CardName.ANTS);
-    expect(cards[1].props().card.name).to.eq(CardName.BIRDS);
-    expect(cards[2].props().card.name).to.eq(CardName.CARTEL);
+    expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
+    expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
     const order = localStorage.getItem('cardOrderfoo');
     expect(order).not.to.be.undefined;
     expect(JSON.parse(order!)).to.deep.eq({
       [CardName.ANTS]: 1,
-      [CardName.CARTEL]: 3,
-      [CardName.BIRDS]: 2,
+      [CardName.CARTEL]: 2,
+      [CardName.BIRDS]: 3,
     });
   });
 });

--- a/tests/client/components/SortableCards.spec.ts
+++ b/tests/client/components/SortableCards.spec.ts
@@ -10,12 +10,12 @@ type DropPosition = 'before' | 'after';
 async function dragCard(sortable: VueWrapper<InstanceType<typeof SortableCards>>, sourceIndex: number, targetIndex: number, position: DropPosition) {
   const draggers = sortable.findAll('[draggable=true]');
   const target = draggers[targetIndex];
-  const bounds = {left: 0, width: 2};
-  // jsdom does not calculate element bounds.
-  target.element.getBoundingClientRect = () => bounds as DOMRect;
+  // jsdom lacks layout; use unit bounds.
+  const targetBounds = {left: 0, width: 1};
+  target.element.getBoundingClientRect = () => targetBounds as DOMRect;
 
   await draggers[sourceIndex].trigger('dragstart');
-  await target.trigger('dragover', {clientX: position === 'before' ? bounds.left : bounds.left + bounds.width});
+  await target.trigger('dragover', {clientX: position === 'before' ? targetBounds.left : targetBounds.left + targetBounds.width});
   await draggers[sourceIndex].trigger('dragend');
 }
 

--- a/tests/client/components/SortableCards.spec.ts
+++ b/tests/client/components/SortableCards.spec.ts
@@ -4,19 +4,52 @@ import {expect} from 'chai';
 import {CardName} from '@/common/cards/CardName';
 import SortableCards from '@/client/components/SortableCards.vue';
 import {FakeLocalStorage} from './FakeLocalStorage';
+import {PlayerId} from '@/common/Types';
 
-type DropPosition = 'before' | 'after';
+type DropSide = 'left' | 'right';
 
-async function dragCard(sortable: VueWrapper<InstanceType<typeof SortableCards>>, sourceIndex: number, targetIndex: number, position: DropPosition) {
+/**
+ * Drag card at `sourceIndex` to `targetIndex` on its left or right side.
+ */
+async function dragCard(sortable: VueWrapper<InstanceType<typeof SortableCards>>, sourceIndex: number, targetIndex: number, position: DropSide) {
   const draggers = sortable.findAll('[draggable=true]');
   const target = draggers[targetIndex];
-  // jsdom lacks layout; use unit bounds.
-  const targetBounds = {left: 0, width: 1};
-  target.element.getBoundingClientRect = () => targetBounds as DOMRect;
+
+  // This test doesn't use a real layout, so cards aren't 200px wide. Here,
+  // they're simulated at 10px. Positions 0-4 are the left side and positions
+  // 5-9 are the right side.
+  target.element.getBoundingClientRect = () => {
+    return {left: 0, width: 10} as DOMRect;
+  };
 
   await draggers[sourceIndex].trigger('dragstart');
-  await target.trigger('dragover', {clientX: position === 'before' ? targetBounds.left : targetBounds.left + targetBounds.width});
+  // 3 is the left side, 8 is the right side.
+  await target.trigger('dragover', {clientX: position === 'left' ? 3 : 8});
   await draggers[sourceIndex].trigger('dragend');
+}
+
+/**
+ * Returns the names of cards in this widget in their current order.
+ */
+function cardsInOrder(sortable: VueWrapper<InstanceType<typeof SortableCards>>): Array<CardName> {
+  return sortable.findAllComponents({
+    name: 'Card',
+  }).map((card) => card.props().card.name);
+}
+
+/**
+ * Returns the entries in local storage for the given player.
+ */
+function getStorageEntries(playerId: PlayerId): {[key in CardName]?: number} {
+  const entries: {[key in CardName]?: number} = {};
+  const item = localStorage.getItem(`cardOrder${playerId}`);
+  if (item) {
+    const parsed = JSON.parse(item);
+    for (const [cardName, order] of Object.entries(parsed)) {
+      entries[cardName as CardName] = order as number;
+    }
+  }
+  return entries;
 }
 
 describe('SortableCards', () => {
@@ -34,35 +67,23 @@ describe('SortableCards', () => {
     const sortable = mount(SortableCards, {
       ...globalConfig,
       props: {
-        cards: [{
-          name: CardName.ANTS,
-        }, {
-          name: CardName.CARTEL,
-        }],
-        playerId: 'foo',
+        cards: [{name: CardName.ANTS}, {name: CardName.CARTEL}],
+        playerId: 'player1',
       },
     });
-    let cards = sortable.findAllComponents({
-      name: 'Card',
-    });
-    expect(cards).has.length(2);
-    expect(cards[0].props().card.name).to.eq(CardName.ANTS);
-    expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
-    await dragCard(sortable, 0, 1, 'after');
-    cards = sortable.findAllComponents({
-      name: 'Card',
-    });
-    expect(cards[0].props().card.name).to.eq(CardName.CARTEL);
-    expect(cards[1].props().card.name).to.eq(CardName.ANTS);
-    const order = localStorage.getItem('cardOrderfoo');
-    expect(order).not.to.be.undefined;
-    expect(JSON.parse(order!)).to.deep.eq({
+    expect(cardsInOrder(sortable)).to.deep.eq([CardName.ANTS, CardName.CARTEL]);
+
+    await dragCard(sortable, 0, 1, 'right');
+
+    expect(cardsInOrder(sortable)).to.deep.eq([CardName.CARTEL, CardName.ANTS]);
+    expect(getStorageEntries('player1')).to.deep.eq({
       [CardName.ANTS]: 2,
       [CardName.CARTEL]: 1,
     });
   });
+
   it('puts new cards at end of order and removes old', async () => {
-    localStorage.setItem('cardOrderfoo', JSON.stringify({
+    localStorage.setItem('cardOrderplayer1', JSON.stringify({
       [CardName.ANTS]: 2,
       [CardName.CARTEL]: 1,
       [CardName.DECOMPOSERS]: 3,
@@ -70,33 +91,17 @@ describe('SortableCards', () => {
     const sortable = mount(SortableCards, {
       ...globalConfig,
       props: {
-        cards: [{
-          name: CardName.ANTS,
-        }, {
-          name: CardName.CARTEL,
-        }, {
-          name: CardName.BIRDS,
-        }],
-        playerId: 'foo',
+        cards: [{name: CardName.ANTS}, {name: CardName.CARTEL}, {name: CardName.BIRDS}],
+        playerId: 'player1',
       },
     });
-    let cards = sortable.findAllComponents({
-      name: 'Card',
-    });
-    expect(cards).has.length(3);
-    expect(cards[0].props().card.name).to.eq(CardName.CARTEL);
-    expect(cards[1].props().card.name).to.eq(CardName.ANTS);
-    expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
-    await dragCard(sortable, 0, 2, 'before');
-    cards = sortable.findAllComponents({
-      name: 'Card',
-    });
-    expect(cards[0].props().card.name).to.eq(CardName.ANTS);
-    expect(cards[1].props().card.name).to.eq(CardName.CARTEL);
-    expect(cards[2].props().card.name).to.eq(CardName.BIRDS);
-    const order = localStorage.getItem('cardOrderfoo');
-    expect(order).not.to.be.undefined;
-    expect(JSON.parse(order!)).to.deep.eq({
+
+    expect(cardsInOrder(sortable)).to.deep.eq([CardName.CARTEL, CardName.ANTS, CardName.BIRDS]);
+
+    await dragCard(sortable, 0, 2, 'left');
+
+    expect(cardsInOrder(sortable)).to.deep.eq([CardName.ANTS, CardName.CARTEL, CardName.BIRDS]);
+    expect(getStorageEntries('player1')).to.deep.eq({
       [CardName.ANTS]: 1,
       [CardName.CARTEL]: 2,
       [CardName.BIRDS]: 3,


### PR DESCRIPTION
## Summary
- Insert dragged hand cards before or after the hovered card based on pointer position.
- Keep the experimental point-and-click reorder UI unchanged.

## Demo
Drag a card over either half of another card; it lands on the corresponding side.

## Testing
- SortableCards component tests
- `npm run lint:server`
- `npm run lint:client`
- `npm run build`