### PR TITLE
Use @tests/ as an import path.

### DIFF
--- a/tests/cards/base/AcquiredCompany.spec.ts
+++ b/tests/cards/base/AcquiredCompany.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
-import {testGame} from '../../TestGame';
-import {AcquiredCompany} from '../../../src/server/cards/base/AcquiredCompany';
+import {testGame} from '@tests/TestGame';
+import {AcquiredCompany} from '@/server/cards/base/AcquiredCompany';
 
 describe('AcquiredCompany', () => {
   it('Should play', () => {

--- a/tests/cards/base/AdaptationTechnology.spec.ts
+++ b/tests/cards/base/AdaptationTechnology.spec.ts
@@ -1,12 +1,12 @@
 import {expect} from 'chai';
-import {testGame} from '../../TestGame';
-import {AdaptationTechnology} from '../../../src/server/cards/base/AdaptationTechnology';
-import {OpenCity} from '../../../src/server/cards/base/OpenCity';
-import {Resource} from '../../../src/common/Resource';
-import {setOxygenLevel} from '../../TestingUtils';
-import {TestPlayer} from '../../TestPlayer';
-import {IGame} from '../../../src/server/IGame';
-import {GlobalParameter} from '../../../src/common/GlobalParameter';
+import {testGame} from '@tests/TestGame';
+import {AdaptationTechnology} from '@/server/cards/base/AdaptationTechnology';
+import {OpenCity} from '@/server/cards/base/OpenCity';
+import {Resource} from '@/common/Resource';
+import {setOxygenLevel} from '@tests/TestingUtils';
+import {TestPlayer} from '@tests/TestPlayer';
+import {IGame} from '@/server/IGame';
+import {GlobalParameter} from '@/common/GlobalParameter';
 
 describe('AdaptationTechnology', () => {
   let adaptationTechnology: AdaptationTechnology;

--- a/tests/cards/base/AdaptedLichen.spec.ts
+++ b/tests/cards/base/AdaptedLichen.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
-import {testGame} from '../../TestGame';
-import {AdaptedLichen} from '../../../src/server/cards/base/AdaptedLichen';
+import {testGame} from '@tests/TestGame';
+import {AdaptedLichen} from '@/server/cards/base/AdaptedLichen';
 
 describe('AdaptedLichen', () => {
   it('Should play', () => {

--- a/tests/cards/base/AdvancedAlloys.spec.ts
+++ b/tests/cards/base/AdvancedAlloys.spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
-import {AdvancedAlloys} from '../../../src/server/cards/base/AdvancedAlloys';
-import {testGame} from '../../TestGame';
+import {AdvancedAlloys} from '@/server/cards/base/AdvancedAlloys';
+import {testGame} from '@tests/TestGame';
 
 describe('AdvancedAlloys', () => {
   it('Should play', () => {

--- a/tests/cards/base/AdvancedEcosystems.spec.ts
+++ b/tests/cards/base/AdvancedEcosystems.spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
-import {AdvancedEcosystems} from '../../../src/server/cards/base/AdvancedEcosystems';
-import {TestPlayer} from '../../TestPlayer';
-import {Tardigrades} from '../../../src/server/cards/base/Tardigrades';
-import {TundraFarming} from '../../../src/server/cards/base/TundraFarming';
-import {ResearchCoordination} from '../../../src/server/cards/prelude/ResearchCoordination';
-import {ResearchNetwork} from '../../../src/server/cards/prelude/ResearchNetwork';
+import {AdvancedEcosystems} from '@/server/cards/base/AdvancedEcosystems';
+import {TestPlayer} from '@tests/TestPlayer';
+import {Tardigrades} from '@/server/cards/base/Tardigrades';
+import {TundraFarming} from '@/server/cards/base/TundraFarming';
+import {ResearchCoordination} from '@/server/cards/prelude/ResearchCoordination';
+import {ResearchNetwork} from '@/server/cards/prelude/ResearchNetwork';
 
 describe('AdvancedEcosystems', () => {
   let card: AdvancedEcosystems;

--- a/tests/client/components/AdjacencyBonus.spec.ts
+++ b/tests/client/components/AdjacencyBonus.spec.ts
@@ -1,6 +1,6 @@
 import {shallowMount} from '@vue/test-utils';
 import {expect} from 'chai';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 import AdjacencyBonus from '@/client/components/AdjacencyBonus.vue';
 import {TileType} from '@/common/TileType';
 

--- a/tests/client/components/AndOptions.spec.ts
+++ b/tests/client/components/AndOptions.spec.ts
@@ -1,6 +1,6 @@
 
 import {mount} from '@vue/test-utils';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 
 import {expect} from 'chai';
 import AndOptions from '@/client/components/AndOptions.vue';

--- a/tests/client/components/App.spec.ts
+++ b/tests/client/components/App.spec.ts
@@ -1,6 +1,6 @@
 import {shallowMount} from '@vue/test-utils';
 import {expect} from 'chai';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 import App from '@/client/components/App.vue';
 
 describe('App', () => {

--- a/tests/client/components/Award.spec.ts
+++ b/tests/client/components/Award.spec.ts
@@ -1,5 +1,5 @@
 import {mount} from '@vue/test-utils';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 import {expect} from 'chai';
 import Award from '@/client/components/Award.vue';
 import {FundedAwardModel} from '@/common/models/FundedAwardModel';

--- a/tests/client/components/Awards.spec.ts
+++ b/tests/client/components/Awards.spec.ts
@@ -1,6 +1,6 @@
 
 import {shallowMount, mount} from '@vue/test-utils';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 import {expect} from 'chai';
 import Awards from '@/client/components/Awards.vue';
 import Award from '@/client/components/Award.vue';

--- a/tests/client/components/Bonus.spec.ts
+++ b/tests/client/components/Bonus.spec.ts
@@ -1,6 +1,6 @@
 import {shallowMount} from '@vue/test-utils';
 import {expect} from 'chai';
-import {globalConfig} from './getLocalVue';
+import {globalConfig} from '@tests/client/components/getLocalVue';
 import Bonus from '@/client/components/Bonus.vue';
 import {SpaceBonus} from '@/common/boards/SpaceBonus';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
         "esModuleInterop": true,
         "allowUnreachableCode": false,
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            "@tests/*": ["./tests/*"]
         },
         "plugins": [
             { "transform": "transformer-module" },

--- a/tsconfig.vue-tsc.json
+++ b/tsconfig.vue-tsc.json
@@ -1,8 +1,16 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "mocha", "chai"]
+  },
   "include": [
     "src/client/**/*.ts",
     "src/client/**/*.vue",
-    "src/common/**/*.ts"
+    "src/common/**/*.ts",
+    "tests/client/components/AdjacencyBonus.spec.ts",
+    "tests/client/components/Bonus.spec.ts",
+    "tests/client/components/App.spec.ts",
+    "tests/client/components/Award.spec.ts",
+    "tests/client/components/Awards.spec.ts"
   ]
 }


### PR DESCRIPTION
Any client tests supplying playerview and other model view will break because the Vue 3 migration includes tests with partial model. Should be fixed.