### PR TITLE
Keep timer stop time monotonic

### DIFF
--- a/src/common/Timer.ts
+++ b/src/common/Timer.ts
@@ -68,8 +68,7 @@ export class Timer {
     timer.running = d.running;
     timer.afterFirstAction = d.afterFirstAction;
 
-    // Should this be `Math.max(Timer.lastStoppedAt, d.lastStoppedAt)`?
-    Timer.lastStoppedAt = d.lastStoppedAt;
+    Timer.lastStoppedAt = Math.max(Timer.lastStoppedAt, d.lastStoppedAt);
     return timer;
   }
 

--- a/src/common/Timer.ts
+++ b/src/common/Timer.ts
@@ -68,6 +68,7 @@ export class Timer {
     timer.running = d.running;
     timer.afterFirstAction = d.afterFirstAction;
 
+    // Never move the shared timer backwards.
     Timer.lastStoppedAt = Math.max(Timer.lastStoppedAt, d.lastStoppedAt);
     return timer;
   }
@@ -140,4 +141,3 @@ export class Timer {
     return elapsedDate.toISOString().substr(14, 5);
   }
 }
-

--- a/tests/common/Timer.spec.ts
+++ b/tests/common/Timer.spec.ts
@@ -51,6 +51,27 @@ describe('Timer', () => {
     expect(Timer.toString(timer.serialize(), clock)).eq('1:00:01');
   });
 
+  it('does not move the shared stop time backwards when loading another game', () => {
+    const target = Timer.deserialize({
+      sumElapsed: 0,
+      startedAt: 0,
+      running: false,
+      afterFirstAction: true,
+      lastStoppedAt: 5000,
+    });
+
+    Timer.deserialize({
+      sumElapsed: 0,
+      startedAt: 0,
+      running: false,
+      afterFirstAction: true,
+      lastStoppedAt: 1000,
+    });
+
+    target.start();
+    expect(target.serialize().startedAt).eq(5000);
+  });
+
   it('rebate', () => {
     timer.start(); // Skipping first action
     timer.stop();


### PR DESCRIPTION
## Summary
- Keep the shared timer stop timestamp monotonic when deserializing games.
- Prevent loading an older saved game from moving subsequent timer starts backwards.

## Demo
1. Deserialize a timer with `lastStoppedAt = 5000`.
2. Deserialize another timer with `lastStoppedAt = 1000`.
3. Start the first timer; its `startedAt` remains `5000`.

## Testing
- `npx mocha --import=tsx --require tests/testing/setup.ts tests/common/Timer.spec.ts`
- `npm run lint:server`
- `npm run lint:client`
- `npm run build`

## Notes
- No UI or gameplay-rule change.