### PR TITLE
Don't create card render metadata on a running server

### DIFF
--- a/src/server/cards/community/LeadershipSummit.ts
+++ b/src/server/cards/community/LeadershipSummit.ts
@@ -6,10 +6,6 @@ import {IGame} from '../../IGame';
 import {Turmoil} from '../../turmoil/Turmoil';
 import {CardRenderer} from '../render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.cards(1).slash().partyLeaders(1).plus().influence();
-});
-
 export class LeadershipSummit extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -17,7 +13,9 @@ export class LeadershipSummit extends GlobalEvent implements IGlobalEvent {
       description: 'Draw 1 card for each party leader (max 5) and influence.',
       revealedDelegate: PartyName.GREENS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.cards(1).slash().partyLeaders(1).plus().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/cards/pathfinders/BalancedDevelopment.ts
+++ b/src/server/cards/pathfinders/BalancedDevelopment.ts
@@ -9,10 +9,6 @@ import {Resource} from '../../../common/Resource';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.MARS).influence({size: Size.SMALL});
-});
-
 export class BalancedDevelopment extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class BalancedDevelopment extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2M€ for each Mars tag you have (max 5) and influence.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.MARS).influence({size: Size.SMALL});
+      }),
     });
   }
 

--- a/src/server/cards/pathfinders/CommunicationBoom.ts
+++ b/src/server/cards/pathfinders/CommunicationBoom.ts
@@ -10,11 +10,6 @@ import {AddResourcesToCards} from '../../deferredActions/AddResourcesToCards';
 import {CardRenderer} from '../render/CardRenderer';
 import {PathfindersExpansion} from '../../pathfinders/PathfindersExpansion';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-10).nbsp.resource(CardResource.DATA, 2).asterix().nbsp;
-  b.resource(CardResource.DATA).slash().influence();
-});
-
 export class CommunicationBoom extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -22,7 +17,10 @@ export class CommunicationBoom extends GlobalEvent implements IGlobalEvent {
       description: 'Pay 10M€. Add 2 data to EVERY data card. Add 1 data to any data card for each influence you have.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-10).nbsp.resource(CardResource.DATA, 2).asterix().nbsp;
+        b.resource(CardResource.DATA).slash().influence();
+      }),
     });
   }
 

--- a/src/server/cards/pathfinders/ConstantStruggle.ts
+++ b/src/server/cards/pathfinders/ConstantStruggle.ts
@@ -10,10 +10,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().megacredits(10).influence({size: Size.SMALL}).planetaryTrack().text('2');
-});
-
 export class ConstantStruggle extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +17,9 @@ export class ConstantStruggle extends GlobalEvent implements IGlobalEvent {
       description: 'Pay 10M€, reduced by 1M€ per influence. Raise every planetary track 2 steps. Nobody gains the "rising player" bonus.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().megacredits(10).influence({size: Size.SMALL}).planetaryTrack().text('2');
+      }),
     });
   }
 

--- a/src/server/cards/pathfinders/MagneticFieldStimulationDelays.ts
+++ b/src/server/cards/pathfinders/MagneticFieldStimulationDelays.ts
@@ -5,10 +5,6 @@ import {PartyName} from '../../../common/turmoil/PartyName';
 import {IGame} from '../../IGame';
 import {CardRenderer} from '../render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().temperature(2).nbsp.minus().oxygen(2);
-});
-
 export class MagneticFieldStimulationDelays extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -16,7 +12,9 @@ export class MagneticFieldStimulationDelays extends GlobalEvent implements IGlob
       description: 'Lower the temperature and oxygen 2 steps each. (-4C, -2% O2)',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().temperature(2).nbsp.minus().oxygen(2);
+      }),
     });
   }
 

--- a/src/server/cards/pathfinders/SpaceRaceToMars.ts
+++ b/src/server/cards/pathfinders/SpaceRaceToMars.ts
@@ -9,11 +9,6 @@ import {IPlayer} from '../../IPlayer';
 import {isSpecialTileSpace, Board} from '../../boards/Board';
 import {CardRenderer} from '../render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.production((pb) => pb.megacredits(1)).slash().specialTile().nbsp;
-  b.energy(1).slash().influence();
-});
-
 export class SpaceRaceToMars extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +16,10 @@ export class SpaceRaceToMars extends GlobalEvent implements IGlobalEvent {
       description: 'Increase your M€ production 1 step for every special tile you own (max 5.) Gain 1 energy for every influence you have',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.production((pb) => pb.megacredits(1)).slash().specialTile().nbsp;
+        b.energy(1).slash().influence();
+      }),
     });
   }
 

--- a/src/server/cards/pathfinders/TiredEarth.ts
+++ b/src/server/cards/pathfinders/TiredEarth.ts
@@ -9,10 +9,6 @@ import {Resource} from '../../../common/Resource';
 import {CardRenderer} from '../render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().plants(1).slash().tag(Tag.EARTH).influence({size: Size.SMALL});
-});
-
 export class TiredEarth extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class TiredEarth extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 1 plant for each Earth tag you own (max 5) then reduced by influence.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().plants(1).slash().tag(Tag.EARTH).influence({size: Size.SMALL});
+      }),
     });
   }
 

--- a/src/server/cards/render/CardRenderer.ts
+++ b/src/server/cards/render/CardRenderer.ts
@@ -8,6 +8,7 @@ import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 import {CardResource} from '../../../common/CardResource';
 import {Tag} from '../../../common/cards/Tag';
 import {liteBoolean, LiteBoolean} from '../../../common/LiteBoolean';
+import {isLiveServer} from '../../utils/server';
 
 export type TextOptions = {
   size?: Size;
@@ -18,6 +19,12 @@ export type TextOptions = {
 
 export class CardRenderer {
   public static builder(f: (builder: Builder<CardRenderRoot>) => void): ICardRenderRoot {
+    // The live server never reads renderData (only export_card_rendering.ts does,
+    // to build the client's cards.json at compile time), so skip building the
+    // real tree there to avoid the CPU cost and per-card-name retained memory.
+    if (isLiveServer()) {
+      return EMPTY_ROOT;
+    }
     const builder = new RootBuilder();
     f(builder);
     return builder.build();
@@ -28,6 +35,8 @@ class CardRenderRoot implements ICardRenderRoot {
   public readonly is ='root';
   constructor(public rows: Array<Array<ItemType>> = [[]]) {}
 }
+
+const EMPTY_ROOT = new CardRenderRoot();
 
 class CardRenderProductionBox implements ICardRenderProductionBox {
   public readonly is = 'production-box';

--- a/src/server/cards/underworld/FairTradeComplaint.ts
+++ b/src/server/cards/underworld/FairTradeComplaint.ts
@@ -9,11 +9,6 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {digit} from '../../cards/Options';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-1).slash().cards(1, {over: 6}).influence({size: Size.SMALL}).nbsp;
-  b.text('MAX 6').cards(1).colon().cards(2, {digit});
-});
-
 export class FairTradeComplaint extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -23,7 +18,10 @@ export class FairTradeComplaint extends GlobalEvent implements IGlobalEvent {
         'Draw 2 cards if your hand contains 6 cards or less.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-1).slash().cards(1, {over: 6}).influence({size: Size.SMALL}).nbsp;
+        b.text('MAX 6').cards(1).colon().cards(2, {digit});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/cards/underworld/LaggingRegulation.ts
+++ b/src/server/cards/underworld/LaggingRegulation.ts
@@ -12,11 +12,6 @@ import {UnderworldExpansion} from '../../underworld/UnderworldExpansion';
 import {Size} from '../../../common/cards/render/Size';
 import {Tag} from '../../../common/cards/Tag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.tag(Tag.CRIME).plus().influence().colon();
-  b.text('1st/2nd', {size: Size.SMALL}).corruption().megacredits(9).slash().megacredits(3);
-});
-
 export class LaggingRegulation extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -25,7 +20,10 @@ export class LaggingRegulation extends GlobalEvent implements IGlobalEvent {
       'Players with 2nd most get 1 corruption and 3 M€. Min 1 to place. (SOLO: Place 1st with sum of 5 or more.)',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.tag(Tag.CRIME).plus().influence().colon();
+        b.text('1st/2nd', {size: Size.SMALL}).corruption().megacredits(9).slash().megacredits(3);
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/cards/underworld/MediaStir.ts
+++ b/src/server/cards/underworld/MediaStir.ts
@@ -8,10 +8,6 @@ import {Resource} from '../../../common/Resource';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-3).slash().corruption().influence({size: Size.SMALL}).nbsp.text('0').corruption().colon().tr(1);
-});
-
 export class MediaStir extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class MediaStir extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 3 M€ per corruption resource you have (max 5), minus influence. Players with 0 corruption gain 1 TR.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-3).slash().corruption().influence({size: Size.SMALL}).nbsp.text('0').corruption().colon().tr(1);
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/cards/underworld/MigrationUnderground.ts
+++ b/src/server/cards/underworld/MigrationUnderground.ts
@@ -9,10 +9,6 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {digit} from '../../cards/Options';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.production((pb) => pb.megacredits(1)).slash().undergroundResources(2, {digit}).influence({size: Size.SMALL});
-});
-
 export class MigrationUnderground extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class MigrationUnderground extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 1 M€ production (max 5) for every 2 underworld tokens you own. Each point of influence counts as an extra underworld token.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.production((pb) => pb.megacredits(1)).slash().undergroundResources(2, {digit}).influence({size: Size.SMALL});
+      }),
     });
   }
 

--- a/src/server/cards/underworld/SeismicPredictions.ts
+++ b/src/server/cards/underworld/SeismicPredictions.ts
@@ -11,10 +11,6 @@ import {Size} from '../../../common/cards/render/Size';
 import {cancelled} from '../../cards/Options';
 import {Tag} from '../../../common/cards/Tag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.text('ALL').undergroundResources(1, {cancelled}).nbsp.megacredits(-2).slash().tag(Tag.BUILDING).minus().undergroundResources().influence({size: Size.SMALL});
-});
-
 export class SeismicPredictions extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -23,7 +19,9 @@ export class SeismicPredictions extends GlobalEvent implements IGlobalEvent {
       'Lose 2 M€ for each building tag (max 7) minus influence and claimed underground resource tokens.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.text('ALL').undergroundResources(1, {cancelled}).nbsp.megacredits(-2).slash().tag(Tag.BUILDING).minus().undergroundResources().influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,8 +1,12 @@
+
 import '@/server/init';
 require('console-stamp')(
   console,
   {format: ':date(yyyy-mm-dd HH:MM:ss Z)'},
 );
+import {markAsLiveServer} from '@/server/utils/server';
+// Must run first.
+markAsLiveServer();
 
 import https from 'https';
 import http from 'http';

--- a/src/server/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
+++ b/src/server/turmoil/globalEvents/AquiferReleasedByPublicCouncil.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {PlaceOceanTile} from '../../deferredActions/PlaceOceanTile';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.oceans(1).nbsp.plants(1).steel(1).slash().influence();
-});
-
 export class AquiferReleasedByPublicCouncil extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class AquiferReleasedByPublicCouncil extends GlobalEvent implements IGlob
       description: 'First player places an ocean tile. Gain 1 plant and 1 steel per influence.',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.oceans(1).nbsp.plants(1).steel(1).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/AsteroidMining.ts
+++ b/src/server/turmoil/globalEvents/AsteroidMining.ts
@@ -10,10 +10,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.titanium(1).slash().tag(Tag.JOVIAN).influence({size: Size.SMALL});
-});
-
 export class AsteroidMining extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +17,9 @@ export class AsteroidMining extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 1 titanium for each Jovian tag (max 5) and influence.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.titanium(1).slash().tag(Tag.JOVIAN).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/CelebrityLeaders.ts
+++ b/src/server/turmoil/globalEvents/CelebrityLeaders.ts
@@ -9,10 +9,6 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {Tag} from '../../../common/cards/Tag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.EVENT).influence({size: Size.SMALL});
-});
-
 export class CelebrityLeaders extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class CelebrityLeaders extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each event played (max 5) and influence.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.EVENT).influence({size: Size.SMALL});
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/CloudSocieties.ts
+++ b/src/server/turmoil/globalEvents/CloudSocieties.ts
@@ -9,11 +9,6 @@ import {AddResourcesToCard} from '../../deferredActions/AddResourcesToCard';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().resource(CardResource.FLOATER).nbsp;
-  b.resource(CardResource.FLOATER).slash().influence();
-});
-
 export class CloudSocieties extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +16,10 @@ export class CloudSocieties extends GlobalEvent implements IGlobalEvent {
       description: 'Add a floater to each card that can collect floaters. Add 1 floater for each influence to a card.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.cards(1, {secondaryTag: AltSecondaryTag.FLOATER}).colon().resource(CardResource.FLOATER).nbsp;
+        b.resource(CardResource.FLOATER).slash().influence();
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/CorrosiveRain.ts
+++ b/src/server/turmoil/globalEvents/CorrosiveRain.ts
@@ -8,10 +8,6 @@ import {CorrosiveRainDeferredAction} from '../../deferredActions/CorrosiveRainDe
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {CardResource} from '../../../common/CardResource';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().resource(CardResource.FLOATER, 2).or().megacredits(-10).nbsp.nbsp.cards(1).slash().influence();
-});
-
 export class CorrosiveRain extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class CorrosiveRain extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 2 floaters from a card or 10 M€. Draw 1 card for each influence.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().resource(CardResource.FLOATER, 2).or().megacredits(-10).nbsp.nbsp.cards(1).slash().influence();
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/Diversity.ts
+++ b/src/server/turmoil/globalEvents/Diversity.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.text('9').diverseTag(1).influence({size: Size.SMALL}).colon().megacredits(10);
-});
-
 export class Diversity extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class Diversity extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 10 M€ if you have 9 or more different tags. Influence counts as unique tags.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.text('9').diverseTag(1).influence({size: Size.SMALL}).colon().megacredits(10);
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/DryDeserts.ts
+++ b/src/server/turmoil/globalEvents/DryDeserts.ts
@@ -9,10 +9,6 @@ import {GainResources} from '../../inputs/GainResources';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {message} from '../../logs/MessageBuilder';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().oceans(1).nbsp.nbsp.wild(1).slash().influence();
-});
-
 export class DryDeserts extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class DryDeserts extends GlobalEvent implements IGlobalEvent {
       description: 'First player removes 1 ocean tile from the gameboard. Gain 1 standard resource per influence.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().oceans(1).nbsp.nbsp.wild(1).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/EcoSabotage.ts
+++ b/src/server/turmoil/globalEvents/EcoSabotage.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.text('max 3').plants(1).influence({size: Size.SMALL});
-});
-
 export class EcoSabotage extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class EcoSabotage extends GlobalEvent implements IGlobalEvent {
       description: 'Lose all plants except 3 + influence.',
       revealedDelegate: PartyName.GREENS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.text('max 3').plants(1).influence({size: Size.SMALL});
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/Election.ts
+++ b/src/server/turmoil/globalEvents/Election.ts
@@ -10,11 +10,6 @@ import {Board} from '../../boards/Board';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.influence().plus().tag(Tag.BUILDING, {size: Size.SMALL}).plus().city({size: Size.MEDIUM}).colon().br;
-  b.text('1st:', {size: Size.SMALL}).tr(2, {size: Size.TINY}).nbsp.text('2nd:', {size: Size.SMALL}).tr(1, {size: Size.TINY});
-});
-
 export class Election extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -22,7 +17,10 @@ export class Election extends GlobalEvent implements IGlobalEvent {
       description: 'Count your influence plus building tags and city tiles (no limits). The player with most (or 10 in solo) gains 2 TR, the 2nd (or 5 in solo) gains 1 TR (ties are friendly).',
       revealedDelegate: PartyName.GREENS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.influence().plus().tag(Tag.BUILDING, {size: Size.SMALL}).plus().city({size: Size.MEDIUM}).colon().br;
+        b.text('1st:', {size: Size.SMALL}).tr(2, {size: Size.TINY}).nbsp.text('2nd:', {size: Size.SMALL}).tr(1, {size: Size.TINY});
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/GenerousFunding.ts
+++ b/src/server/turmoil/globalEvents/GenerousFunding.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {digit} from '../../cards/Options';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().influence().plus().tr(5, {digit, over: 15}).br.br;
-});
-
 export class GenerousFunding extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class GenerousFunding extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each influence and set of 5 TR over 15 (max 5 sets).',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().influence().plus().tr(5, {digit, over: 15}).br.br;
+      }),
     });
   }
 

--- a/src/server/turmoil/globalEvents/GlobalDustStorm.ts
+++ b/src/server/turmoil/globalEvents/GlobalDustStorm.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.text('Lose all').heat(1).nbsp.megacredits(-2).slash().tag(Tag.BUILDING).influence({size: Size.SMALL});
-});
-
 export class GlobalDustStorm extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class GlobalDustStorm extends GlobalEvent implements IGlobalEvent {
       description: 'Lose all heat. Lose 2 M€ for each building tag (max 5, then reduced by influence).',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.text('Lose all').heat(1).nbsp.megacredits(-2).slash().tag(Tag.BUILDING).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil): void {

--- a/src/server/turmoil/globalEvents/HomeworldSupport.ts
+++ b/src/server/turmoil/globalEvents/HomeworldSupport.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.EARTH).influence({size: Size.SMALL});
-});
-
 export class HomeworldSupport extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class HomeworldSupport extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each Earth tag (max 5) and influence.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.EARTH).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/ImprovedEnergyTemplates.ts
+++ b/src/server/turmoil/globalEvents/ImprovedEnergyTemplates.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.production((pb) => pb.energy(1)).slash().tag(Tag.POWER, 2).influence({size: Size.SMALL});
-});
-
 export class ImprovedEnergyTemplates extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class ImprovedEnergyTemplates extends GlobalEvent implements IGlobalEvent
       description: 'Increase energy production 1 step per 2 power tags (no limit). Influence counts as power tags.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.KELVINISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.production((pb) => pb.energy(1)).slash().tag(Tag.POWER, 2).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/InterplanetaryTrade.ts
+++ b/src/server/turmoil/globalEvents/InterplanetaryTrade.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.SPACE).influence({size: Size.SMALL});
-});
-
 export class InterplanetaryTrade extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class InterplanetaryTrade extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each space tag (max 5) and influence.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.SPACE).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/JovianTaxRights.ts
+++ b/src/server/turmoil/globalEvents/JovianTaxRights.ts
@@ -7,10 +7,6 @@ import {Resource} from '../../../common/Resource';
 import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.production((pb) => pb.megacredits(1)).slash().colonies(1).nbsp.titanium(1).slash().influence();
-});
-
 export class JovianTaxRights extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -18,7 +14,9 @@ export class JovianTaxRights extends GlobalEvent implements IGlobalEvent {
       description: 'Increase M€ production 1 step for each colony. Gain 1 titanium for each influence.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.production((pb) => pb.megacredits(1)).slash().colonies(1).nbsp.titanium(1).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/MicrogravityHealthProblems.ts
+++ b/src/server/turmoil/globalEvents/MicrogravityHealthProblems.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-3).slash().colonies(1).influence({size: Size.SMALL});
-});
-
 export class MicrogravityHealthProblems extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class MicrogravityHealthProblems extends GlobalEvent implements IGlobalEv
       description: 'Lose 3 M€ for each colony (max 5, then reduced by influence).',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-3).slash().colonies(1).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/MinersOnStrike.ts
+++ b/src/server/turmoil/globalEvents/MinersOnStrike.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().titanium(1).slash().tag(Tag.JOVIAN).influence({size: Size.SMALL});
-});
-
 export class MinersOnStrike extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class MinersOnStrike extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 1 titanium for each Jovian tag (max 5, then reduced by influence).',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().titanium(1).slash().tag(Tag.JOVIAN).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/MudSlides.ts
+++ b/src/server/turmoil/globalEvents/MudSlides.ts
@@ -9,10 +9,6 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {Board} from '../../boards/Board';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().megacredits(4).slash().oceans(1).emptyTile().influence({size: Size.SMALL});
-});
-
 export class MudSlides extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class MudSlides extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 4 M€ for each tile adjacent to ocean (max 5, then reduced by influence).',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().megacredits(4).slash().oceans(1).emptyTile().influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/Pandemic.ts
+++ b/src/server/turmoil/globalEvents/Pandemic.ts
@@ -9,10 +9,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-3).slash().tag(Tag.BUILDING).influence({size: Size.SMALL});
-});
-
 export class Pandemic extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class Pandemic extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 3 M€ for each building tag (max 5, then reduced by influence).',
       revealedDelegate: PartyName.GREENS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-3).slash().tag(Tag.BUILDING).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/ParadigmBreakdown.ts
+++ b/src/server/turmoil/globalEvents/ParadigmBreakdown.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {DiscardCards} from '../../deferredActions/DiscardCards';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().cards(2).nbsp.megacredits(2).slash().influence();
-});
-
 export class ParadigmBreakdown extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class ParadigmBreakdown extends GlobalEvent implements IGlobalEvent {
       description: 'Discard 2 cards from hand. Gain 2 M€ per influence.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().cards(2).nbsp.megacredits(2).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/Productivity.ts
+++ b/src/server/turmoil/globalEvents/Productivity.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.steel(1).slash().production((pb) => pb.steel(1)).nbsp.influence({size: Size.SMALL});
-});
-
 export class Productivity extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class Productivity extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 1 steel for each steel production (max 5) and influence.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.steel(1).slash().production((pb) => pb.steel(1)).nbsp.influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/RedInfluence.ts
+++ b/src/server/turmoil/globalEvents/RedInfluence.ts
@@ -8,11 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {digit} from '../../cards/Options';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(-3).slash().tr(5, {digit, over: 10}).nbsp.production((pb) => pb.megacredits(1)).slash().influence().br;
-});
-
-
 export class RedInfluence extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +15,9 @@ export class RedInfluence extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 3 M€ for each set of 5 TR over 10 (max 5 sets). Increase M€ production 1 step per influence.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(-3).slash().tr(5, {digit, over: 10}).nbsp.production((pb) => pb.megacredits(1)).slash().influence().br;
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/Revolution.ts
+++ b/src/server/turmoil/globalEvents/Revolution.ts
@@ -9,12 +9,6 @@ import {IPlayer} from '../../IPlayer';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.tag(Tag.EARTH, {size: Size.SMALL}).plus().influence().colon().br;
-  b.text('1st:', {size: Size.SMALL}).minus().tr(2, {size: Size.TINY}).nbsp;
-  b.text('2nd:', {size: Size.SMALL}).minus().tr(1, {size: Size.TINY});
-});
-
 export class Revolution extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -22,7 +16,11 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
       description: 'Count Earth tags and ADD(!) influence. The player(s) with most (at least 1) loses 2 TR, and 2nd most (at least 1) loses 1 TR. SOLO: Lose 2 TR if the sum is 4 or more.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.tag(Tag.EARTH, {size: Size.SMALL}).plus().influence().colon().br;
+        b.text('1st:', {size: Size.SMALL}).minus().tr(2, {size: Size.TINY}).nbsp;
+        b.text('2nd:', {size: Size.SMALL}).minus().tr(1, {size: Size.TINY});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/Riots.ts
+++ b/src/server/turmoil/globalEvents/Riots.ts
@@ -9,10 +9,6 @@ import {Board} from '../../boards/Board';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().megacredits(4).slash().city().influence({size: Size.SMALL});
-});
-
 export class Riots extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class Riots extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 4 M€ for each city tile (max 5, then reduced by influence).',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().megacredits(4).slash().city().influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/Sabotage.ts
+++ b/src/server/turmoil/globalEvents/Sabotage.ts
@@ -8,11 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.production((pb) => pb.minus().energy(1).steel(1)).nbsp.nbsp;
-  b.steel(1).slash().influence({size: Size.MEDIUM});
-});
-
 export class Sabotage extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +15,10 @@ export class Sabotage extends GlobalEvent implements IGlobalEvent {
       description: 'Decrease steel and energy production 1 step each. Gain 1 steel per influence.',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.REDS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.production((pb) => pb.minus().energy(1).steel(1)).nbsp.nbsp;
+        b.steel(1).slash().influence({size: Size.MEDIUM});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/ScientificCommunity.ts
+++ b/src/server/turmoil/globalEvents/ScientificCommunity.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(1).slash().cards(1).influence({size: Size.SMALL});
-});
-
 export class ScientificCommunity extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class ScientificCommunity extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 1 M€ for each card in hand (no limit) and influence.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(1).slash().cards(1).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SnowCover.ts
+++ b/src/server/turmoil/globalEvents/SnowCover.ts
@@ -6,10 +6,6 @@ import {IGame} from '../../IGame';
 import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().temperature(2).nbsp.cards(1).slash().influence();
-});
-
 export class SnowCover extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -17,7 +13,9 @@ export class SnowCover extends GlobalEvent implements IGlobalEvent {
       description: 'Decrease temperature 2 steps. Draw 1 card per influence.',
       revealedDelegate: PartyName.KELVINISTS,
       currentDelegate: PartyName.KELVINISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().temperature(2).nbsp.cards(1).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SolarFlare.ts
+++ b/src/server/turmoil/globalEvents/SolarFlare.ts
@@ -9,10 +9,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().megacredits(3).slash().tag(Tag.SPACE).influence({size: Size.SMALL});
-});
-
 export class SolarFlare extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class SolarFlare extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 3 M€ for each space tag (max 5, then reduced by influence).',
       revealedDelegate: PartyName.UNITY,
       currentDelegate: PartyName.KELVINISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().megacredits(3).slash().tag(Tag.SPACE).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SolarnetShutdown.ts
+++ b/src/server/turmoil/globalEvents/SolarnetShutdown.ts
@@ -10,10 +10,6 @@ import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().megacredits(3).slash().cards(1, {secondaryTag: AltSecondaryTag.BLUE}).influence({size: Size.SMALL});
-});
-
 export class SolarnetShutdown extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +17,9 @@ export class SolarnetShutdown extends GlobalEvent implements IGlobalEvent {
       description: 'Lose 3 M€ for each blue card (max 5, then reduced by influence).',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().megacredits(3).slash().cards(1, {secondaryTag: AltSecondaryTag.BLUE}).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SpinoffProducts.ts
+++ b/src/server/turmoil/globalEvents/SpinoffProducts.ts
@@ -10,10 +10,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.SCIENCE).influence({size: Size.SMALL});
-});
-
 export class SpinoffProducts extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -21,7 +17,9 @@ export class SpinoffProducts extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each science tag (max 5) and influence.',
       revealedDelegate: PartyName.GREENS,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.SCIENCE).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SponsoredProjects.ts
+++ b/src/server/turmoil/globalEvents/SponsoredProjects.ts
@@ -7,11 +7,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {AltSecondaryTag} from '../../../common/cards/render/AltSecondaryTag';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.cards(1, {secondaryTag: AltSecondaryTag.WILD_RESOURCE}).colon().wild(1).nbsp;
-  b.cards(1).slash().influence();
-});
-
 export class SponsoredProjects extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +14,10 @@ export class SponsoredProjects extends GlobalEvent implements IGlobalEvent {
       description: 'All cards with resources on them gain 1 resource. Draw 1 card for each influence.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.GREENS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.cards(1, {secondaryTag: AltSecondaryTag.WILD_RESOURCE}).colon().wild(1).nbsp;
+        b.cards(1).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/StrongSociety.ts
+++ b/src/server/turmoil/globalEvents/StrongSociety.ts
@@ -8,10 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().city().influence({size: Size.SMALL});
-});
-
 export class StrongSociety extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -19,7 +15,9 @@ export class StrongSociety extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ for each city tile (max 5) and influence.',
       revealedDelegate: PartyName.REDS,
       currentDelegate: PartyName.MARS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().city().influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/SuccessfulOrganisms.ts
+++ b/src/server/turmoil/globalEvents/SuccessfulOrganisms.ts
@@ -8,11 +8,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.plants(1).slash().production((pb) => pb.plants(1)).nbsp.influence({size: Size.SMALL});
-});
-
-
 export class SuccessfulOrganisms extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +15,9 @@ export class SuccessfulOrganisms extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 1 plant per plant production (max 5) and influence.',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.SCIENTISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.plants(1).slash().production((pb) => pb.plants(1)).nbsp.influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/VenusInfrastructure.ts
+++ b/src/server/turmoil/globalEvents/VenusInfrastructure.ts
@@ -9,10 +9,6 @@ import {Tag} from '../../../common/cards/Tag';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.megacredits(2).slash().tag(Tag.VENUS).influence({size: Size.SMALL});
-});
-
 export class VenusInfrastructure extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -20,7 +16,9 @@ export class VenusInfrastructure extends GlobalEvent implements IGlobalEvent {
       description: 'Gain 2 M€ per Venus tag (max 5) and influence.',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.UNITY,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.megacredits(2).slash().tag(Tag.VENUS).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/VolcanicEruptions.ts
+++ b/src/server/turmoil/globalEvents/VolcanicEruptions.ts
@@ -7,10 +7,6 @@ import {Resource} from '../../../common/Resource';
 import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.temperature(2).nbsp.production((pb)=>pb.heat(1)).slash().influence();
-});
-
 export class VolcanicEruptions extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -18,7 +14,9 @@ export class VolcanicEruptions extends GlobalEvent implements IGlobalEvent {
       description: 'Increase temperature 2 steps. Increase heat production 1 step per influence.',
       revealedDelegate: PartyName.SCIENTISTS,
       currentDelegate: PartyName.KELVINISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.temperature(2).nbsp.production((pb)=>pb.heat(1)).slash().influence();
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/turmoil/globalEvents/WarOnEarth.ts
+++ b/src/server/turmoil/globalEvents/WarOnEarth.ts
@@ -7,10 +7,6 @@ import {Turmoil} from '../Turmoil';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
 
-const RENDER_DATA = CardRenderer.builder((b) => {
-  b.minus().text('4').tr(1).influence({size: Size.SMALL});
-});
-
 export class WarOnEarth extends GlobalEvent implements IGlobalEvent {
   constructor() {
     super({
@@ -18,7 +14,9 @@ export class WarOnEarth extends GlobalEvent implements IGlobalEvent {
       description: 'Reduce TR 4 steps. Each influence prevents 1 step.',
       revealedDelegate: PartyName.MARS,
       currentDelegate: PartyName.KELVINISTS,
-      renderData: RENDER_DATA,
+      renderData: CardRenderer.builder((b) => {
+        b.minus().text('4').tr(1).influence({size: Size.SMALL});
+      }),
     });
   }
   public resolve(game: IGame, turmoil: Turmoil) {

--- a/src/server/utils/server.ts
+++ b/src/server/utils/server.ts
@@ -1,3 +1,16 @@
 export function isProduction(): boolean {
   return process.env.NODE_ENV === 'production';
 }
+
+// Set once, by server.ts, when running as the live request-serving process
+// (never by build scripts like export_card_rendering.ts, or by tests).
+// Lets code skip work whose only consumer is that build script.
+let liveServer = false;
+
+export function markAsLiveServer(): void {
+  liveServer = true;
+}
+
+export function isLiveServer(): boolean {
+  return liveServer;
+}


### PR DESCRIPTION
ICardMetadata is not used for a running instance, so take the memory back.