### PR TITLE
Add agent-readable card database export (base, corpera, prelude)

### DIFF
--- a/data/cards/README.md
+++ b/data/cards/README.md
@@ -1,0 +1,72 @@
+# Terraforming Mars card database
+
+Generated from the game source by `npm run make:card-db`. Do not edit by hand —
+regenerate instead. The schema of record is
+`src/server/tools/cardDatabase/CardDatabaseTypes.ts`.
+
+## Files
+
+- `cards.json` — an array of every card in the `base`, `corpera` (Corporate Era)
+  and `prelude` sets. Sorted by set, then by `id`. This is the whole database;
+  read it in one go.
+- `index.json` — the same cards reduced to `id`, `name`, `set`, `kind`, `type`,
+  `cost`, `tags`, `vp` and `bespoke`. Use it to find a card, then look the full
+  entry up in `cards.json` by `id`.
+
+## Reading an entry
+
+```json
+{
+  "id": "ai_central",
+  "name": "AI Central",
+  "set": "corpera",
+  "kind": "project",
+  "type": "active",
+  "card_number": "208",
+  "cost": 21,
+  "tags": ["science", "building"],
+  "vp": 1,
+  "requirements": [{"type": "tag", "tag": "science", "min": 3}],
+  "immediate": {"production": {"energy": -1}},
+  "action": {"draw": {"count": 2}},
+  "bespoke": false
+}
+```
+
+- `kind` says how the card enters play: `project` (from hand), `corporation`
+  (chosen at setup) or `prelude`.
+- `type` is the printed card type: `automated`, `active`, `event`,
+  `corporation` or `prelude`.
+- `cost` is absent for corporations. `starting_megacredits` is present for
+  corporations and preludes; **a negative value is a cost the player pays**, not
+  a gain.
+- `immediate` is what happens when the card is played. `action` is the
+  repeatable action of an active card. `first_action` is a corporation's first
+  action of the game.
+- Card draws always appear as `"draw": {"count": n}`, never as
+  `"gain": {"cards": n}`, because draws can carry qualifiers (`keep`, `pay`,
+  `tag`, `type`, `resource`).
+- Numbers inside an effect may instead be `{"dynamic": {...}}`, meaning the
+  amount depends on the game state. `counts` says what is measured; `each`
+  multiplies and `per` divides (rounding down). When `scope` is absent the
+  default is your own assets for tags, and the whole board for tiles.
+
+## `bespoke` and `semantics`
+
+Most cards are described entirely by their structured fields. Some are not:
+their effect lives in game code. Those carry `"bespoke": true` plus:
+
+- `semantics` — plain-English statement of everything the structured fields
+  cannot express. **Read this; the structured fields alone are incomplete.**
+- `passive` — a list of `{trigger, effect}` pairs for continuous and triggered
+  abilities.
+- `play_restriction` — when the card may be played, or where its tile may go.
+
+A card with `"bespoke": false` is fully described by its structured fields.
+
+## Coverage
+
+Only the `base`, `corpera` and `prelude` modules. Cards from Venus Next,
+Colonies, Turmoil, Prelude 2, Promo and the fan expansions are not included. The
+exporter throws rather than emitting partial data if it meets a mechanic it does
+not model, so an entry that is present is an entry that is complete.

--- a/data/cards/cards.json
+++ b/data/cards/cards.json
@@ -1,0 +1,6450 @@
+[
+  {
+    "id": "adaptation_technology",
+    "name": "Adaptation Technology",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "153",
+    "cost": 12,
+    "vp": 1,
+    "global_parameter_requirement_bonus": {
+      "steps": 2
+    }
+  },
+  {
+    "id": "adapted_lichen",
+    "name": "Adapted Lichen",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "048",
+    "description": "Increase your plant production 1 step.",
+    "cost": 9,
+    "immediate": {
+      "production": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "advanced_ecosystems",
+    "name": "Advanced Ecosystems",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "microbe",
+      "animal"
+    ],
+    "bespoke": false,
+    "card_number": "135",
+    "description": "Requires a plant tag, a microbe tag, and an animal tag.",
+    "cost": 11,
+    "vp": 3,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "plant",
+        "min": 1
+      },
+      {
+        "type": "tag",
+        "tag": "animal",
+        "min": 1
+      },
+      {
+        "type": "tag",
+        "tag": "microbe",
+        "min": 1
+      }
+    ]
+  },
+  {
+    "id": "aerobraked_ammonia_asteroid",
+    "name": "Aerobraked Ammonia Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "170",
+    "description": "Increase your heat production 3 steps and your plant production 1 step. Add 2 microbes to ANOTHER card.",
+    "cost": 26,
+    "immediate": {
+      "production": {
+        "plants": 1,
+        "heat": 3
+      },
+      "add_resources_to_any_card": [
+        {
+          "count": 2,
+          "resource": "Microbe"
+        }
+      ]
+    }
+  },
+  {
+    "id": "algae",
+    "name": "Algae",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "047",
+    "description": "Requires 5 ocean tiles. Gain 1 plant and increase your plant production 2 steps.",
+    "cost": 10,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 5
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 2
+      },
+      "gain": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "ants",
+    "name": "Ants",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "035",
+    "description": "Requires 4% oxygen.",
+    "cost": 9,
+    "resource_type": "Microbe",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 2
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 4
+      }
+    ],
+    "semantics": "The action removes 1 microbe from any other player's card and adds 1 microbe to this card. In a solo game the action is always available."
+  },
+  {
+    "id": "aquifer_pumping",
+    "name": "Aquifer Pumping",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "187",
+    "cost": 18,
+    "action": {
+      "spend": {
+        "megacredits": 8,
+        "can_pay_with": [
+          "steel"
+        ]
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "archaebacteria",
+    "name": "ArchaeBacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "042",
+    "description": "It must be -18 C or colder. Increase your plant production 1 step.",
+    "cost": 6,
+    "requirements": [
+      {
+        "type": "temperature",
+        "max": -18
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "arctic_algae",
+    "name": "Arctic Algae",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "card_number": "023",
+    "description": "It must be -12 C or colder to play. Gain 1 plant.",
+    "cost": 12,
+    "requirements": [
+      {
+        "type": "temperature",
+        "max": -12
+      }
+    ],
+    "immediate": {
+      "gain": {
+        "plants": 1
+      }
+    },
+    "semantics": "The trigger fires for every player's ocean placements, not only your own.",
+    "passive": [
+      {
+        "trigger": "any player places an ocean tile",
+        "effect": "gain 2 plants"
+      }
+    ]
+  },
+  {
+    "id": "artificial_lake",
+    "name": "Artificial Lake",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "116",
+    "description": "Requires -6 C or warmer. Place 1 ocean tile ON AN AREA NOT RESERVED FOR OCEAN.",
+    "cost": 15,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -6
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean",
+          "on": "land"
+        }
+      ]
+    }
+  },
+  {
+    "id": "artificial_photosynthesis",
+    "name": "Artificial Photosynthesis",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "115",
+    "description": "Increase your plant production 1 step or your energy production 2 steps.",
+    "cost": 12,
+    "immediate": {
+      "or": [
+        {
+          "title": "Increase your energy production 2 steps",
+          "production": {
+            "energy": 2
+          }
+        },
+        {
+          "title": "Increase your plant production 1 step",
+          "production": {
+            "plants": 1
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "asteroid",
+    "name": "Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "009",
+    "description": "Raise temperature 1 step and gain 2 titanium. Remove up to 3 plants from any player.",
+    "cost": 14,
+    "immediate": {
+      "gain": {
+        "titanium": 2
+      },
+      "global": {
+        "temperature": 1
+      },
+      "remove_any_plants": 3
+    }
+  },
+  {
+    "id": "asteroid_mining",
+    "name": "Asteroid Mining",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "040",
+    "description": "Increase your titanium production 2 steps.",
+    "cost": 30,
+    "vp": 2,
+    "immediate": {
+      "production": {
+        "titanium": 2
+      }
+    }
+  },
+  {
+    "id": "beam_from_a_thorium_asteroid",
+    "name": "Beam From A Thorium Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space",
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "058",
+    "description": "Requires a Jovian tag. Increase your heat production and energy production 3 steps each.",
+    "cost": 32,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "jovian",
+        "min": 1
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 3,
+        "heat": 3
+      }
+    }
+  },
+  {
+    "id": "beginner_corporation",
+    "name": "Beginner Corporation",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "R00",
+    "description": "You start with 42 M€. Instead of choosing from 10 cards during setup, you get 10 cards for free.",
+    "starting_megacredits": 42,
+    "immediate": {
+      "draw": {
+        "count": 10
+      }
+    }
+  },
+  {
+    "id": "big_asteroid",
+    "name": "Big Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "011",
+    "description": "Raise temperature 2 steps and gain 4 titanium. Remove up to 4 plants from any player.",
+    "cost": 27,
+    "immediate": {
+      "gain": {
+        "titanium": 4
+      },
+      "global": {
+        "temperature": 2
+      },
+      "remove_any_plants": 4
+    }
+  },
+  {
+    "id": "biomass_combustors",
+    "name": "Biomass Combustors",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "183",
+    "description": "Requires 6% oxygen. Decrease any plant production 1 step and increase your energy production 2 steps.",
+    "cost": 4,
+    "vp": -1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 6
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 2
+      },
+      "decrease_any_production": {
+        "resource": "plants",
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "birds",
+    "name": "Birds",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "card_number": "072",
+    "cost": 10,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here"
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 13
+      }
+    ],
+    "immediate": {
+      "decrease_any_production": {
+        "resource": "plants",
+        "count": 2
+      }
+    },
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "black_polar_dust",
+    "name": "Black Polar Dust",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "022",
+    "description": "Place an ocean tile. Decrease your M€ production 2 steps and increase your heat production 3 steps.",
+    "cost": 15,
+    "immediate": {
+      "production": {
+        "megacredits": -2,
+        "heat": 3
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "breathing_filters",
+    "name": "Breathing Filters",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "114",
+    "description": "Requires 7% oxygen.",
+    "cost": 11,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 7
+      }
+    ]
+  },
+  {
+    "id": "bushes",
+    "name": "Bushes",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "093",
+    "description": "Requires -10 C or warmer. Increase your plant production 2 steps. Gain 2 plants.",
+    "cost": 10,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -10
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 2
+      },
+      "gain": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "capital",
+    "name": "Capital",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "008",
+    "description": "Requires 4 ocean tiles. Place this tile. Decrease your energy production 2 steps and increase your M€ production 5 steps.",
+    "cost": 26,
+    "vp_dynamic": {
+      "counts": "oceans",
+      "next_to_this": true
+    },
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 5,
+        "energy": -2
+      },
+      "place": [
+        {
+          "tile": 3,
+          "on": "city",
+          "title": "Select space for special city tile"
+        }
+      ]
+    }
+  },
+  {
+    "id": "carbonate_processing",
+    "name": "Carbonate Processing",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "043",
+    "description": "Decrease your energy production 1 step and increase your heat production 3 steps.",
+    "cost": 6,
+    "immediate": {
+      "production": {
+        "energy": -1,
+        "heat": 3
+      }
+    }
+  },
+  {
+    "id": "cloud_seeding",
+    "name": "Cloud Seeding",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "004",
+    "description": "Requires 3 ocean tiles. Decrease your M€ production 1 step and any heat production 1 step. Increase your plant production 2 steps.",
+    "cost": 11,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": -1,
+        "plants": 2
+      },
+      "decrease_any_production": {
+        "resource": "heat",
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "colonizer_training_camp",
+    "name": "Colonizer Training Camp",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "001",
+    "description": "Oxygen must be 5% or less.",
+    "cost": 8,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 5
+      }
+    ]
+  },
+  {
+    "id": "comet",
+    "name": "Comet",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "010",
+    "description": "Raise temperature 1 step and place an ocean tile. Remove up to 3 plants from any player.",
+    "cost": 21,
+    "immediate": {
+      "global": {
+        "temperature": 1
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ],
+      "remove_any_plants": 3
+    }
+  },
+  {
+    "id": "convoy_from_europa",
+    "name": "Convoy From Europa",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "161",
+    "description": "Place 1 ocean tile and draw 1 card.",
+    "cost": 15,
+    "immediate": {
+      "draw": {
+        "count": 1
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "credicor",
+    "name": "CrediCor",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "R08",
+    "description": "You start with 57 M€.",
+    "starting_megacredits": 57,
+    "semantics": "A continuous effect that pays out on expensive purchases. The 20 M€ threshold is the printed basic cost, before any discounts.",
+    "passive": [
+      {
+        "trigger": "you pay for a project card or a standard project whose basic cost is 20 M€ or more",
+        "effect": "gain 4 M€"
+      }
+    ]
+  },
+  {
+    "id": "cupola_city",
+    "name": "Cupola City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "029",
+    "description": "Oxygen must be 9% or less. Place a city tile. Decrease your energy production 1 step and increase your M€ production 3 steps.",
+    "cost": 16,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 9
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 3,
+        "energy": -1
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "decomposers",
+    "name": "Decomposers",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "131",
+    "description": "Requires 3% oxygen.",
+    "cost": 5,
+    "resource_type": "Microbe",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 3
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 3
+      }
+    ],
+    "semantics": "Worth 1 victory point for every 3 microbes on this card. If this card is played in the prelude phase immediately after Ecology Experts, it starts with 2 extra microbes.",
+    "passive": [
+      {
+        "trigger": "you play a card with an animal, plant, or microbe tag",
+        "effect": "add 1 microbe to this card for each matching tag"
+      }
+    ]
+  },
+  {
+    "id": "deep_well_heating",
+    "name": "Deep Well Heating",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "003",
+    "description": "Increase your energy production 1 step. Increase temperature 1 step.",
+    "cost": 13,
+    "immediate": {
+      "production": {
+        "energy": 1
+      },
+      "global": {
+        "temperature": 1
+      }
+    }
+  },
+  {
+    "id": "deimos_down",
+    "name": "Deimos Down",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "039",
+    "description": "Raise temperature 3 steps and gain 4 steel. Remove up to 8 plants from any player.",
+    "cost": 31,
+    "immediate": {
+      "gain": {
+        "steel": 4
+      },
+      "global": {
+        "temperature": 3
+      },
+      "remove_any_plants": 8
+    }
+  },
+  {
+    "id": "designed_microorganisms",
+    "name": "Designed Microorganisms",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "155",
+    "description": "It must be -14 C or colder. Increase your plant production 2 steps.",
+    "cost": 16,
+    "requirements": [
+      {
+        "type": "temperature",
+        "max": -14
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "domed_crater",
+    "name": "Domed Crater",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "016",
+    "description": "Oxygen must be 7% or less. Gain 3 plants. Place a city tile. Decrease your energy production 1 step and increase your M€ production 3 steps.",
+    "cost": 24,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 7
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 3,
+        "energy": -1
+      },
+      "gain": {
+        "plants": 3
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "dust_seals",
+    "name": "Dust Seals",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "119",
+    "description": "Requires 3 or less ocean tiles.",
+    "cost": 2,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oceans",
+        "max": 3
+      }
+    ]
+  },
+  {
+    "id": "ecoline",
+    "name": "Ecoline",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "R17",
+    "description": "You start with 2 plant production, 3 plants, and 36 M€.",
+    "starting_megacredits": 36,
+    "immediate": {
+      "production": {
+        "plants": 2
+      },
+      "gain": {
+        "plants": 3
+      },
+      "greenery_discount": 1
+    }
+  },
+  {
+    "id": "ecological_zone",
+    "name": "Ecological Zone",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal",
+      "plant"
+    ],
+    "bespoke": true,
+    "card_number": "128",
+    "cost": 12,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 2
+    },
+    "requirements": [
+      {
+        "type": "greeneries",
+        "min": 1
+      }
+    ],
+    "semantics": "On play, place the Ecological Zone special tile. If this card is played in the prelude phase immediately after Ecology Experts, it starts with 1 extra animal.",
+    "passive": [
+      {
+        "trigger": "you play a card with an animal or plant tag",
+        "effect": "add 1 animal to this card for each matching tag"
+      }
+    ],
+    "play_restriction": "the Ecological Zone tile must go on a land space adjacent to a greenery tile"
+  },
+  {
+    "id": "energy_saving",
+    "name": "Energy Saving",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "189",
+    "description": "Increase your energy production 1 step for each city tile in play.",
+    "cost": 15,
+    "immediate": {
+      "production": {
+        "energy": {
+          "dynamic": {
+            "counts": "cities"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "eos_chasma_national_park",
+    "name": "Eos Chasma National Park",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "026",
+    "description": "Requires -12 C or warmer. Add 1 animal TO ANY ANIMAL CARD. Gain 3 plants. Increase your M€ production 2 steps.",
+    "cost": 16,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -12
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      },
+      "gain": {
+        "plants": 3
+      },
+      "add_resources_to_any_card": [
+        {
+          "count": 1,
+          "resource": "Animal"
+        }
+      ]
+    }
+  },
+  {
+    "id": "equatorial_magnetizer",
+    "name": "Equatorial Magnetizer",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "015",
+    "cost": 11,
+    "action": {
+      "production": {
+        "energy": -1
+      },
+      "gain": {
+        "tr": 1
+      }
+    }
+  },
+  {
+    "id": "extreme_cold_fungus",
+    "name": "Extreme-Cold Fungus",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "134",
+    "description": "It must be -10 C or colder.",
+    "cost": 13,
+    "requirements": [
+      {
+        "type": "temperature",
+        "max": -10
+      }
+    ],
+    "semantics": "The action is a choice: add 2 microbes to another card, or gain 1 plant. With no other microbe card in play the plant is taken automatically."
+  },
+  {
+    "id": "farming",
+    "name": "Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "118",
+    "description": "Requires +4° C or warmer. Increase your M€ production 2 steps and your plant production 2 steps. Gain 2 plants.",
+    "cost": 16,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "plants": 2
+      },
+      "gain": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "fish",
+    "name": "Fish",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "card_number": "052",
+    "description": "Requires +2 C° or warmer. Decrease any plant production 1 step.",
+    "cost": 9,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here"
+    },
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "decrease_any_production": {
+        "resource": "plants",
+        "count": 1
+      }
+    },
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "flooding",
+    "name": "Flooding",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "188",
+    "description": "Place an ocean tile. IF THERE ARE TILES ADJACENT TO THIS OCEAN TILE, YOU MAY REMOVE 4 M€ FROM THE OWNER OF ONE OF THOSE TILES.",
+    "cost": 7,
+    "vp": -1,
+    "semantics": "Place an ocean tile. If any tile owned by another player is adjacent to it, you may remove 4 M€ from one of those owners. Worth -1 victory point."
+  },
+  {
+    "id": "food_factory",
+    "name": "Food Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "041",
+    "description": "Decrease your plant production 1 step and increase your M€ production 4 steps.",
+    "cost": 12,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "megacredits": 4,
+        "plants": -1
+      }
+    }
+  },
+  {
+    "id": "fueled_generators",
+    "name": "Fueled Generators",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "100",
+    "description": "Decrease your M€ production 1 step and increase your energy production 1 steps.",
+    "cost": 1,
+    "immediate": {
+      "production": {
+        "megacredits": -1,
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "fusion_power",
+    "name": "Fusion Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "132",
+    "description": "Requires 2 power tags. Increase your energy production 3 steps.",
+    "cost": 14,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "power",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 3
+      }
+    }
+  },
+  {
+    "id": "ganymede_colony",
+    "name": "Ganymede Colony",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space",
+      "city"
+    ],
+    "bespoke": false,
+    "card_number": "081",
+    "description": "Place a city tile ON THE RESERVED AREA.",
+    "cost": 20,
+    "vp_dynamic": {
+      "counts": "tag",
+      "tag": "jovian"
+    },
+    "immediate": {
+      "place": [
+        {
+          "tile": "city",
+          "space": "01"
+        }
+      ]
+    }
+  },
+  {
+    "id": "geothermal_power",
+    "name": "Geothermal Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "117",
+    "description": "Increase your energy production 2 steps.",
+    "cost": 11,
+    "immediate": {
+      "production": {
+        "energy": 2
+      }
+    }
+  },
+  {
+    "id": "ghg_factories",
+    "name": "GHG Factories",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "126",
+    "description": "Decrease your energy production 1 step and increase your heat production 4 steps.",
+    "cost": 11,
+    "immediate": {
+      "production": {
+        "energy": -1,
+        "heat": 4
+      }
+    }
+  },
+  {
+    "id": "ghg_producing_bacteria",
+    "name": "GHG Producing Bacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "034",
+    "description": "Requires 4% oxygen.",
+    "cost": 8,
+    "resource_type": "Microbe",
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 4
+      }
+    ],
+    "action": {
+      "or": [
+        {
+          "title": "Remove 2 microbes to raise temperature 1 step",
+          "spend": {
+            "resources_here": 2
+          },
+          "global": {
+            "temperature": 1
+          }
+        },
+        {
+          "title": "Add 1 microbe to this card",
+          "gain": {
+            "resources_here": 1
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "giant_ice_asteroid",
+    "name": "Giant Ice Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "080",
+    "description": "Raise temperature 2 steps and place 2 ocean tiles. Remove up to 6 plants from any player.",
+    "cost": 36,
+    "immediate": {
+      "global": {
+        "temperature": 2
+      },
+      "place": [
+        {
+          "tile": "ocean",
+          "count": 2
+        }
+      ],
+      "remove_any_plants": 6
+    }
+  },
+  {
+    "id": "giant_space_mirror",
+    "name": "Giant Space Mirror",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "083",
+    "description": "Increase your energy production 3 steps.",
+    "cost": 17,
+    "immediate": {
+      "production": {
+        "energy": 3
+      }
+    }
+  },
+  {
+    "id": "grass",
+    "name": "Grass",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "087",
+    "description": "Requires -16° C or warmer. Increase your plant production 1 step. Gain 3 plants.",
+    "cost": 11,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -16
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 1
+      },
+      "gain": {
+        "plants": 3
+      }
+    }
+  },
+  {
+    "id": "great_dam",
+    "name": "Great Dam",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "136",
+    "description": "Requires 4 ocean tiles. Increase your energy production 2 steps.",
+    "cost": 12,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 2
+      }
+    }
+  },
+  {
+    "id": "greenhouses",
+    "name": "Greenhouses",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "096",
+    "description": "Gain 1 plant for each city tile in play.",
+    "cost": 6,
+    "immediate": {
+      "gain": {
+        "plants": {
+          "dynamic": {
+            "counts": "cities"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "heat_trappers",
+    "name": "Heat Trappers",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "178",
+    "description": "Decrease any heat production 2 steps and increase your energy production 1 step.",
+    "cost": 6,
+    "vp": -1,
+    "immediate": {
+      "production": {
+        "energy": 1
+      },
+      "decrease_any_production": {
+        "resource": "heat",
+        "count": 2
+      }
+    }
+  },
+  {
+    "id": "heather",
+    "name": "Heather",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "88",
+    "description": "Requires -14 C° or warmer. Increase your plant production 1 step. Gain 1 plant.",
+    "cost": 6,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -14
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 1
+      },
+      "gain": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "helion",
+    "name": "Helion",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "R18",
+    "description": "You start with 3 heat production and 42 M€.",
+    "starting_megacredits": 42,
+    "immediate": {
+      "production": {
+        "heat": 3
+      }
+    },
+    "semantics": "A continuous payment ability: heat may be spent as if it were M€, at 1 heat per 1 M€, when paying for anything. M€ may never be spent as heat.",
+    "passive": [
+      {
+        "trigger": "you pay for anything",
+        "effect": "you may substitute heat for M€ one for one"
+      }
+    ]
+  },
+  {
+    "id": "herbivores",
+    "name": "Herbivores",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": true,
+    "card_number": "147",
+    "description": "Requires 8% oxygen. +1 animal to this card. -1 any plant production",
+    "cost": 12,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 2
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 8
+      }
+    ],
+    "immediate": {
+      "gain": {
+        "resources_here": 1
+      },
+      "decrease_any_production": {
+        "resource": "plants",
+        "count": 1
+      }
+    },
+    "semantics": "On play, add 1 animal to this card and decrease any player's plant production 1 step.",
+    "passive": [
+      {
+        "trigger": "you place a greenery tile",
+        "effect": "add 1 animal to this card"
+      }
+    ]
+  },
+  {
+    "id": "ice_asteroid",
+    "name": "Ice Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "078",
+    "description": "Place 2 ocean tiles.",
+    "cost": 23,
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean",
+          "count": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "ice_cap_melting",
+    "name": "Ice Cap Melting",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "181",
+    "description": "Requires +2 C or warmer. Place 1 ocean tile.",
+    "cost": 5,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "immigrant_city",
+    "name": "Immigrant City",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "200",
+    "description": "Decrease your energy production 1 step and decrease your M€ production 2 steps. Place a city tile.",
+    "cost": 13,
+    "semantics": "On play, place a city tile, then decrease your energy production 1 step and your M€ production 2 steps.",
+    "passive": [
+      {
+        "trigger": "any player places a city tile",
+        "effect": "increase your M€ production 1 step"
+      }
+    ],
+    "play_restriction": "you need 1 energy production, a legal city space, and enough M€ production to absorb the 2 step loss"
+  },
+  {
+    "id": "immigration_shuttles",
+    "name": "Immigration Shuttles",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "198",
+    "description": "Increase your M€ production 5 steps.",
+    "cost": 31,
+    "vp_dynamic": {
+      "counts": "cities",
+      "scope": "everyone",
+      "per": 3
+    },
+    "immediate": {
+      "production": {
+        "megacredits": 5
+      }
+    }
+  },
+  {
+    "id": "import_of_advanced_ghg",
+    "name": "Import of Advanced GHG",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "167",
+    "description": "Increase your heat production 2 steps.",
+    "cost": 9,
+    "immediate": {
+      "production": {
+        "heat": 2
+      }
+    }
+  },
+  {
+    "id": "imported_ghg",
+    "name": "Imported GHG",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "162",
+    "description": "Increase your heat production 1 step and gain 3 heat.",
+    "cost": 7,
+    "immediate": {
+      "production": {
+        "heat": 1
+      },
+      "gain": {
+        "heat": 3
+      }
+    }
+  },
+  {
+    "id": "imported_hydrogen",
+    "name": "Imported Hydrogen",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "019",
+    "description": "Gain 3 plants, or add 3 microbes or 2 animals to ANOTHER card. Place an ocean tile.",
+    "cost": 16,
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    },
+    "semantics": "Place an ocean tile, then choose one: gain 3 plants, add 3 microbes to another card, or add 2 animals to another card. With no eligible card, the plants are taken automatically."
+  },
+  {
+    "id": "imported_nitrogen",
+    "name": "Imported Nitrogen",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "163",
+    "description": "Raise your TR 1 step and gain 4 plants. Add 3 microbes to ANOTHER card and 2 animals to ANOTHER card.",
+    "cost": 23,
+    "immediate": {
+      "gain": {
+        "plants": 4,
+        "tr": 1
+      },
+      "add_resources_to_any_card": [
+        {
+          "count": 3,
+          "resource": "Microbe"
+        },
+        {
+          "count": 2,
+          "resource": "Animal"
+        }
+      ]
+    }
+  },
+  {
+    "id": "industrial_microbes",
+    "name": "Industrial Microbes",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "158",
+    "description": "Increase your energy production and your steel production 1 step each.",
+    "cost": 12,
+    "immediate": {
+      "production": {
+        "steel": 1,
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "insects",
+    "name": "Insects",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "148",
+    "description": "Requires 6% oxygen. Increase your plant production 1 step for each plant tag you have.",
+    "cost": 9,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 6
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "plant"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "insulation",
+    "name": "Insulation",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "152",
+    "description": "Decrease your heat production any number of steps and increase your M€ production the same number of steps.",
+    "cost": 2,
+    "semantics": "Choose any number of steps, at least 1 and at most your heat production. Decrease your heat production by that amount and increase your M€ production by the same amount.",
+    "play_restriction": "you must have at least 1 heat production"
+  },
+  {
+    "id": "interplanetary_cinematics",
+    "name": "Interplanetary Cinematics",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "R19",
+    "description": "You start with 20 steel and 30 M€.",
+    "starting_megacredits": 30,
+    "immediate": {
+      "gain": {
+        "steel": 20
+      }
+    },
+    "semantics": "A trigger on your own event cards only.",
+    "passive": [
+      {
+        "trigger": "you play an event card",
+        "effect": "gain 2 M€"
+      }
+    ]
+  },
+  {
+    "id": "inventrix",
+    "name": "Inventrix",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "R43",
+    "description": "As your first action in the game, draw 3 cards. Start with 45 M€.",
+    "starting_megacredits": 45,
+    "first_action": {
+      "draw": {
+        "count": 3
+      },
+      "text": "Draw 3 cards"
+    },
+    "global_parameter_requirement_bonus": {
+      "steps": 2
+    }
+  },
+  {
+    "id": "ironworks",
+    "name": "Ironworks",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "101",
+    "cost": 11,
+    "action": {
+      "spend": {
+        "energy": 4
+      },
+      "gain": {
+        "steel": 1
+      },
+      "global": {
+        "oxygen": 1
+      }
+    }
+  },
+  {
+    "id": "kelp_farming",
+    "name": "Kelp Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "055",
+    "description": "Requires 6 ocean tiles. Increase your M€ production 2 steps and your plant production 3 steps. Gain 2 plants.",
+    "cost": 17,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 6
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "plants": 3
+      },
+      "gain": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "lake_marineris",
+    "name": "Lake Marineris",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "053",
+    "description": "Requires 0° C or warmer. Place 2 ocean tiles.",
+    "cost": 18,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 0
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean",
+          "count": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "large_convoy",
+    "name": "Large Convoy",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "143",
+    "description": "Place an ocean tile and draw 2 cards. Gain 5 plants or add 4 animals to ANOTHER card.",
+    "cost": 36,
+    "vp": 2,
+    "immediate": {
+      "draw": {
+        "count": 2
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    },
+    "semantics": "Place an ocean tile, draw 2 cards, then choose one: gain 5 plants, or add 4 animals to another card. With no animal card in play the plants are taken automatically."
+  },
+  {
+    "id": "lava_flows",
+    "name": "Lava Flows",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "140",
+    "description": "Raise temperature 2 steps and place this tile ON EITHER THARSIS THOLUS, ASCRAEUS MONS, PAVONIS MONS OR ARSIA MONS.",
+    "cost": 18,
+    "immediate": {
+      "global": {
+        "temperature": 2
+      },
+      "place": [
+        {
+          "tile": 7,
+          "on": "volcanic",
+          "title": "Select either Tharsis Tholus, Ascraeus Mons, Pavonis Mons or Arsia Mons"
+        }
+      ]
+    }
+  },
+  {
+    "id": "lichen",
+    "name": "Lichen",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "159",
+    "description": "Requires -24 C or warmer. Increase your plant production 1 step.",
+    "cost": 7,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -24
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "livestock",
+    "name": "Livestock",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "card_number": "184",
+    "description": "Requires 9% oxygen. Decrease your plant production 1 step and increase your M€ production 2 steps.",
+    "cost": 13,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here"
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 9
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "plants": -1
+      }
+    },
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "local_heat_trapping",
+    "name": "Local Heat Trapping",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "190",
+    "description": "Spend 5 heat to gain either 4 plants, or to add 2 animals to ANOTHER card.",
+    "cost": 1,
+    "semantics": "Spend 5 heat, then choose one: gain 4 plants, or add 2 animals to another card. With no animal card in play the plants are taken automatically. The heat this card spends is reserved so it cannot be paid for with Helion's heat-as-M€ substitution; Stormcraft Incorporated floaters may still cover part of the cost, each floater counting as 2 heat."
+  },
+  {
+    "id": "lunar_beam",
+    "name": "Lunar Beam",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth",
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "030",
+    "description": "Decrease your M€ production 2 steps and increase your heat production and energy production 2 steps each.",
+    "cost": 13,
+    "immediate": {
+      "production": {
+        "megacredits": -2,
+        "energy": 2,
+        "heat": 2
+      }
+    }
+  },
+  {
+    "id": "magnetic_field_dome",
+    "name": "Magnetic Field Dome",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "171",
+    "description": "Decrease your energy production 2 steps and increase your plant production 1 step. Raise your TR 1 step.",
+    "cost": 5,
+    "immediate": {
+      "production": {
+        "plants": 1,
+        "energy": -2
+      },
+      "gain": {
+        "tr": 1
+      }
+    }
+  },
+  {
+    "id": "magnetic_field_generators",
+    "name": "Magnetic Field Generators",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "165",
+    "description": "Decrease your energy production 4 steps and increase your plant production 2 steps. Raise your TR 3 steps.",
+    "cost": 20,
+    "immediate": {
+      "production": {
+        "plants": 2,
+        "energy": -4
+      },
+      "gain": {
+        "tr": 3
+      }
+    }
+  },
+  {
+    "id": "mangrove",
+    "name": "Mangrove",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "059",
+    "description": "Requires +4 C or warmer. Place a greenery tile ON AN AREA RESERVED FOR OCEAN and raise oxygen 1 step. Disregard normal placement restrictions for this.",
+    "cost": 12,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "greenery",
+          "on": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "martian_rails",
+    "name": "Martian Rails",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "007",
+    "cost": 13,
+    "action": {
+      "spend": {
+        "energy": 1
+      },
+      "gain": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "cities"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "methane_from_titan",
+    "name": "Methane From Titan",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "018",
+    "description": "Requires 2% oxygen. Increase your heat production 2 steps and your plant production 2 steps.",
+    "cost": 28,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 2,
+        "heat": 2
+      }
+    }
+  },
+  {
+    "id": "micro_mills",
+    "name": "Micro-Mills",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "164",
+    "description": "Increase your heat production 1 step.",
+    "cost": 3,
+    "immediate": {
+      "production": {
+        "heat": 1
+      }
+    }
+  },
+  {
+    "id": "mining_expedition",
+    "name": "Mining Expedition",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "063",
+    "description": "Raise oxygen 1 step. Remove 2 plants from any player. Gain 2 steel.",
+    "cost": 12,
+    "immediate": {
+      "gain": {
+        "steel": 2
+      },
+      "global": {
+        "oxygen": 1
+      },
+      "remove_any_plants": 2
+    }
+  },
+  {
+    "id": "mining_guild",
+    "name": "Mining Guild",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "R24",
+    "description": "You start with 30 M€, 5 steel and 1 steel production.",
+    "starting_megacredits": 30,
+    "immediate": {
+      "production": {
+        "steel": 1
+      },
+      "gain": {
+        "steel": 5
+      }
+    },
+    "semantics": "A trigger on your own tile placements on Mars. It does not fire for tiles you place off Mars, nor during the solar phase.",
+    "passive": [
+      {
+        "trigger": "you place a tile on Mars on a space with a steel or titanium placement bonus",
+        "effect": "increase your steel production 1 step"
+      }
+    ]
+  },
+  {
+    "id": "mining_rights",
+    "name": "Mining Rights",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "067",
+    "description": "Place this tile on an area with a steel or titanium placement bonus. Increase that production 1 step.",
+    "cost": 9,
+    "semantics": "Place the Mining Rights special tile and permanently increase your production of the resource that space grants: steel or titanium. If the space grants both, you choose.",
+    "play_restriction": "the tile must go on any space with a steel or titanium placement bonus"
+  },
+  {
+    "id": "mohole_area",
+    "name": "Mohole Area",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "142",
+    "description": "Increase your heat production 4 steps. Place this tile ON AN AREA RESERVED FOR OCEAN.",
+    "cost": 20,
+    "immediate": {
+      "production": {
+        "heat": 4
+      },
+      "place": [
+        {
+          "tile": 10,
+          "on": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "moss",
+    "name": "Moss",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "card_number": "122",
+    "description": "Requires 3 ocean tiles and that you lose 1 plant. Increase your plant production 1 step.",
+    "cost": 4,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 1
+      }
+    },
+    "semantics": "You pay 1 plant as an additional cost when this card is played.",
+    "play_restriction": "you must have 1 plant, or a card that supplies one such as Viral Enhancers or Manutech"
+  },
+  {
+    "id": "natural_preserve",
+    "name": "Natural Preserve",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "044",
+    "description": "Oxygen must be 4% or less. Place this tile NEXT TO NO OTHER TILE. Increase your M€ production 1 step.",
+    "cost": 9,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 1
+      },
+      "place": [
+        {
+          "tile": 11,
+          "on": "isolated"
+        }
+      ]
+    }
+  },
+  {
+    "id": "nitrite_reducing_bacteria",
+    "name": "Nitrite Reducing Bacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "157",
+    "description": "Add 3 microbes to this card.",
+    "cost": 11,
+    "resource_type": "Microbe",
+    "immediate": {
+      "gain": {
+        "resources_here": 3
+      }
+    },
+    "action": {
+      "or": [
+        {
+          "title": "Remove 3 microbes to increase your terraform rating 1 step",
+          "spend": {
+            "resources_here": 3
+          },
+          "gain": {
+            "tr": 1
+          }
+        },
+        {
+          "title": "Add 1 microbe to this card",
+          "gain": {
+            "resources_here": 1
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "nitrogen_rich_asteroid",
+    "name": "Nitrogen-Rich Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "037",
+    "description": "Raise your terraforming rating 2 steps and temperature 1 step. Increase your plant production 1 step, or 4 steps if you have 3 plant tags.",
+    "cost": 31,
+    "immediate": {
+      "gain": {
+        "tr": 2
+      },
+      "global": {
+        "temperature": 1
+      }
+    },
+    "semantics": "Raise your terraform rating 2 steps and the temperature 1 step, then increase your plant production 1 step — or 4 steps instead if you have at least 3 plant tags, counted after this card is played."
+  },
+  {
+    "id": "nitrophilic_moss",
+    "name": "Nitrophilic Moss",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "card_number": "146",
+    "description": "Requires 3 ocean tiles and that you lose 2 plants. Increase your plant production 2 steps.",
+    "cost": 8,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 2
+      }
+    },
+    "semantics": "You pay 2 plants as an additional cost when this card is played.",
+    "play_restriction": "you must have 2 plants, or 1 plant plus Viral Enhancers, or Manutech"
+  },
+  {
+    "id": "noctis_city",
+    "name": "Noctis City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "017",
+    "description": "Decrease your energy production 1 step and increase your M€ production 3 steps. Place a city tile ON THE RESERVED AREA, disregarding normal placement restrictions.",
+    "cost": 18,
+    "immediate": {
+      "production": {
+        "megacredits": 3
+      }
+    },
+    "semantics": "Place a city tile on the reserved Noctis City area, ignoring the usual placement restrictions, and decrease your energy production 1 step while increasing your M€ production 3 steps. On a board with no reserved Noctis area, the city goes on any legal city space.",
+    "play_restriction": "you must have at least 1 energy production"
+  },
+  {
+    "id": "noctis_farming",
+    "name": "Noctis Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "176",
+    "description": "Requires -20 C or warmer. Increase your M€ production 1 step and gain 2 plants.",
+    "cost": 10,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -20
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 1
+      },
+      "gain": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "nuclear_power",
+    "name": "Nuclear Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "045",
+    "description": "Decrease your M€ production 2 steps and increase your energy production 3 steps.",
+    "cost": 10,
+    "immediate": {
+      "production": {
+        "megacredits": -2,
+        "energy": 3
+      }
+    }
+  },
+  {
+    "id": "nuclear_zone",
+    "name": "Nuclear Zone",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "097",
+    "description": "Place this tile and raise temperature 2 steps.",
+    "cost": 10,
+    "vp": -2,
+    "immediate": {
+      "global": {
+        "temperature": 2
+      },
+      "place": [
+        {
+          "tile": 12,
+          "on": "land"
+        }
+      ]
+    }
+  },
+  {
+    "id": "open_city",
+    "name": "Open City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "108",
+    "description": "Requires 12% oxygen. Gain 2 plants. Place a city tile. Decrease your energy production 1 step and increase your M€ production 4 steps.",
+    "cost": 23,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 12
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 4,
+        "energy": -1
+      },
+      "gain": {
+        "plants": 2
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "optimal_aerobraking",
+    "name": "Optimal Aerobraking",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "031",
+    "cost": 7,
+    "semantics": "The played card must be both an event and carry a space tag.",
+    "passive": [
+      {
+        "trigger": "you play a space event card",
+        "effect": "gain 3 M€ and 3 heat"
+      }
+    ]
+  },
+  {
+    "id": "ore_processor",
+    "name": "Ore Processor",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "104",
+    "cost": 13,
+    "action": {
+      "spend": {
+        "energy": 4
+      },
+      "gain": {
+        "titanium": 1
+      },
+      "global": {
+        "oxygen": 1
+      }
+    }
+  },
+  {
+    "id": "permafrost_extraction",
+    "name": "Permafrost Extraction",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "191",
+    "description": "Requires -8 C or warmer. Place 1 ocean tile.",
+    "cost": 8,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -8
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "peroxide_power",
+    "name": "Peroxide Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "089",
+    "description": "Decrease your M€ production 1 step and increase your energy production 2 steps.",
+    "cost": 7,
+    "immediate": {
+      "production": {
+        "megacredits": -1,
+        "energy": 2
+      }
+    }
+  },
+  {
+    "id": "pets",
+    "name": "Pets",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth",
+      "animal"
+    ],
+    "bespoke": true,
+    "card_number": "172",
+    "description": "Add 1 animal to this card.",
+    "cost": 10,
+    "resource_type": "Animal",
+    "protected_resources": true,
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 2
+    },
+    "immediate": {
+      "gain": {
+        "resources_here": 1
+      }
+    },
+    "semantics": "On play, add 1 animal to this card. Animals here are protected: other players cannot remove them.",
+    "passive": [
+      {
+        "trigger": "any player places a city tile",
+        "effect": "add 1 animal to this card"
+      }
+    ]
+  },
+  {
+    "id": "phobolog",
+    "name": "PhoboLog",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "R09",
+    "description": "You start with 10 titanium and 23 M€.",
+    "starting_megacredits": 23,
+    "immediate": {
+      "gain": {
+        "titanium": 10
+      },
+      "titanium_value": 1
+    }
+  },
+  {
+    "id": "phobos_space_haven",
+    "name": "Phobos Space Haven",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space",
+      "city"
+    ],
+    "bespoke": false,
+    "card_number": "021",
+    "description": "Increase your titanium production 1 step and place a city tile ON THE RESERVED AREA.",
+    "cost": 25,
+    "vp": 3,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      },
+      "place": [
+        {
+          "tile": "city",
+          "space": "02"
+        }
+      ]
+    }
+  },
+  {
+    "id": "plantation",
+    "name": "Plantation",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "193",
+    "description": "Requires 2 science tags. Place a greenery tile and raise oxygen 1 step.",
+    "cost": 15,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "place": [
+        {
+          "tile": "greenery"
+        }
+      ]
+    }
+  },
+  {
+    "id": "power_grid",
+    "name": "Power Grid",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "102",
+    "description": "Increase your energy production step for each power tag you have, including this.",
+    "cost": 18,
+    "immediate": {
+      "production": {
+        "energy": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "power"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "power_plant",
+    "name": "Power Plant",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "141",
+    "description": "Increase your energy production 1 step.",
+    "cost": 4,
+    "immediate": {
+      "production": {
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "predators",
+    "name": "Predators",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": true,
+    "card_number": "024",
+    "description": "Requires 11% oxygen.",
+    "cost": 14,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here"
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 11
+      }
+    ],
+    "semantics": "The action removes 1 animal from any other player's card and adds 1 animal to this card. In a solo game the action is always available."
+  },
+  {
+    "id": "protected_valley",
+    "name": "Protected Valley",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "174",
+    "description": "Increase your M€ production 2 steps. Place a greenery tile ON AN AREA RESERVED FOR OCEAN, disregarding normal placement restrictions, and increase oxygen 1 step.",
+    "cost": 23,
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      },
+      "place": [
+        {
+          "tile": "greenery",
+          "on": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "rad_chem_factory",
+    "name": "Rad-Chem Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "205",
+    "description": "Decrease your energy production 1 step. Raise your TR 2 steps.",
+    "cost": 8,
+    "immediate": {
+      "production": {
+        "energy": -1
+      },
+      "gain": {
+        "tr": 2
+      }
+    }
+  },
+  {
+    "id": "regolith_eaters",
+    "name": "Regolith Eaters",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "033",
+    "cost": 13,
+    "resource_type": "Microbe",
+    "action": {
+      "or": [
+        {
+          "title": "Remove 2 microbes to raise oxygen level 1 step",
+          "spend": {
+            "resources_here": 2
+          },
+          "global": {
+            "oxygen": 1
+          }
+        },
+        {
+          "title": "Add 1 microbe to this card",
+          "gain": {
+            "resources_here": 1
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "release_of_inert_gases",
+    "name": "Release of Inert Gases",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "036",
+    "description": "Raise your terraforming rating 2 steps.",
+    "cost": 14,
+    "immediate": {
+      "gain": {
+        "tr": 2
+      }
+    }
+  },
+  {
+    "id": "research_outpost",
+    "name": "Research Outpost",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "020",
+    "description": "Place a city tile NEXT TO NO OTHER TILE.",
+    "cost": 18,
+    "immediate": {
+      "place": [
+        {
+          "tile": "city",
+          "on": "isolated"
+        }
+      ]
+    },
+    "card_discount": [
+      {
+        "amount": 1
+      }
+    ]
+  },
+  {
+    "id": "rover_construction",
+    "name": "Rover Construction",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "038",
+    "cost": 8,
+    "vp": 1,
+    "semantics": "The trigger fires for every player's city placements, not only your own.",
+    "passive": [
+      {
+        "trigger": "any player places a city tile",
+        "effect": "gain 2 M€"
+      }
+    ]
+  },
+  {
+    "id": "search_for_life",
+    "name": "Search For Life",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "card_number": "005",
+    "description": "Oxygen must be 6% or less.",
+    "cost": 3,
+    "resource_type": "Science",
+    "vp_special": true,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 6
+      }
+    ],
+    "semantics": "Worth 3 victory points if this card holds at least 1 science resource, and 0 otherwise. The action costs 1 M€: reveal the top card of the project deck, add 1 science resource to this card if the revealed card has a microbe tag, then discard the revealed card."
+  },
+  {
+    "id": "shuttles",
+    "name": "Shuttles",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "166",
+    "description": "Requires 5% oxygen. Decrease your energy production 1 step and increase your M€ production 2 steps.",
+    "cost": 10,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 5
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "energy": -1
+      }
+    },
+    "card_discount": [
+      {
+        "tag": "space",
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "small_animals",
+    "name": "Small Animals",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "card_number": "054",
+    "description": "Requires 6% oxygen. Decrease any plant production 1 step.",
+    "cost": 6,
+    "resource_type": "Animal",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 2
+    },
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 6
+      }
+    ],
+    "immediate": {
+      "decrease_any_production": {
+        "resource": "plants",
+        "count": 1
+      }
+    },
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "soil_factory",
+    "name": "Soil Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "179",
+    "description": "Decrease your energy production 1 step and increase your plant production 1 step.",
+    "cost": 9,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "plants": 1,
+        "energy": -1
+      }
+    }
+  },
+  {
+    "id": "solar_power",
+    "name": "Solar Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "113",
+    "description": "Increase your energy production 1 step.",
+    "cost": 11,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "solar_wind_power",
+    "name": "Solar Wind Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space",
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "077",
+    "description": "Increase your energy production 1 step and gain 2 titanium.",
+    "cost": 11,
+    "immediate": {
+      "production": {
+        "energy": 1
+      },
+      "gain": {
+        "titanium": 2
+      }
+    }
+  },
+  {
+    "id": "soletta",
+    "name": "Soletta",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "203",
+    "description": "Increase your heat production 7 steps.",
+    "cost": 35,
+    "immediate": {
+      "production": {
+        "heat": 7
+      }
+    }
+  },
+  {
+    "id": "space_mirrors",
+    "name": "Space Mirrors",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "power",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "076",
+    "cost": 3,
+    "action": {
+      "spend": {
+        "megacredits": 7
+      },
+      "production": {
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "special_design",
+    "name": "Special Design",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "206",
+    "description": "The next card you play this generation is +2 or -2 steps in global requirements, your choice.",
+    "cost": 4,
+    "global_parameter_requirement_bonus": {
+      "steps": 2,
+      "next_card_only": true
+    }
+  },
+  {
+    "id": "steelworks",
+    "name": "Steelworks",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "103",
+    "cost": 15,
+    "action": {
+      "spend": {
+        "energy": 4
+      },
+      "gain": {
+        "steel": 2
+      },
+      "global": {
+        "oxygen": 1
+      }
+    }
+  },
+  {
+    "id": "strip_mine",
+    "name": "Strip Mine",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "138",
+    "description": "Decrease your energy production 2 steps. Increase your steel production 2 steps and your titanium production 1 step. Raise oxygen 2 steps.",
+    "cost": 25,
+    "immediate": {
+      "production": {
+        "steel": 2,
+        "titanium": 1,
+        "energy": -2
+      },
+      "global": {
+        "oxygen": 2
+      }
+    }
+  },
+  {
+    "id": "subterranean_reservoir",
+    "name": "Subterranean Reservoir",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "127",
+    "description": "Place 1 ocean tile.",
+    "cost": 11,
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "symbiotic_fungus",
+    "name": "Symbiotic Fungus",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "133",
+    "description": "Requires -14 C° or warmer.",
+    "cost": 4,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -14
+      }
+    ],
+    "action": {
+      "add_resources_to_any_card": [
+        {
+          "count": 1,
+          "resource": "Microbe"
+        }
+      ]
+    }
+  },
+  {
+    "id": "tectonic_stress_power",
+    "name": "Tectonic Stress Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "145",
+    "description": "Requires 2 science tags. Increase your energy production 3 steps.",
+    "cost": 18,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 3
+      }
+    }
+  },
+  {
+    "id": "tharsis_republic",
+    "name": "Tharsis Republic",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "R31",
+    "description": "You start with 40 M€. As your first action in the game, place a city tile.",
+    "starting_megacredits": 40,
+    "first_action": {
+      "place": [
+        {
+          "tile": "city"
+        }
+      ],
+      "text": "Place a city tile"
+    },
+    "semantics": "In a solo game the two neutral cities placed during setup pay out immediately, so playing this corporation grants 2 M€ production straight away.",
+    "passive": [
+      {
+        "trigger": "any player places a city tile on Mars",
+        "effect": "increase your M€ production 1 step"
+      },
+      {
+        "trigger": "you place a city tile anywhere",
+        "effect": "gain 3 M€"
+      }
+    ]
+  },
+  {
+    "id": "thorgate",
+    "name": "ThorGate",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "card_number": "R13",
+    "description": "You start with 1 energy production and 48 M€.",
+    "starting_megacredits": 48,
+    "immediate": {
+      "production": {
+        "energy": 1
+      }
+    },
+    "card_discount": [
+      {
+        "tag": "power",
+        "amount": 3
+      }
+    ],
+    "semantics": "The 3 M€ discount on power-tag cards is in card_discount. What the data cannot express is that the same discount also applies to the Power Plant standard project.",
+    "passive": [
+      {
+        "trigger": "you buy the Power Plant standard project",
+        "effect": "pay 3 M€ less for it"
+      }
+    ]
+  },
+  {
+    "id": "towing_a_comet",
+    "name": "Towing A Comet",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "075",
+    "description": "Gain 2 plants. Raise oxygen level 1 step and place an ocean tile.",
+    "cost": 23,
+    "immediate": {
+      "gain": {
+        "plants": 2
+      },
+      "global": {
+        "oxygen": 1
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "trees",
+    "name": "Trees",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "060",
+    "description": "Requires -4 C or warmer. Increase your plant production 3 steps. Gain 1 plant.",
+    "cost": 13,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": 3
+      },
+      "gain": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "tundra_farming",
+    "name": "Tundra Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "169",
+    "description": "Requires -6° C or warmer. Increase your plant production 1 step and your M€ production 2 steps. Gain 1 plant.",
+    "cost": 16,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": -6
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "plants": 1
+      },
+      "gain": {
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "underground_city",
+    "name": "Underground City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "032",
+    "description": "Place a city tile. Decrease your energy production 2 steps and increase your steel production 2 steps.",
+    "cost": 18,
+    "immediate": {
+      "production": {
+        "steel": 2,
+        "energy": -2
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "underground_detonations",
+    "name": "Underground Detonations",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "202",
+    "cost": 6,
+    "action": {
+      "spend": {
+        "megacredits": 10
+      },
+      "production": {
+        "heat": 2
+      }
+    }
+  },
+  {
+    "id": "united_nations_mars_initiative",
+    "name": "United Nations Mars Initiative",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "R32",
+    "description": "You start with 40 M€.",
+    "starting_megacredits": 40,
+    "semantics": "The action costs 3 M€ and raises your terraform rating 1 step. It is only available if your terraform rating already went up this generation for some other reason."
+  },
+  {
+    "id": "urbanized_area",
+    "name": "Urbanized Area",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "120",
+    "description": "Decrease your energy production 1 step and increase your M€ production 2 steps. Place a city tile ADJACENT TO AT LEAST 2 OTHER CITY TILES.",
+    "cost": 10,
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      }
+    },
+    "semantics": "Place a city tile, decrease your energy production 1 step and increase your M€ production 2 steps.",
+    "play_restriction": "the city must go on a land space adjacent to at least 2 other city tiles, and you must have 1 energy production"
+  },
+  {
+    "id": "water_import_from_europa",
+    "name": "Water Import From Europa",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "012",
+    "cost": 25,
+    "vp_dynamic": {
+      "counts": "tag",
+      "tag": "jovian"
+    },
+    "action": {
+      "spend": {
+        "megacredits": 12,
+        "can_pay_with": [
+          "titanium"
+        ]
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "water_splitting_plant",
+    "name": "Water Splitting Plant",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "177",
+    "description": "Requires 2 ocean tiles.",
+    "cost": 12,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 2
+      }
+    ],
+    "action": {
+      "spend": {
+        "energy": 3
+      },
+      "global": {
+        "oxygen": 1
+      }
+    }
+  },
+  {
+    "id": "wave_power",
+    "name": "Wave Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "139",
+    "description": "Requires 3 ocean tiles. Increase your energy production 1 step.",
+    "cost": 8,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oceans",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "windmills",
+    "name": "Windmills",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "168",
+    "description": "Requires 7% oxygen. Increase your energy production 1 step.",
+    "cost": 6,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 7
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "worms",
+    "name": "Worms",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "130",
+    "description": "Requires 4% oxygen. Increase your plant production 1 step for every 2 microbe tags you have, including this.",
+    "cost": 8,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "plants": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "microbe",
+            "per": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "zeppelins",
+    "name": "Zeppelins",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "129",
+    "description": "Requires 5% oxygen. Increase your M€ production 1 step for each city tile ON MARS.",
+    "cost": 13,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "min": 5
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "cities"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "acquired_company",
+    "name": "Acquired Company",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "106",
+    "description": "Increase your M€ production 3 steps.",
+    "cost": 10,
+    "immediate": {
+      "production": {
+        "megacredits": 3
+      }
+    }
+  },
+  {
+    "id": "advanced_alloys",
+    "name": "Advanced Alloys",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "071",
+    "cost": 9,
+    "immediate": {
+      "steel_value": 1,
+      "titanium_value": 1
+    }
+  },
+  {
+    "id": "ai_central",
+    "name": "AI Central",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "208",
+    "cost": 21,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": -1
+      }
+    },
+    "action": {
+      "draw": {
+        "count": 2
+      }
+    }
+  },
+  {
+    "id": "anti_gravity_technology",
+    "name": "Anti-Gravity Technology",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "150",
+    "description": "Requires 7 science tags.",
+    "cost": 14,
+    "vp": 3,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 7
+      }
+    ],
+    "card_discount": [
+      {
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "asteroid_mining_consortium",
+    "name": "Asteroid Mining Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true,
+    "card_number": "002",
+    "description": "Requires that you have titanium production. Decrease any titanium production 1 step and increase your own 1 step.",
+    "cost": 13,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "production",
+        "resource": "titanium",
+        "min": 1
+      }
+    ],
+    "semantics": "Decrease any one player's titanium production 1 step and increase your own 1 step. You may target yourself, which nets no change."
+  },
+  {
+    "id": "bribed_committee",
+    "name": "Bribed Committee",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "112",
+    "description": "Raise your TR 2 steps.",
+    "cost": 7,
+    "vp": -2,
+    "immediate": {
+      "gain": {
+        "tr": 2
+      }
+    }
+  },
+  {
+    "id": "building_industries",
+    "name": "Building Industries",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "065",
+    "description": "Decrease your energy production 1 step and increase your steel production 2 steps.",
+    "cost": 6,
+    "immediate": {
+      "production": {
+        "steel": 2,
+        "energy": -1
+      }
+    }
+  },
+  {
+    "id": "business_contacts",
+    "name": "Business Contacts",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "111",
+    "cost": 7,
+    "immediate": {
+      "draw": {
+        "count": 4,
+        "keep": 2
+      }
+    }
+  },
+  {
+    "id": "business_network",
+    "name": "Business Network",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "110",
+    "description": "Decrease your M€ production 1 step.",
+    "cost": 4,
+    "immediate": {
+      "production": {
+        "megacredits": -1
+      }
+    },
+    "action": {
+      "draw": {
+        "count": 1,
+        "pay": true
+      }
+    }
+  },
+  {
+    "id": "callisto_penal_mines",
+    "name": "Callisto Penal Mines",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "082",
+    "description": "Increase your M€ production 3 steps.",
+    "cost": 24,
+    "vp": 2,
+    "immediate": {
+      "production": {
+        "megacredits": 3
+      }
+    }
+  },
+  {
+    "id": "caretaker_contract",
+    "name": "Caretaker Contract",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "154",
+    "description": "Requires 0° C or warmer.",
+    "cost": 3,
+    "requirements": [
+      {
+        "type": "temperature",
+        "min": 0
+      }
+    ],
+    "action": {
+      "spend": {
+        "heat": 8
+      },
+      "gain": {
+        "tr": 1
+      }
+    }
+  },
+  {
+    "id": "cartel",
+    "name": "Cartel",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "137",
+    "description": "Increase your M€ production 1 step for each Earth tag you have, including this.",
+    "cost": 8,
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "earth"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "ceo_s_favorite_project",
+    "name": "CEO's Favorite Project",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "149",
+    "cost": 1,
+    "immediate": {
+      "add_resources_to_any_card": [
+        {
+          "count": 1,
+          "must_have_card": true,
+          "min": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "commercial_district",
+    "name": "Commercial District",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "085",
+    "description": "Place this tile. Decrease your energy production 1 step and increase your M€ production 4 steps.",
+    "cost": 16,
+    "vp_dynamic": {
+      "counts": "cities",
+      "next_to_this": true
+    },
+    "immediate": {
+      "production": {
+        "megacredits": 4,
+        "energy": -1
+      },
+      "place": [
+        {
+          "tile": 4,
+          "on": "land"
+        }
+      ]
+    }
+  },
+  {
+    "id": "corporate_stronghold",
+    "name": "Corporate Stronghold",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "182",
+    "description": "Decrease your energy production 1 step and increase your M€ production 3 steps. Place a city tile.",
+    "cost": 11,
+    "vp": -2,
+    "immediate": {
+      "production": {
+        "megacredits": 3,
+        "energy": -1
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "development_center",
+    "name": "Development Center",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "014",
+    "cost": 11,
+    "action": {
+      "spend": {
+        "energy": 1
+      },
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "earth_catapult",
+    "name": "Earth Catapult",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "070",
+    "cost": 23,
+    "vp": 2,
+    "card_discount": [
+      {
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "earth_office",
+    "name": "Earth Office",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "105",
+    "cost": 1,
+    "card_discount": [
+      {
+        "tag": "earth",
+        "amount": 3
+      }
+    ]
+  },
+  {
+    "id": "electro_catapult",
+    "name": "Electro Catapult",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "069",
+    "cost": 17,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 8
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": -1
+      }
+    },
+    "action": {
+      "or": [
+        {
+          "title": "Spend 1 plant to gain 7 M€.",
+          "spend": {
+            "plants": 1
+          },
+          "gain": {
+            "megacredits": 7
+          }
+        },
+        {
+          "title": "Spend 1 steel to gain 7 M€.",
+          "spend": {
+            "steel": 1
+          },
+          "gain": {
+            "megacredits": 7
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "energy_tapping",
+    "name": "Energy Tapping",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "card_number": "201",
+    "description": "Decrease any energy production 1 step and increase your own 1 step.",
+    "cost": 3,
+    "vp": -1,
+    "semantics": "Decrease any one player's energy production 1 step and increase your own 1 step. You may target yourself."
+  },
+  {
+    "id": "fuel_factory",
+    "name": "Fuel Factory",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "180",
+    "description": "Decrease your energy production 1 step and increase your titanium and your M€ production 1 step each.",
+    "cost": 6,
+    "immediate": {
+      "production": {
+        "megacredits": 1,
+        "titanium": 1,
+        "energy": -1
+      }
+    }
+  },
+  {
+    "id": "gene_repair",
+    "name": "Gene Repair",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "091",
+    "description": "Requires 3 science tags. Increase your M€ production 2 steps.",
+    "cost": 12,
+    "vp": 2,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      }
+    }
+  },
+  {
+    "id": "great_escarpment_consortium",
+    "name": "Great Escarpment Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "061",
+    "description": "Requires that you have steel production. Decrease any steel production 1 step and increase your own 1 step.",
+    "cost": 6,
+    "requirements": [
+      {
+        "type": "production",
+        "resource": "steel",
+        "min": 1
+      }
+    ],
+    "semantics": "Decrease any one player's steel production 1 step and increase your own 1 step. You may target yourself."
+  },
+  {
+    "id": "hackers",
+    "name": "Hackers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "125",
+    "description": "Decrease your energy production 1 step and any M€ production 2 steps. Increase your M€ production 2 steps.",
+    "cost": 3,
+    "vp": -1,
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "energy": -1
+      }
+    },
+    "semantics": "Decrease your energy production 1 step and increase your M€ production 2 steps, and separately decrease any one player's M€ production 2 steps. You may target yourself."
+  },
+  {
+    "id": "hired_raiders",
+    "name": "Hired Raiders",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "124",
+    "description": "Steal up to 2 steel, or 3 M€ from any player.",
+    "cost": 1,
+    "semantics": "Steal 2 steel or 3 M€ from one opponent of your choice. Steel cannot be taken from a player whose alloys are protected. In a solo game you simply gain the resources."
+  },
+  {
+    "id": "indentured_workers",
+    "name": "Indentured Workers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "195",
+    "description": "The next card you play this generation costs 8 M€ less.",
+    "cost": 0,
+    "vp": -1,
+    "semantics": "The discount applies once, to the very next card you play this generation, and is lost if you play no further card.",
+    "passive": [
+      {
+        "trigger": "you play your next card this generation",
+        "effect": "it costs 8 M€ less"
+      }
+    ]
+  },
+  {
+    "id": "industrial_center",
+    "name": "Industrial Center",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "123",
+    "description": "Place this tile adjacent to a city tile.",
+    "cost": 4,
+    "action": {
+      "spend": {
+        "megacredits": 7
+      },
+      "production": {
+        "steel": 1
+      }
+    },
+    "semantics": "On play, place the Industrial Center special tile. The repeatable action is fully described in the action field: spend 7 M€ to increase your steel production 1 step.",
+    "play_restriction": "the Industrial Center tile must go on a land space adjacent to a city tile"
+  },
+  {
+    "id": "interstellar_colony_ship",
+    "name": "Interstellar Colony Ship",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "027",
+    "description": "Requires that you have 5 science tags.",
+    "cost": 24,
+    "vp": 4,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 5
+      }
+    ]
+  },
+  {
+    "id": "invention_contest",
+    "name": "Invention Contest",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "192",
+    "cost": 2,
+    "immediate": {
+      "draw": {
+        "count": 3,
+        "keep": 1
+      }
+    }
+  },
+  {
+    "id": "inventors_guild",
+    "name": "Inventors' Guild",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "006",
+    "cost": 9,
+    "action": {
+      "draw": {
+        "count": 1,
+        "pay": true
+      }
+    }
+  },
+  {
+    "id": "investment_loan",
+    "name": "Investment Loan",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "151",
+    "description": "Decrease your M€ production 1 step. Gain 10 M€.",
+    "cost": 3,
+    "immediate": {
+      "production": {
+        "megacredits": -1
+      },
+      "gain": {
+        "megacredits": 10
+      }
+    }
+  },
+  {
+    "id": "io_mining_industries",
+    "name": "Io Mining Industries",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "092",
+    "description": "Increase your titanium production 2 steps and your M€ production 2 steps.",
+    "cost": 41,
+    "vp_dynamic": {
+      "counts": "tag",
+      "tag": "jovian"
+    },
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "titanium": 2
+      }
+    }
+  },
+  {
+    "id": "lagrange_observatory",
+    "name": "Lagrange Observatory",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "196",
+    "description": "Draw 1 card.",
+    "cost": 9,
+    "vp": 1,
+    "immediate": {
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "land_claim",
+    "name": "Land Claim",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "066",
+    "cost": 1,
+    "semantics": "Reserve any non-reserved land space. Only you may place a tile on that space for the rest of the game. No tile is placed now."
+  },
+  {
+    "id": "lightning_harvest",
+    "name": "Lightning Harvest",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "046",
+    "description": "Requires 3 science tags. Increase your energy production and your M€ production one step each.",
+    "cost": 8,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 3
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 1,
+        "energy": 1
+      }
+    }
+  },
+  {
+    "id": "mars_university",
+    "name": "Mars University",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "073",
+    "cost": 8,
+    "vp": 1,
+    "semantics": "Triggers once for each science tag played, including this card's own science tag when it enters play. If your hand is empty the trigger does nothing.",
+    "passive": [
+      {
+        "trigger": "you play a card with a science tag, including this card",
+        "effect": "for each science tag, you may discard 1 card from your hand to draw 1 card"
+      }
+    ]
+  },
+  {
+    "id": "mass_converter",
+    "name": "Mass Converter",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "094",
+    "description": "Requires 5 science tags. Increase your energy production 6 steps.",
+    "cost": 8,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 5
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 6
+      }
+    },
+    "card_discount": [
+      {
+        "tag": "space",
+        "amount": 2,
+        "per": "card"
+      }
+    ]
+  },
+  {
+    "id": "media_archives",
+    "name": "Media Archives",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "107",
+    "description": "Gain 1 M€ for each event EVER PLAYED by all players.",
+    "cost": 8,
+    "immediate": {
+      "gain": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "events_played",
+            "scope": "everyone"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "media_group",
+    "name": "Media Group",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "109",
+    "cost": 6,
+    "semantics": "A trigger on your own event cards only.",
+    "passive": [
+      {
+        "trigger": "you play an event card",
+        "effect": "gain 3 M€"
+      }
+    ]
+  },
+  {
+    "id": "medical_lab",
+    "name": "Medical Lab",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "207",
+    "description": "Increase your M€ production 1 step for every 2 building tags you have, including this.",
+    "cost": 13,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "building",
+            "per": 2
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "mine",
+    "name": "Mine",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "056",
+    "description": "Increase your steel production 1 step.",
+    "cost": 4,
+    "immediate": {
+      "production": {
+        "steel": 1
+      }
+    }
+  },
+  {
+    "id": "mineral_deposit",
+    "name": "Mineral Deposit",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "062",
+    "description": "Gain 5 steel.",
+    "cost": 5,
+    "immediate": {
+      "gain": {
+        "steel": 5
+      }
+    }
+  },
+  {
+    "id": "mining_area",
+    "name": "Mining Area",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "064",
+    "description": "Place this tile on an area with a steel or titanium placement bonus, adjacent to another of your tiles. Increase your production of that resource 1 step.",
+    "cost": 4,
+    "semantics": "Place the Mining Area special tile and permanently increase your production of the resource that space grants: steel or titanium. If the space grants both, you choose.",
+    "play_restriction": "the tile must go on a space with a steel or titanium placement bonus that is adjacent to one of your own non-ocean tiles"
+  },
+  {
+    "id": "miranda_resort",
+    "name": "Miranda Resort",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "051",
+    "description": "Increase your M€ production 1 step for each Earth tag you have.",
+    "cost": 12,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "earth"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "olympus_conference",
+    "name": "Olympus Conference",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "earth",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "185",
+    "description": "When you play a science tag, including this, either add a science resource to this card, or remove a science resource from this card to draw a card.",
+    "cost": 10,
+    "resource_type": "Science",
+    "vp": 1,
+    "semantics": "The choice is only offered when there is already a science resource here; otherwise a resource is simply added.",
+    "passive": [
+      {
+        "trigger": "you play a card with a science tag, including this card",
+        "effect": "for each science tag, either add 1 science resource to this card, or remove 1 science resource from this card to draw a card"
+      }
+    ]
+  },
+  {
+    "id": "physics_complex",
+    "name": "Physics Complex",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "095",
+    "cost": 12,
+    "resource_type": "Science",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "each": 2
+    },
+    "action": {
+      "spend": {
+        "energy": 6
+      },
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "power_infrastructure",
+    "name": "Power Infrastructure",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": true,
+    "card_number": "194",
+    "cost": 4,
+    "semantics": "The action converts energy to M€ one for one. You choose the amount, from 1 up to all the energy you hold."
+  },
+  {
+    "id": "power_supply_consortium",
+    "name": "Power Supply Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "card_number": "160",
+    "description": "Requires 2 power tags. Decrease any energy production 1 step and increase your own 1 step.",
+    "cost": 5,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "power",
+        "min": 2
+      }
+    ],
+    "semantics": "Decrease any one player's energy production 1 step and increase your own 1 step. You may target yourself."
+  },
+  {
+    "id": "protected_habitats",
+    "name": "Protected Habitats",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "173",
+    "cost": 5
+  },
+  {
+    "id": "quantum_extractor",
+    "name": "Quantum Extractor",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "079",
+    "description": "Requires 4 science tags. Increase your energy production 4 steps.",
+    "cost": 13,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "science",
+        "min": 4
+      }
+    ],
+    "immediate": {
+      "production": {
+        "energy": 4
+      }
+    },
+    "card_discount": [
+      {
+        "tag": "space",
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "rad_suits",
+    "name": "Rad-Suits",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "186",
+    "description": "Requires two cities in play. Increase your M€ production 1 step.",
+    "cost": 6,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "cities",
+        "min": 2,
+        "scope": "any_player"
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 1
+      }
+    }
+  },
+  {
+    "id": "research",
+    "name": "Research",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "090",
+    "description": "Counts as playing 2 science cards. Draw 2 cards.",
+    "cost": 11,
+    "vp": 1,
+    "immediate": {
+      "draw": {
+        "count": 2
+      }
+    }
+  },
+  {
+    "id": "restricted_area",
+    "name": "Restricted Area",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "199",
+    "description": "Place this tile.",
+    "cost": 11,
+    "immediate": {
+      "place": [
+        {
+          "tile": 13,
+          "on": "land"
+        }
+      ]
+    },
+    "action": {
+      "spend": {
+        "megacredits": 2
+      },
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "robotic_workforce",
+    "name": "Robotic Workforce",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "card_number": "086",
+    "description": "Duplicate only the production box of one of your building cards.",
+    "cost": 9,
+    "semantics": "Copy the production box of one card you have already played that carries a building tag. Only the production change is copied, nothing else the card does.",
+    "play_restriction": "you must have a played building-tag card whose production box can be applied again"
+  },
+  {
+    "id": "sabotage",
+    "name": "Sabotage",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "121",
+    "description": "Remove up to 3 titanium from any player, or 4 steel, or 7 M€.",
+    "cost": 1,
+    "semantics": "Remove 3 titanium, 4 steel, or 7 M€ from one opponent of your choice. Titanium and steel cannot be taken from a player whose alloys are protected."
+  },
+  {
+    "id": "satellites",
+    "name": "Satellites",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "175",
+    "description": "Increase your M€ production 1 step for each space tag you have, including this one.",
+    "cost": 10,
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "space"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "saturn_systems",
+    "name": "Saturn Systems",
+    "set": "corpera",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true,
+    "card_number": "R03",
+    "description": "You start with 1 titanium production and 42 M€.",
+    "starting_megacredits": 42,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      }
+    },
+    "semantics": "A trigger on every player, including yourself, and including this card's own Jovian tag when it is played.",
+    "passive": [
+      {
+        "trigger": "any player puts a Jovian tag into play",
+        "effect": "increase your M€ production 1 step for each Jovian tag played"
+      }
+    ]
+  },
+  {
+    "id": "security_fleet",
+    "name": "Security Fleet",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "028",
+    "cost": 12,
+    "resource_type": "Fighter",
+    "vp_dynamic": {
+      "counts": "resources_here"
+    },
+    "action": {
+      "spend": {
+        "titanium": 1
+      },
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "space_elevator",
+    "name": "Space Elevator",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "013",
+    "description": "Increase your titanium production 1 step.",
+    "cost": 27,
+    "vp": 2,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      }
+    },
+    "action": {
+      "spend": {
+        "steel": 1
+      },
+      "gain": {
+        "megacredits": 5
+      }
+    }
+  },
+  {
+    "id": "space_station",
+    "name": "Space Station",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "025",
+    "cost": 10,
+    "vp": 1,
+    "card_discount": [
+      {
+        "tag": "space",
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "sponsors",
+    "name": "Sponsors",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "068",
+    "description": "Increase your M€ production 2 steps.",
+    "cost": 6,
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      }
+    }
+  },
+  {
+    "id": "standard_technology",
+    "name": "Standard Technology",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "card_number": "156",
+    "cost": 6,
+    "semantics": "Sell Patents is explicitly excluded.",
+    "passive": [
+      {
+        "trigger": "you pay for a standard project other than Sell Patents",
+        "effect": "gain 3 M€"
+      }
+    ]
+  },
+  {
+    "id": "tardigrades",
+    "name": "Tardigrades",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "049",
+    "cost": 4,
+    "resource_type": "Microbe",
+    "vp_dynamic": {
+      "counts": "resources_here",
+      "per": 4
+    },
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "technology_demonstration",
+    "name": "Technology Demonstration",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "204",
+    "description": "Draw two cards.",
+    "cost": 5,
+    "immediate": {
+      "draw": {
+        "count": 2
+      }
+    }
+  },
+  {
+    "id": "teractor",
+    "name": "Teractor",
+    "set": "corpera",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "R30",
+    "description": "You start with 60 M€.",
+    "starting_megacredits": 60,
+    "card_discount": [
+      {
+        "tag": "earth",
+        "amount": 3
+      }
+    ]
+  },
+  {
+    "id": "terraforming_ganymede",
+    "name": "Terraforming Ganymede",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": true,
+    "card_number": "197",
+    "description": "Raise your TR 1 step for each Jovian tag you have, including this.",
+    "cost": 33,
+    "vp": 2,
+    "semantics": "Raise your terraform rating 1 step for each Jovian tag you have, counting this card's own Jovian tag."
+  },
+  {
+    "id": "titanium_mine",
+    "name": "Titanium Mine",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "144",
+    "description": "Increase your titanium production 1 step.",
+    "cost": 7,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      }
+    }
+  },
+  {
+    "id": "toll_station",
+    "name": "Toll Station",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "099",
+    "description": "Increase your M€ production 1 step for each space tag your OPPONENTS have.",
+    "cost": 12,
+    "immediate": {
+      "production": {
+        "megacredits": {
+          "dynamic": {
+            "counts": "tag",
+            "tag": "space",
+            "scope": "opponents"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "trans_neptune_probe",
+    "name": "Trans-Neptune Probe",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "084",
+    "cost": 6,
+    "vp": 1
+  },
+  {
+    "id": "tropical_resort",
+    "name": "Tropical Resort",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "098",
+    "description": "Reduce your heat production 2 steps and increase your M€ production 3 steps.",
+    "cost": 13,
+    "vp": 2,
+    "immediate": {
+      "production": {
+        "megacredits": 3,
+        "heat": -2
+      }
+    }
+  },
+  {
+    "id": "vesta_shipyard",
+    "name": "Vesta Shipyard",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "057",
+    "description": "Increase your titanium production 1 step.",
+    "cost": 15,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      }
+    }
+  },
+  {
+    "id": "viral_enhancers",
+    "name": "Viral Enhancers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "074",
+    "cost": 9,
+    "semantics": "The choice between a plant and a card resource is offered once per matching tag, and only when the played card itself stores microbes or animals. Otherwise you simply gain the plants.",
+    "passive": [
+      {
+        "trigger": "you play a card with a plant, microbe, or animal tag",
+        "effect": "for each matching tag, gain 1 plant, or add 1 resource to the played card if it stores microbes or animals"
+      }
+    ]
+  },
+  {
+    "id": "virus",
+    "name": "Virus",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "050",
+    "description": "Remove up to 2 animals or 5 plants from any player.",
+    "cost": 1,
+    "semantics": "Choose one: remove up to 2 animals from any one card, or remove up to 5 plants from any one player."
+  },
+  {
+    "id": "acquired_space_agency",
+    "name": "Acquired Space Agency",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P35",
+    "description": "Gain 6 titanium. Reveal cards until you reveal two cards with Space Tags. Take them into your hand, discard the rest.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "gain": {
+        "titanium": 6
+      },
+      "draw": {
+        "count": 2,
+        "tag": "space"
+      }
+    }
+  },
+  {
+    "id": "allied_bank",
+    "name": "Allied Bank",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "P01",
+    "description": "Increase your M€ production 4 steps. Gain 3 M€.",
+    "cost": 0,
+    "starting_megacredits": 3,
+    "immediate": {
+      "production": {
+        "megacredits": 4
+      },
+      "gain": {
+        "megacredits": 3
+      }
+    }
+  },
+  {
+    "id": "aquifer_turbines",
+    "name": "Aquifer Turbines",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "card_number": "P02",
+    "description": "Place an ocean tile. Increase your energy production 2 steps. Pay 3 M€.",
+    "cost": 0,
+    "starting_megacredits": -3,
+    "immediate": {
+      "production": {
+        "energy": 2
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    },
+    "semantics": "The starting_megacredits of -3 is a cost: you pay 3 M€ when this prelude is played, you do not gain it.",
+    "play_restriction": "you must be able to pay 3 M€"
+  },
+  {
+    "id": "biofuels",
+    "name": "Biofuels",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "P03",
+    "description": "Increase your energy and plant production 1 step. Gain 2 plants.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "plants": 1,
+        "energy": 1
+      },
+      "gain": {
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "biolab",
+    "name": "Biolab",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "P04",
+    "description": "Increase your plant production 1 step. Draw 3 cards.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "plants": 1
+      },
+      "draw": {
+        "count": 3
+      }
+    }
+  },
+  {
+    "id": "biosphere_support",
+    "name": "Biosphere Support",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "P05",
+    "description": "Increase your plant production 2 steps. Decrease your M€ production 1 step.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": -1,
+        "plants": 2
+      }
+    }
+  },
+  {
+    "id": "business_empire",
+    "name": "Business Empire",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "P06",
+    "description": "Increase your M€ production 6 steps. Pay 6 M€.",
+    "cost": 0,
+    "starting_megacredits": -6,
+    "immediate": {
+      "production": {
+        "megacredits": 6
+      }
+    },
+    "semantics": "The starting_megacredits of -6 is a cost: you pay 6 M€ when this prelude is played, you do not gain it.",
+    "play_restriction": "you must be able to pay 6 M€, unless you have Manutech, whose M€ production gain covers the cost"
+  },
+  {
+    "id": "cheung_shing_mars",
+    "name": "Cheung Shing MARS",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "R16",
+    "description": "You start with 3 M€ production and 44 M€.",
+    "starting_megacredits": 44,
+    "immediate": {
+      "production": {
+        "megacredits": 3
+      }
+    },
+    "card_discount": [
+      {
+        "tag": "building",
+        "amount": 2
+      }
+    ]
+  },
+  {
+    "id": "dome_farming",
+    "name": "Dome Farming",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P07",
+    "description": "Increase your M€ production 2 steps and plant production 1 step.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "plants": 1
+      }
+    }
+  },
+  {
+    "id": "donation",
+    "name": "Donation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P08",
+    "description": "Gain 21 M€.",
+    "cost": 0,
+    "starting_megacredits": 21,
+    "immediate": {
+      "gain": {
+        "megacredits": 21
+      }
+    }
+  },
+  {
+    "id": "early_settlement",
+    "name": "Early Settlement",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": false,
+    "card_number": "P09",
+    "description": "Increase your plant production 1 step. Place a city tile.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "plants": 1
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "eccentric_sponsor",
+    "name": "Eccentric Sponsor",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "P11",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "semantics": "Play one card from your hand at a 25 M€ discount, which makes almost any card free. If you play no card the prelude fizzles and the discount is not carried over."
+  },
+  {
+    "id": "ecology_experts",
+    "name": "Ecology Experts",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant",
+      "microbe"
+    ],
+    "bespoke": true,
+    "card_number": "P10",
+    "description": "Increase your plant production 1 step. PLAY A CARD FROM HAND, IGNORING GLOBAL REQUIREMENTS.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "plants": 1
+      }
+    },
+    "semantics": "Increase your plant production 1 step, then play one card from your hand ignoring its global parameter requirements. Tag and other non-global requirements still apply.",
+    "play_restriction": "you must have at least one card in hand that becomes playable once global requirements are ignored"
+  },
+  {
+    "id": "experimental_forest",
+    "name": "Experimental Forest",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "card_number": "P12",
+    "description": "Place 1 greenery tile and raise oxygen 1 step. Reveal cards until you reveal two cards with plant tags on them. Take them into your hand and discard the rest.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "draw": {
+        "count": 2,
+        "tag": "plant"
+      },
+      "place": [
+        {
+          "tile": "greenery"
+        }
+      ]
+    }
+  },
+  {
+    "id": "galilean_mining",
+    "name": "Galilean Mining",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true,
+    "card_number": "P13",
+    "description": "Increase your titanium production 2 steps. Pay 5 M€.",
+    "cost": 0,
+    "starting_megacredits": -5,
+    "immediate": {
+      "production": {
+        "titanium": 2
+      }
+    },
+    "semantics": "The starting_megacredits of -5 is a cost: you pay 5 M€ when this prelude is played, you do not gain it.",
+    "play_restriction": "you must be able to pay 5 M€"
+  },
+  {
+    "id": "great_aquifer",
+    "name": "Great Aquifer",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P14",
+    "description": "Place 2 ocean tiles.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "place": [
+        {
+          "tile": "ocean",
+          "count": 2
+        }
+      ]
+    }
+  },
+  {
+    "id": "house_printing",
+    "name": "House Printing",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P36",
+    "description": "Increase your steel production 1 step.",
+    "cost": 10,
+    "vp": 1,
+    "immediate": {
+      "production": {
+        "steel": 1
+      }
+    }
+  },
+  {
+    "id": "huge_asteroid",
+    "name": "Huge Asteroid",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "P15",
+    "description": "Increase temperature 3 steps. Pay 5 M€.",
+    "cost": 0,
+    "starting_megacredits": -5,
+    "immediate": {
+      "global": {
+        "temperature": 3
+      }
+    },
+    "semantics": "The starting_megacredits of -5 is a cost: you pay 5 M€ when this prelude is played, you do not gain it.",
+    "play_restriction": "you must be able to pay 5 M€"
+  },
+  {
+    "id": "io_research_outpost",
+    "name": "Io Research Outpost",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "jovian",
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "P16",
+    "description": "Increase your titanium production 1 step. Draw a card.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      },
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "lava_tube_settlement",
+    "name": "Lava Tube Settlement",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": true,
+    "card_number": "P37",
+    "description": "Decrease your energy production 1 step and increase your M€ production 2 steps. Place a city tile on a VOLCANIC AREA regardless of adjacent cities.",
+    "cost": 15,
+    "immediate": {
+      "production": {
+        "megacredits": 2,
+        "energy": -1
+      }
+    },
+    "semantics": "Places a city tile on a volcanic area, ignoring the usual rule that cities may not be placed next to another city. On a board with no volcanic spaces the city may go on any city-legal space.",
+    "play_restriction": "you must have at least 1 energy production and there must be a legal volcanic space"
+  },
+  {
+    "id": "loan",
+    "name": "Loan",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P17",
+    "description": "Gain 30 M€. Decrease your M€ production 2 steps.",
+    "cost": 0,
+    "starting_megacredits": 30,
+    "immediate": {
+      "production": {
+        "megacredits": -2
+      },
+      "gain": {
+        "megacredits": 30
+      }
+    }
+  },
+  {
+    "id": "martian_industries",
+    "name": "Martian Industries",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P18",
+    "description": "Increase your energy and steel production 1 step. Gain 6 M€.",
+    "cost": 0,
+    "starting_megacredits": 6,
+    "immediate": {
+      "production": {
+        "steel": 1,
+        "energy": 1
+      },
+      "gain": {
+        "megacredits": 6
+      }
+    }
+  },
+  {
+    "id": "martian_survey",
+    "name": "Martian Survey",
+    "set": "prelude",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "card_number": "P38",
+    "description": "Oxygen must be 4% or lower. Draw two cards.",
+    "cost": 9,
+    "vp": 1,
+    "requirements": [
+      {
+        "type": "oxygen",
+        "max": 4
+      }
+    ],
+    "immediate": {
+      "draw": {
+        "count": 2
+      }
+    }
+  },
+  {
+    "id": "metal_rich_asteroid",
+    "name": "Metal-Rich Asteroid",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P19",
+    "description": "Increase temperature 1 step. Gain 4 titanium and 4 steel.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "gain": {
+        "steel": 4,
+        "titanium": 4
+      },
+      "global": {
+        "temperature": 1
+      }
+    }
+  },
+  {
+    "id": "metals_company",
+    "name": "Metals Company",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P20",
+    "description": "Increase your M€, steel and titanium production 1 step.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": 1,
+        "steel": 1,
+        "titanium": 1
+      }
+    }
+  },
+  {
+    "id": "mining_operations",
+    "name": "Mining Operations",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P21",
+    "description": "Increase your steel production 2 steps. Gain 4 steel.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "steel": 2
+      },
+      "gain": {
+        "steel": 4
+      }
+    }
+  },
+  {
+    "id": "mohole",
+    "name": "Mohole",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P22",
+    "description": "Increase your heat production 3 steps. Gain 3 heat.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "heat": 3
+      },
+      "gain": {
+        "heat": 3
+      }
+    }
+  },
+  {
+    "id": "mohole_excavation",
+    "name": "Mohole Excavation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P23",
+    "description": "Increase your steel production 1 step and heat production 2 steps. Gain 2 heat.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "steel": 1,
+        "heat": 2
+      },
+      "gain": {
+        "heat": 2
+      }
+    }
+  },
+  {
+    "id": "nitrogen_shipment",
+    "name": "Nitrogen Shipment",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P24",
+    "description": "Increase your plant production 1 step. Increase your TR 1 step. Gain 5 M€.",
+    "cost": 0,
+    "starting_megacredits": 5,
+    "immediate": {
+      "production": {
+        "plants": 1
+      },
+      "gain": {
+        "megacredits": 5,
+        "tr": 1
+      }
+    }
+  },
+  {
+    "id": "orbital_construction_yard",
+    "name": "Orbital Construction Yard",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "card_number": "P25",
+    "description": "Increase your titanium production 1 step. Gain 4 titanium.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      },
+      "gain": {
+        "titanium": 4
+      }
+    }
+  },
+  {
+    "id": "point_luna",
+    "name": "Point Luna",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space",
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "R10",
+    "description": "You start with 1 titanium production and 38 M€.",
+    "starting_megacredits": 38,
+    "immediate": {
+      "production": {
+        "titanium": 1
+      }
+    },
+    "semantics": "A trigger on your own cards only.",
+    "passive": [
+      {
+        "trigger": "you play a card with at least one Earth tag",
+        "effect": "draw 1 card for each Earth tag on it"
+      }
+    ]
+  },
+  {
+    "id": "polar_industries",
+    "name": "Polar Industries",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P26",
+    "description": "Increase your heat production 2 steps. Place an ocean tile.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "heat": 2
+      },
+      "place": [
+        {
+          "tile": "ocean"
+        }
+      ]
+    }
+  },
+  {
+    "id": "power_generation",
+    "name": "Power Generation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "P27",
+    "description": "Increase your energy production 3 steps.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "energy": 3
+      }
+    }
+  },
+  {
+    "id": "psychrophiles",
+    "name": "Psychrophiles",
+    "set": "prelude",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "card_number": "P39",
+    "description": "Temperature must be -20 C or lower.",
+    "cost": 2,
+    "resource_type": "Microbe",
+    "requirements": [
+      {
+        "type": "temperature",
+        "max": -20
+      }
+    ],
+    "action": {
+      "gain": {
+        "resources_here": 1
+      }
+    }
+  },
+  {
+    "id": "research_coordination",
+    "name": "Research Coordination",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "wild"
+    ],
+    "bespoke": false,
+    "card_number": "P40",
+    "description": "After being played, when you perform an action, the wild tag counts as any tag of your choice.",
+    "cost": 4
+  },
+  {
+    "id": "research_network",
+    "name": "Research Network",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "wild"
+    ],
+    "bespoke": false,
+    "card_number": "P28",
+    "description": "Increase your M€ production 1 step. Draw 3 cards. After being played, when you perform an action, the wild tag counts as any tag of your choice.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": 1
+      },
+      "draw": {
+        "count": 3
+      }
+    }
+  },
+  {
+    "id": "robinson_industries",
+    "name": "Robinson Industries",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": true,
+    "card_number": "R27",
+    "description": "You start with 47 M€.",
+    "starting_megacredits": 47,
+    "semantics": "The action costs 4 M€ and increases your lowest production 1 step. Only productions tied for lowest are eligible; if several tie, you choose among them."
+  },
+  {
+    "id": "self_sufficient_settlement",
+    "name": "Self-Sufficient Settlement",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": false,
+    "card_number": "P29",
+    "description": "Increase your M€ production 2 steps. Place a city tile.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": 2
+      },
+      "place": [
+        {
+          "tile": "city"
+        }
+      ]
+    }
+  },
+  {
+    "id": "sf_memorial",
+    "name": "SF Memorial",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P41",
+    "description": "Draw 1 card.",
+    "cost": 7,
+    "vp": 1,
+    "immediate": {
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "smelting_plant",
+    "name": "Smelting Plant",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "card_number": "P30",
+    "description": "Raise oxygen 2 steps. Gain 5 steel.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "gain": {
+        "steel": 5
+      },
+      "global": {
+        "oxygen": 2
+      }
+    }
+  },
+  {
+    "id": "society_support",
+    "name": "Society Support",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P31",
+    "description": "Increase your plant, energy and heat production 1 step. Decrease M€ production 1 step.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "megacredits": -1,
+        "plants": 1,
+        "energy": 1,
+        "heat": 1
+      }
+    }
+  },
+  {
+    "id": "space_hotels",
+    "name": "Space Hotels",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space",
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "P42",
+    "description": "Requires 2 Earth tags. Increase M€ production 4 steps.",
+    "cost": 12,
+    "requirements": [
+      {
+        "type": "tag",
+        "tag": "earth",
+        "min": 2
+      }
+    ],
+    "immediate": {
+      "production": {
+        "megacredits": 4
+      }
+    }
+  },
+  {
+    "id": "supplier",
+    "name": "Supplier",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "card_number": "P32",
+    "description": "Increase your energy production 2 steps. Gain 4 steel.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "production": {
+        "energy": 2
+      },
+      "gain": {
+        "steel": 4
+      }
+    }
+  },
+  {
+    "id": "supply_drop",
+    "name": "Supply Drop",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "card_number": "P33",
+    "description": "Gain 3 titanium, 8 steel and 3 plants.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "gain": {
+        "steel": 8,
+        "titanium": 3,
+        "plants": 3
+      }
+    }
+  },
+  {
+    "id": "unmi_contractor",
+    "name": "UNMI Contractor",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "card_number": "P34",
+    "description": "Increase your TR 3 steps. Draw a card.",
+    "cost": 0,
+    "starting_megacredits": 0,
+    "immediate": {
+      "gain": {
+        "tr": 3
+      },
+      "draw": {
+        "count": 1
+      }
+    }
+  },
+  {
+    "id": "valley_trust",
+    "name": "Valley Trust",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "R34",
+    "description": "You start with 37 M€. As your first action, draw 3 Prelude cards, and play one of them. Discard the other two.",
+    "starting_megacredits": 37,
+    "first_action": {
+      "text": "Draw 3 Prelude cards, and play one of them"
+    },
+    "card_discount": [
+      {
+        "tag": "science",
+        "amount": 2
+      }
+    ],
+    "semantics": "The 2 M€ discount on science-tag cards is in card_discount. The first action draws 3 Prelude cards from the prelude deck; you play one and discard the other two."
+  },
+  {
+    "id": "vitor",
+    "name": "Vitor",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "card_number": "R35",
+    "description": "You start with 45 M€. As your first action, fund an award for free.",
+    "starting_megacredits": 48,
+    "first_action": {
+      "text": "Fund an award for free"
+    },
+    "semantics": "The printed starting M€ is 45. The database says 48 because Vitor's own effect fires when the corporation is played. The first action funds one award at no cost; in a solo game there are no awards, so it does nothing.",
+    "passive": [
+      {
+        "trigger": "you play a card with a printed victory point value greater than zero",
+        "effect": "gain 3 M€"
+      }
+    ]
+  }
+]

--- a/data/cards/index.json
+++ b/data/cards/index.json
@@ -1,0 +1,3275 @@
+[
+  {
+    "id": "adaptation_technology",
+    "name": "Adaptation Technology",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 1
+  },
+  {
+    "id": "adapted_lichen",
+    "name": "Adapted Lichen",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "advanced_ecosystems",
+    "name": "Advanced Ecosystems",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "microbe",
+      "animal"
+    ],
+    "bespoke": false,
+    "cost": 11,
+    "vp": 3
+  },
+  {
+    "id": "aerobraked_ammonia_asteroid",
+    "name": "Aerobraked Ammonia Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 26
+  },
+  {
+    "id": "algae",
+    "name": "Algae",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "ants",
+    "name": "Ants",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 9
+  },
+  {
+    "id": "aquifer_pumping",
+    "name": "Aquifer Pumping",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 18
+  },
+  {
+    "id": "archaebacteria",
+    "name": "ArchaeBacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "arctic_algae",
+    "name": "Arctic Algae",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "cost": 12
+  },
+  {
+    "id": "artificial_lake",
+    "name": "Artificial Lake",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 15,
+    "vp": 1
+  },
+  {
+    "id": "artificial_photosynthesis",
+    "name": "Artificial Photosynthesis",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "asteroid",
+    "name": "Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 14
+  },
+  {
+    "id": "asteroid_mining",
+    "name": "Asteroid Mining",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 30,
+    "vp": 2
+  },
+  {
+    "id": "beam_from_a_thorium_asteroid",
+    "name": "Beam From A Thorium Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space",
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 32,
+    "vp": 1
+  },
+  {
+    "id": "beginner_corporation",
+    "name": "Beginner Corporation",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": false
+  },
+  {
+    "id": "big_asteroid",
+    "name": "Big Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 27
+  },
+  {
+    "id": "biomass_combustors",
+    "name": "Biomass Combustors",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 4,
+    "vp": -1
+  },
+  {
+    "id": "birds",
+    "name": "Birds",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "black_polar_dust",
+    "name": "Black Polar Dust",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 15
+  },
+  {
+    "id": "breathing_filters",
+    "name": "Breathing Filters",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 11,
+    "vp": 2
+  },
+  {
+    "id": "bushes",
+    "name": "Bushes",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "capital",
+    "name": "Capital",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 26
+  },
+  {
+    "id": "carbonate_processing",
+    "name": "Carbonate Processing",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "cloud_seeding",
+    "name": "Cloud Seeding",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "colonizer_training_camp",
+    "name": "Colonizer Training Camp",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 8,
+    "vp": 2
+  },
+  {
+    "id": "comet",
+    "name": "Comet",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 21
+  },
+  {
+    "id": "convoy_from_europa",
+    "name": "Convoy From Europa",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 15
+  },
+  {
+    "id": "credicor",
+    "name": "CrediCor",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": true
+  },
+  {
+    "id": "cupola_city",
+    "name": "Cupola City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 16
+  },
+  {
+    "id": "decomposers",
+    "name": "Decomposers",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 5
+  },
+  {
+    "id": "deep_well_heating",
+    "name": "Deep Well Heating",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "deimos_down",
+    "name": "Deimos Down",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 31
+  },
+  {
+    "id": "designed_microorganisms",
+    "name": "Designed Microorganisms",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 16
+  },
+  {
+    "id": "domed_crater",
+    "name": "Domed Crater",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 24,
+    "vp": 1
+  },
+  {
+    "id": "dust_seals",
+    "name": "Dust Seals",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 2,
+    "vp": 1
+  },
+  {
+    "id": "ecoline",
+    "name": "Ecoline",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false
+  },
+  {
+    "id": "ecological_zone",
+    "name": "Ecological Zone",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal",
+      "plant"
+    ],
+    "bespoke": true,
+    "cost": 12
+  },
+  {
+    "id": "energy_saving",
+    "name": "Energy Saving",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 15
+  },
+  {
+    "id": "eos_chasma_national_park",
+    "name": "Eos Chasma National Park",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 16,
+    "vp": 1
+  },
+  {
+    "id": "equatorial_magnetizer",
+    "name": "Equatorial Magnetizer",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "extreme_cold_fungus",
+    "name": "Extreme-Cold Fungus",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 13
+  },
+  {
+    "id": "farming",
+    "name": "Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 16,
+    "vp": 2
+  },
+  {
+    "id": "fish",
+    "name": "Fish",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "flooding",
+    "name": "Flooding",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 7,
+    "vp": -1
+  },
+  {
+    "id": "food_factory",
+    "name": "Food Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 1
+  },
+  {
+    "id": "fueled_generators",
+    "name": "Fueled Generators",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 1
+  },
+  {
+    "id": "fusion_power",
+    "name": "Fusion Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 14
+  },
+  {
+    "id": "ganymede_colony",
+    "name": "Ganymede Colony",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space",
+      "city"
+    ],
+    "bespoke": false,
+    "cost": 20
+  },
+  {
+    "id": "geothermal_power",
+    "name": "Geothermal Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "ghg_factories",
+    "name": "GHG Factories",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "ghg_producing_bacteria",
+    "name": "GHG Producing Bacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "giant_ice_asteroid",
+    "name": "Giant Ice Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 36
+  },
+  {
+    "id": "giant_space_mirror",
+    "name": "Giant Space Mirror",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 17
+  },
+  {
+    "id": "grass",
+    "name": "Grass",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "great_dam",
+    "name": "Great Dam",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 1
+  },
+  {
+    "id": "greenhouses",
+    "name": "Greenhouses",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "heat_trappers",
+    "name": "Heat Trappers",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6,
+    "vp": -1
+  },
+  {
+    "id": "heather",
+    "name": "Heather",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "helion",
+    "name": "Helion",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "herbivores",
+    "name": "Herbivores",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": true,
+    "cost": 12
+  },
+  {
+    "id": "ice_asteroid",
+    "name": "Ice Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 23
+  },
+  {
+    "id": "ice_cap_melting",
+    "name": "Ice Cap Melting",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 5
+  },
+  {
+    "id": "immigrant_city",
+    "name": "Immigrant City",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 13
+  },
+  {
+    "id": "immigration_shuttles",
+    "name": "Immigration Shuttles",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 31
+  },
+  {
+    "id": "import_of_advanced_ghg",
+    "name": "Import of Advanced GHG",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "imported_ghg",
+    "name": "Imported GHG",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 7
+  },
+  {
+    "id": "imported_hydrogen",
+    "name": "Imported Hydrogen",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": true,
+    "cost": 16
+  },
+  {
+    "id": "imported_nitrogen",
+    "name": "Imported Nitrogen",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 23
+  },
+  {
+    "id": "industrial_microbes",
+    "name": "Industrial Microbes",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "insects",
+    "name": "Insects",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "insulation",
+    "name": "Insulation",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "cost": 2
+  },
+  {
+    "id": "interplanetary_cinematics",
+    "name": "Interplanetary Cinematics",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "inventrix",
+    "name": "Inventrix",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false
+  },
+  {
+    "id": "ironworks",
+    "name": "Ironworks",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "kelp_farming",
+    "name": "Kelp Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 17,
+    "vp": 1
+  },
+  {
+    "id": "lake_marineris",
+    "name": "Lake Marineris",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 18,
+    "vp": 2
+  },
+  {
+    "id": "large_convoy",
+    "name": "Large Convoy",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": true,
+    "cost": 36,
+    "vp": 2
+  },
+  {
+    "id": "lava_flows",
+    "name": "Lava Flows",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 18
+  },
+  {
+    "id": "lichen",
+    "name": "Lichen",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 7
+  },
+  {
+    "id": "livestock",
+    "name": "Livestock",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "local_heat_trapping",
+    "name": "Local Heat Trapping",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 1
+  },
+  {
+    "id": "lunar_beam",
+    "name": "Lunar Beam",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth",
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "magnetic_field_dome",
+    "name": "Magnetic Field Dome",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 5
+  },
+  {
+    "id": "magnetic_field_generators",
+    "name": "Magnetic Field Generators",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 20
+  },
+  {
+    "id": "mangrove",
+    "name": "Mangrove",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 1
+  },
+  {
+    "id": "martian_rails",
+    "name": "Martian Rails",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "methane_from_titan",
+    "name": "Methane From Titan",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 28,
+    "vp": 2
+  },
+  {
+    "id": "micro_mills",
+    "name": "Micro-Mills",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 3
+  },
+  {
+    "id": "mining_expedition",
+    "name": "Mining Expedition",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "mining_guild",
+    "name": "Mining Guild",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building",
+      "building"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "mining_rights",
+    "name": "Mining Rights",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 9
+  },
+  {
+    "id": "mohole_area",
+    "name": "Mohole Area",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 20
+  },
+  {
+    "id": "moss",
+    "name": "Moss",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "cost": 4
+  },
+  {
+    "id": "natural_preserve",
+    "name": "Natural Preserve",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 9,
+    "vp": 1
+  },
+  {
+    "id": "nitrite_reducing_bacteria",
+    "name": "Nitrite Reducing Bacteria",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "nitrogen_rich_asteroid",
+    "name": "Nitrogen-Rich Asteroid",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true,
+    "cost": 31
+  },
+  {
+    "id": "nitrophilic_moss",
+    "name": "Nitrophilic Moss",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": true,
+    "cost": 8
+  },
+  {
+    "id": "noctis_city",
+    "name": "Noctis City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 18
+  },
+  {
+    "id": "noctis_farming",
+    "name": "Noctis Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 10,
+    "vp": 1
+  },
+  {
+    "id": "nuclear_power",
+    "name": "Nuclear Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "nuclear_zone",
+    "name": "Nuclear Zone",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 10,
+    "vp": -2
+  },
+  {
+    "id": "open_city",
+    "name": "Open City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 23,
+    "vp": 1
+  },
+  {
+    "id": "optimal_aerobraking",
+    "name": "Optimal Aerobraking",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": true,
+    "cost": 7
+  },
+  {
+    "id": "ore_processor",
+    "name": "Ore Processor",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "permafrost_extraction",
+    "name": "Permafrost Extraction",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "peroxide_power",
+    "name": "Peroxide Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 7
+  },
+  {
+    "id": "pets",
+    "name": "Pets",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth",
+      "animal"
+    ],
+    "bespoke": true,
+    "cost": 10
+  },
+  {
+    "id": "phobolog",
+    "name": "PhoboLog",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false
+  },
+  {
+    "id": "phobos_space_haven",
+    "name": "Phobos Space Haven",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space",
+      "city"
+    ],
+    "bespoke": false,
+    "cost": 25,
+    "vp": 3
+  },
+  {
+    "id": "plantation",
+    "name": "Plantation",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 15
+  },
+  {
+    "id": "power_grid",
+    "name": "Power Grid",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 18
+  },
+  {
+    "id": "power_plant",
+    "name": "Power Plant",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "predators",
+    "name": "Predators",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": true,
+    "cost": 14
+  },
+  {
+    "id": "protected_valley",
+    "name": "Protected Valley",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 23
+  },
+  {
+    "id": "rad_chem_factory",
+    "name": "Rad-Chem Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "regolith_eaters",
+    "name": "Regolith Eaters",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "release_of_inert_gases",
+    "name": "Release of Inert Gases",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 14
+  },
+  {
+    "id": "research_outpost",
+    "name": "Research Outpost",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 18
+  },
+  {
+    "id": "rover_construction",
+    "name": "Rover Construction",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 8,
+    "vp": 1
+  },
+  {
+    "id": "search_for_life",
+    "name": "Search For Life",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "cost": 3
+  },
+  {
+    "id": "shuttles",
+    "name": "Shuttles",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 10,
+    "vp": 1
+  },
+  {
+    "id": "small_animals",
+    "name": "Small Animals",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "animal"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "soil_factory",
+    "name": "Soil Factory",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 9,
+    "vp": 1
+  },
+  {
+    "id": "solar_power",
+    "name": "Solar Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11,
+    "vp": 1
+  },
+  {
+    "id": "solar_wind_power",
+    "name": "Solar Wind Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space",
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "soletta",
+    "name": "Soletta",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 35
+  },
+  {
+    "id": "space_mirrors",
+    "name": "Space Mirrors",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "power",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 3
+  },
+  {
+    "id": "special_design",
+    "name": "Special Design",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "steelworks",
+    "name": "Steelworks",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 15
+  },
+  {
+    "id": "strip_mine",
+    "name": "Strip Mine",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 25
+  },
+  {
+    "id": "subterranean_reservoir",
+    "name": "Subterranean Reservoir",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "symbiotic_fungus",
+    "name": "Symbiotic Fungus",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "tectonic_stress_power",
+    "name": "Tectonic Stress Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 18,
+    "vp": 1
+  },
+  {
+    "id": "tharsis_republic",
+    "name": "Tharsis Republic",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "thorgate",
+    "name": "ThorGate",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "towing_a_comet",
+    "name": "Towing A Comet",
+    "set": "base",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 23
+  },
+  {
+    "id": "trees",
+    "name": "Trees",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 13,
+    "vp": 1
+  },
+  {
+    "id": "tundra_farming",
+    "name": "Tundra Farming",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 16,
+    "vp": 2
+  },
+  {
+    "id": "underground_city",
+    "name": "Underground City",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 18
+  },
+  {
+    "id": "underground_detonations",
+    "name": "Underground Detonations",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "united_nations_mars_initiative",
+    "name": "United Nations Mars Initiative",
+    "set": "base",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "urbanized_area",
+    "name": "Urbanized Area",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 10
+  },
+  {
+    "id": "water_import_from_europa",
+    "name": "Water Import From Europa",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 25
+  },
+  {
+    "id": "water_splitting_plant",
+    "name": "Water Splitting Plant",
+    "set": "base",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "wave_power",
+    "name": "Wave Power",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 8,
+    "vp": 1
+  },
+  {
+    "id": "windmills",
+    "name": "Windmills",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6,
+    "vp": 1
+  },
+  {
+    "id": "worms",
+    "name": "Worms",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "zeppelins",
+    "name": "Zeppelins",
+    "set": "base",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 13,
+    "vp": 1
+  },
+  {
+    "id": "acquired_company",
+    "name": "Acquired Company",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "advanced_alloys",
+    "name": "Advanced Alloys",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "ai_central",
+    "name": "AI Central",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 21,
+    "vp": 1
+  },
+  {
+    "id": "anti_gravity_technology",
+    "name": "Anti-Gravity Technology",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 14,
+    "vp": 3
+  },
+  {
+    "id": "asteroid_mining_consortium",
+    "name": "Asteroid Mining Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true,
+    "cost": 13,
+    "vp": 1
+  },
+  {
+    "id": "bribed_committee",
+    "name": "Bribed Committee",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 7,
+    "vp": -2
+  },
+  {
+    "id": "building_industries",
+    "name": "Building Industries",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "business_contacts",
+    "name": "Business Contacts",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 7
+  },
+  {
+    "id": "business_network",
+    "name": "Business Network",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "callisto_penal_mines",
+    "name": "Callisto Penal Mines",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 24,
+    "vp": 2
+  },
+  {
+    "id": "caretaker_contract",
+    "name": "Caretaker Contract",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [],
+    "bespoke": false,
+    "cost": 3
+  },
+  {
+    "id": "cartel",
+    "name": "Cartel",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "ceo_s_favorite_project",
+    "name": "CEO's Favorite Project",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 1
+  },
+  {
+    "id": "commercial_district",
+    "name": "Commercial District",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 16
+  },
+  {
+    "id": "corporate_stronghold",
+    "name": "Corporate Stronghold",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "city",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11,
+    "vp": -2
+  },
+  {
+    "id": "development_center",
+    "name": "Development Center",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "earth_catapult",
+    "name": "Earth Catapult",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 23,
+    "vp": 2
+  },
+  {
+    "id": "earth_office",
+    "name": "Earth Office",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 1
+  },
+  {
+    "id": "electro_catapult",
+    "name": "Electro Catapult",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 17,
+    "vp": 1
+  },
+  {
+    "id": "energy_tapping",
+    "name": "Energy Tapping",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "cost": 3,
+    "vp": -1
+  },
+  {
+    "id": "fuel_factory",
+    "name": "Fuel Factory",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "gene_repair",
+    "name": "Gene Repair",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 2
+  },
+  {
+    "id": "great_escarpment_consortium",
+    "name": "Great Escarpment Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "cost": 6
+  },
+  {
+    "id": "hackers",
+    "name": "Hackers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": true,
+    "cost": 3,
+    "vp": -1
+  },
+  {
+    "id": "hired_raiders",
+    "name": "Hired Raiders",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 1
+  },
+  {
+    "id": "indentured_workers",
+    "name": "Indentured Workers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 0,
+    "vp": -1
+  },
+  {
+    "id": "industrial_center",
+    "name": "Industrial Center",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 4
+  },
+  {
+    "id": "interstellar_colony_ship",
+    "name": "Interstellar Colony Ship",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 24,
+    "vp": 4
+  },
+  {
+    "id": "invention_contest",
+    "name": "Invention Contest",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 2
+  },
+  {
+    "id": "inventors_guild",
+    "name": "Inventors' Guild",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 9
+  },
+  {
+    "id": "investment_loan",
+    "name": "Investment Loan",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 3
+  },
+  {
+    "id": "io_mining_industries",
+    "name": "Io Mining Industries",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 41
+  },
+  {
+    "id": "lagrange_observatory",
+    "name": "Lagrange Observatory",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 9,
+    "vp": 1
+  },
+  {
+    "id": "land_claim",
+    "name": "Land Claim",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 1
+  },
+  {
+    "id": "lightning_harvest",
+    "name": "Lightning Harvest",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 8,
+    "vp": 1
+  },
+  {
+    "id": "mars_university",
+    "name": "Mars University",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 8,
+    "vp": 1
+  },
+  {
+    "id": "mass_converter",
+    "name": "Mass Converter",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "media_archives",
+    "name": "Media Archives",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 8
+  },
+  {
+    "id": "media_group",
+    "name": "Media Group",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "cost": 6
+  },
+  {
+    "id": "medical_lab",
+    "name": "Medical Lab",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 13,
+    "vp": 1
+  },
+  {
+    "id": "mine",
+    "name": "Mine",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "mineral_deposit",
+    "name": "Mineral Deposit",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": false,
+    "cost": 5
+  },
+  {
+    "id": "mining_area",
+    "name": "Mining Area",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 4
+  },
+  {
+    "id": "miranda_resort",
+    "name": "Miranda Resort",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 12,
+    "vp": 1
+  },
+  {
+    "id": "olympus_conference",
+    "name": "Olympus Conference",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "earth",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 10,
+    "vp": 1
+  },
+  {
+    "id": "physics_complex",
+    "name": "Physics Complex",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "power_infrastructure",
+    "name": "Power Infrastructure",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "power",
+      "building"
+    ],
+    "bespoke": true,
+    "cost": 4
+  },
+  {
+    "id": "power_supply_consortium",
+    "name": "Power Supply Consortium",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "cost": 5
+  },
+  {
+    "id": "protected_habitats",
+    "name": "Protected Habitats",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [],
+    "bespoke": false,
+    "cost": 5
+  },
+  {
+    "id": "quantum_extractor",
+    "name": "Quantum Extractor",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 13
+  },
+  {
+    "id": "rad_suits",
+    "name": "Rad-Suits",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [],
+    "bespoke": false,
+    "cost": 6,
+    "vp": 1
+  },
+  {
+    "id": "research",
+    "name": "Research",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 11,
+    "vp": 1
+  },
+  {
+    "id": "restricted_area",
+    "name": "Restricted Area",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 11
+  },
+  {
+    "id": "robotic_workforce",
+    "name": "Robotic Workforce",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "cost": 9
+  },
+  {
+    "id": "sabotage",
+    "name": "Sabotage",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [],
+    "bespoke": true,
+    "cost": 1
+  },
+  {
+    "id": "satellites",
+    "name": "Satellites",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 10
+  },
+  {
+    "id": "saturn_systems",
+    "name": "Saturn Systems",
+    "set": "corpera",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "security_fleet",
+    "name": "Security Fleet",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "space_elevator",
+    "name": "Space Elevator",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 27,
+    "vp": 2
+  },
+  {
+    "id": "space_station",
+    "name": "Space Station",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 10,
+    "vp": 1
+  },
+  {
+    "id": "sponsors",
+    "name": "Sponsors",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 6
+  },
+  {
+    "id": "standard_technology",
+    "name": "Standard Technology",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science"
+    ],
+    "bespoke": true,
+    "cost": 6
+  },
+  {
+    "id": "tardigrades",
+    "name": "Tardigrades",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "technology_demonstration",
+    "name": "Technology Demonstration",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 5
+  },
+  {
+    "id": "teractor",
+    "name": "Teractor",
+    "set": "corpera",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false
+  },
+  {
+    "id": "terraforming_ganymede",
+    "name": "Terraforming Ganymede",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": true,
+    "cost": 33,
+    "vp": 2
+  },
+  {
+    "id": "titanium_mine",
+    "name": "Titanium Mine",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 7
+  },
+  {
+    "id": "toll_station",
+    "name": "Toll Station",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "trans_neptune_probe",
+    "name": "Trans-Neptune Probe",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "science",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 6,
+    "vp": 1
+  },
+  {
+    "id": "tropical_resort",
+    "name": "Tropical Resort",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 13,
+    "vp": 2
+  },
+  {
+    "id": "vesta_shipyard",
+    "name": "Vesta Shipyard",
+    "set": "corpera",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "jovian",
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 15,
+    "vp": 1
+  },
+  {
+    "id": "viral_enhancers",
+    "name": "Viral Enhancers",
+    "set": "corpera",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "science",
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 9
+  },
+  {
+    "id": "virus",
+    "name": "Virus",
+    "set": "corpera",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 1
+  },
+  {
+    "id": "acquired_space_agency",
+    "name": "Acquired Space Agency",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "allied_bank",
+    "name": "Allied Bank",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "aquifer_turbines",
+    "name": "Aquifer Turbines",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "biofuels",
+    "name": "Biofuels",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "biolab",
+    "name": "Biolab",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "biosphere_support",
+    "name": "Biosphere Support",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "business_empire",
+    "name": "Business Empire",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "cheung_shing_mars",
+    "name": "Cheung Shing MARS",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false
+  },
+  {
+    "id": "dome_farming",
+    "name": "Dome Farming",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant",
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "donation",
+    "name": "Donation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "early_settlement",
+    "name": "Early Settlement",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "eccentric_sponsor",
+    "name": "Eccentric Sponsor",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "ecology_experts",
+    "name": "Ecology Experts",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant",
+      "microbe"
+    ],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "experimental_forest",
+    "name": "Experimental Forest",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "plant"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "galilean_mining",
+    "name": "Galilean Mining",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "jovian"
+    ],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "great_aquifer",
+    "name": "Great Aquifer",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "house_printing",
+    "name": "House Printing",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 10,
+    "vp": 1
+  },
+  {
+    "id": "huge_asteroid",
+    "name": "Huge Asteroid",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": true,
+    "cost": 0
+  },
+  {
+    "id": "io_research_outpost",
+    "name": "Io Research Outpost",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "jovian",
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "lava_tube_settlement",
+    "name": "Lava Tube Settlement",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": true,
+    "cost": 15
+  },
+  {
+    "id": "loan",
+    "name": "Loan",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "martian_industries",
+    "name": "Martian Industries",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "martian_survey",
+    "name": "Martian Survey",
+    "set": "prelude",
+    "kind": "project",
+    "type": "event",
+    "tags": [
+      "science"
+    ],
+    "bespoke": false,
+    "cost": 9,
+    "vp": 1
+  },
+  {
+    "id": "metal_rich_asteroid",
+    "name": "Metal-Rich Asteroid",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "metals_company",
+    "name": "Metals Company",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "mining_operations",
+    "name": "Mining Operations",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "mohole",
+    "name": "Mohole",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "mohole_excavation",
+    "name": "Mohole Excavation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "nitrogen_shipment",
+    "name": "Nitrogen Shipment",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "orbital_construction_yard",
+    "name": "Orbital Construction Yard",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "space"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "point_luna",
+    "name": "Point Luna",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "space",
+      "earth"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "polar_industries",
+    "name": "Polar Industries",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "power_generation",
+    "name": "Power Generation",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "psychrophiles",
+    "name": "Psychrophiles",
+    "set": "prelude",
+    "kind": "project",
+    "type": "active",
+    "tags": [
+      "microbe"
+    ],
+    "bespoke": false,
+    "cost": 2
+  },
+  {
+    "id": "research_coordination",
+    "name": "Research Coordination",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "wild"
+    ],
+    "bespoke": false,
+    "cost": 4
+  },
+  {
+    "id": "research_network",
+    "name": "Research Network",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "wild"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "robinson_industries",
+    "name": "Robinson Industries",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [],
+    "bespoke": true
+  },
+  {
+    "id": "self_sufficient_settlement",
+    "name": "Self-Sufficient Settlement",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building",
+      "city"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "sf_memorial",
+    "name": "SF Memorial",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 7,
+    "vp": 1
+  },
+  {
+    "id": "smelting_plant",
+    "name": "Smelting Plant",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "building"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "society_support",
+    "name": "Society Support",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "space_hotels",
+    "name": "Space Hotels",
+    "set": "prelude",
+    "kind": "project",
+    "type": "automated",
+    "tags": [
+      "space",
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 12
+  },
+  {
+    "id": "supplier",
+    "name": "Supplier",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "power"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "supply_drop",
+    "name": "Supply Drop",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "unmi_contractor",
+    "name": "UNMI Contractor",
+    "set": "prelude",
+    "kind": "prelude",
+    "type": "prelude",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": false,
+    "cost": 0
+  },
+  {
+    "id": "valley_trust",
+    "name": "Valley Trust",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true
+  },
+  {
+    "id": "vitor",
+    "name": "Vitor",
+    "set": "prelude",
+    "kind": "corporation",
+    "type": "corporation",
+    "tags": [
+      "earth"
+    ],
+    "bespoke": true
+  }
+]

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "lint:css:fix": "stylelint --fix \"src/styles/**/*.less\" \"src/client/**/*.vue\"",
     "lint:fix": "eslint --fix src tests",
     "make:cards": "npx tsx src/server/tools/export_card_rendering.ts",
+    "make:card-db": "npx tsx src/server/tools/export_card_database.ts",
     "make:css": "lessc src/styles/common.less build/styles.css && node src/server/tools/gzip.js",
     "watch:less": "npx tsx scripts/watchcss.ts src/styles",
     "watch:cards": "npx tsx scripts/watchcards.ts src/server/cards",

--- a/src/server/cards/Card.ts
+++ b/src/server/cards/Card.ts
@@ -227,6 +227,17 @@ export abstract class Card implements ICard {
   public get cardDiscount() {
     return this.properties.cardDiscount;
   }
+  /**
+   * The data-defined behavior of this card's repeatable action.
+   *
+   * Named to avoid colliding with `IActionCard.action`, which executes it.
+   */
+  public get actionBehavior() {
+    return this.properties.action;
+  }
+  public get globalParameterRequirementBonus() {
+    return this.properties.globalParameterRequirementBonus;
+  }
   public get reserveUnits(): Units {
     return this.properties.reserveUnits || Units.EMPTY;
   }

--- a/src/server/tools/cardDatabase/CardDatabaseTypes.ts
+++ b/src/server/tools/cardDatabase/CardDatabaseTypes.ts
@@ -3,6 +3,7 @@ import {CardType} from '@/common/cards/CardType';
 import {Expansion} from '@/common/cards/GameModule';
 import {Resource} from '@/common/Resource';
 import {Tag} from '@/common/cards/Tag';
+import {TileType} from '@/common/TileType';
 
 /** The game modules this database covers. */
 export const CARD_SETS = ['base', 'corpera', 'prelude'] as const;
@@ -77,7 +78,7 @@ export type ResourceAmounts = Partial<Record<Resource, Amount>>;
 /** A tile this card puts on the board. */
 export type PlaceTile = {
   /** 'ocean', 'city', 'greenery', or a `TileType` value for a special tile. */
-  tile: string,
+  tile: string | TileType,
   /** How many tiles. Defaults to 1 when absent. */
   count?: number,
   /** The `PlacementType` restricting where the tile may go. */

--- a/src/server/tools/cardDatabase/CardDatabaseTypes.ts
+++ b/src/server/tools/cardDatabase/CardDatabaseTypes.ts
@@ -1,0 +1,230 @@
+import {CardResource} from '@/common/CardResource';
+import {CardType} from '@/common/cards/CardType';
+import {Expansion} from '@/common/cards/GameModule';
+import {Resource} from '@/common/Resource';
+import {Tag} from '@/common/cards/Tag';
+
+/** The game modules this database covers. */
+export const CARD_SETS = ['base', 'corpera', 'prelude'] as const;
+export type CardSet = typeof CARD_SETS[number];
+
+/** How a card enters play: as a project from hand, as a starting corporation, or as a prelude. */
+export const CARD_KINDS = ['project', 'corporation', 'prelude'] as const;
+export type CardKind = typeof CARD_KINDS[number];
+
+/** The named quantities a requirement can measure. */
+export const REQUIREMENT_TYPES = [
+  'tag', 'production', 'removed_plants',
+  'oxygen', 'temperature', 'oceans', 'greeneries', 'cities',
+  'venus', 'tr', 'resource_types', 'colonies', 'floaters', 'party_leaders',
+  'habitat_tiles', 'mining_tiles', 'road_tiles',
+  'habitat_rate', 'mining_rate', 'logistic_rate',
+  'underground_tokens', 'corruption',
+] as const;
+export type RequirementType = typeof REQUIREMENT_TYPES[number];
+
+/** A condition that must hold before the card may be played. */
+export type Requirement = {
+  type: RequirementType,
+  /** Set when `type` is 'tag'. */
+  tag?: Tag,
+  /** Set when `type` is 'production'. */
+  resource?: Resource,
+  /** Inclusive lower bound. Present unless the requirement is a maximum. */
+  min?: number,
+  /** Inclusive upper bound. */
+  max?: number,
+  /** When 'any_player', every player's assets count, not only the card owner's. */
+  scope?: 'any_player',
+  /** When true, only tiles adjacent to the tile this card places are counted. */
+  next_to?: boolean,
+  /** Free text printed on the physical card that the structured fields do not capture. */
+  text?: string,
+};
+
+/** The things a game-state-dependent quantity can count. */
+export const DYNAMIC_COUNTS = [
+  'tag', 'cities', 'greeneries', 'oceans', 'resources_here', 'floaters', 'events_played',
+] as const;
+export type DynamicCount = typeof DYNAMIC_COUNTS[number];
+
+/** A quantity derived from the game state instead of a fixed number. */
+export type Dynamic = {
+  counts: DynamicCount,
+  /** Which tag or tags are counted. Set when `counts` is 'tag'. */
+  tag?: Tag | Array<Tag>,
+  /**
+   * Whose assets are counted. Omitted means the natural default: your own for
+   * tags, the whole board for tiles.
+   */
+  scope?: 'everyone' | 'opponents',
+  /** Multiply the count by this. Applied before `per`. */
+  each?: number,
+  /** Divide the count by this, rounding down. */
+  per?: number,
+  /** Only count things adjacent to the tile this card places. */
+  next_to_this?: boolean,
+  /** Include event cards when counting tags. */
+  include_events?: boolean,
+};
+
+/** A fixed number, or a quantity computed from the game state. */
+export type Amount = number | {dynamic: Dynamic};
+
+/** Standard resource quantities. Negative values are reductions. */
+export type ResourceAmounts = Partial<Record<Resource, Amount>>;
+
+/** A tile this card puts on the board. */
+export type PlaceTile = {
+  /** 'ocean', 'city', 'greenery', or a `TileType` value for a special tile. */
+  tile: string,
+  /** How many tiles. Defaults to 1 when absent. */
+  count?: number,
+  /** The `PlacementType` restricting where the tile may go. */
+  on?: string,
+  /** A named space the tile must occupy. */
+  space?: string,
+  /** The prompt shown to the player, which usually spells out the placement rule. */
+  title?: string,
+};
+
+/** Something the card does: on play, as its action, or as its corporation first action. */
+export type Effect = {
+  /** Paid before the rest of the effect happens. Only one kind of payment per effect. */
+  spend?: ResourceAmounts & {
+    resources_here?: number,
+    cards?: number,
+    resource_from_any_card?: CardResource,
+    /** Standard resources accepted in place of M€. */
+    can_pay_with?: Array<'steel' | 'titanium'>,
+  },
+  /** Forgiving loss: takes what the player has and never blocks the effect. */
+  lose?: {production?: ResourceAmounts, stock?: ResourceAmounts},
+  /** Production changes for the card owner. */
+  production?: ResourceAmounts,
+  /** Resources and rating the card owner gains. */
+  gain?: ResourceAmounts & {
+    tr?: Amount,
+    /** Resources added to this card itself. */
+    resources_here?: Amount,
+    /** Free choice of standard resources. */
+    standard_resource?: {count: number, same: boolean},
+  },
+  /** Cards drawn from the project deck. */
+  draw?: {
+    count: Amount,
+    /** Keep this many of the drawn cards and discard the rest. */
+    keep?: number,
+    /** The player may buy the drawn cards instead of taking them free. */
+    pay?: boolean,
+    /** Only cards with this tag are kept. */
+    tag?: Tag,
+    /** Only cards of this type are kept. */
+    type?: CardType,
+    /** Only cards storing this resource are kept. */
+    resource?: CardResource,
+  },
+  /** Global parameter increases, in steps. */
+  global?: {temperature?: number, oxygen?: number, venus?: number},
+  /** Tiles placed on the board. */
+  place?: Array<PlaceTile>,
+  /** Reduce a chosen player's production. The card owner may be the target. */
+  decrease_any_production?: {resource: Resource, count: number},
+  /** Remove plants from a chosen player. */
+  remove_any_plants?: number,
+  /** Resources added to cards other than, or including, this one. */
+  add_resources_to_any_card?: Array<{
+    count: Amount,
+    resource?: CardResource,
+    tag?: Tag,
+    /** This card cannot be the target. */
+    exclude_this?: boolean,
+    /** A legal target card must exist for the effect to be taken. */
+    must_have_card?: boolean,
+    /** Only cards already holding at least this many resources are eligible. */
+    min?: number,
+  }>,
+  /** Permanent increase to what one steel is worth in M€. */
+  steel_value?: number,
+  /** Permanent increase to what one titanium is worth in M€. */
+  titanium_value?: number,
+  /** Permanent reduction to the plant cost of placing a greenery. */
+  greenery_discount?: number,
+  /** The player picks exactly one of these. */
+  or?: Array<Effect & {title: string}>,
+};
+
+/** A continuous or triggered effect that is not expressible as declarative data. */
+export type Passive = {
+  /** The game event that fires the effect. */
+  trigger: string,
+  /** What happens when it fires. */
+  effect: string,
+};
+
+/** One card. */
+export type CardEntry = {
+  id: string,
+  name: string,
+  set: CardSet,
+  kind: CardKind,
+  type: CardType,
+  /** The number printed on the physical card. */
+  card_number?: string,
+  /** The rules text printed on the physical card. */
+  description?: string,
+  /** M€ cost. Absent for corporations. */
+  cost?: number,
+  /**
+   * M€ a corporation starts with, or the M€ a prelude grants. A negative value
+   * is a cost the player must pay when the prelude is played.
+   */
+  starting_megacredits?: number,
+  /** Fixed price this corporation pays per card during research. */
+  card_cost?: number,
+  tags: Array<Tag>,
+  /** The card resource this card stores. */
+  resource_type?: CardResource,
+  /** Other players may not remove resources from this card. */
+  protected_resources?: boolean,
+  /** Fixed victory points. Negative values are penalties. */
+  vp?: number,
+  /** Victory points computed from the game state. */
+  vp_dynamic?: Dynamic,
+  /** True when scoring needs bespoke logic; read `semantics`. */
+  vp_special?: boolean,
+  requirements?: Array<Requirement>,
+  /** What happens when the card is played. */
+  immediate?: Effect,
+  /** A corporation's first action of the game. */
+  first_action?: Effect & {text?: string},
+  /** The repeatable action of an active card. */
+  action?: Effect,
+  /** Permanent discount this card gives on playing other cards. */
+  card_discount?: Array<{tag?: Tag, amount: number, per?: 'card' | 'tag'}>,
+  /** Permanent shift to this player's global parameter requirements. */
+  global_parameter_requirement_bonus?: {steps: number, parameter?: string, next_card_only?: boolean},
+  /** Expansions this card additionally requires. */
+  compatibility?: Array<Expansion>,
+  /** True when part of this card's behavior lives in code, not in data. */
+  bespoke: boolean,
+  /** Prose statement of everything the structured fields cannot express. */
+  semantics?: string,
+  /** Triggered and continuous effects. */
+  passive?: Array<Passive>,
+  /** Restriction on when the card may be played or where its tile may go. */
+  play_restriction?: string,
+};
+
+/** A row of the lightweight lookup table. */
+export type IndexEntry = {
+  id: string,
+  name: string,
+  set: CardSet,
+  kind: CardKind,
+  type: CardType,
+  cost?: number,
+  tags: Array<Tag>,
+  vp?: number,
+  bespoke: boolean,
+};

--- a/src/server/tools/cardDatabase/buildCardDatabase.ts
+++ b/src/server/tools/cardDatabase/buildCardDatabase.ts
@@ -1,0 +1,186 @@
+import {ALL_MODULE_MANIFESTS} from '@/server/cards/AllManifests';
+import {CardEntry, CardKind, CardSet, IndexEntry} from './CardDatabaseTypes';
+import {CardManifest, ModuleManifest} from '@/server/cards/ModuleManifest';
+import {Expansion, GameModule} from '@/common/cards/GameModule';
+import {normalizeEffect, normalizeVictoryPoints} from './normalizeEffect';
+import {Card} from '@/server/cards/Card';
+import {CardType} from '@/common/cards/CardType';
+import {ICard} from '@/server/cards/ICard';
+import {OneOrArray} from '@/common/utils/types';
+import {asArray} from '@/common/utils/utils';
+import {cardId} from './cardId';
+import {hasBespokeLogic} from './hasBespokeLogic';
+import {isIDescription} from '@/common/cards/render/ICardRenderDescription';
+import {normalizeRequirements} from './normalizeRequirements';
+
+/** The sets this database covers, in the order they are emitted. */
+const SETS: ReadonlyArray<CardSet> = ['base', 'corpera', 'prelude'];
+
+function isCardSet(module: GameModule): module is CardSet {
+  return SETS.includes(module as CardSet);
+}
+
+function kindOf(type: CardType): CardKind {
+  switch (type) {
+  case CardType.CORPORATION:
+    return 'corporation';
+  case CardType.PRELUDE:
+    return 'prelude';
+  default:
+    return 'project';
+  }
+}
+
+function describe(card: ICard): string | undefined {
+  const description = card.metadata.description;
+  if (description === undefined) {
+    return undefined;
+  }
+  return isIDescription(description) ? description.text : description;
+}
+
+function entryFor(set: CardSet, card: Card, compatibility: undefined | OneOrArray<Expansion>): CardEntry {
+  const kind = kindOf(card.type);
+  const entry: CardEntry = {
+    id: cardId(card.name),
+    name: card.name,
+    set: set,
+    kind: kind,
+    type: card.type,
+    tags: [...card.tags],
+    bespoke: hasBespokeLogic(card),
+  };
+
+  if (card.metadata.cardNumber !== undefined) {
+    entry.card_number = card.metadata.cardNumber;
+  }
+  const description = describe(card);
+  if (description !== undefined) {
+    entry.description = description;
+  }
+  if (kind !== 'corporation') {
+    entry.cost = card.cost;
+  }
+  if (kind !== 'project') {
+    entry.starting_megacredits = card.startingMegaCredits;
+  }
+  if (card.cardCost !== undefined) {
+    entry.card_cost = card.cardCost;
+  }
+  if (card.resourceType !== undefined) {
+    entry.resource_type = card.resourceType;
+  }
+  if (card.protectedResources === true) {
+    entry.protected_resources = true;
+  }
+
+  const vp = card.victoryPoints;
+  if (typeof vp === 'number') {
+    entry.vp = vp;
+  } else if (vp === 'special') {
+    entry.vp_special = true;
+  } else if (vp !== undefined) {
+    entry.vp_dynamic = normalizeVictoryPoints(vp);
+  }
+
+  if (card.requirements.length > 0) {
+    entry.requirements = normalizeRequirements(card.requirements);
+  }
+
+  const immediate = normalizeEffect(card.behavior);
+  if (immediate !== undefined) {
+    entry.immediate = immediate;
+  }
+  const firstAction = normalizeEffect(card.firstAction);
+  const firstActionText = card.initialActionText;
+  if (firstAction !== undefined || firstActionText !== undefined) {
+    entry.first_action = {...firstAction};
+    if (firstActionText !== undefined) {
+      entry.first_action.text = firstActionText;
+    }
+  }
+  const action = normalizeEffect(card.actionBehavior);
+  if (action !== undefined) {
+    entry.action = action;
+  }
+
+  if (card.cardDiscount !== undefined) {
+    entry.card_discount = asArray(card.cardDiscount).map((discount) => ({...discount}));
+  }
+  const bonus = card.globalParameterRequirementBonus;
+  if (bonus !== undefined) {
+    entry.global_parameter_requirement_bonus = {steps: bonus.steps};
+    if (bonus.parameter !== undefined) {
+      entry.global_parameter_requirement_bonus.parameter = bonus.parameter;
+    }
+    if (bonus.nextCardOnly === true) {
+      entry.global_parameter_requirement_bonus.next_card_only = true;
+    }
+  }
+  if (compatibility !== undefined) {
+    entry.compatibility = [...asArray(compatibility)];
+  }
+  return entry;
+}
+
+function entriesFromDeck<T extends ICard>(deck: CardManifest<T>, set: CardSet, entries: Array<CardEntry>): void {
+  for (const factory of CardManifest.values(deck)) {
+    const card = new factory.Factory();
+    if (card.type === CardType.PROXY) {
+      continue;
+    }
+    if (!(card instanceof Card)) {
+      throw new Error('Not a data-driven card: ' + card.name);
+    }
+    entries.push(entryFor(set, card, factory.compatibility));
+  }
+}
+
+function entriesForManifest(manifest: ModuleManifest, set: CardSet): Array<CardEntry> {
+  const entries: Array<CardEntry> = [];
+  entriesFromDeck(manifest.projectCards, set, entries);
+  entriesFromDeck(manifest.corporationCards, set, entries);
+  entriesFromDeck(manifest.preludeCards, set, entries);
+  return entries;
+}
+
+/**
+ * Builds the card database for the base, Corporate Era and Prelude modules.
+ *
+ * Entries are sorted by set and then by id so that repeated runs produce
+ * identical output.
+ */
+export function buildCardDatabase(): Array<CardEntry> {
+  const entries: Array<CardEntry> = [];
+  for (const manifest of ALL_MODULE_MANIFESTS) {
+    if (isCardSet(manifest.module)) {
+      entries.push(...entriesForManifest(manifest, manifest.module));
+    }
+  }
+  return entries.sort((a, b) => {
+    const bySet = SETS.indexOf(a.set) - SETS.indexOf(b.set);
+    return bySet !== 0 ? bySet : a.id.localeCompare(b.id);
+  });
+}
+
+/** Reduces the database to the fields an agent needs to find a card. */
+export function buildIndex(entries: ReadonlyArray<CardEntry>): Array<IndexEntry> {
+  return entries.map((entry) => {
+    const row: IndexEntry = {
+      id: entry.id,
+      name: entry.name,
+      set: entry.set,
+      kind: entry.kind,
+      type: entry.type,
+      tags: entry.tags,
+      bespoke: entry.bespoke,
+    };
+    if (entry.cost !== undefined) {
+      row.cost = entry.cost;
+    }
+    if (entry.vp !== undefined) {
+      row.vp = entry.vp;
+    }
+    return row;
+  });
+}

--- a/src/server/tools/cardDatabase/buildCardDatabase.ts
+++ b/src/server/tools/cardDatabase/buildCardDatabase.ts
@@ -12,6 +12,7 @@ import {cardId} from './cardId';
 import {hasBespokeLogic} from './hasBespokeLogic';
 import {isIDescription} from '@/common/cards/render/ICardRenderDescription';
 import {normalizeRequirements} from './normalizeRequirements';
+import {applyOverlay} from './overlay';
 
 /** The sets this database covers, in the order they are emitted. */
 const SETS: ReadonlyArray<CardSet> = ['base', 'corpera', 'prelude'];
@@ -132,7 +133,7 @@ function entriesFromDeck<T extends ICard>(deck: CardManifest<T>, set: CardSet, e
     if (!(card instanceof Card)) {
       throw new Error('Not a data-driven card: ' + card.name);
     }
-    entries.push(entryFor(set, card, factory.compatibility));
+    entries.push(applyOverlay(entryFor(set, card, factory.compatibility)));
   }
 }
 

--- a/src/server/tools/cardDatabase/cardId.ts
+++ b/src/server/tools/cardDatabase/cardId.ts
@@ -1,0 +1,16 @@
+import {CardName} from '@/common/cards/CardName';
+
+/**
+ * Returns a stable, lowercase, underscore-separated identifier for a card.
+ *
+ * Card names are display strings, so they contain spaces, punctuation and
+ * decorations like ':SP'. The identifier strips all of that, leaving something
+ * safe to use as a JSON key, a filename, or a URL fragment.
+ */
+export function cardId(name: CardName): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+/, '')
+    .replace(/_+$/, '');
+}

--- a/src/server/tools/cardDatabase/hasBespokeLogic.ts
+++ b/src/server/tools/cardDatabase/hasBespokeLogic.ts
@@ -1,0 +1,70 @@
+import {ICard} from '@/server/cards/ICard';
+
+/**
+ * Members a card subclass defines when its behavior cannot be expressed as data.
+ *
+ * Base classes define most of these too, which is why the search stops at them.
+ */
+const BESPOKE_MEMBERS: ReadonlyArray<string> = [
+  'action',
+  'bespokeAction',
+  'bespokeCanAct',
+  'bespokeCanPlay',
+  'bespokeOnDiscard',
+  'bespokePlay',
+  'canAct',
+  'canPlay',
+  'computeTr',
+  'getCardDiscount',
+  'getGlobalParameterRequirementBonus',
+  'getInfluenceBonus',
+  'getStandardProjectDiscount',
+  'getVictoryPoints',
+  'initialAction',
+  'onCardPlayed',
+  'onCardPlayedByAnyPlayer',
+  'onClaim',
+  'onColonyAddedByAnyPlayer',
+  'onDiscard',
+  'onGlobalParameterIncrease',
+  'onIdentificationByAnyPlayer',
+  'onIncreaseTerraformRatingByAnyPlayer',
+  'onNonCardTagAdded',
+  'onNonCardTagAddedByAnyPlayer',
+  'onProductionGain',
+  'onProductionPhase',
+  'onResourceAdded',
+  'onStandardProject',
+  'onTilePlaced',
+  'play',
+  'produce',
+  'productionBox',
+];
+
+/** Classes that supply the data-driven default implementations. */
+const DATA_DRIVEN_BASES: ReadonlyArray<string> = [
+  'ActionCard',
+  'ActiveCorporationCard',
+  'Card',
+  'CorporationCard',
+  'Object',
+  'PreludeCard',
+];
+
+/**
+ * Returns true when some of the card's behavior lives in TypeScript rather than
+ * in its declarative properties, which means the exported data alone does not
+ * describe it fully.
+ */
+export function hasBespokeLogic(card: ICard): boolean {
+  let prototype = Object.getPrototypeOf(card);
+  while (prototype !== null && !DATA_DRIVEN_BASES.includes(prototype.constructor.name)) {
+    for (const member of BESPOKE_MEMBERS) {
+      if (Object.prototype.hasOwnProperty.call(prototype, member)) {
+        return true;
+      }
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return false;
+}

--- a/src/server/tools/cardDatabase/normalizeEffect.ts
+++ b/src/server/tools/cardDatabase/normalizeEffect.ts
@@ -1,0 +1,321 @@
+import {AddResource, Behavior} from '@/server/behavior/Behavior';
+import {Amount, Dynamic, DynamicCount, Effect, PlaceTile, ResourceAmounts} from './CardDatabaseTypes';
+import {Countable, CountableUnits, _Countable} from '@/server/behavior/Countable';
+import {CountableVictoryPoints} from '@/common/cards/CountableVictoryPoints';
+import {Units} from '@/common/Units';
+import {asArray} from '@/common/utils/utils';
+
+/** Behavior stanzas belonging to modules this database does not cover. */
+const OUT_OF_SCOPE = ['colonies', 'turmoil', 'moon', 'underworld'] as const;
+
+/** Countable keys that carry no attributes, mapped to their exported name. */
+const SIMPLE_COUNTS = {
+  cities: 'cities',
+  greeneries: 'greeneries',
+  oceans: 'oceans',
+  resourcesHere: 'resources_here',
+  floaters: 'floaters',
+  eventsPlayed: 'events_played',
+} as const satisfies Partial<Record<keyof _Countable, DynamicCount>>;
+
+function isEmpty(value: object): boolean {
+  return Object.keys(value).length === 0;
+}
+
+function undefinedIfEmpty<T extends object>(value: T): T | undefined {
+  return isEmpty(value) ? undefined : value;
+}
+
+/** Translates a game-state-dependent count into the exported database's form. */
+export function normalizeDynamic(countable: _Countable): Dynamic {
+  for (const key of OUT_OF_SCOPE) {
+    if (countable[key] !== undefined) {
+      throw new Error('Unsupported countable: ' + JSON.stringify(countable));
+    }
+  }
+
+  let dynamic: Dynamic | undefined = undefined;
+  if (countable.tag !== undefined) {
+    dynamic = {counts: 'tag', tag: Array.isArray(countable.tag) ? [...countable.tag] : countable.tag};
+  } else {
+    for (const key of Object.keys(SIMPLE_COUNTS) as Array<keyof typeof SIMPLE_COUNTS>) {
+      if (countable[key] !== undefined) {
+        dynamic = {counts: SIMPLE_COUNTS[key]};
+        break;
+      }
+    }
+  }
+  if (dynamic === undefined) {
+    throw new Error('Unsupported countable: ' + JSON.stringify(countable));
+  }
+
+  if (countable.others === true) {
+    dynamic.scope = 'opponents';
+  } else if (countable.all === true) {
+    dynamic.scope = 'everyone';
+  }
+  if (countable.each !== undefined) {
+    dynamic.each = countable.each;
+  }
+  if (countable.per !== undefined) {
+    dynamic.per = countable.per;
+  }
+  if (countable.nextToThis !== undefined) {
+    dynamic.next_to_this = true;
+  }
+  if (countable.includeEvents !== undefined) {
+    dynamic.include_events = true;
+  }
+  return dynamic;
+}
+
+/** Translates a card's state-dependent victory points into the exported database's form. */
+export function normalizeVictoryPoints(vp: CountableVictoryPoints): Dynamic {
+  return normalizeDynamic(vp as _Countable);
+}
+
+function amount(countable: Countable): Amount {
+  return typeof countable === 'number' ? countable : {dynamic: normalizeDynamic(countable)};
+}
+
+function resourceAmounts(units: Partial<CountableUnits>): ResourceAmounts | undefined {
+  const amounts: ResourceAmounts = {};
+  for (const key of Units.keys) {
+    const value = units[key];
+    if (value !== undefined) {
+      amounts[key] = amount(value);
+    }
+  }
+  return undefinedIfEmpty(amounts);
+}
+
+function place(behavior: Behavior): Array<PlaceTile> | undefined {
+  const tiles: Array<PlaceTile> = [];
+  if (behavior.ocean !== undefined) {
+    const tile: PlaceTile = {tile: 'ocean'};
+    if (behavior.ocean.count !== undefined) {
+      tile.count = behavior.ocean.count;
+    }
+    if (behavior.ocean.on !== undefined) {
+      tile.on = behavior.ocean.on;
+    }
+    tiles.push(tile);
+  }
+  if (behavior.city !== undefined) {
+    const tile: PlaceTile = {tile: 'city'};
+    if (behavior.city.on !== undefined) {
+      tile.on = behavior.city.on;
+    }
+    if (behavior.city.space !== undefined) {
+      tile.space = behavior.city.space;
+    }
+    tiles.push(tile);
+  }
+  if (behavior.greenery !== undefined) {
+    const tile: PlaceTile = {tile: 'greenery'};
+    if (behavior.greenery.on !== undefined) {
+      tile.on = behavior.greenery.on;
+    }
+    tiles.push(tile);
+  }
+  if (behavior.tile !== undefined) {
+    if (behavior.tile.adjacencyBonus !== undefined) {
+      throw new Error('Unsupported behavior: tile.adjacencyBonus');
+    }
+    const tile: PlaceTile = {tile: behavior.tile.type, on: behavior.tile.on};
+    if (behavior.tile.title !== undefined) {
+      tile.title = behavior.tile.title;
+    }
+    tiles.push(tile);
+  }
+  return tiles.length === 0 ? undefined : tiles;
+}
+
+function addResource(add: Omit<AddResource, 'mustHaveCard'> & {mustHaveCard?: boolean}) {
+  const normalized: {
+    count: Amount,
+    resource?: AddResource['type'],
+    tag?: AddResource['tag'],
+    exclude_this?: boolean,
+    must_have_card?: boolean,
+    min?: number,
+  } = {count: amount(add.count)};
+  if (add.type !== undefined) {
+    normalized.resource = add.type;
+  }
+  if (add.tag !== undefined) {
+    normalized.tag = add.tag;
+  }
+  if (add.excludeThis === true) {
+    normalized.exclude_this = true;
+  }
+  if (add.mustHaveCard === true) {
+    normalized.must_have_card = true;
+  }
+  if (add.min !== undefined) {
+    normalized.min = add.min;
+  }
+  return normalized;
+}
+
+function spend(behavior: Behavior): Effect['spend'] {
+  const source = behavior.spend;
+  if (source === undefined) {
+    return undefined;
+  }
+  if (source.corruption !== undefined) {
+    throw new Error('Unsupported behavior: spend.corruption');
+  }
+  const spent: Effect['spend'] = {};
+  for (const key of Units.keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null) {
+      spent[key] = value;
+    }
+  }
+  if (source.resourcesHere !== undefined && source.resourcesHere !== null) {
+    spent.resources_here = source.resourcesHere;
+  }
+  if (source.cards !== undefined && source.cards !== null) {
+    spent.cards = source.cards;
+  }
+  if (source.resourceFromAnyCard !== undefined && source.resourceFromAnyCard !== null) {
+    spent.resource_from_any_card = source.resourceFromAnyCard.type;
+  }
+  const payWith: Array<'steel' | 'titanium'> = [];
+  if (source.canUseSteel === true) {
+    payWith.push('steel');
+  }
+  if (source.canUseTitanium === true) {
+    payWith.push('titanium');
+  }
+  if (payWith.length > 0) {
+    spent.can_pay_with = payWith;
+  }
+  return spent;
+}
+
+function gain(behavior: Behavior): Effect['gain'] {
+  const gained: Effect['gain'] = {...resourceAmounts(behavior.stock ?? {})};
+  if (behavior.tr !== undefined) {
+    gained.tr = amount(behavior.tr);
+  }
+  if (behavior.addResources !== undefined) {
+    gained.resources_here = amount(behavior.addResources);
+  }
+  if (behavior.standardResource !== undefined) {
+    const standard = behavior.standardResource;
+    gained.standard_resource = typeof standard === 'number' ?
+      {count: standard, same: true} :
+      {count: standard.count, same: standard.same ?? true};
+  }
+  return undefinedIfEmpty(gained);
+}
+
+function draw(behavior: Behavior): Effect['draw'] {
+  const source = behavior.drawCard;
+  if (source === undefined) {
+    return undefined;
+  }
+  if (typeof source === 'number') {
+    return {count: source};
+  }
+  const drawn: Effect['draw'] = {count: amount(source.count)};
+  if (source.keep !== undefined) {
+    drawn.keep = source.keep;
+  }
+  if (source.pay === true) {
+    drawn.pay = true;
+  }
+  if (source.tag !== undefined) {
+    drawn.tag = source.tag;
+  }
+  if (source.type !== undefined) {
+    drawn.type = source.type;
+  }
+  if (source.resource !== undefined) {
+    drawn.resource = source.resource;
+  }
+  return drawn;
+}
+
+/**
+ * Translates a card's declarative behavior into the exported database's form.
+ *
+ * Returns undefined when the behavior contributes nothing the database records.
+ */
+export function normalizeEffect(behavior: Behavior | undefined): Effect | undefined {
+  if (behavior === undefined) {
+    return undefined;
+  }
+  for (const key of OUT_OF_SCOPE) {
+    if (behavior[key] !== undefined) {
+      throw new Error('Unsupported behavior: ' + key);
+    }
+  }
+
+  const effect: Effect = {};
+  const spent = spend(behavior);
+  if (spent !== undefined && !isEmpty(spent)) {
+    effect.spend = spent;
+  }
+  if (behavior.lose !== undefined) {
+    const lost: {production?: ResourceAmounts, stock?: ResourceAmounts} = {};
+    const production = behavior.lose.production;
+    const stock = behavior.lose.stock;
+    if (production !== undefined && production !== null) {
+      lost.production = resourceAmounts(production);
+    }
+    if (stock !== undefined && stock !== null) {
+      lost.stock = resourceAmounts(stock);
+    }
+    effect.lose = lost;
+  }
+  const production = resourceAmounts(behavior.production ?? {});
+  if (production !== undefined) {
+    effect.production = production;
+  }
+  const gained = gain(behavior);
+  if (gained !== undefined) {
+    effect.gain = gained;
+  }
+  const drawn = draw(behavior);
+  if (drawn !== undefined) {
+    effect.draw = drawn;
+  }
+  if (behavior.global !== undefined) {
+    effect.global = {...behavior.global};
+  }
+  const tiles = place(behavior);
+  if (tiles !== undefined) {
+    effect.place = tiles;
+  }
+  if (behavior.decreaseAnyProduction !== undefined) {
+    effect.decrease_any_production = {
+      resource: behavior.decreaseAnyProduction.type,
+      count: behavior.decreaseAnyProduction.count,
+    };
+  }
+  if (behavior.removeAnyPlants !== undefined) {
+    effect.remove_any_plants = behavior.removeAnyPlants;
+  }
+  if (behavior.addResourcesToAnyCard !== undefined) {
+    effect.add_resources_to_any_card = asArray(behavior.addResourcesToAnyCard).map(addResource);
+  }
+  if (behavior.steelValue !== undefined) {
+    effect.steel_value = behavior.steelValue;
+  }
+  if (behavior.titanumValue !== undefined) {
+    effect.titanium_value = behavior.titanumValue;
+  }
+  if (behavior.greeneryDiscount !== undefined) {
+    effect.greenery_discount = behavior.greeneryDiscount;
+  }
+  if (behavior.or !== undefined) {
+    effect.or = behavior.or.behaviors.map((alternative) => ({
+      title: alternative.title,
+      ...normalizeEffect(alternative),
+    }));
+  }
+  return undefinedIfEmpty(effect);
+}

--- a/src/server/tools/cardDatabase/normalizeRequirements.ts
+++ b/src/server/tools/cardDatabase/normalizeRequirements.ts
@@ -1,0 +1,68 @@
+import {CardRequirementDescriptor} from '@/common/cards/CardRequirementDescriptor';
+import {Requirement, RequirementType} from './CardDatabaseTypes';
+
+/**
+ * Requirement keys that hold a plain number, mapped to the name used in the
+ * exported database.
+ */
+const SCALAR_REQUIREMENTS = {
+  oxygen: 'oxygen',
+  temperature: 'temperature',
+  oceans: 'oceans',
+  greeneries: 'greeneries',
+  cities: 'cities',
+  venus: 'venus',
+  tr: 'tr',
+  resourceTypes: 'resource_types',
+  colonies: 'colonies',
+  floaters: 'floaters',
+  partyLeader: 'party_leaders',
+  habitatTiles: 'habitat_tiles',
+  miningTiles: 'mining_tiles',
+  roadTiles: 'road_tiles',
+  habitatRate: 'habitat_rate',
+  miningRate: 'mining_rate',
+  logisticRate: 'logistic_rate',
+  undergroundTokens: 'underground_tokens',
+  corruption: 'corruption',
+} as const satisfies Partial<Record<keyof CardRequirementDescriptor, RequirementType>>;
+
+function bound(value: number, isMax: boolean | undefined): {min: number} | {max: number} {
+  return isMax === true ? {max: value} : {min: value};
+}
+
+function core(descriptor: CardRequirementDescriptor): Requirement {
+  if (descriptor.tag !== undefined) {
+    return {type: 'tag', tag: descriptor.tag, ...bound(descriptor.count ?? 1, descriptor.max)};
+  }
+  if (descriptor.production !== undefined) {
+    return {type: 'production', resource: descriptor.production, ...bound(descriptor.count ?? 1, descriptor.max)};
+  }
+  if (descriptor.plantsRemoved !== undefined) {
+    return {type: 'removed_plants', min: 1};
+  }
+  for (const key of Object.keys(SCALAR_REQUIREMENTS) as Array<keyof typeof SCALAR_REQUIREMENTS>) {
+    const value = descriptor[key];
+    if (typeof value === 'number') {
+      return {type: SCALAR_REQUIREMENTS[key], ...bound(value, descriptor.max)};
+    }
+  }
+  throw new Error('Unsupported requirement: ' + JSON.stringify(descriptor));
+}
+
+/** Translates the game's card requirements into the exported database's form. */
+export function normalizeRequirements(descriptors: ReadonlyArray<CardRequirementDescriptor>): Array<Requirement> {
+  return descriptors.map((descriptor) => {
+    const requirement = core(descriptor);
+    if (descriptor.all === true) {
+      requirement.scope = 'any_player';
+    }
+    if (descriptor.nextTo === true) {
+      requirement.next_to = true;
+    }
+    if (descriptor.text !== undefined) {
+      requirement.text = descriptor.text;
+    }
+    return requirement;
+  });
+}

--- a/src/server/tools/cardDatabase/overlay.ts
+++ b/src/server/tools/cardDatabase/overlay.ts
@@ -151,6 +151,104 @@ export const CARD_OVERLAY: Partial<Record<CardName, Overlay>> = {
     semantics: 'Places a city tile on a volcanic area, ignoring the usual rule that cities may not be placed next to another city. On a board with no volcanic spaces the city may go on any city-legal space.',
     play_restriction: 'you must have at least 1 energy production and there must be a legal volcanic space',
   },
+
+  // ---------------------------------------------------------------------------
+  // Base: triggered and continuous effects
+  // ---------------------------------------------------------------------------
+  [CardName.ARCTIC_ALGAE]: {
+    status: 'documented',
+    semantics: 'The trigger fires for every player\'s ocean placements, not only your own.',
+    passive: [{trigger: 'any player places an ocean tile', effect: 'gain 2 plants'}],
+  },
+  [CardName.DECOMPOSERS]: {
+    status: 'documented',
+    semantics: 'Worth 1 victory point for every 3 microbes on this card. If this card is played in the prelude phase immediately after Ecology Experts, it starts with 2 extra microbes.',
+    passive: [{
+      trigger: 'you play a card with an animal, plant, or microbe tag',
+      effect: 'add 1 microbe to this card for each matching tag',
+    }],
+  },
+  [CardName.ECOLOGICAL_ZONE]: {
+    status: 'documented',
+    semantics: 'On play, place the Ecological Zone special tile. If this card is played in the prelude phase immediately after Ecology Experts, it starts with 1 extra animal.',
+    passive: [{
+      trigger: 'you play a card with an animal or plant tag',
+      effect: 'add 1 animal to this card for each matching tag',
+    }],
+    play_restriction: 'the Ecological Zone tile must go on a land space adjacent to a greenery tile',
+  },
+  [CardName.HERBIVORES]: {
+    status: 'documented',
+    semantics: 'On play, add 1 animal to this card and decrease any player\'s plant production 1 step.',
+    passive: [{trigger: 'you place a greenery tile', effect: 'add 1 animal to this card'}],
+  },
+  [CardName.IMMIGRANT_CITY]: {
+    status: 'documented',
+    semantics: 'On play, place a city tile, then decrease your energy production 1 step and your M€ production 2 steps.',
+    passive: [{trigger: 'any player places a city tile', effect: 'increase your M€ production 1 step'}],
+    play_restriction: 'you need 1 energy production, a legal city space, and enough M€ production to absorb the 2 step loss',
+  },
+  [CardName.INDENTURED_WORKERS]: {
+    status: 'documented',
+    semantics: 'The discount applies once, to the very next card you play this generation, and is lost if you play no further card.',
+    passive: [{trigger: 'you play your next card this generation', effect: 'it costs 8 M€ less'}],
+  },
+  [CardName.MARS_UNIVERSITY]: {
+    status: 'documented',
+    semantics: 'Triggers once for each science tag played, including this card\'s own science tag when it enters play. If your hand is empty the trigger does nothing.',
+    passive: [{
+      trigger: 'you play a card with a science tag, including this card',
+      effect: 'for each science tag, you may discard 1 card from your hand to draw 1 card',
+    }],
+  },
+  [CardName.MEDIA_GROUP]: {
+    status: 'documented',
+    semantics: 'A trigger on your own event cards only.',
+    passive: [{trigger: 'you play an event card', effect: 'gain 3 M€'}],
+  },
+  [CardName.OLYMPUS_CONFERENCE]: {
+    status: 'documented',
+    semantics: 'The choice is only offered when there is already a science resource here; otherwise a resource is simply added.',
+    passive: [{
+      trigger: 'you play a card with a science tag, including this card',
+      effect: 'for each science tag, either add 1 science resource to this card, or remove 1 science resource from this card to draw a card',
+    }],
+  },
+  [CardName.OPTIMAL_AEROBRAKING]: {
+    status: 'documented',
+    semantics: 'The played card must be both an event and carry a space tag.',
+    passive: [{trigger: 'you play a space event card', effect: 'gain 3 M€ and 3 heat'}],
+  },
+  [CardName.PETS]: {
+    status: 'documented',
+    semantics: 'On play, add 1 animal to this card. Animals here are protected: other players cannot remove them.',
+    passive: [{trigger: 'any player places a city tile', effect: 'add 1 animal to this card'}],
+  },
+  [CardName.ROVER_CONSTRUCTION]: {
+    status: 'documented',
+    semantics: 'The trigger fires for every player\'s city placements, not only your own.',
+    passive: [{trigger: 'any player places a city tile', effect: 'gain 2 M€'}],
+  },
+  [CardName.SEARCH_FOR_LIFE]: {
+    status: 'documented',
+    semantics: 'Worth 3 victory points if this card holds at least 1 science resource, and 0 otherwise. The action costs 1 M€: reveal the top card of the project deck, add 1 science resource to this card if the revealed card has a microbe tag, then discard the revealed card.',
+  },
+  [CardName.STANDARD_TECHNOLOGY]: {
+    status: 'documented',
+    semantics: 'Sell Patents is explicitly excluded.',
+    passive: [{
+      trigger: 'you pay for a standard project other than Sell Patents',
+      effect: 'gain 3 M€',
+    }],
+  },
+  [CardName.VIRAL_ENHANCERS]: {
+    status: 'documented',
+    semantics: 'The choice between a plant and a card resource is offered once per matching tag, and only when the played card itself stores microbes or animals. Otherwise you simply gain the plants.',
+    passive: [{
+      trigger: 'you play a card with a plant, microbe, or animal tag',
+      effect: 'for each matching tag, gain 1 plant, or add 1 resource to the played card if it stores microbes or animals',
+    }],
+  },
 };
 
 /**

--- a/src/server/tools/cardDatabase/overlay.ts
+++ b/src/server/tools/cardDatabase/overlay.ts
@@ -81,6 +81,76 @@ export const CARD_OVERLAY: Partial<Record<CardName, Overlay>> = {
     status: 'documented',
     semantics: 'The action costs 3 M€ and raises your terraform rating 1 step. It is only available if your terraform rating already went up this generation for some other reason.',
   },
+
+  // ---------------------------------------------------------------------------
+  // Prelude: corporations
+  // ---------------------------------------------------------------------------
+  [CardName.POINT_LUNA]: {
+    status: 'documented',
+    semantics: 'A trigger on your own cards only.',
+    passive: [{
+      trigger: 'you play a card with at least one Earth tag',
+      effect: 'draw 1 card for each Earth tag on it',
+    }],
+  },
+  [CardName.ROBINSON_INDUSTRIES]: {
+    status: 'documented',
+    semantics: 'The action costs 4 M€ and increases your lowest production 1 step. Only productions tied for lowest are eligible; if several tie, you choose among them.',
+  },
+  [CardName.VALLEY_TRUST]: {
+    status: 'documented',
+    semantics: 'The 2 M€ discount on science-tag cards is in card_discount. The first action draws 3 Prelude cards from the prelude deck; you play one and discard the other two.',
+  },
+  [CardName.VITOR]: {
+    status: 'documented',
+    semantics: 'The printed starting M€ is 45. The database says 48 because Vitor\'s own effect fires when the corporation is played. The first action funds one award at no cost; in a solo game there are no awards, so it does nothing.',
+    passive: [{
+      trigger: 'you play a card with a printed victory point value greater than zero',
+      effect: 'gain 3 M€',
+    }],
+  },
+
+  // ---------------------------------------------------------------------------
+  // Prelude: preludes
+  // ---------------------------------------------------------------------------
+  [CardName.AQUIFER_TURBINES]: {
+    status: 'documented',
+    semantics: 'The starting_megacredits of -3 is a cost: you pay 3 M€ when this prelude is played, you do not gain it.',
+    play_restriction: 'you must be able to pay 3 M€',
+  },
+  [CardName.GALILEAN_MINING]: {
+    status: 'documented',
+    semantics: 'The starting_megacredits of -5 is a cost: you pay 5 M€ when this prelude is played, you do not gain it.',
+    play_restriction: 'you must be able to pay 5 M€',
+  },
+  [CardName.BUSINESS_EMPIRE]: {
+    status: 'documented',
+    semantics: 'The starting_megacredits of -6 is a cost: you pay 6 M€ when this prelude is played, you do not gain it.',
+    play_restriction: 'you must be able to pay 6 M€, unless you have Manutech, whose M€ production gain covers the cost',
+  },
+  [CardName.HUGE_ASTEROID]: {
+    status: 'documented',
+    semantics: 'The starting_megacredits of -5 is a cost: you pay 5 M€ when this prelude is played, you do not gain it.',
+    play_restriction: 'you must be able to pay 5 M€',
+  },
+  [CardName.ECCENTRIC_SPONSOR]: {
+    status: 'documented',
+    semantics: 'Play one card from your hand at a 25 M€ discount, which makes almost any card free. If you play no card the prelude fizzles and the discount is not carried over.',
+  },
+  [CardName.ECOLOGY_EXPERTS]: {
+    status: 'documented',
+    semantics: 'Increase your plant production 1 step, then play one card from your hand ignoring its global parameter requirements. Tag and other non-global requirements still apply.',
+    play_restriction: 'you must have at least one card in hand that becomes playable once global requirements are ignored',
+  },
+
+  // ---------------------------------------------------------------------------
+  // Prelude: project cards
+  // ---------------------------------------------------------------------------
+  [CardName.LAVA_TUBE_SETTLEMENT]: {
+    status: 'documented',
+    semantics: 'Places a city tile on a volcanic area, ignoring the usual rule that cities may not be placed next to another city. On a board with no volcanic spaces the city may go on any city-legal space.',
+    play_restriction: 'you must have at least 1 energy production and there must be a legal volcanic space',
+  },
 };
 
 /**

--- a/src/server/tools/cardDatabase/overlay.ts
+++ b/src/server/tools/cardDatabase/overlay.ts
@@ -1,0 +1,107 @@
+import {CardEntry, Passive} from './CardDatabaseTypes';
+import {CardName} from '@/common/cards/CardName';
+
+/**
+ * Hand-written semantics for a card whose behavior is not fully declarative.
+ *
+ * 'documented' supplies what the generated data cannot say. 'complete' records
+ * that the card's bespoke code only guards playability or tile placement, so
+ * the generated data already describes the card.
+ */
+export type Overlay =
+  | {
+    status: 'documented',
+    /** Everything the structured fields cannot express, in plain English. */
+    semantics: string,
+    /** Continuous and triggered effects. */
+    passive?: ReadonlyArray<Passive>,
+    /** Restriction on when the card may be played or where its tile may go. */
+    play_restriction?: string,
+  }
+  | {status: 'complete', reason: string};
+
+export const CARD_OVERLAY: Partial<Record<CardName, Overlay>> = {
+  // ---------------------------------------------------------------------------
+  // Corporations: base and Corporate Era
+  // ---------------------------------------------------------------------------
+  [CardName.CREDICOR]: {
+    status: 'documented',
+    semantics: 'A continuous effect that pays out on expensive purchases. The 20 M€ threshold is the printed basic cost, before any discounts.',
+    passive: [{
+      trigger: 'you pay for a project card or a standard project whose basic cost is 20 M€ or more',
+      effect: 'gain 4 M€',
+    }],
+  },
+  [CardName.HELION]: {
+    status: 'documented',
+    semantics: 'A continuous payment ability: heat may be spent as if it were M€, at 1 heat per 1 M€, when paying for anything. M€ may never be spent as heat.',
+    passive: [{
+      trigger: 'you pay for anything',
+      effect: 'you may substitute heat for M€ one for one',
+    }],
+  },
+  [CardName.INTERPLANETARY_CINEMATICS]: {
+    status: 'documented',
+    semantics: 'A trigger on your own event cards only.',
+    passive: [{trigger: 'you play an event card', effect: 'gain 2 M€'}],
+  },
+  [CardName.MINING_GUILD]: {
+    status: 'documented',
+    semantics: 'A trigger on your own tile placements on Mars. It does not fire for tiles you place off Mars, nor during the solar phase.',
+    passive: [{
+      trigger: 'you place a tile on Mars on a space with a steel or titanium placement bonus',
+      effect: 'increase your steel production 1 step',
+    }],
+  },
+  [CardName.SATURN_SYSTEMS]: {
+    status: 'documented',
+    semantics: 'A trigger on every player, including yourself, and including this card\'s own Jovian tag when it is played.',
+    passive: [{
+      trigger: 'any player puts a Jovian tag into play',
+      effect: 'increase your M€ production 1 step for each Jovian tag played',
+    }],
+  },
+  [CardName.THARSIS_REPUBLIC]: {
+    status: 'documented',
+    semantics: 'In a solo game the two neutral cities placed during setup pay out immediately, so playing this corporation grants 2 M€ production straight away.',
+    passive: [
+      {trigger: 'any player places a city tile on Mars', effect: 'increase your M€ production 1 step'},
+      {trigger: 'you place a city tile anywhere', effect: 'gain 3 M€'},
+    ],
+  },
+  [CardName.THORGATE]: {
+    status: 'documented',
+    semantics: 'The 3 M€ discount on power-tag cards is in card_discount. What the data cannot express is that the same discount also applies to the Power Plant standard project.',
+    passive: [{
+      trigger: 'you buy the Power Plant standard project',
+      effect: 'pay 3 M€ less for it',
+    }],
+  },
+  [CardName.UNITED_NATIONS_MARS_INITIATIVE]: {
+    status: 'documented',
+    semantics: 'The action costs 3 M€ and raises your terraform rating 1 step. It is only available if your terraform rating already went up this generation for some other reason.',
+  },
+};
+
+/**
+ * Applies the hand-written semantics for a card, and corrects the bespoke flag
+ * when the card's bespoke code turns out to add nothing the data does not say.
+ */
+export function applyOverlay(entry: CardEntry): CardEntry {
+  const overlay = CARD_OVERLAY[entry.name as CardName];
+  if (overlay === undefined) {
+    return entry;
+  }
+  if (overlay.status === 'complete') {
+    entry.bespoke = false;
+    return entry;
+  }
+  entry.semantics = overlay.semantics;
+  if (overlay.passive !== undefined) {
+    entry.passive = overlay.passive.map((passive) => ({...passive}));
+  }
+  if (overlay.play_restriction !== undefined) {
+    entry.play_restriction = overlay.play_restriction;
+  }
+  return entry;
+}

--- a/src/server/tools/cardDatabase/overlay.ts
+++ b/src/server/tools/cardDatabase/overlay.ts
@@ -249,6 +249,139 @@ export const CARD_OVERLAY: Partial<Record<CardName, Overlay>> = {
       effect: 'for each matching tag, gain 1 plant, or add 1 resource to the played card if it stores microbes or animals',
     }],
   },
+
+  // ---------------------------------------------------------------------------
+  // Base: bespoke play and action logic
+  // ---------------------------------------------------------------------------
+  [CardName.ANTS]: {
+    status: 'documented',
+    semantics: 'The action removes 1 microbe from any other player\'s card and adds 1 microbe to this card. In a solo game the action is always available.',
+  },
+  [CardName.ARTIFICIAL_LAKE]: {
+    status: 'complete',
+    reason: 'The bespoke code only checks that a legal land space exists; the ocean placement itself is in immediate.place.',
+  },
+  [CardName.ASTEROID_MINING_CONSORTIUM]: {
+    status: 'documented',
+    semantics: 'Decrease any one player\'s titanium production 1 step and increase your own 1 step. You may target yourself, which nets no change.',
+  },
+  [CardName.ENERGY_TAPPING]: {
+    status: 'documented',
+    semantics: 'Decrease any one player\'s energy production 1 step and increase your own 1 step. You may target yourself.',
+  },
+  [CardName.POWER_SUPPLY_CONSORTIUM]: {
+    status: 'documented',
+    semantics: 'Decrease any one player\'s energy production 1 step and increase your own 1 step. You may target yourself.',
+  },
+  [CardName.GREAT_ESCARPMENT_CONSORTIUM]: {
+    status: 'documented',
+    semantics: 'Decrease any one player\'s steel production 1 step and increase your own 1 step. You may target yourself.',
+  },
+  [CardName.HACKERS]: {
+    status: 'documented',
+    semantics: 'Decrease your energy production 1 step and increase your M€ production 2 steps, and separately decrease any one player\'s M€ production 2 steps. You may target yourself.',
+  },
+  [CardName.EXTREME_COLD_FUNGUS]: {
+    status: 'documented',
+    semantics: 'The action is a choice: add 2 microbes to another card, or gain 1 plant. With no other microbe card in play the plant is taken automatically.',
+  },
+  [CardName.FLOODING]: {
+    status: 'documented',
+    semantics: 'Place an ocean tile. If any tile owned by another player is adjacent to it, you may remove 4 M€ from one of those owners. Worth -1 victory point.',
+  },
+  [CardName.HIRED_RAIDERS]: {
+    status: 'documented',
+    semantics: 'Steal 2 steel or 3 M€ from one opponent of your choice. Steel cannot be taken from a player whose alloys are protected. In a solo game you simply gain the resources.',
+  },
+  [CardName.IMPORTED_HYDROGEN]: {
+    status: 'documented',
+    semantics: 'Place an ocean tile, then choose one: gain 3 plants, add 3 microbes to another card, or add 2 animals to another card. With no eligible card, the plants are taken automatically.',
+  },
+  [CardName.INDUSTRIAL_CENTER]: {
+    status: 'documented',
+    semantics: 'On play, place the Industrial Center special tile. The repeatable action is fully described in the action field: spend 7 M€ to increase your steel production 1 step.',
+    play_restriction: 'the Industrial Center tile must go on a land space adjacent to a city tile',
+  },
+  [CardName.INSULATION]: {
+    status: 'documented',
+    semantics: 'Choose any number of steps, at least 1 and at most your heat production. Decrease your heat production by that amount and increase your M€ production by the same amount.',
+    play_restriction: 'you must have at least 1 heat production',
+  },
+  [CardName.LAND_CLAIM]: {
+    status: 'documented',
+    semantics: 'Reserve any non-reserved land space. Only you may place a tile on that space for the rest of the game. No tile is placed now.',
+  },
+  [CardName.LARGE_CONVOY]: {
+    status: 'documented',
+    semantics: 'Place an ocean tile, draw 2 cards, then choose one: gain 5 plants, or add 4 animals to another card. With no animal card in play the plants are taken automatically.',
+  },
+  [CardName.LOCAL_HEAT_TRAPPING]: {
+    status: 'documented',
+    semantics: 'Spend 5 heat, then choose one: gain 4 plants, or add 2 animals to another card. With no animal card in play the plants are taken automatically. The heat this card spends is reserved so it cannot be paid for with Helion\'s heat-as-M€ substitution; Stormcraft Incorporated floaters may still cover part of the cost, each floater counting as 2 heat.',
+  },
+  [CardName.MINING_AREA]: {
+    status: 'documented',
+    semantics: 'Place the Mining Area special tile and permanently increase your production of the resource that space grants: steel or titanium. If the space grants both, you choose.',
+    play_restriction: 'the tile must go on a space with a steel or titanium placement bonus that is adjacent to one of your own non-ocean tiles',
+  },
+  [CardName.MINING_RIGHTS]: {
+    status: 'documented',
+    semantics: 'Place the Mining Rights special tile and permanently increase your production of the resource that space grants: steel or titanium. If the space grants both, you choose.',
+    play_restriction: 'the tile must go on any space with a steel or titanium placement bonus',
+  },
+  [CardName.MOSS]: {
+    status: 'documented',
+    semantics: 'You pay 1 plant as an additional cost when this card is played.',
+    play_restriction: 'you must have 1 plant, or a card that supplies one such as Viral Enhancers or Manutech',
+  },
+  [CardName.NITROPHILIC_MOSS]: {
+    status: 'documented',
+    semantics: 'You pay 2 plants as an additional cost when this card is played.',
+    play_restriction: 'you must have 2 plants, or 1 plant plus Viral Enhancers, or Manutech',
+  },
+  [CardName.NITROGEN_RICH_ASTEROID]: {
+    status: 'documented',
+    semantics: 'Raise your terraform rating 2 steps and the temperature 1 step, then increase your plant production 1 step — or 4 steps instead if you have at least 3 plant tags, counted after this card is played.',
+  },
+  [CardName.NOCTIS_CITY]: {
+    status: 'documented',
+    semantics: 'Place a city tile on the reserved Noctis City area, ignoring the usual placement restrictions, and decrease your energy production 1 step while increasing your M€ production 3 steps. On a board with no reserved Noctis area, the city goes on any legal city space.',
+    play_restriction: 'you must have at least 1 energy production',
+  },
+  [CardName.POWER_INFRASTRUCTURE]: {
+    status: 'documented',
+    semantics: 'The action converts energy to M€ one for one. You choose the amount, from 1 up to all the energy you hold.',
+  },
+  [CardName.PREDATORS]: {
+    status: 'documented',
+    semantics: 'The action removes 1 animal from any other player\'s card and adds 1 animal to this card. In a solo game the action is always available.',
+  },
+  [CardName.ROBOTIC_WORKFORCE]: {
+    status: 'documented',
+    semantics: 'Copy the production box of one card you have already played that carries a building tag. Only the production change is copied, nothing else the card does.',
+    play_restriction: 'you must have a played building-tag card whose production box can be applied again',
+  },
+  [CardName.SABOTAGE]: {
+    status: 'documented',
+    semantics: 'Remove 3 titanium, 4 steel, or 7 M€ from one opponent of your choice. Titanium and steel cannot be taken from a player whose alloys are protected.',
+  },
+  [CardName.TERRAFORMING_GANYMEDE]: {
+    status: 'documented',
+    semantics: 'Raise your terraform rating 1 step for each Jovian tag you have, counting this card\'s own Jovian tag.',
+  },
+  [CardName.URBANIZED_AREA]: {
+    status: 'documented',
+    semantics: 'Place a city tile, decrease your energy production 1 step and increase your M€ production 2 steps.',
+    play_restriction: 'the city must go on a land space adjacent to at least 2 other city tiles, and you must have 1 energy production',
+  },
+  [CardName.VIRUS]: {
+    status: 'documented',
+    semantics: 'Choose one: remove up to 2 animals from any one card, or remove up to 5 plants from any one player.',
+  },
+  [CardName.WATER_SPLITTING_PLANT]: {
+    status: 'complete',
+    reason: 'The bespoke code only re-checks that the player can afford the Reds tax on raising oxygen; the action itself is declarative.',
+  },
 };
 
 /**

--- a/src/server/tools/export_card_database.ts
+++ b/src/server/tools/export_card_database.ts
@@ -1,0 +1,19 @@
+import '@/server/init';
+import fs from 'fs';
+import path from 'path';
+import {buildCardDatabase, buildIndex} from './cardDatabase/buildCardDatabase';
+import {globalInitialize} from '@/server/globalInitialize';
+
+const OUTPUT_DIRECTORY = 'data/cards';
+
+globalInitialize();
+
+const cards = buildCardDatabase();
+const index = buildIndex(cards);
+
+fs.mkdirSync(OUTPUT_DIRECTORY, {recursive: true});
+fs.writeFileSync(path.join(OUTPUT_DIRECTORY, 'cards.json'), JSON.stringify(cards, undefined, 2) + '\n');
+fs.writeFileSync(path.join(OUTPUT_DIRECTORY, 'index.json'), JSON.stringify(index, undefined, 2) + '\n');
+
+const bespoke = cards.filter((card) => card.bespoke).length;
+console.log(`Wrote ${cards.length} cards to ${OUTPUT_DIRECTORY}/cards.json (${bespoke} with hand-written semantics).`);

--- a/tests/tools/cardDatabase/buildCardDatabase.spec.ts
+++ b/tests/tools/cardDatabase/buildCardDatabase.spec.ts
@@ -1,0 +1,119 @@
+import {expect} from 'chai';
+import {CardName} from '@/common/cards/CardName';
+import {CardType} from '@/common/cards/CardType';
+import {Tag} from '@/common/cards/Tag';
+import {CardEntry} from '@/server/tools/cardDatabase/CardDatabaseTypes';
+import {buildCardDatabase, buildIndex} from '@/server/tools/cardDatabase/buildCardDatabase';
+
+describe('buildCardDatabase', () => {
+  const entries = buildCardDatabase();
+  const byName = new Map<string, CardEntry>(entries.map((entry) => [entry.name, entry]));
+
+  function get(name: CardName): CardEntry {
+    const entry = byName.get(name);
+    if (entry === undefined) {
+      throw new Error('Not in the database: ' + name);
+    }
+    return entry;
+  }
+
+  it('covers only the base, corpera and prelude sets', () => {
+    const sets = new Set(entries.map((entry) => entry.set));
+    expect([...sets].sort()).deep.eq(['base', 'corpera', 'prelude']);
+  });
+
+  it('gives every card a unique id', () => {
+    const ids = entries.map((entry) => entry.id);
+    expect(new Set(ids).size).eq(ids.length);
+  });
+
+  it('is sorted by set then id', () => {
+    const order = ['base', 'corpera', 'prelude'];
+    const keys = entries.map((entry) => `${order.indexOf(entry.set)}:${entry.id}`);
+    expect(keys).deep.eq([...keys].sort());
+  });
+
+  it('describes a declarative automated card', () => {
+    expect(get(CardName.ALGAE)).deep.eq({
+      id: 'algae',
+      name: CardName.ALGAE,
+      set: 'base',
+      kind: 'project',
+      type: CardType.AUTOMATED,
+      card_number: '047',
+      description: 'Requires 5 ocean tiles. Gain 1 plant and increase your plant production 2 steps.',
+      cost: 10,
+      tags: [Tag.PLANT],
+      requirements: [{type: 'oceans', min: 5}],
+      immediate: {production: {plants: 2}, gain: {plants: 1}},
+      bespoke: false,
+    });
+  });
+
+  it('describes an active card with a declarative action', () => {
+    const aiCentral = get(CardName.AI_CENTRAL);
+    expect(aiCentral.type).eq(CardType.ACTIVE);
+    expect(aiCentral.cost).eq(21);
+    expect(aiCentral.vp).eq(1);
+    expect(aiCentral.requirements).deep.eq([{type: 'tag', tag: Tag.SCIENCE, min: 3}]);
+    expect(aiCentral.immediate).deep.eq({production: {energy: -1}});
+    expect(aiCentral.action).deep.eq({draw: {count: 2}});
+    expect(aiCentral.bespoke).is.false;
+  });
+
+  it('records a corporation starting M€ and omits its cost', () => {
+    const teractor = get(CardName.TERACTOR);
+    expect(teractor.kind).eq('corporation');
+    expect(teractor.set).eq('corpera');
+    expect(teractor.cost).eq(undefined);
+    expect(teractor.starting_megacredits).eq(60);
+    expect(teractor.card_discount).deep.eq([{tag: Tag.EARTH, amount: 3}]);
+  });
+
+  it('records a corporation first action', () => {
+    const inventrix = get(CardName.INVENTRIX);
+    expect(inventrix.first_action).deep.eq({text: 'Draw 3 cards', draw: {count: 3}});
+    expect(inventrix.global_parameter_requirement_bonus).deep.eq({steps: 2});
+  });
+
+  it('records a prelude cost as a negative starting M€', () => {
+    const hugeAsteroid = get(CardName.HUGE_ASTEROID);
+    expect(hugeAsteroid.kind).eq('prelude');
+    expect(hugeAsteroid.set).eq('prelude');
+    expect(hugeAsteroid.starting_megacredits).eq(-5);
+    expect(hugeAsteroid.immediate).deep.eq({global: {temperature: 3}});
+  });
+
+  it('records dynamic victory points', () => {
+    expect(get(CardName.ANTS).vp_dynamic).deep.eq({counts: 'resources_here', per: 2});
+  });
+
+  it('records special victory points', () => {
+    const searchForLife = get(CardName.SEARCH_FOR_LIFE);
+    expect(searchForLife.vp_special).is.true;
+    expect(searchForLife.vp).eq(undefined);
+  });
+
+  it('flags cards whose behavior is not fully declarative', () => {
+    expect(get(CardName.ROBOTIC_WORKFORCE).bespoke).is.true;
+    expect(get(CardName.HELION).bespoke).is.true;
+    expect(get(CardName.ALGAE).bespoke).is.false;
+  });
+});
+
+describe('buildIndex', () => {
+  it('reduces each entry to its lookup fields', () => {
+    const index = buildIndex(buildCardDatabase());
+    const algae = index.find((entry) => entry.id === 'algae');
+    expect(algae).deep.eq({
+      id: 'algae',
+      name: CardName.ALGAE,
+      set: 'base',
+      kind: 'project',
+      type: CardType.AUTOMATED,
+      cost: 10,
+      tags: [Tag.PLANT],
+      bespoke: false,
+    });
+  });
+});

--- a/tests/tools/cardDatabase/buildCardDatabase.spec.ts
+++ b/tests/tools/cardDatabase/buildCardDatabase.spec.ts
@@ -4,6 +4,7 @@ import {CardType} from '@/common/cards/CardType';
 import {Tag} from '@/common/cards/Tag';
 import {CardEntry} from '@/server/tools/cardDatabase/CardDatabaseTypes';
 import {buildCardDatabase, buildIndex} from '@/server/tools/cardDatabase/buildCardDatabase';
+import {CARD_OVERLAY} from '@/server/tools/cardDatabase/overlay';
 
 describe('buildCardDatabase', () => {
   const entries = buildCardDatabase();
@@ -98,6 +99,30 @@ describe('buildCardDatabase', () => {
     expect(get(CardName.ROBOTIC_WORKFORCE).bespoke).is.true;
     expect(get(CardName.HELION).bespoke).is.true;
     expect(get(CardName.ALGAE).bespoke).is.false;
+  });
+
+  it('documents every card whose behavior is not fully declarative', () => {
+    const undocumented = entries
+      .filter((entry) => entry.bespoke && entry.semantics === undefined && entry.passive === undefined)
+      .map((entry) => `${entry.set}/${entry.name}`);
+    expect(undocumented, 'cards missing an entry in CARD_OVERLAY').deep.eq([]);
+  });
+
+  it('has no overlay entry for a card that does not need one', () => {
+    const documented = new Set(Object.keys(CARD_OVERLAY));
+    const unnecessary = entries
+      .filter((entry) => !entry.bespoke && documented.has(entry.name) && entry.semantics !== undefined)
+      .map((entry) => entry.name);
+    expect(unnecessary, 'overlay entries for cards that no longer need one').deep.eq([]);
+  });
+
+  it('applies corporation semantics', () => {
+    const helion = get(CardName.HELION);
+    expect(helion.semantics).contains('heat may be spent as if it were M€');
+    expect(helion.passive).deep.eq([{
+      trigger: 'you pay for anything',
+      effect: 'you may substitute heat for M€ one for one',
+    }]);
   });
 });
 

--- a/tests/tools/cardDatabase/cardId.spec.ts
+++ b/tests/tools/cardDatabase/cardId.spec.ts
@@ -1,0 +1,22 @@
+import {expect} from 'chai';
+import {CardName} from '@/common/cards/CardName';
+import {cardId} from '@/server/tools/cardDatabase/cardId';
+
+describe('cardId', () => {
+  it('lowercases and underscores a plain name', () => {
+    expect(cardId(CardName.AI_CENTRAL)).eq('ai_central');
+  });
+
+  it('collapses runs of punctuation and whitespace into a single underscore', () => {
+    expect(cardId(CardName.POWER_PLANT_STANDARD_PROJECT)).eq('power_plant_sp');
+  });
+
+  it('does not leave leading or trailing underscores', () => {
+    expect(cardId(CardName.UNMI_CONTRACTOR)).eq('unmi_contractor');
+    expect(cardId(CardName.AIR_SCRAPPING_STANDARD_PROJECT_VARIANT)).eq('air_scrapping_var');
+  });
+
+  it('preserves digits', () => {
+    expect(cardId(CardName.SEARCH_FOR_LIFE)).eq('search_for_life');
+  });
+});

--- a/tests/tools/cardDatabase/hasBespokeLogic.spec.ts
+++ b/tests/tools/cardDatabase/hasBespokeLogic.spec.ts
@@ -1,0 +1,29 @@
+import {expect} from 'chai';
+import {AICentral} from '@/server/cards/base/AICentral';
+import {Algae} from '@/server/cards/base/Algae';
+import {Helion} from '@/server/cards/corporation/Helion';
+import {MiningArea} from '@/server/cards/base/MiningArea';
+import {Teractor} from '@/server/cards/corporation/Teractor';
+import {hasBespokeLogic} from '@/server/tools/cardDatabase/hasBespokeLogic';
+
+describe('hasBespokeLogic', () => {
+  it('is false for a purely declarative card', () => {
+    expect(hasBespokeLogic(new Algae())).is.false;
+  });
+
+  it('is false for a card whose action is declarative', () => {
+    expect(hasBespokeLogic(new AICentral())).is.false;
+  });
+
+  it('is false for a corporation whose effect is a declared card discount', () => {
+    expect(hasBespokeLogic(new Teractor())).is.false;
+  });
+
+  it('is true for a card that overrides bespokePlay', () => {
+    expect(hasBespokeLogic(new Helion())).is.true;
+  });
+
+  it('is true for a card that inherits bespoke logic from an intermediate base class', () => {
+    expect(hasBespokeLogic(new MiningArea())).is.true;
+  });
+});

--- a/tests/tools/cardDatabase/normalizeEffect.spec.ts
+++ b/tests/tools/cardDatabase/normalizeEffect.spec.ts
@@ -1,0 +1,146 @@
+import {expect} from 'chai';
+import {CardResource} from '@/common/CardResource';
+import {Resource} from '@/common/Resource';
+import {Tag} from '@/common/cards/Tag';
+import {TileType} from '@/common/TileType';
+import {normalizeDynamic, normalizeEffect, normalizeVictoryPoints} from '@/server/tools/cardDatabase/normalizeEffect';
+
+describe('normalizeEffect', () => {
+  it('returns undefined for no behavior', () => {
+    expect(normalizeEffect(undefined)).eq(undefined);
+    expect(normalizeEffect({})).eq(undefined);
+  });
+
+  it('splits production from stock gains', () => {
+    expect(normalizeEffect({production: {plants: 2}, stock: {plants: 1}}))
+      .deep.eq({production: {plants: 2}, gain: {plants: 1}});
+  });
+
+  it('keeps negative production', () => {
+    expect(normalizeEffect({production: {energy: -1, megacredits: 2}}))
+      .deep.eq({production: {energy: -1, megacredits: 2}});
+  });
+
+  it('turns a numeric card draw into a draw count', () => {
+    expect(normalizeEffect({drawCard: 2})).deep.eq({draw: {count: 2}});
+  });
+
+  it('carries card draw qualifiers through', () => {
+    expect(normalizeEffect({drawCard: {count: 4, keep: 1, tag: Tag.MICROBE}}))
+      .deep.eq({draw: {count: 4, keep: 1, tag: Tag.MICROBE}});
+  });
+
+  it('records terraform rating under gain', () => {
+    expect(normalizeEffect({tr: 2, global: {temperature: 1}}))
+      .deep.eq({gain: {tr: 2}, global: {temperature: 1}});
+  });
+
+  it('records resources added to this card under gain', () => {
+    expect(normalizeEffect({addResources: 1})).deep.eq({gain: {resources_here: 1}});
+  });
+
+  it('lists an ocean placement', () => {
+    expect(normalizeEffect({ocean: {}})).deep.eq({place: [{tile: 'ocean'}]});
+  });
+
+  it('carries a placement restriction through', () => {
+    expect(normalizeEffect({ocean: {on: 'land'}})).deep.eq({place: [{tile: 'ocean', on: 'land'}]});
+  });
+
+  it('lists ocean, city, greenery and special tiles in that order', () => {
+    expect(normalizeEffect({
+      greenery: {},
+      city: {},
+      ocean: {},
+      tile: {type: TileType.INDUSTRIAL_CENTER, on: 'land', title: 'Select space adjacent to a city tile'},
+    })).deep.eq({
+      place: [
+        {tile: 'ocean'},
+        {tile: 'city'},
+        {tile: 'greenery'},
+        {tile: TileType.INDUSTRIAL_CENTER, on: 'land', title: 'Select space adjacent to a city tile'},
+      ],
+    });
+  });
+
+  it('describes a spend', () => {
+    expect(normalizeEffect({spend: {energy: 1}, drawCard: 1}))
+      .deep.eq({spend: {energy: 1}, draw: {count: 1}});
+  });
+
+  it('lists the resources a spend may be paid with', () => {
+    expect(normalizeEffect({spend: {megacredits: 8, canUseSteel: true}, global: {temperature: 1}}))
+      .deep.eq({spend: {megacredits: 8, can_pay_with: ['steel']}, global: {temperature: 1}});
+  });
+
+  it('describes production removal from any player', () => {
+    expect(normalizeEffect({decreaseAnyProduction: {type: Resource.PLANTS, count: 1}}))
+      .deep.eq({decrease_any_production: {resource: Resource.PLANTS, count: 1}});
+  });
+
+  it('normalizes resources added to other cards to a list', () => {
+    expect(normalizeEffect({addResourcesToAnyCard: {count: 2, type: CardResource.MICROBE, mustHaveCard: true}}))
+      .deep.eq({add_resources_to_any_card: [{count: 2, resource: CardResource.MICROBE, must_have_card: true}]});
+  });
+
+  it('corrects the misspelled titanium value key', () => {
+    expect(normalizeEffect({titanumValue: 1, steelValue: 1}))
+      .deep.eq({titanium_value: 1, steel_value: 1});
+  });
+
+  it('flattens an or-behavior into titled alternatives', () => {
+    expect(normalizeEffect({
+      or: {
+        behaviors: [
+          {title: 'Gain 4 plants', stock: {plants: 4}},
+          {title: 'Gain 2 titanium', stock: {titanium: 2}},
+        ],
+      },
+    })).deep.eq({
+      or: [
+        {title: 'Gain 4 plants', gain: {plants: 4}},
+        {title: 'Gain 2 titanium', gain: {titanium: 2}},
+      ],
+    });
+  });
+
+  it('drops log directives', () => {
+    expect(normalizeEffect({log: '${player} did a thing'})).eq(undefined);
+  });
+
+  it('throws on a stanza from an out-of-scope module', () => {
+    expect(() => normalizeEffect({moon: {miningRate: 1}})).to.throw('Unsupported behavior');
+    expect(() => normalizeEffect({underworld: {excavate: 1}})).to.throw('Unsupported behavior');
+  });
+
+  it('expresses a state-dependent amount as a dynamic', () => {
+    expect(normalizeEffect({stock: {megacredits: {tag: Tag.EARTH}}}))
+      .deep.eq({gain: {megacredits: {dynamic: {counts: 'tag', tag: Tag.EARTH}}}});
+  });
+});
+
+describe('normalizeDynamic', () => {
+  it('counts tags', () => {
+    expect(normalizeDynamic({tag: Tag.JOVIAN})).deep.eq({counts: 'tag', tag: Tag.JOVIAN});
+  });
+
+  it('counts cities across the board', () => {
+    expect(normalizeDynamic({cities: {}, all: true})).deep.eq({counts: 'cities', scope: 'everyone'});
+  });
+
+  it('counts opponents tags', () => {
+    expect(normalizeDynamic({tag: Tag.SPACE, others: true})).deep.eq({counts: 'tag', tag: Tag.SPACE, scope: 'opponents'});
+  });
+
+  it('carries multipliers and divisors', () => {
+    expect(normalizeDynamic({tag: Tag.MOON, each: 2, per: 3}))
+      .deep.eq({counts: 'tag', tag: Tag.MOON, each: 2, per: 3});
+  });
+});
+
+describe('normalizeVictoryPoints', () => {
+  it('counts resources on this card', () => {
+    expect(normalizeVictoryPoints({resourcesHere: {}, per: 2}))
+      .deep.eq({counts: 'resources_here', per: 2});
+  });
+});

--- a/tests/tools/cardDatabase/normalizeRequirements.spec.ts
+++ b/tests/tools/cardDatabase/normalizeRequirements.spec.ts
@@ -1,0 +1,61 @@
+import {expect} from 'chai';
+import {PartyName} from '@/common/turmoil/PartyName';
+import {Resource} from '@/common/Resource';
+import {Tag} from '@/common/cards/Tag';
+import {normalizeRequirements} from '@/server/tools/cardDatabase/normalizeRequirements';
+
+describe('normalizeRequirements', () => {
+  it('turns a counted tag requirement into a minimum', () => {
+    expect(normalizeRequirements([{tag: Tag.SCIENCE, count: 3}]))
+      .deep.eq([{type: 'tag', tag: Tag.SCIENCE, min: 3}]);
+  });
+
+  it('defaults an uncounted tag requirement to one', () => {
+    expect(normalizeRequirements([{tag: Tag.JOVIAN}]))
+      .deep.eq([{type: 'tag', tag: Tag.JOVIAN, min: 1}]);
+  });
+
+  it('turns a global parameter requirement into a minimum', () => {
+    expect(normalizeRequirements([{temperature: -6}]))
+      .deep.eq([{type: 'temperature', min: -6}]);
+  });
+
+  it('turns a max requirement into a maximum', () => {
+    expect(normalizeRequirements([{oxygen: 6, max: true}]))
+      .deep.eq([{type: 'oxygen', max: 6}]);
+  });
+
+  it('names the resource of a production requirement', () => {
+    expect(normalizeRequirements([{production: Resource.TITANIUM, count: 1}]))
+      .deep.eq([{type: 'production', resource: Resource.TITANIUM, min: 1}]);
+  });
+
+  it('marks an all-player requirement', () => {
+    expect(normalizeRequirements([{cities: 2, all: true}]))
+      .deep.eq([{type: 'cities', min: 2, scope: 'any_player'}]);
+  });
+
+  it('carries next_to and text through', () => {
+    expect(normalizeRequirements([{cities: 1, nextTo: true, text: 'next to a city'}]))
+      .deep.eq([{type: 'cities', min: 1, next_to: true, text: 'next to a city'}]);
+  });
+
+  it('turns a removed plants requirement into a minimum of one', () => {
+    expect(normalizeRequirements([{plantsRemoved: true}]))
+      .deep.eq([{type: 'removed_plants', min: 1}]);
+  });
+
+  it('normalizes every element of a multi-requirement list', () => {
+    expect(normalizeRequirements([{tag: Tag.PLANT}, {tag: Tag.ANIMAL}, {tag: Tag.MICROBE}]))
+      .deep.eq([
+        {type: 'tag', tag: Tag.PLANT, min: 1},
+        {type: 'tag', tag: Tag.ANIMAL, min: 1},
+        {type: 'tag', tag: Tag.MICROBE, min: 1},
+      ]);
+  });
+
+  it('throws on a requirement it cannot express', () => {
+    expect(() => normalizeRequirements([{party: PartyName.MARS}]))
+      .to.throw('Unsupported requirement');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `npm run make:card-db`, which walks the existing card manifests at runtime (same technique as `export_card_rendering.ts`) to produce a normalized, agent-readable JSON database at `data/cards/cards.json` (+ `index.json` lookup table + `README.md`), covering the `base`, `corpera` and `prelude` modules.
- Pure normalizer functions (`normalizeRequirements.ts`, `normalizeEffect.ts`) translate the game's `CardRequirementDescriptor` / `Behavior` DSLs into a flat schema (`CardDatabaseTypes.ts`), throwing rather than silently dropping data for any mechanic outside the three covered modules.
- Cards whose behavior lives in TypeScript rather than declarative data are detected mechanically via a prototype-chain walk (`hasBespokeLogic.ts`) and their semantics are supplied by a hand-authored `overlay.ts`, keyed by `CardName`. A test (`buildCardDatabase.spec.ts`) fails the build if any mechanically-detected card lacks an overlay entry, or if an overlay entry is no longer needed — the completeness check is exhaustive and currently green.
- Adds two small getters to `Card.ts` (`actionBehavior`, `globalParameterRequirementBonus`) so the exporter can read data otherwise only reachable via the protected `properties` field.
- No new dependencies.

## Test plan
- [x] `npm run test:server` — 7304 passing
- [x] `npm run lint:server` — clean
- [x] `npx tsc --noEmit -p src/tsconfig.json` — clean (pre-existing unrelated genfiles errors excluded)
- [x] `npm run make:card-db` regenerates `data/cards/*` byte-identically on repeated runs (verified via diff)
- [x] `git status --short data/cards` clean after regenerating, confirming the committed output matches the generator