### PR TITLE
Share the first and second place ranking walk

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -134,6 +134,27 @@ export function zip<S, T>(first: ReadonlyArray<S>, second: ReadonlyArray<T>): Ar
 }
 
 /**
+ * Groups items by score, highest first: the first tier holds everything tied for first
+ * place, the second tier everything tied for second place, and so on.
+ *
+ * `scorer` is called once per item.
+ */
+export function rankedTiers<T>(items: ReadonlyArray<T>, scorer: (item: T) => number): Array<{score: number, items: Array<T>}> {
+  const scored = items.map((item) => ({item, score: scorer(item)}));
+  scored.sort((a, b) => b.score - a.score);
+  const tiers: Array<{score: number, items: Array<T>}> = [];
+  for (const {item, score} of scored) {
+    const tier = tiers[tiers.length - 1];
+    if (tier !== undefined && tier.score === score) {
+      tier.items.push(item);
+    } else {
+      tiers.push({score, items: [item]});
+    }
+  }
+  return tiers;
+}
+
+/**
  * Returns `elem` if it is an array. If it is not an array, returns `[elem]`
  */
 export function asArray<T>(elem: OneOrArray<T>): Array<T> {

--- a/src/server/game/calculateVictoryPoints.ts
+++ b/src/server/game/calculateVictoryPoints.ts
@@ -6,6 +6,7 @@ import {PathfindersExpansion} from '../pathfinders/PathfindersExpansion';
 import {DeltaProjectExpansion} from '../delta/DeltaProjectExpansion';
 import {Turmoil} from '../turmoil/Turmoil';
 import {VictoryPointsBreakdownBuilder} from './VictoryPointsBreakdownBuilder';
+import {rankedTiers} from '../../common/utils/utils';
 import {FundedAward} from '../awards/FundedAward';
 import {AwardScorer} from '../awards/AwardScorer';
 import {CardName} from '../../common/cards/CardName';
@@ -125,33 +126,21 @@ function giveAwards(player: IPlayer, builder: VictoryPointsBreakdownBuilder) {
   player.game.fundedAwards.forEach((fundedAward) => {
     const award = fundedAward.award;
     const scorer = new AwardScorer(player.game, award);
-    const players: Array<IPlayer> = player.game.players.slice();
-    players.sort((p1, p2) => scorer.get(p2) - scorer.get(p1));
+    const players = player.game.players;
+    const [first, second] = rankedTiers(players, (p) => scorer.get(p));
 
-    // There is one rank 1 player
-    if (scorer.get(players[0]) > scorer.get(players[1])) {
-      maybeSetVP(player, players[0], fundedAward, 5, '1st', builder);
-      players.shift();
-
-      if (players.length > 1) {
-        // There is one rank 2 player
-        if (scorer.get(players[0]) > scorer.get(players[1])) {
-          maybeSetVP(player, players[0], fundedAward, 2, '2nd', builder);
-        } else {
-          // There are at least two rank 2 players
-          const score = scorer.get(players[0]);
-          while (players.length > 0 && scorer.get(players[0]) === score) {
-            maybeSetVP(player, players[0], fundedAward, 2, '2nd', builder);
-            players.shift();
-          }
+    if (first.items.length === 1) {
+      maybeSetVP(player, first.items[0], fundedAward, 5, '1st', builder);
+      // Second place is not awarded in 2 player games.
+      if (players.length > 2 && second !== undefined) {
+        for (const p of second.items) {
+          maybeSetVP(player, p, fundedAward, 2, '2nd', builder);
         }
       }
     } else {
-      // There are at least two rank 1 players
-      const score = scorer.get(players[0]);
-      while (players.length > 0 && scorer.get(players[0]) === score) {
-        maybeSetVP(player, players[0], fundedAward, 5, '1st', builder);
-        players.shift();
+      // A tie for first place is friendly, and takes the second place award with it.
+      for (const p of first.items) {
+        maybeSetVP(player, p, fundedAward, 5, '1st', builder);
       }
     }
   });

--- a/src/server/turmoil/globalEvents/Election.ts
+++ b/src/server/turmoil/globalEvents/Election.ts
@@ -9,6 +9,7 @@ import {IPlayer} from '../../IPlayer';
 import {Board} from '../../boards/Board';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
+import {rankedTiers} from '../../../common/utils/utils';
 
 export class Election extends GlobalEvent implements IGlobalEvent {
   constructor() {
@@ -37,36 +38,19 @@ export class Election extends GlobalEvent implements IGlobalEvent {
         player.increaseTerraformRating(1, {log: true});
       }
     } else {
-      const players = game.players.slice().sort(
-        (p1, p2) => this.getScore(p2, turmoil, game) - this.getScore(p1, turmoil, game),
-      );
+      const [first, second] = rankedTiers(game.players, (player) => this.getScore(player, turmoil, game));
 
-      // We have one rank 1 player
-      if (this.getScore(players[0], turmoil, game) > this.getScore(players[1], turmoil, game)) {
-        players[0].increaseTerraformRating(2, {log: true});
-        players.shift();
-
-        if (players.length === 1) {
-          players[0].increaseTerraformRating(1, {log: true});
-        } else if (players.length > 1) {
-          // We have one rank 2 player
-          if (this.getScore(players[0], turmoil, game) > this.getScore(players[1], turmoil, game)) {
-            players[0].increaseTerraformRating(1, {log: true});
-            // We have at least two rank 2 players
-          } else {
-            const score = this.getScore(players[0], turmoil, game);
-            while (players.length > 0 && this.getScore(players[0], turmoil, game) === score) {
-              players[0].increaseTerraformRating(1, {log: true});
-              players.shift();
-            }
+      if (first.items.length === 1) {
+        first.items[0].increaseTerraformRating(2, {log: true});
+        if (second !== undefined) {
+          for (const player of second.items) {
+            player.increaseTerraformRating(1, {log: true});
           }
         }
-        // We have at least two rank 1 players
       } else {
-        const score = this.getScore(players[0], turmoil, game);
-        while (players.length > 0 && this.getScore(players[0], turmoil, game) === score) {
-          players[0].increaseTerraformRating(2, {log: true});
-          players.shift();
+        // A tie for first place is friendly, and takes the second place prize with it.
+        for (const player of first.items) {
+          player.increaseTerraformRating(2, {log: true});
         }
       }
     }

--- a/src/server/turmoil/globalEvents/Revolution.ts
+++ b/src/server/turmoil/globalEvents/Revolution.ts
@@ -8,6 +8,7 @@ import {Tag} from '../../../common/cards/Tag';
 import {IPlayer} from '../../IPlayer';
 import {CardRenderer} from '../../cards/render/CardRenderer';
 import {Size} from '../../../common/cards/render/Size';
+import {rankedTiers} from '../../../common/utils/utils';
 
 export class Revolution extends GlobalEvent implements IGlobalEvent {
   constructor() {
@@ -30,40 +31,19 @@ export class Revolution extends GlobalEvent implements IGlobalEvent {
         game.playersInGenerationOrder[0].decreaseTerraformRating(2, {log: true});
       }
     } else {
-      const players = [...game.playersInGenerationOrder].sort(
-        (p1, p2) => this.getScore(p2, turmoil) - this.getScore(p1, turmoil),
-      );
+      const [first, second] = rankedTiers(game.playersInGenerationOrder, (player) => this.getScore(player, turmoil));
 
-      // We have one rank 1 player
-      if (this.getScore(players[0], turmoil) > this.getScore(players[1], turmoil)) {
-        players[0].decreaseTerraformRating(2, {log: true});
-        players.shift();
-
-        if (players.length === 1 && this.getScore(players[0], turmoil) > 0) {
-          players[0].decreaseTerraformRating(1, {log: true});
-        } else if (players.length > 1) {
-          // We have one rank 2 player
-          if (this.getScore(players[0], turmoil) > this.getScore(players[1], turmoil)) {
-            players[0].decreaseTerraformRating(1, {log: true});
-            // We have at least two rank 2 players
-          } else {
-            const score = this.getScore(players[0], turmoil);
-            while (players.length > 0 && this.getScore(players[0], turmoil) === score) {
-              if (this.getScore(players[0], turmoil) > 0) {
-                players[0].decreaseTerraformRating(1, {log: true});
-              }
-              players.shift();
-            }
+      if (first.items.length === 1) {
+        first.items[0].decreaseTerraformRating(2, {log: true});
+        if (second !== undefined && second.score > 0) {
+          for (const player of second.items) {
+            player.decreaseTerraformRating(1, {log: true});
           }
         }
-        // We have at least two rank 1 players
-      } else {
-        const score = this.getScore(players[0], turmoil);
-        while (players.length > 0 && this.getScore(players[0], turmoil) === score) {
-          if (this.getScore(players[0], turmoil) > 0) {
-            players[0].decreaseTerraformRating(2, {log: true});
-          }
-          players.shift();
+      } else if (first.score > 0) {
+        // A tie for first place is friendly, and takes the second place penalty with it.
+        for (const player of first.items) {
+          player.decreaseTerraformRating(2, {log: true});
         }
       }
     }

--- a/tests/common/utils/utils.spec.ts
+++ b/tests/common/utils/utils.spec.ts
@@ -68,6 +68,27 @@ describe('utils', () => {
     ]);
   });
 
+  it('rankedTiers', () => {
+    expect(utils.rankedTiers([], (n: number) => n)).deep.eq([]);
+    expect(utils.rankedTiers(['a'], () => 4)).deep.eq([
+      {score: 4, items: ['a']},
+    ]);
+    expect(utils.rankedTiers(['a', 'b', 'c', 'd'], (s) => s.charCodeAt(0))).deep.eq([
+      {score: 100, items: ['d']},
+      {score: 99, items: ['c']},
+      {score: 98, items: ['b']},
+      {score: 97, items: ['a']},
+    ]);
+    expect(utils.rankedTiers([1, 2, 2, 3, 1], (n) => n)).deep.eq([
+      {score: 3, items: [3]},
+      {score: 2, items: [2, 2]},
+      {score: 1, items: [1, 1]},
+    ]);
+    expect(utils.rankedTiers(['x', 'y'], () => 0)).deep.eq([
+      {score: 0, items: ['x', 'y']},
+    ]);
+  });
+
   it('oneWayDifference', () => {
     expect(utils.oneWayDifference([], [])).is.empty;
     expect(utils.oneWayDifference([1], [1])).is.empty;

--- a/tests/game/calculateVictoryPoints.spec.ts
+++ b/tests/game/calculateVictoryPoints.spec.ts
@@ -1,0 +1,27 @@
+import {expect} from 'chai';
+import {testGame} from '../TestGame';
+import {Banker} from '../../src/server/awards/Banker';
+import {Resource} from '../../src/common/Resource';
+
+describe('calculateVictoryPoints', () => {
+  it('with two players, second place scores no award points', () => {
+    const [game, player, player2] = testGame(2);
+    game.fundAward(player, new Banker());
+    player.production.add(Resource.MEGACREDITS, 7);
+    player2.production.add(Resource.MEGACREDITS, 10);
+
+    expect(player2.getVictoryPoints().awards).to.eq(5);
+    expect(player.getVictoryPoints().awards).to.eq(0);
+  });
+
+  it('with three players, second place scores 2 award points', () => {
+    const [game, player, player2, player3] = testGame(3);
+    game.fundAward(player, new Banker());
+    player.production.add(Resource.MEGACREDITS, 7);
+    player2.production.add(Resource.MEGACREDITS, 10);
+
+    expect(player2.getVictoryPoints().awards).to.eq(5);
+    expect(player.getVictoryPoints().awards).to.eq(2);
+    expect(player3.getVictoryPoints().awards).to.eq(0);
+  });
+});

--- a/tests/globalEvents/Election.spec.ts
+++ b/tests/globalEvents/Election.spec.ts
@@ -31,6 +31,35 @@ describe('Election', () => {
   });
 
 
+  it('a tie for first place gives every tied player 2 TR and skips second place', () => {
+    const card = new Election();
+    const [game, player, player2, player3] = testGame(3, {turmoilExtension: true});
+    const turmoil = game.turmoil!;
+    turmoil.initGlobalEvent(game);
+    player.tagsForTest = {building: 3};
+    player2.tagsForTest = {building: 3};
+    player3.tagsForTest = {building: 1};
+
+    card.resolve(game);
+
+    expect(player.terraformRating).to.eq(22);
+    expect(player2.terraformRating).to.eq(22);
+    expect(player3.terraformRating).to.eq(20);
+  });
+
+  it('with two players, second place gets 1 TR', () => {
+    const card = new Election();
+    const [game, player, player2] = testGame(2, {turmoilExtension: true});
+    const turmoil = game.turmoil!;
+    turmoil.initGlobalEvent(game);
+    player.tagsForTest = {building: 2};
+
+    card.resolve(game);
+
+    expect(player.terraformRating).to.eq(22);
+    expect(player2.terraformRating).to.eq(21);
+  });
+
   it('solo play', () => {
     const card = new Election();
     const [game, player] = testGame(1, {turmoilExtension: true});

--- a/tests/globalEvents/Revolution.spec.ts
+++ b/tests/globalEvents/Revolution.spec.ts
@@ -40,4 +40,16 @@ describe('Revolution', () => {
     expect(player.terraformRating).to.eq(20);
     expect(player2.terraformRating).to.eq(18);
   });
+
+  it('a tie for first place costs every tied player 2 TR', () => {
+    // Two influence come with player2's chairman and party leader seats, so three Earth
+    // tags against one make the scores equal.
+    player.tagsForTest = {earth: 3};
+    player2.tagsForTest = {earth: 1};
+    expect(card.getScore(player, turmoil)).to.eq(card.getScore(player2, turmoil));
+
+    card.resolve(game);
+    expect(player.terraformRating).to.eq(18);
+    expect(player2.terraformRating).to.eq(18);
+  });
 });


### PR DESCRIPTION
Election, Revolution and the award scoring each carry their own copy of the same walk: sort players by score, prize for first place, prize for second, ties are friendly. This pulls the grouping into `rankedTiers` in utils and refits the three sites. The old loops also recomputed each score on every comparison, the helper calls the scorer once per player.

Adds the tests the walk was missing: a tie for first in both global events, Election with two players, and a small `calculateVictoryPoints` spec proving two player games award no second place, which nothing covered before.

Follows kberg's note in #8209 that we rank items by score in more than one place.
