### PR TITLE
Add the automa game option and MarsBot player setup

### DIFF
--- a/src/server/Game.ts
+++ b/src/server/Game.ts
@@ -38,6 +38,8 @@ import {SerializedGame} from './SerializedGame';
 import {SpaceBonus} from '../common/boards/SpaceBonus';
 import {TileType} from '../common/TileType';
 import {Turmoil} from './turmoil/Turmoil';
+import {AutomaGameHooks} from './automa/AutomaGameHooks';
+import {AutomaGameSetup} from './automa/AutomaGameSetup';
 import {RandomMAOptionType} from '../common/ma/RandomMAOptionType';
 import {AresHandler} from './ares/AresHandler';
 import {AresData} from '../common/ares/AresData';
@@ -150,6 +152,7 @@ export class Game implements IGame, Logger {
   public colonies: Array<IColony> = [];
   public discardedColonies: Array<IColony> = []; // Not serialized
   public turmoil: Turmoil | undefined;
+  public automaHooks: AutomaGameHooks | undefined;
   public aresData: AresData | undefined;
   public moonData: MoonData | undefined;
   public pathfindersData: PathfindersData | undefined;
@@ -357,7 +360,9 @@ export class Game implements IGame, Logger {
     }
 
     // and 2 neutral cities and forests on board
-    if (players.length === 1) {
+    if (players.length === 1 && gameOptions.automaOption) {
+      game.automaHooks = AutomaGameSetup.setup(game);
+    } else if (players.length === 1) {
       //  Setup solo player's starting tiles
       GameSetup.setupNeutralPlayer(game);
     }
@@ -530,6 +535,10 @@ export class Game implements IGame, Logger {
   }
 
   public isSoloMode() :boolean {
+    // An automa game has one human player, but plays by MarsBot's rules, not the solo ones.
+    if (this.automaHooks !== undefined) {
+      return false;
+    }
     return this.players.length === 1;
   }
 
@@ -1706,7 +1715,15 @@ export class Game implements IGame, Logger {
       throw new Error(`Player ${d.first} not found when rebuilding First Player`);
     }
 
-    const board = GameSetup.deserializeBoard(players, gameOptions, d);
+    // MarsBot's player is not in d.players, so it is recreated for the subsystems that
+    // resolve players by id, like the board and the Turmoil delegates.
+    let marsBotPlayer: IPlayer | undefined;
+    if (gameOptions.automaOption) {
+      marsBotPlayer = AutomaGameSetup.createMarsBotPlayer(d.id);
+    }
+    const playersWithMarsBot = marsBotPlayer !== undefined ? [...players, marsBotPlayer] : players;
+
+    const board = GameSetup.deserializeBoard(playersWithMarsBot, gameOptions, d);
 
     const rng = new SeededRandom(d.seed, d.currentSeed);
 
@@ -1758,7 +1775,12 @@ export class Game implements IGame, Logger {
 
     // Reload turmoil elements if needed
     if (d.turmoil && gameOptions.turmoilExtension) {
-      game.turmoil = Turmoil.deserialize(d.turmoil, players);
+      game.turmoil = Turmoil.deserialize(d.turmoil, playersWithMarsBot);
+    }
+
+    if (marsBotPlayer !== undefined) {
+      marsBotPlayer.setup(game);
+      game.automaHooks = {marsBotPlayer};
     }
 
     // Reload moon elements if needed

--- a/src/server/IGame.ts
+++ b/src/server/IGame.ts
@@ -20,6 +20,7 @@ import {SpaceBonus} from '../common/boards/SpaceBonus';
 import {TileType} from '../common/TileType';
 import {ICard} from './cards/ICard';
 import {Turmoil} from './turmoil/Turmoil';
+import {AutomaGameHooks} from './automa/AutomaGameHooks';
 import {AresData} from '../common/ares/AresData';
 import {MoonData} from './moon/MoonData';
 import {SeededRandom} from '../common/utils/Random';
@@ -79,6 +80,7 @@ export interface IGame extends Logger {
   colonies: Array<IColony>;
   discardedColonies: Array<IColony>; // Not serialized
   turmoil: Turmoil | undefined;
+  automaHooks: AutomaGameHooks | undefined;
   // True when resolving Turmoil phase. Does not need to be serialized since the turmoil phase isn't saved in between.
   inTurmoil: boolean;
   aresData: AresData | undefined;

--- a/src/server/automa/AutomaGameHooks.ts
+++ b/src/server/automa/AutomaGameHooks.ts
@@ -1,0 +1,10 @@
+import {IPlayer} from '../IPlayer';
+
+/**
+ * The game's automa (MarsBot) machinery, present when the automa variant is on.
+ * Grows as the automa port lands. For now it only names the MarsBot player,
+ * which is deliberately not part of game.players.
+ */
+export type AutomaGameHooks = {
+  marsBotPlayer: IPlayer;
+};

--- a/src/server/automa/AutomaGameSetup.ts
+++ b/src/server/automa/AutomaGameSetup.ts
@@ -1,0 +1,28 @@
+import {GameId, isPlayerId} from '../../common/Types';
+import {DELEGATES_PER_PLAYER} from '../../common/constants';
+import {IGame} from '../IGame';
+import {IPlayer} from '../IPlayer';
+import {Player} from '../Player';
+import {AutomaGameHooks} from './AutomaGameHooks';
+
+/** Builds the automa (MarsBot) side of a new game. */
+export class AutomaGameSetup {
+  /** Returns MarsBot's player. Its id is derived from the game id, so a reload recreates it. */
+  public static createMarsBotPlayer(gameId: GameId): IPlayer {
+    const playerId = 'p-' + gameId + '-marsbot';
+    if (!isPlayerId(playerId)) {
+      throw new Error('Not a player id: ' + playerId);
+    }
+    return new Player('MarsBot', 'bronze', false, 0, playerId);
+  }
+
+  /** Creates MarsBot's player for `game` and gives it its delegates when Turmoil is on. */
+  public static setup(game: IGame): AutomaGameHooks {
+    const marsBotPlayer = AutomaGameSetup.createMarsBotPlayer(game.id);
+    marsBotPlayer.setup(game);
+    if (game.turmoil !== undefined) {
+      game.turmoil.delegateReserve.add(marsBotPlayer, DELEGATES_PER_PLAYER);
+    }
+    return {marsBotPlayer};
+  }
+}

--- a/src/server/game/GameOptions.ts
+++ b/src/server/game/GameOptions.ts
@@ -39,6 +39,7 @@ export type GameOptions = {
   starWarsExpansion: boolean;
   underworldExpansion: boolean;
   deltaProjectExpansion: boolean;
+  automaOption: boolean;
 
   expansions: Record<Expansion, boolean>,
 
@@ -142,6 +143,7 @@ export const DEFAULT_GAME_OPTIONS: GameOptions = {
   turmoilExtension: false,
   underworldExpansion: false,
   deltaProjectExpansion: false,
+  automaOption: false,
   undoOption: false,
   venusNextExtension: false,
   twoCorpsVariant: false,

--- a/src/server/routes/ApiCreateGame.ts
+++ b/src/server/routes/ApiCreateGame.ts
@@ -128,6 +128,7 @@ export class ApiCreateGame extends Handler {
             altVenusBoard: gameReq.altVenusBoard,
             aresExtension: gameReq.expansions.ares,
             aresHazards: true, // Not a runtime option.
+            automaOption: false, // No create-game UI yet.
             aresExtremeVariant: gameReq.aresExtremeVariant,
             bannedCards: gameReq.bannedCards,
             boardName: gameReq.board,

--- a/tests/automa/AutomaGameSetup.spec.ts
+++ b/tests/automa/AutomaGameSetup.spec.ts
@@ -1,0 +1,61 @@
+import {expect} from 'chai';
+import {testGame} from '../TestGame';
+import {Game} from '../../src/server/Game';
+import {Turmoil} from '../../src/server/turmoil/Turmoil';
+import {PartyName} from '../../src/common/turmoil/PartyName';
+import {DELEGATES_PER_PLAYER} from '../../src/common/constants';
+import {cast} from '@/common/utils/utils';
+
+describe('AutomaGameSetup', () => {
+  it('does nothing without the automa option', () => {
+    const [game] = testGame(1);
+
+    cast(game.automaHooks, undefined);
+    expect(game.isSoloMode()).is.true;
+  });
+
+  it('creates the MarsBot player outside game.players', () => {
+    const [game, human] = testGame(1, {automaOption: true});
+
+    const marsBotPlayer = game.automaHooks!.marsBotPlayer;
+    expect(marsBotPlayer.name).to.eq('MarsBot');
+    expect(game.players).to.deep.eq([human]);
+    expect(marsBotPlayer.id).to.eq('p-' + game.id + '-marsbot');
+  });
+
+  it('an automa game is not solo mode', () => {
+    const [game] = testGame(1, {automaOption: true});
+
+    expect(game.isSoloMode()).is.false;
+  });
+
+  it('an automa game starts without the solo neutral tiles', () => {
+    const [game] = testGame(1, {automaOption: true});
+
+    expect(game.board.spaces.filter((space) => space.tile !== undefined)).is.empty;
+  });
+
+  it('seeds MarsBot delegates when Turmoil is on', () => {
+    const [game] = testGame(1, {automaOption: true, turmoilExtension: true});
+
+    const turmoil = Turmoil.getTurmoil(game);
+    const marsBotPlayer = game.automaHooks!.marsBotPlayer;
+    expect(turmoil.getAvailableDelegateCount(marsBotPlayer)).to.eq(DELEGATES_PER_PLAYER);
+  });
+
+  it('a reload recreates the player and keeps its Turmoil delegates', () => {
+    const [game] = testGame(1, {automaOption: true, turmoilExtension: true});
+    const turmoil = Turmoil.getTurmoil(game);
+    const marsBotPlayer = game.automaHooks!.marsBotPlayer;
+    turmoil.sendDelegateToParty(marsBotPlayer, PartyName.GREENS, game);
+
+    const restored = Game.deserialize(game.serialize());
+
+    const restoredBot = restored.automaHooks!.marsBotPlayer;
+    expect(restoredBot.id).to.eq(marsBotPlayer.id);
+    const restoredTurmoil = Turmoil.getTurmoil(restored);
+    expect(restoredTurmoil.getPartyByName(PartyName.GREENS).delegates.get(restoredBot)).to.eq(1);
+    expect(restoredTurmoil.getAvailableDelegateCount(restoredBot)).to.eq(DELEGATES_PER_PLAYER - 1);
+    expect(restored.isSoloMode()).is.false;
+  });
+});


### PR DESCRIPTION
Splits game setup out of #8211: the automa game option, AutomaGameSetup creating the MarsBot player during setup (outside game.players, with its turmoil delegates seeded), the deserialize path recreating it by id, and the AutomaGameHooks seam on IGame that later PRs fill. #8211 sits on top of this branch.
