### PR TITLE
Remove Counter.start attribute.

### DIFF
--- a/src/server/behavior/Countable.ts
+++ b/src/server/behavior/Countable.ts
@@ -7,9 +7,6 @@ import {NoAttributes} from './NoAttributes';
  * Describes something that can be counted.
  */
 export type _Countable = {
-  /** An initial value for the countable. e.g. { start: 10 } returns 10. */
-  start?: number;
-
   /**
    * Count the number of tags on the players' played cards.
    *

--- a/src/server/behavior/Counter.ts
+++ b/src/server/behavior/Counter.ts
@@ -76,7 +76,7 @@ export class Counter {
       return countable;
     }
 
-    let sum = countable.start ?? 0;
+    let sum = 0;
 
     const player = this.player;
     const card = this.card;

--- a/tests/behavior/Counter.spec.ts
+++ b/tests/behavior/Counter.spec.ts
@@ -34,12 +34,6 @@ describe('Counter', () => {
     expect(counter.count(8)).eq(8);
   });
 
-  it('start', () => {
-    const counter = new Counter(player, fakeCard());
-    expect(counter.count({start: 3})).eq(3);
-    expect(counter.count({start: 3, each: 7})).eq(21);
-  });
-
   it('tags, simple', () => {
     player.tagsForTest = {building: 2, space: 3, moon: 7};
     const counter = new Counter(player, fakeCard());


### PR DESCRIPTION
This was part of the Underworld V1 for Space Wargames, and is no longer required.