### PR TITLE
Conditionally compress PostgreSQL data

### DIFF
--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -292,7 +292,7 @@ export class PostgreSQL implements IDatabase {
   // Purge unfinished games older than MAX_GAME_DAYS days. If this environment variable is absent, it uses the default of 10 days.
   async purgeUnfinishedGames(maxGameDays: string | undefined = process.env.MAX_GAME_DAYS): Promise<Array<GameId>> {
     const dateToSeconds = daysAgoToSeconds(maxGameDays, 10);
-    const selectResult = await this.client.query('SELECT DISTINCT game_id FROM games WHERE created_time < to_timestamp($1) AND status = \'running\'', [dateToSeconds]);
+    const selectResult = await this.client.query('SELECT game_id FROM game WHERE created_time < to_timestamp($1) AND status = \'running\'', [dateToSeconds]);
     let gameIds = selectResult.rows.map((row) => row.game_id);
     if (gameIds.length > 1000) {
       console.log('Truncated purge to 1000 games.');

--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -21,7 +21,7 @@ type StoredSerializedGame = Omit<SerializedGame, 'gameOptions' | 'gameLog'> & {l
 export const POSTGRESQL_TABLES = ['game', 'games', 'game_results', 'participants', 'completed_game', 'session'] as const;
 
 const POSTGRES_TRIM_COUNT = stringToNumber(process.env.POSTGRES_TRIM_COUNT, 10);
-const POSTGRES_COMPRESS_ON_WRITE = stringToBoolean(process.env.POSTGRES_COMPRESS_ON_WRITE, false);
+const DB_COMPRESS_ON_WRITE = stringToBoolean(process.env.DB_COMPRESS_ON_WRITE, false);
 
 // How often the (expensive) table/database size stats are actually recomputed. Scrapes that land
 // between refreshes just get the cached values.
@@ -60,6 +60,7 @@ const metrics = {
 
 export class PostgreSQL implements IDatabase {
   protected trimCount = POSTGRES_TRIM_COUNT;
+  protected compressOnWrite = DB_COMPRESS_ON_WRITE;
 
   protected statistics = {
     saveCount: 0,
@@ -373,7 +374,7 @@ export class PostgreSQL implements IDatabase {
     (storedSerialized as any).gameLog = [];
     (storedSerialized as any).gameOptions = {};
     const gameJSON = JSON.stringify(storedSerialized);
-    const gameCompressed = POSTGRES_COMPRESS_ON_WRITE ? compressToBrotli(gameJSON) : null;
+    const gameCompressed = this.compressOnWrite ? compressToBrotli(gameJSON) : null;
 
     this.statistics.saveCount++;
     try {
@@ -382,15 +383,15 @@ export class PostgreSQL implements IDatabase {
       // Holding onto a value avoids certain race conditions where saveGame is called twice in a row.
       const thisSaveId = game.lastSaveId;
       // xmax = 0 is described at https://stackoverflow.com/questions/39058213/postgresql-upsert-differentiate-inserted-and-updated-rows-using-system-columns-x
-      // Only game_compressed is written going forward; game is explicitly nulled so a
-      // row already carrying old plain-text data sheds it as soon as it's saved again.
-
+      //
+      // When compressOnWrite is true, the game state is written to game_compressed; when it's
+      // false, it's written to game. The other column is set to null so a row never carries both.
       const res = await this.client.query(
         `INSERT INTO games (game_id, save_id, game, game_compressed, players)
         VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT (game_id, save_id) DO UPDATE SET game = NULL, game_compressed = $3
+        ON CONFLICT (game_id, save_id) DO UPDATE SET game = $3, game_compressed = $4
         RETURNING (xmax = 0) AS inserted`,
-        [game.id, game.lastSaveId, POSTGRES_COMPRESS_ON_WRITE ? null : gameJSON, POSTGRES_COMPRESS_ON_WRITE ? gameCompressed : null, game.players.length]);
+        [game.id, game.lastSaveId, this.compressOnWrite ? null : gameJSON, this.compressOnWrite ? gameCompressed : null, game.players.length]);
 
       await this.client.query(
         `INSERT INTO game (game_id, log, options)

--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -5,7 +5,7 @@ import {IGame, Score} from '../IGame';
 import {GameOptions} from '../game/GameOptions';
 import {GameId, ParticipantId, isGameId, safeCast} from '../../common/Types';
 import {SerializedGame} from '../SerializedGame';
-import {daysAgoToSeconds, stringToNumber} from './utils';
+import {daysAgoToSeconds, stringToBoolean, stringToNumber} from './utils';
 import {GameIdLedger} from './IDatabase';
 import {Session, SessionId} from '../auth/Session';
 import {toID} from '../../common/utils/utils';
@@ -21,6 +21,7 @@ type StoredSerializedGame = Omit<SerializedGame, 'gameOptions' | 'gameLog'> & {l
 export const POSTGRESQL_TABLES = ['game', 'games', 'game_results', 'participants', 'completed_game', 'session'] as const;
 
 const POSTGRES_TRIM_COUNT = stringToNumber(process.env.POSTGRES_TRIM_COUNT, 10);
+const POSTGRES_COMPRESS_ON_WRITE = stringToBoolean(process.env.POSTGRES_COMPRESS_ON_WRITE, false);
 
 // How often the (expensive) table/database size stats are actually recomputed. Scrapes that land
 // between refreshes just get the cached values.
@@ -372,7 +373,7 @@ export class PostgreSQL implements IDatabase {
     (storedSerialized as any).gameLog = [];
     (storedSerialized as any).gameOptions = {};
     const gameJSON = JSON.stringify(storedSerialized);
-    const gameCompressed = compressToBrotli(gameJSON);
+    const gameCompressed = POSTGRES_COMPRESS_ON_WRITE ? compressToBrotli(gameJSON) : null;
 
     this.statistics.saveCount++;
     try {
@@ -383,12 +384,13 @@ export class PostgreSQL implements IDatabase {
       // xmax = 0 is described at https://stackoverflow.com/questions/39058213/postgresql-upsert-differentiate-inserted-and-updated-rows-using-system-columns-x
       // Only game_compressed is written going forward; game is explicitly nulled so a
       // row already carrying old plain-text data sheds it as soon as it's saved again.
+
       const res = await this.client.query(
         `INSERT INTO games (game_id, save_id, game, game_compressed, players)
-        VALUES ($1, $2, NULL, $3, $4)
+        VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (game_id, save_id) DO UPDATE SET game = NULL, game_compressed = $3
         RETURNING (xmax = 0) AS inserted`,
-        [game.id, game.lastSaveId, gameCompressed, game.players.length]);
+        [game.id, game.lastSaveId, POSTGRES_COMPRESS_ON_WRITE ? null : gameJSON, POSTGRES_COMPRESS_ON_WRITE ? gameCompressed : null, game.players.length]);
 
       await this.client.query(
         `INSERT INTO game (game_id, log, options)

--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -452,46 +452,6 @@ export class PostgreSQL implements IDatabase {
     }
   }
 
-  // // Not part of IDatabase: a one-off migration helper for converting existing games.game
-  // // (plain text) rows to games.game_compressed (Brotli). Intended to be driven by a
-  // // standalone tool, not called from application code.
-  // async migrateGameCompression(batchSize = 500): Promise<number> {
-  //   let converted = 0;
-  //   let cursor: {gameId: string; saveId: number} | undefined = undefined;
-  //   for (;;) {
-  //     const res: pg.QueryResult = cursor === undefined ?
-  //       await this.client.query(
-  //         `SELECT game_id, save_id, game FROM games
-  //          WHERE game IS NOT NULL AND game_compressed IS NULL
-  //          ORDER BY game_id, save_id
-  //          LIMIT $1`,
-  //         [batchSize]) :
-  //       await this.client.query(
-  //         `SELECT game_id, save_id, game FROM games
-  //          WHERE game IS NOT NULL AND game_compressed IS NULL
-  //          AND (game_id, save_id) > ($1, $2)
-  //          ORDER BY game_id, save_id
-  //          LIMIT $3`,
-  //         [cursor.gameId, cursor.saveId, batchSize]);
-  //     if (res.rows.length === 0) {
-  //       break;
-  //     }
-
-  //     for (const row of res.rows) {
-  //       const compressed = compressToBrotli(row.game);
-  //       await this.client.query(
-  //         'UPDATE games SET game_compressed = $1, game = NULL WHERE game_id = $2 AND save_id = $3',
-  //         [compressed, row.game_id, row.save_id]);
-  //       converted++;
-  //     }
-
-  //     const last = res.rows[res.rows.length - 1];
-  //     cursor = {gameId: last.game_id, saveId: last.save_id};
-  //     console.log(`Converted ${converted} rows so far...`);
-  //   }
-  //   return converted;
-  // }
-
   async deleteGameNbrSaves(gameId: GameId, rollbackCount: number): Promise<void> {
     if (rollbackCount <= 0) {
       console.error(`invalid rollback count for ${gameId}: ${rollbackCount}`);

--- a/src/server/database/PostgreSQL.ts
+++ b/src/server/database/PostgreSQL.ts
@@ -14,6 +14,7 @@ import {ThrottledCache} from './ThrottledCache';
 import {Clock} from '@/common/Timer';
 import {parseInterned} from './parseInterned';
 import {LogMessage} from '@/common/logs/LogMessage';
+import {compressToBrotli, decompressFromBrotli} from './compression';
 
 type StoredSerializedGame = Omit<SerializedGame, 'gameOptions' | 'gameLog'> & {logLength: number};
 
@@ -103,6 +104,7 @@ export class PostgreSQL implements IDatabase {
       players integer,
       save_id integer,
       game text,
+      game_compressed bytea,
       status text default 'running',
       created_time timestamp default now(),
       PRIMARY KEY (game_id, save_id));
@@ -149,6 +151,10 @@ export class PostgreSQL implements IDatabase {
     CREATE INDEX IF NOT EXISTS session_idx_expiration_time on session(expiration_time);
     `;
     await this.client.query(sql);
+
+    // games.game_compressed is already in the CREATE TABLE above for fresh databases;
+    // this covers databases where the table already existed without it.
+    await this.client.query('ALTER TABLE games ADD COLUMN IF NOT EXISTS game_compressed bytea;');
   }
 
   public async getPlayerCount(gameId: GameId): Promise<number> {
@@ -173,6 +179,19 @@ export class PostgreSQL implements IDatabase {
     ORDER BY created_time DESC`;
     const res = await this.client.query(sql);
     return res.rows.map((row) => row.game_id);
+  }
+
+  // game_compressed is the new format (Brotli-compressed JSON); game is the old
+  // plain-text format, kept for rows not yet migrated. New writes only populate
+  // game_compressed, so at most one of the two is ever set for a given row.
+  private resolveGameText(row: {game: string | null; game_compressed: Buffer | null}): string {
+    if (row.game_compressed !== null) {
+      return decompressFromBrotli(row.game_compressed);
+    }
+    if (row.game !== null) {
+      return row.game;
+    }
+    throw new Error('games row has neither game nor game_compressed set');
   }
 
   private compose(game: string, log: string, options: string): SerializedGame {
@@ -214,6 +233,7 @@ export class PostgreSQL implements IDatabase {
     const res = await this.client.query(
       `SELECT
         games.game as game,
+        games.game_compressed as game_compressed,
         game.log as log,
         game.options as options
       FROM games
@@ -227,13 +247,14 @@ export class PostgreSQL implements IDatabase {
       throw new Error(`Game ${gameId} not found`);
     }
     const row = res.rows[0];
-    return this.compose(row.game, row.log, row.options);
+    return this.compose(this.resolveGameText(row), row.log, row.options);
   }
 
   async getGameVersion(gameId: GameId, saveId: number): Promise<SerializedGame> {
     const res = await this.client.query(
       `SELECT
         games.game as game,
+        games.game_compressed as game_compressed,
         game.log as log,
         game.options as options
       FROM games
@@ -247,7 +268,7 @@ export class PostgreSQL implements IDatabase {
       throw new Error(`Game ${gameId} not found at save_id ${saveId}`);
     }
     const row = res.rows[0];
-    return this.compose(row.game, row.log, row.options);
+    return this.compose(this.resolveGameText(row), row.log, row.options);
   }
 
   // Not part of IDatabase: void/callback-based, so MetricsDelegate can't observe its completion or
@@ -351,6 +372,7 @@ export class PostgreSQL implements IDatabase {
     (storedSerialized as any).gameLog = [];
     (storedSerialized as any).gameOptions = {};
     const gameJSON = JSON.stringify(storedSerialized);
+    const gameCompressed = compressToBrotli(gameJSON);
 
     this.statistics.saveCount++;
     try {
@@ -359,12 +381,14 @@ export class PostgreSQL implements IDatabase {
       // Holding onto a value avoids certain race conditions where saveGame is called twice in a row.
       const thisSaveId = game.lastSaveId;
       // xmax = 0 is described at https://stackoverflow.com/questions/39058213/postgresql-upsert-differentiate-inserted-and-updated-rows-using-system-columns-x
+      // Only game_compressed is written going forward; game is explicitly nulled so a
+      // row already carrying old plain-text data sheds it as soon as it's saved again.
       const res = await this.client.query(
-        `INSERT INTO games (game_id, save_id, game, players)
-        VALUES ($1, $2, $3, $4)
-        ON CONFLICT (game_id, save_id) DO UPDATE SET game = $3
+        `INSERT INTO games (game_id, save_id, game, game_compressed, players)
+        VALUES ($1, $2, NULL, $3, $4)
+        ON CONFLICT (game_id, save_id) DO UPDATE SET game = NULL, game_compressed = $3
         RETURNING (xmax = 0) AS inserted`,
-        [game.id, game.lastSaveId, gameJSON, game.players.length]);
+        [game.id, game.lastSaveId, gameCompressed, game.players.length]);
 
       await this.client.query(
         `INSERT INTO game (game_id, log, options)
@@ -424,6 +448,46 @@ export class PostgreSQL implements IDatabase {
         'DELETE FROM games WHERE game_id = $1 AND save_id > 0 AND save_id < $2', [game.id, maxSaveId]);
     }
   }
+
+  // // Not part of IDatabase: a one-off migration helper for converting existing games.game
+  // // (plain text) rows to games.game_compressed (Brotli). Intended to be driven by a
+  // // standalone tool, not called from application code.
+  // async migrateGameCompression(batchSize = 500): Promise<number> {
+  //   let converted = 0;
+  //   let cursor: {gameId: string; saveId: number} | undefined = undefined;
+  //   for (;;) {
+  //     const res: pg.QueryResult = cursor === undefined ?
+  //       await this.client.query(
+  //         `SELECT game_id, save_id, game FROM games
+  //          WHERE game IS NOT NULL AND game_compressed IS NULL
+  //          ORDER BY game_id, save_id
+  //          LIMIT $1`,
+  //         [batchSize]) :
+  //       await this.client.query(
+  //         `SELECT game_id, save_id, game FROM games
+  //          WHERE game IS NOT NULL AND game_compressed IS NULL
+  //          AND (game_id, save_id) > ($1, $2)
+  //          ORDER BY game_id, save_id
+  //          LIMIT $3`,
+  //         [cursor.gameId, cursor.saveId, batchSize]);
+  //     if (res.rows.length === 0) {
+  //       break;
+  //     }
+
+  //     for (const row of res.rows) {
+  //       const compressed = compressToBrotli(row.game);
+  //       await this.client.query(
+  //         'UPDATE games SET game_compressed = $1, game = NULL WHERE game_id = $2 AND save_id = $3',
+  //         [compressed, row.game_id, row.save_id]);
+  //       converted++;
+  //     }
+
+  //     const last = res.rows[res.rows.length - 1];
+  //     cursor = {gameId: last.game_id, saveId: last.save_id};
+  //     console.log(`Converted ${converted} rows so far...`);
+  //   }
+  //   return converted;
+  // }
 
   async deleteGameNbrSaves(gameId: GameId, rollbackCount: number): Promise<void> {
     if (rollbackCount <= 0) {

--- a/src/server/database/compression.ts
+++ b/src/server/database/compression.ts
@@ -1,0 +1,17 @@
+import zlib from 'zlib';
+
+// Quality 6 measured as the sweet spot: near-best compression ratio at
+// single-digit-to-tens-of-ms latency, even on the largest game snapshots.
+const BROTLI_QUALITY = 6;
+
+export function compressToBrotli(text: string): Buffer {
+  return zlib.brotliCompressSync(Buffer.from(text, 'utf8'), {
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY,
+    },
+  });
+}
+
+export function decompressFromBrotli(buf: Buffer): string {
+  return zlib.brotliDecompressSync(buf).toString('utf8');
+}

--- a/src/server/database/utils.ts
+++ b/src/server/database/utils.ts
@@ -15,8 +15,25 @@ export function dateToSeconds(date: Date) {
 }
 
 export function stringToNumber(s: string | undefined, defaultValue: number): number {
-  const parsed = parseInt(s || '');
+  if (s === undefined) {
+    return defaultValue;
+  }
+  const parsed = parseInt(s);
   return Number.isInteger(parsed) ? parsed : defaultValue;
+}
+
+export function stringToBoolean(s: string | undefined, defaultValue: boolean): boolean {
+  if (s === undefined) {
+    return defaultValue;
+  }
+  if (s === 'true') {
+    return true;
+  }
+  if (s === 'false') {
+    return false;
+  }
+  const parsed = parseInt(s);
+  return Number.isInteger(parsed) ? parsed > 0 : defaultValue;
 }
 
 export function daysAgoToSeconds(dayString: string | undefined, defaultValue: number): number {

--- a/tests/database/databaseSuite.ts
+++ b/tests/database/databaseSuite.ts
@@ -302,6 +302,28 @@ export function describeDatabaseSuite<T extends ITestDatabase>(dtor: DatabaseTes
       await expect(db.getGameVersion('game-id-123', 0)).to.be.rejectedWith(/Game game-id-123 not found/);
     });
 
+    it('saveGame updates in place when re-saving an existing saveId', async () => {
+      const player = TestPlayer.BLACK.newPlayer();
+      const game = Game.newInstance('game-id', [player], player, 'spectatorid');
+      await db.lastSaveGamePromise;
+      expect(game.lastSaveId).eq(1);
+
+      // A normal save at a fresh saveId (1).
+      player.megaCredits = 100;
+      await db.saveGame(game);
+      expect(await db.getSaveIds(game.id)).has.members([0, 1]);
+      expect((await db.getGameVersion(game.id, 1)).players[0].megaCredits).eq(100);
+
+      // Re-save the same saveId (1) with a changed value. This is the upsert / ON CONFLICT
+      // path: the existing row is updated in place rather than adding a new save, and the
+      // updated value reads back.
+      player.megaCredits = 200;
+      game.lastSaveId = 1;
+      await db.saveGame(game);
+      expect(await db.getSaveIds(game.id)).has.members([0, 1]);
+      expect((await db.getGameVersion(game.id, 1)).players[0].megaCredits).eq(200);
+    });
+
     it('participantIds', async () => {
       expect(await db.getParticipants()).is.empty;
       testGame(2, {}, '1');

--- a/tests/integration/PostgreSQL.spec.ts
+++ b/tests/integration/PostgreSQL.spec.ts
@@ -33,6 +33,8 @@ class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
       host: 'localhost',
       password: process.env.POSTGRES_INTEGRATION_TEST_PASSWORD,
     });
+    // Overwrite compression.
+    this.compressOnWrite = true;
   }
 
   // Tests can wait for saveGamePromise since save() is called inside other methods.
@@ -49,6 +51,10 @@ class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
 
   public setTrimCount(trimCount: number) {
     this.trimCount = trimCount;
+  }
+
+  public setCompressOnWrite(compressOnWrite: boolean) {
+    this.compressOnWrite = compressOnWrite;
   }
 
   public async afterEach() {
@@ -96,6 +102,13 @@ class TestPostgreSQL extends PostgreSQL implements ITestDatabase {
   // `game` and `participants` rows behind.
   public async deleteGamesRows(gameId: GameId): Promise<void> {
     await this.client.query('DELETE FROM games WHERE game_id = $1', [gameId]);
+  }
+
+  // Reads the two raw storage columns for a single save so tests can assert which
+  // representation (plain-text `game` vs. compressed `game_compressed`) is populated.
+  public async getRawGame(gameId: GameId, saveId: number): Promise<{game: string | null, gameCompressed: Buffer | null}> {
+    const res = await this.client.query('SELECT game, game_compressed FROM games WHERE game_id = $1 AND save_id = $2', [gameId, saveId]);
+    return {game: res.rows[0].game, gameCompressed: res.rows[0].game_compressed};
   }
 }
 
@@ -663,6 +676,96 @@ describeDatabaseSuite({
 
       await db.saveGame(game);
       expect(await db.getSaveIds(game.id)).has.members(range(3));
+    });
+
+    // Verifies that each save lands in the column matching compressOnWrite, and that a row
+    // reads back correctly even when its stored format doesn't match the current setting.
+    it('saveGame on conflict swaps between plain-text and compressed storage', async () => {
+      const db = dbFactory();
+
+      // Save the game uncompressed: the plain-text `game` column is populated and
+      // `game_compressed` is empty.
+      db.setCompressOnWrite(false);
+      const player = TestPlayer.BLACK.newPlayer();
+      const game = Game.newInstance('game-id-conflict', [player], player, 'spectatorid');
+      await db.awaitAllSaves();
+
+      let raw = await db.getRawGame(game.id, 0);
+      expect(raw.game).is.not.null;
+      expect(raw.gameCompressed).is.null;
+
+      // Resave save_id 0 with compression on. This is the ON CONFLICT DO UPDATE path:
+      // `game` is cleared and `game_compressed` is populated with the new value.
+      db.setCompressOnWrite(true);
+      player.megaCredits = 123;
+      game.lastSaveId = 0;
+      await db.saveGame(game);
+
+      expect(await db.getSaveIds(game.id)).has.members([0]);
+      raw = await db.getRawGame(game.id, 0);
+      expect(raw.game).is.null;
+      expect(raw.gameCompressed).is.not.null;
+      const compressed = await db.getGameVersion(game.id, 0);
+      expect(compressed.players[0].megaCredits).eq(123);
+
+      // Resave save_id 0 again, uncompressed. The conflict path now clears
+      // `game_compressed` and repopulates `game`.
+      db.setCompressOnWrite(false);
+      player.megaCredits = 456;
+      game.lastSaveId = 0;
+      await db.saveGame(game);
+
+      raw = await db.getRawGame(game.id, 0);
+      expect(raw.game).is.not.null;
+      expect(raw.gameCompressed).is.null;
+      const plain = await db.getGameVersion(game.id, 0);
+      expect(plain.players[0].megaCredits).eq(456);
+    });
+
+    it('reads an uncompressed row while compression is enabled', async () => {
+      const db = dbFactory();
+
+      // Write the row uncompressed.
+      db.setCompressOnWrite(false);
+      const player = TestPlayer.BLACK.newPlayer();
+      const game = Game.newInstance('game-id-read-uncompressed', [player], player, 'spectatorid');
+      await db.awaitAllSaves();
+      const saveId = game.lastSaveId;
+      player.megaCredits = 87;
+      await db.saveGame(game);
+
+      // Confirm it really was stored as plain text.
+      const raw = await db.getRawGame(game.id, saveId);
+      expect(raw.game).is.not.null;
+      expect(raw.gameCompressed).is.null;
+
+      // Turn compression on. The read path must still decode the older uncompressed row.
+      db.setCompressOnWrite(true);
+      const serialized = await db.getGameVersion(game.id, saveId);
+      expect(serialized.players[0].megaCredits).eq(87);
+    });
+
+    it('reads a compressed row after compression is disabled', async () => {
+      const db = dbFactory();
+
+      // Write the row compressed.
+      db.setCompressOnWrite(true);
+      const player = TestPlayer.BLACK.newPlayer();
+      const game = Game.newInstance('game-id-read-compressed', [player], player, 'spectatorid');
+      await db.awaitAllSaves();
+      const saveId = game.lastSaveId;
+      player.megaCredits = 91;
+      await db.saveGame(game);
+
+      // Confirm it really was stored compressed.
+      const raw = await db.getRawGame(game.id, saveId);
+      expect(raw.game).is.null;
+      expect(raw.gameCompressed).is.not.null;
+
+      // Turn compression off. The read path must still decompress the older compressed row.
+      db.setCompressOnWrite(false);
+      const serialized = await db.getGameVersion(game.id, saveId);
+      expect(serialized.players[0].megaCredits).eq(91);
     });
   },
 });


### PR DESCRIPTION
This compression mechanism is more efficient that PostgreSQL's default compression for these JSON strings. Reduced storage stats are on another machine, hopefully I can update them later.